### PR TITLE
[misc] Fix build failure of cpp_bindings.so

### DIFF
--- a/xls/dslx/python/cpp_ast.h
+++ b/xls/dslx/python/cpp_ast.h
@@ -15,6 +15,7 @@
 #ifndef XLS_DSLX_PYTHON_CPP_AST_H_
 #define XLS_DSLX_PYTHON_CPP_AST_H_
 
+#include "absl/base/casts.h"
 #include "pybind11/pybind11.h"
 #include "xls/dslx/cpp_ast.h"
 


### PR DESCRIPTION
Without the include, (clean) build fails for me; compiler is unable to find `absl::bit_cast`.