### PR TITLE
Fix the accidental scope-leaking of enum values.

### DIFF
--- a/xls/dslx/parser.py
+++ b/xls/dslx/parser.py
@@ -927,13 +927,14 @@ class Parser(token_parser.TokenParser):
     )
     type_ = self._parse_type_annotation(bindings)
     self._dropt_or_error(TokenKind.OBRACE)
+    enum_bindings = Bindings(parent=bindings)
 
     def parse_enum_entry(
     ) -> Tuple[ast.NameDef, Union[ast.Number, ast.NameRef]]:
       """Parses a single entry in an enum definition."""
-      name_def = self._parse_name_def(bindings)
+      name_def = self._parse_name_def(enum_bindings)
       self._dropt_or_error(TokenKind.EQUALS)
-      value = self._parse_num_or_const_ref(bindings)
+      value = self._parse_num_or_const_ref(enum_bindings)
       if isinstance(value, ast.Number):
         if value.type_ is not None:
           raise ParseError(

--- a/xls/dslx/parser_test.py
+++ b/xls/dslx/parser_test.py
@@ -977,6 +977,23 @@ proc simple(addend: u32) {
     self.assertIsInstance(bindings.resolve_node('other', fake_span), ast.Import)
     self.assertIsNone(bindings.resolve_node_or_none('thing'), None)
 
+  def test_bad_enum_ref(self):
+    program = """
+    enum MyEnum : u1 {
+      FOO = 0
+    }
+
+    fn my_fun() -> MyEnum {
+      FOO  // Should be qualified as MyEnum::FOO!
+    }
+    """
+    bindings = parser.Bindings(None)
+    fparse = lambda p, bindings: p.parse_module('test_module', bindings)
+    with self.assertRaises(parser.ParseError) as cm:
+      self._parse_internal(program, bindings, fparse)
+    self.assertIn('Cannot find a definition for name: \'FOO\'',
+                  str(cm.exception))
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
They were leaking into the module-level scope, and then things like the
IR converter would subsequently blow up, because it expected you
couldn't refer to `MyEnum::FOO` as just bare `FOO`.