### PR TITLE
Simplify setup using python-is-python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,20 +16,13 @@ echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" |
 apt-get update -y && apt-get install -y bazel
 
 # Install dependencies
-RUN apt-get -y install python3-distutils python3-dev libtinfo5
+RUN apt-get -y install python3-distutils python3-dev python-is-python3 libtinfo5
 
 # Install development tools
 RUN apt-get install -y git vim
 
 RUN useradd -m xls-developer
 USER xls-developer
-
-# Create "python" binary in PATH for Bazel Python environment.
-# (Ubuntu 20.04 only has "python3" in PATH.)
-RUN mkdir -p ~/opt/bin && \
-ln -s $(which python3) ~/opt/bin/python
-
-ENV PATH /home/xls-developer/opt/bin:$PATH
 
 # Clone the project
 WORKDIR /home/xls-developer/

--- a/README.md
+++ b/README.md
@@ -49,16 +49,7 @@ installed](https://docs.bazel.build/versions/master/install-ubuntu.html).
 $ bazel --version
 bazel 3.2.0
 
-$ sudo apt install python3-dev python3-distutils python3-dev libtinfo5
-
-# py_binary currently assume they can refer to /usr/bin/env python
-# even though Ubuntu 20.04 has no `python`, only `python3`.
-# See https://github.com/bazelbuild/bazel/issues/8685
-
-$ mkdir -p $HOME/opt/bin/
-$ ln -s $(which python3) $HOME/opt/bin/python
-$ echo 'export PATH=$HOME/opt/bin:$PATH' >> ~/.bashrc
-$ source ~/.bashrc
+$ sudo apt install python3-dev python3-distutils python3-dev python-is-python3 libtinfo5
 
 $ bazel test -c opt ...
 ```


### PR DESCRIPTION
The `python-is-python3` package in Ubuntu 20.04 provides `/usr/bin/python` as a symlink to `python3`, which can be used to simply the setup process.