### PR TITLE
Fixes for python3.9 and gcc-10.2.1

### DIFF
--- a/dependency_support/com_github_grpc_grpc/BUILD
+++ b/dependency_support/com_github_grpc_grpc/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/com_github_grpc_grpc/grpc-cython.patch
+++ b/dependency_support/com_github_grpc_grpc/grpc-cython.patch
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- bazel/grpc_python_deps.bzl.org	2020-09-30 22:00:25.398703720 +0300
++++ bazel/grpc_python_deps.bzl	2020-09-30 22:02:23.149274235 +0300
+@@ -59,9 +59,9 @@
+         http_archive(
+             name = "cython",
+             build_file = "@com_github_grpc_grpc//third_party:cython.BUILD",
+-            sha256 = "d68138a2381afbdd0876c3cb2a22389043fa01c4badede1228ee073032b07a27",
+-            strip_prefix = "cython-c2b80d87658a8525ce091cbe146cb7eaa29fed5c",
++            sha256 = "9ccf2d1d2fdb9e12d01aee8e0a157833991cbdc6bb001b593b40508c47b9908f",
++            strip_prefix = "cython-28f5f26ba7073bc589b5dfc1438c62813d17063f",
+             urls = [
+-                "https://github.com/cython/cython/archive/c2b80d87658a8525ce091cbe146cb7eaa29fed5c.tar.gz",
++                "https://github.com/cython/cython/archive/28f5f26ba7073bc589b5dfc1438c62813d17063f.tar.gz",
+             ],
+         )

--- a/dependency_support/initialize_external.bzl
+++ b/dependency_support/initialize_external.bzl
@@ -32,5 +32,6 @@ def initialize_external_repositories():
         name = "xls_pip_deps",
         requirements = "//dependency_support:pip_requirements.txt",
         python_interpreter = "python3",
+        timeout = 600000,
     )
     initialize_boost()

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -184,7 +184,8 @@ def load_external_repositories():
 
     http_archive(
         name = "com_github_grpc_grpc",
-        urls = ["https://github.com/grpc/grpc/archive/v1.30.1.tar.gz"],
-        sha256 = "d6a10be7e803cc7ba73b3a03d34f6d18c046b562e4b08752c17aa978464baea3",
-        strip_prefix = "grpc-1.30.1",
+        urls = ["https://github.com/grpc/grpc/archive/v1.32.0.tar.gz"],
+        sha256 = "f880ebeb2ccf0e47721526c10dd97469200e40b5f101a0d9774eb69efa0bd07a",
+        strip_prefix = "grpc-1.32.0",
+        patches = ["//dependency_support/com_github_grpc_grpc:grpc-cython.patch"],
     )

--- a/dependency_support/pip_requirements.txt
+++ b/dependency_support/pip_requirements.txt
@@ -6,7 +6,7 @@ itsdangerous==1.1.0
 click==7.1.2
 numpy==1.18.4
 markupsafe==1.1.1
-scipy==1.4.1
+scipy==1.5.0
 termcolor==1.1.0
 psutil==5.7.0
 portpicker==1.3.1


### PR DESCRIPTION
Proposed PR fixes build on more recent systems.

* Increase the default 600s (way too small) timeout for **pip_deps** fetches.
* Impose a newer **cython** compatible with python 3.9 too.
* Update **grpc** to be able build with latest gcc-10.2.1 too.
* Request newer **scipy** buildable with gcc-10.2.1 and python 3.9 headers


These fixes works on a Fedora 34 (rawhide) distro.

Thank You !

----------

PS:
* Preparing more patches towards (optional) distro friendly **unbundled** builds, (like ```systemlibs``` option for tensorflow)
#141 




