### PR TITLE
Adds protobuf mirror type of the IR Op listing.

### DIFF
--- a/xls/ir/BUILD
+++ b/xls/ir/BUILD
@@ -110,6 +110,7 @@ cc_library(
     srcs = ["op.cc"],
     hdrs = ["op.h"],
     deps = [
+        ":op_cc_proto",
         "@com_google_absl//absl/base:core_headers",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/strings",
@@ -119,6 +120,16 @@ cc_library(
         "//xls/common/logging",
         "//xls/common/status:statusor",
     ],
+)
+
+proto_library(
+    name = "op_proto",
+    srcs = ["op.proto"],
+)
+
+cc_proto_library(
+    name = "op_cc_proto",
+    deps = [":op_proto"]
 )
 
 cc_library(
@@ -704,6 +715,18 @@ genrule(
     name = "op_header",
     outs = ["op.h"],
     cmd = "$(location :render_specification_against_template) xls/ir/op_header.tmpl" +
+          " | $(location @llvm_toolchain//:bin/clang-format)" +
+          " > $(OUTS)",
+    exec_tools = [
+        ":render_specification_against_template",
+        "@llvm_toolchain//:bin/clang-format",
+    ],
+)
+
+genrule(
+    name = "gen_op_proto",
+    outs = ["op.proto"],
+    cmd = "$(location :render_specification_against_template) xls/ir/op_proto.tmpl" +
           " | $(location @llvm_toolchain//:bin/clang-format)" +
           " > $(OUTS)",
     exec_tools = [

--- a/xls/ir/op_header.tmpl
+++ b/xls/ir/op_header.tmpl
@@ -4,10 +4,11 @@
 #include <string>
 #include <vector>
 
-#include "xls/common/integral_types.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
+#include "xls/common/integral_types.h"
 #include "xls/common/status/statusor.h"
+#include "xls/ir/op.pb.h"
 
 namespace xls {
 
@@ -27,6 +28,12 @@ inline std::vector<Op> AllOps() {
 }
 
 const int64 kOpLimit = static_cast<int64>(Op::{{ spec.OPS[-1].enum_name }})+1;
+
+// Converts an OpProto into an Op.
+xabsl::StatusOr<Op> FromOpProto(OpProto op_proto);
+
+// Converts an Op into an OpProto.
+xabsl::StatusOr<OpProto> ToOpProto(Op op);
 
 // Converts the "op" enumeration to a human readable string.
 std::string OpToString(Op op);

--- a/xls/ir/op_proto.tmpl
+++ b/xls/ir/op_proto.tmpl
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+package xls;
+
+// Listing of all XLS IR operations.
+enum OpProto {
+  {% for op in spec.OPS -%}
+  OP_{{ op.name.upper() }} = {{ loop.index }};
+  {% endfor -%}
+}

--- a/xls/ir/op_source.tmpl
+++ b/xls/ir/op_source.tmpl
@@ -6,6 +6,25 @@
 
 namespace xls {
 
+xabsl::StatusOr<Op> FromOpProto(OpProto op_proto) {
+  switch (op_proto) {
+{% for op in spec.OPS -%}
+    case OP_{{ op.name.upper() }}: return Op::{{ op.enum_name }};
+{% endfor -%}
+    default: return absl::InvalidArgumentError("Unknown op.");
+  }
+}
+
+xabsl::StatusOr<OpProto> ToOpProto(Op op) {
+  switch (op) {
+{% for op in spec.OPS -%}
+    case Op::{{ op.enum_name }}: return OP_{{ op.name.upper() }};
+{% endfor -%}
+
+    default: return absl::InvalidArgumentError("Unknown op.");
+  }
+}
+
 std::string OpToString(Op op) {
   static const absl::flat_hash_map<Op, std::string>* op_map =
       new absl::flat_hash_map<Op, std::string>({


### PR DESCRIPTION
Precursor work for solver time-to-solution characterization across ops and sizes - need a way to store results!