### PR TITLE
[xlscc] Quick changes to enable combinational IO blocks

### DIFF
--- a/xls/contrib/xlscc/driver/main.py
+++ b/xls/contrib/xlscc/driver/main.py
@@ -82,5 +82,11 @@ def main():
   with open(args.output_filename, "w") as text_file:
     text_file.write(translator.gen_ir().dump_ir())
 
+
+  if args.wrapper is not None:
+    with open(args.wrapper, "w") as text_file:
+      text_file.write(translator.gen_wrapper(args.package_name))
+
+
 if __name__ == "__main__":
   main()

--- a/xls/contrib/xlscc/translate/translator.py
+++ b/xls/contrib/xlscc/translate/translator.py
@@ -1060,8 +1060,11 @@ class Translator(object):
 
           obj_expr, obj_type = self.gen_expr_ir(obj, condition)
 
+          obj_id = id(obj_expr)
+          if obj_id not in self.read_tokens:
+            raise NotImplementedError("Rvalue is not from a channel read(). A type conversion may have occurred, which is unimplemented.")
 
-          in_ch_name = self.read_tokens[id(obj_expr)]
+          in_ch_name = self.read_tokens[obj_id]
           out_ch_name = left_var.name
 
           # z


### PR DESCRIPTION
These changes support an internal project. 

The gist is that we want to have HLS-generated combinational mux blocks, with no flops. This requires generating logic to select both the forward signals of data and valid, as well as the backward ready signal. 

There are also improvements to the driver, and make some initial steps toward supporting IO channels. 