### PR TITLE
Fixed bug in BDD simplification pass. 

### DIFF
--- a/xls/passes/bdd_simplification_pass.cc
+++ b/xls/passes/bdd_simplification_pass.cc
@@ -323,10 +323,6 @@ xabsl::StatusOr<bool> SimplifyNode(Node* node, const QueryEngine& query_engine,
 }
 
 xabsl::StatusOr<bool> SimplifyOneHotMsb(Function* f) {
-  // TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-  // xls/dslx/fuzzer/crashers/2020-08-24-min.x
-  return false;
-#if 0
   bool changed = false;
   XLS_ASSIGN_OR_RETURN(
       std::unique_ptr<PostDominatorAnalysis> post_dominator_analysis,
@@ -435,7 +431,6 @@ xabsl::StatusOr<bool> SimplifyOneHotMsb(Function* f) {
   }
 
   return changed;
-#endif
 }
 
 }  // namespace
@@ -446,14 +441,14 @@ xabsl::StatusOr<bool> BddSimplificationPass::RunOnFunction(
   XLS_VLOG(3) << "Before:";
   XLS_VLOG_LINES(3, f->DumpIr());
 
-  // TODO(meheff): Try tuning the minterm limit.
-  XLS_ASSIGN_OR_RETURN(std::unique_ptr<BddQueryEngine> query_engine,
-                       BddQueryEngine::Run(f, /*minterm_limit=*/4096));
-
   bool one_hot_modified = false;
   if (split_ops_) {
     XLS_ASSIGN_OR_RETURN(one_hot_modified, SimplifyOneHotMsb(f));
   }
+
+  // TODO(meheff): Try tuning the minterm limit.
+  XLS_ASSIGN_OR_RETURN(std::unique_ptr<BddQueryEngine> query_engine,
+                       BddQueryEngine::Run(f, /*minterm_limit=*/4096));
 
   bool modified = false;
   for (Node* node : TopoSort(f)) {

--- a/xls/passes/bdd_simplification_pass_test.cc
+++ b/xls/passes/bdd_simplification_pass_test.cc
@@ -200,9 +200,7 @@ TEST_F(BddSimplificationPassTest, SelectChainOneHotOrZeroSelectors) {
                                m::Param("x2")}));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbTypical) {
+TEST_F(BddSimplificationPassTest, OneHotMsbTypical) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -223,9 +221,7 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbTypical) {
                             m::BitSlice(m::OneHot(m::Param("input")), 0, 7)))));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbAlternateForm) {
+TEST_F(BddSimplificationPassTest, OneHotMsbAlternateForm) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -247,10 +243,8 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbAlternateForm) {
                             m::BitSlice(m::OneHot(m::Param("input")), 0, 7)))));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
 TEST_F(BddSimplificationPassTest,
-       DISABLED_OneHotMsbRequireFullBddToAnalyzeOneMsbCase) {
+       OneHotMsbRequireFullBddToAnalyzeOneMsbCase) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -266,9 +260,7 @@ TEST_F(BddSimplificationPassTest,
                         m::BitSlice(m::OneHot(m::Param("input")), 0, 7)));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbMsbLeaks) {
+TEST_F(BddSimplificationPassTest, OneHotMsbMsbLeaks) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -285,9 +277,7 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbMsbLeaks) {
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/true), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNonMsbOneComparison) {
+TEST_F(BddSimplificationPassTest, OneHotMsbNonMsbOneComparison) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -304,9 +294,7 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNonMsbOneComparison) {
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/true), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNonZeroReplacementValue) {
+TEST_F(BddSimplificationPassTest, OneHotMsbNonZeroReplacementValue) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -323,9 +311,7 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNonZeroReplacementValue) {
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/true), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNoRecursion) {
+TEST_F(BddSimplificationPassTest, OneHotMsbNoRecursion) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -347,10 +333,8 @@ TEST_F(BddSimplificationPassTest, DISABLED_OneHotMsbNoRecursion) {
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/false), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
 TEST_F(BddSimplificationPassTest,
-       DISABLED_OneHotMsbNoRecursionExistingSliceIncludesMsb) {
+       OneHotMsbNoRecursionExistingSliceIncludesMsb) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -373,10 +357,8 @@ TEST_F(BddSimplificationPassTest,
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/false), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
 TEST_F(BddSimplificationPassTest,
-       DISABLED_OneHotMsbNoRecursionExistingSliceExcludesMsb) {
+       OneHotMsbNoRecursionExistingSliceExcludesMsb) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(7));
@@ -394,11 +376,9 @@ TEST_F(BddSimplificationPassTest,
   EXPECT_THAT(Run(f, /*run_cleanup_passes=*/true), IsOkAndHolds(false));
 }
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
 TEST_F(
     BddSimplificationPassTest,
-    DISABLED_OneHotMsbPostponeOneHotNativeOneHotDetectionUntilAfterOneHotMsb) {
+    OneHotMsbPostponeOneHotNativeOneHotDetectionUntilAfterOneHotMsb) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());
   BValue input = fb.Param("input", p->GetBitsType(2));
@@ -425,6 +405,22 @@ TEST_F(
           m::Literal(UBits(0, 1)),
           m::Concat(m::Eq(m::Literal(UBits(1, 2)), m::Param("input")),
                     m::Eq(m::Literal(UBits(3, 2)), m::Param("input"))))));
+}
+
+TEST_F(BddSimplificationPassTest, BddNotStaleAfterOneHotSimplification) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+  BValue input = fb.Param("input", p->GetBitsType(1));
+  BValue literal_zero2 = fb.Literal(UBits(0, 2));
+  BValue concat = fb.Concat({input, literal_zero2});
+  BValue hot = fb.OneHot(concat, LsbOrMsb::kLsb);
+  BValue encode = fb.Encode(hot);
+  fb.XorReduce(encode);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+  ASSERT_THAT(Run(f, /*run_cleanup_passes=*/true), IsOkAndHolds(true));
+  EXPECT_THAT(f->return_value(),
+              m::Param("input"));
 }
 
 }  // namespace

--- a/xls/tests/dslx_optimization_test.cc
+++ b/xls/tests/dslx_optimization_test.cc
@@ -55,9 +55,7 @@ class DslxOptimizationTest : public IrTestBase {
   }
 };
 
-// TODO(meheff): 2020-08-24 Disabled for debugging of crasher
-// xls/dslx/fuzzer/crashers/2020-08-24-min.x
-TEST_F(DslxOptimizationTest, DISABLED_StdFindIndexOfLiteralArray) {
+TEST_F(DslxOptimizationTest, StdFindIndexOfLiteralArray) {
   std::string input = R"(import std
 
 const A = u32[3]:[10, 20, 30];


### PR DESCRIPTION
The bug occured because we reused BDD analysis generated before OneHot MSB simplification after OneHot MSB simplification. Although the OneHot transform is only performed if the output is unaffected, this transform may change intermediate values. The previous BDD analysis on such intermediate values may therefore no longer be accurate. Fixed by performing a fresh analysis after the OneHot Transfrom.

Fixes #115