### PR TITLE
Specialize select arms

### DIFF
--- a/xls/ir/node.h
+++ b/xls/ir/node.h
@@ -82,7 +82,8 @@ class Node {
   // SwapOperands() below.
   absl::Span<Node* const> operands() const { return operands_; }
 
-  // Returns whether at least one operand was replaced.
+  // Replaces all instances of 'old_operand' with 'new_operand', and returns
+  // whether at least one operand was replaced.
   bool ReplaceOperand(Node* old_operand, Node* new_operand);
 
   // Replaces the existing operand at position 'operand_no' with 'new_operand'.

--- a/xls/passes/BUILD
+++ b/xls/passes/BUILD
@@ -471,6 +471,7 @@ cc_library(
     hdrs = ["select_simplification_pass.h"],
     deps = [
         ":passes",
+        ":post_dominator_analysis",
         ":ternary_query_engine",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/container:flat_hash_set",

--- a/xls/passes/post_dominator_analysis.h
+++ b/xls/passes/post_dominator_analysis.h
@@ -31,19 +31,20 @@ class PostDominatorAnalysis {
       Function* f);
 
   // Returns the nodes that post-dominate this node.
-  absl::Span<Node* const> GetPostDominatorsOfNode(const Node* node) {
+  absl::Span<Node* const> GetPostDominatorsOfNode(const Node* node) const {
     return dominated_node_to_post_dominators_ordered_by_id_.at(node);
   }
   // Returns the nodes that are post-dominated by this node.
-  absl::Span<Node* const> GetNodesPostDominatedByNode(const Node* node) {
+  absl::Span<Node* const> GetNodesPostDominatedByNode(const Node* node) const {
     return post_dominator_to_dominated_nodes_ordered_by_id_.at(node);
   }
   // Returns true if 'node' is post-dominated by 'post_dominator'.
-  bool NodeIsPostDominatedBy(const Node* node, const Node* post_dominator) {
+  bool NodeIsPostDominatedBy(const Node* node,
+                             const Node* post_dominator) const {
     return dominated_node_to_post_dominators_.at(node).contains(post_dominator);
   }
   // Returns true if 'node' post_dominates 'post_dominated'.
-  bool NodePostDominates(const Node* node, const Node* post_dominated) {
+  bool NodePostDominates(const Node* node, const Node* post_dominated) const {
     return post_dominator_to_dominated_nodes_.at(node).contains(post_dominated);
   }
 


### PR DESCRIPTION
Closes #145 

Adds a step to `SimplifyNode` in the select simplification pass that will try to specialize the arms of the select. The current implementation does not support simplifying cases where the selector is not post-dominated by the arm, and works by doing an exact match on the selector within each arm.

Test by running: `bazel test -c opt --test_output=errors //xls/passes/...`