### PR TITLE
Enable optional dependency unbundle for system libs and tools.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,11 +1,17 @@
 workspace(name = "com_google_xls")
 
+load("//dependency_support/systemlibs:syslibs_configure.bzl", "syslibs_configure")
+syslibs_configure(name = "local_config_syslibs")
+load("@local_config_syslibs//:build_defs.bzl", "SYSTEM_LIBS_LIST")
+
+print("Enabled external system libs: %s" % SYSTEM_LIBS_LIST)
+
 # Load and configure a hermetic LLVM based C/C++ toolchain. This is done here
 # and not in load_external.bzl because it requires several sequential steps of
 # declaring archives and using things in them, which is awkward to do in .bzl
 # files because it's not allowed to use `load` inside of a function.
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
+load("//dependency_support:repo.bzl", "xls_http_archive")
+xls_http_archive(
     name = "com_grail_bazel_toolchain",
     urls = [
         "https://github.com/grailbio/bazel-toolchain/archive/f4c17a3ae40f927ff62cc0fb8fe22b1530871807.zip",
@@ -13,6 +19,14 @@ http_archive(
     strip_prefix = "bazel-toolchain-f4c17a3ae40f927ff62cc0fb8fe22b1530871807",
     sha256 = "715fd98d566ed1304cb53e0c640427cf0916ec6db89588e3ac2b6a87632276d4",
     patches = ["//dependency_support/com_grail_bazel_toolchain:google_workstation_workaround.patch"],
+    system_build_file = "//dependency_support/com_grail_bazel_toolchain:BUILD",
+    system_link_files = {
+        "//dependency_support/systemlibs:com_grail_bazel_toolchain.toolchain.BUILD": "toolchain/BUILD",
+        "//dependency_support/systemlibs:com_grail_bazel_toolchain.toolchain.deps.bzl": "toolchain/deps.bzl",
+        "//dependency_support/systemlibs:com_grail_bazel_toolchain.toolchain.rules.bzl": "toolchain/rules.bzl",
+        "//dependency_support/systemlibs:com_grail_bazel_toolchain.internal.BUILD": "toolchain/internal/BUILD",
+        "//dependency_support/systemlibs:com_grail_bazel_toolchain.internal.configure.bzl": "toolchain/internal/configure.bzl",
+    },
 )
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")
 bazel_toolchain_dependencies()

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -16,6 +16,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("//dependency_support:repo.bzl", "xls_http_archive")
 load("//dependency_support:edu_berkeley_abc/workspace.bzl", repo_abc = "repo")
 load("//dependency_support/boost:workspace.bzl", repo_boost = "repo")
 load("//dependency_support/org_gnu_bison:workspace.bzl", repo_bison = "repo")
@@ -89,12 +90,13 @@ def load_external_repositories():
         shallow_since = "1543277914 +0000",
     )
 
-    http_archive(
+    xls_http_archive(
         name = "llvm",
         urls = ["https://github.com/llvm/llvm-project/archive/52cae05e087b3d4fd02849fc37c387c720055ffb.tar.gz"],
         sha256 = "84af24a605a9e20d999e65f87a36baeed56773d74ccc0287517f5fdcf44e737a",
         strip_prefix = "llvm-project-52cae05e087b3d4fd02849fc37c387c720055ffb/llvm",
         build_file = "@//dependency_support/llvm:bundled.BUILD.bazel",
+        system_build_file = "@//dependency_support/systemlibs:llvm.BUILD",
     )
 
     http_archive(
@@ -150,12 +152,13 @@ def load_external_repositories():
         sha256 = "b5668cde8bb6e3515057ef465a35ad712214962f0b3a314e551204266c7be90c",
     )
 
-    http_archive(
+    xls_http_archive(
         name = "z3",
         urls = ["https://github.com/Z3Prover/z3/archive/z3-4.8.7.tar.gz"],
         sha256 = "8c1c49a1eccf5d8b952dadadba3552b0eac67482b8a29eaad62aa7343a0732c3",
         strip_prefix = "z3-z3-4.8.7",
         build_file = "@//dependency_support/z3:bundled.BUILD.bazel",
+        system_build_file = "@//dependency_support/systemlibs:z3.BUILD",
     )
 
     http_archive(
@@ -171,7 +174,7 @@ def load_external_repositories():
     # does not include all the source code (e.g., gzread is missing) which
     # breaks other users of zlib like iverilog. So add zlib explicitly here with
     # a working BUILD file.
-    http_archive(
+    xls_http_archive(
         name = "zlib",
         sha256 = "f5cc4ab910db99b2bdbba39ebbdc225ffc2aa04b4057bc2817f1b94b6978cfc3",
         strip_prefix = "zlib-1.2.11",
@@ -179,6 +182,7 @@ def load_external_repositories():
             "https://github.com/madler/zlib/archive/v1.2.11.zip",
         ],
         build_file = "@//dependency_support/zlib:bundled.BUILD.bazel",
+        system_build_file = "@//dependency_support/systemlibs:zlib.BUILD",
     )
 
     http_archive(

--- a/dependency_support/org_gnu_m4/workspace.bzl
+++ b/dependency_support/org_gnu_m4/workspace.bzl
@@ -14,12 +14,12 @@
 
 """Loads the m4 macro processor, used by Bison."""
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//dependency_support:repo.bzl", "xls_http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def repo():
     maybe(
-        http_archive,
+        xls_http_archive,
         name = "org_gnu_m4",
         urls = [
             "http://ftp.acc.umu.se/mirror/gnu.org/gnu/m4/m4-1.4.18.tar.xz",
@@ -28,4 +28,5 @@ def repo():
         strip_prefix = "m4-1.4.18",
         sha256 = "f2c1e86ca0a404ff281631bdc8377638992744b175afb806e25871a24a934e07",
         build_file = Label("//dependency_support:org_gnu_m4/bundled.BUILD.bazel"),
+        system_build_file = "@//dependency_support/systemlibs:org_gnu_m4.BUILD",
     )

--- a/dependency_support/repo.bzl
+++ b/dependency_support/repo.bzl
@@ -1,0 +1,145 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for defining XLS Bazel external system dependencies."""
+
+_SINGLE_URL_WHITELIST = depset([
+    "arm_compiler",
+])
+
+def _is_windows(ctx):
+    return ctx.os.name.lower().find("windows") != -1
+
+def _wrap_bash_cmd(ctx, cmd):
+    if _is_windows(ctx):
+        bazel_sh = _get_env_var(ctx, "BAZEL_SH")
+        if not bazel_sh:
+            fail("BAZEL_SH environment variable is not set")
+        cmd = [bazel_sh, "-l", "-c", " ".join(["\"%s\"" % s for s in cmd])]
+    return cmd
+
+def _get_env_var(ctx, name):
+    if name in ctx.os.environ:
+        return ctx.os.environ[name]
+    else:
+        return None
+
+# Checks if we should use the system lib instead of the bundled one
+def _use_system_lib(ctx, name):
+    syslibenv = _get_env_var(ctx, "XLS_SYSTEM_LIBS")
+    if syslibenv:
+        for n in syslibenv.strip().split(","):
+            if n.strip() == name:
+                return True
+    return False
+
+# Executes specified command with arguments and calls 'fail' if it exited with
+# non-zero code
+def _execute_and_check_ret_code(repo_ctx, cmd_and_args):
+    result = repo_ctx.execute(cmd_and_args, timeout = 60)
+    if result.return_code != 0:
+        fail(("Non-zero return code({1}) when executing '{0}':\n" + "Stdout: {2}\n" +
+              "Stderr: {3}").format(
+            " ".join([str(x) for x in cmd_and_args]),
+            result.return_code,
+            result.stdout,
+            result.stderr,
+        ))
+
+def _repos_are_siblings():
+    return Label("@foo//bar").workspace_root.startswith("../")
+
+# Apply a patches to the repository root directory.
+def _apply_patch(ctx, patches):
+    for patch in patches:
+        ctx.patch(Label(str(patch)), strip = 0)
+
+def _apply_delete(ctx, paths):
+    for path in paths:
+        if path.startswith("/"):
+            fail("refusing to rm -rf path starting with '/': " + path)
+        if ".." in path:
+            fail("refusing to rm -rf path containing '..': " + path)
+    cmd = _wrap_bash_cmd(ctx, ["rm", "-rf"] + [ctx.path(path) for path in paths])
+    _execute_and_check_ret_code(ctx, cmd)
+
+def _xls_http_archive(ctx):
+
+    use_syslib = _use_system_lib(ctx, ctx.attr.name)
+
+    # Work around the bazel bug that redownloads the whole library.
+    # Remove this after https://github.com/bazelbuild/bazel/issues/10515 is fixed.
+    if ctx.attr.additional_build_files:
+        for internal_src in ctx.attr.additional_build_files:
+            _ = ctx.path(Label(internal_src))
+
+    # End of workaround.
+
+    if not use_syslib:
+        ctx.download_and_extract(
+            ctx.attr.urls,
+            "",
+            ctx.attr.sha256,
+            ctx.attr.type,
+            ctx.attr.strip_prefix,
+        )
+        if ctx.attr.delete:
+            _apply_delete(ctx, ctx.attr.delete)
+        if ctx.attr.patches != None:
+            _apply_patch(ctx, ctx.attr.patches)
+
+    if use_syslib and ctx.attr.system_build_file != None:
+        # Use BUILD.bazel to avoid conflict with third party projects with
+        # BUILD or build (directory) underneath.
+        ctx.template("BUILD.bazel", ctx.attr.system_build_file, {
+            "%prefix%": ".." if _repos_are_siblings() else "external",
+        }, False)
+
+    elif ctx.attr.build_file != None:
+        # Use BUILD.bazel to avoid conflict with third party projects with
+        # BUILD or build (directory) underneath.
+        ctx.template("BUILD.bazel", ctx.attr.build_file, {
+            "%prefix%": ".." if _repos_are_siblings() else "external",
+        }, False)
+
+    if use_syslib:
+        for internal_src, external_dest in ctx.attr.system_link_files.items():
+            ctx.symlink(Label(internal_src), ctx.path(external_dest))
+
+    if ctx.attr.additional_build_files:
+        for internal_src, external_dest in ctx.attr.additional_build_files.items():
+            ctx.symlink(Label(internal_src), ctx.path(external_dest))
+
+xls_http_archive = repository_rule(
+    attrs = {
+        "sha256": attr.string(mandatory = True),
+        "urls": attr.string_list(
+            mandatory = True,
+            allow_empty = False,
+        ),
+        "strip_prefix": attr.string(),
+        "type": attr.string(),
+        "delete": attr.string_list(),
+        "patches": attr.string_list(),
+        "build_file": attr.label(),
+        "build_file_content": attr.string(),
+        "system_build_file": attr.label(),
+        "system_link_files": attr.string_dict(),
+        "additional_build_files": attr.string_dict(),
+    },
+    environ = [
+        "XLS_SYSTEM_LIBS",
+    ],
+    implementation = _xls_http_archive,
+)

--- a/dependency_support/systemlibs/BUILD
+++ b/dependency_support/systemlibs/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/BUILD.tpl
+++ b/dependency_support/systemlibs/BUILD.tpl
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/build_defs.bzl.tpl
+++ b/dependency_support/systemlibs/build_defs.bzl.tpl
@@ -1,0 +1,46 @@
+# -*- Python -*-
+
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Skylark macros for system libraries."""
+
+SYSTEM_LIBS_ENABLED = %{syslibs_enabled}
+
+SYSTEM_LIBS_LIST = [
+%{syslibs_list}
+]
+
+
+def if_any_system_libs(a, b=[]):
+  """Conditional which evaluates to 'a' if any system libraries are configured."""
+  if SYSTEM_LIBS_ENABLED:
+    return a
+  else:
+    return b
+
+
+def if_system_lib(lib, a, b=[]):
+  """Conditional which evaluates to 'a' if we're using the system version of lib"""
+
+  if SYSTEM_LIBS_ENABLED and lib in SYSTEM_LIBS_LIST:
+    return a
+  else:
+    return b
+
+
+def if_not_system_lib(lib, a, b=[]):
+  """Conditional which evaluates to 'a' if we're using the system version of lib"""
+
+  return if_system_lib(lib, b, a)

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.BUILD
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.BUILD
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.internal.BUILD
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.internal.BUILD
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.internal.configure.bzl
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.internal.configure.bzl
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.BUILD
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.BUILD
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.deps.bzl
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.deps.bzl
@@ -1,0 +1,36 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@//dependency_support:repo.bzl", "xls_http_archive")
+
+def bazel_toolchain_dependencies():
+
+    xls_http_archive(
+        name = "llvm_toolchain",
+        urls = [ "https://github.com/grailbio/bazel-toolchain/archive/f4c17a3ae40f927ff62cc0fb8fe22b1530871807.zip", ],
+        sha256 = "715fd98d566ed1304cb53e0c640427cf0916ec6db89588e3ac2b6a87632276d4",
+        system_build_file = "@//dependency_support/systemlibs:llvm_toolchain.BUILD",
+        system_link_files = {
+            "@//dependency_support/systemlibs:llvm_toolchain.toolchains.bzl": "toolchains.bzl",
+            "@//dependency_support/systemlibs:llvm_toolchain.cc_toolchain_config.bzl": "cc_toolchain_config.bzl",
+        },
+    )
+
+    if not native.existing_rule("rules_cc"):
+        xls_http_archive(
+            name = "rules_cc",
+            sha256 = "b6f34b3261ec02f85dbc5a8bdc9414ce548e1f5f67e000d7069571799cb88b25",
+            strip_prefix = "rules_cc-726dd8157557f1456b3656e26ab21a1646653405",
+            urls = ["https://github.com/bazelbuild/rules_cc/archive/726dd8157557f1456b3656e26ab21a1646653405.tar.gz"],
+        )

--- a/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.rules.bzl
+++ b/dependency_support/systemlibs/com_grail_bazel_toolchain.toolchain.rules.bzl
@@ -1,0 +1,27 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _llvm_toolchain_impl():
+    pass
+
+llvm_toolchain = repository_rule(
+    attrs = {
+        "llvm_version": attr.string(
+            default = "6.0.0",
+            doc = "One of the supported versions of LLVM.",
+        ),
+    },
+    local = False,
+    implementation = _llvm_toolchain_impl,
+)

--- a/dependency_support/systemlibs/llvm.BUILD
+++ b/dependency_support/systemlibs/llvm.BUILD
@@ -1,0 +1,182 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # MIT
+
+filegroup(
+    name = "COPYING",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Core",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Object",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "TransformUtils",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Support",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Scalar",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Linker",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Analysis",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "BitReader",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "BitWriter",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "IPO",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ObjCARC",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "IRReader",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "AMDGPUCodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ARMCodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "PowerPCCodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "X86CodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "NVPTXCodeGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "X86AsmParser",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "Target",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "JITLink",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "MC",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "OrcJIT",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "CallOpInterfacesIncGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "DerivedAttributeOpInterface",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "TableGen",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "ExecutionEngine",
+    linkopts = ["-lLLVM"],
+    visibility = ["//visibility:public"],
+)

--- a/dependency_support/systemlibs/llvm_toolchain.BUILD
+++ b/dependency_support/systemlibs/llvm_toolchain.BUILD
@@ -1,0 +1,33 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_LLVM_BINS = [
+    "clang",
+    "clang-format",
+]
+
+_LLVM_PREFIXED_BINS = ["bin/" + bin for bin in _LLVM_BINS]
+
+genrule(
+    name = "link_clang_bins",
+    outs = _LLVM_PREFIXED_BINS,
+    cmd = """
+      for i in $(OUTS); do
+        f=$${i#$(@D)}
+        mkdir -p $(@D)
+        ln -sf $$(which $$f) $(@D)/$$f
+      done
+    """,
+    visibility = ["//visibility:public"],
+)

--- a/dependency_support/systemlibs/llvm_toolchain.cc_toolchain_config.bzl
+++ b/dependency_support/systemlibs/llvm_toolchain.cc_toolchain_config.bzl
@@ -1,0 +1,15 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/systemlibs/llvm_toolchain.toolchains.bzl
+++ b/dependency_support/systemlibs/llvm_toolchain.toolchains.bzl
@@ -1,0 +1,16 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def llvm_register_toolchains():
+    pass

--- a/dependency_support/systemlibs/org_gnu_m4.BUILD
+++ b/dependency_support/systemlibs/org_gnu_m4.BUILD
@@ -1,0 +1,27 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["restricted"])  # GPLv3
+
+genrule(
+    name = "link_m4",
+    outs = ["bin/m4"],
+    cmd = "ln -sf $$(which m4) $@",
+)
+
+sh_binary(
+    name = "m4",
+    srcs = ["bin/m4"],
+    visibility = ["//visibility:public"],
+)

--- a/dependency_support/systemlibs/syslibs_configure.bzl
+++ b/dependency_support/systemlibs/syslibs_configure.bzl
@@ -1,0 +1,156 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Repository rule for system library autoconfiguration.
+
+`syslibs_configure` depends on the following environment variables:
+
+  * `XLS_SYSTEM_LIBS`: list of third party dependencies that should use
+    the system version instead
+"""
+
+_XLS_SYSTEM_LIBS = "XLS_SYSTEM_LIBS"
+
+VALID_LIBS = [
+    "com_grail_bazel_toolchain",
+    "llvm",
+    "llvm_toolchain",
+    "org_gnu_m4",
+    "z3",
+    "zlib",
+]
+
+def auto_configure_fail(msg):
+    """Output failure message when syslibs configuration fails."""
+    red = "\033[0;31m"
+    no_color = "\033[0m"
+    fail("\n%sSystem Library Configuration Error:%s %s\n" % (red, no_color, msg))
+
+def _is_windows(repository_ctx):
+    """Returns true if the host operating system is windows."""
+    os_name = repository_ctx.os.name.lower()
+    if os_name.find("windows") != -1:
+        return True
+    return False
+
+def _enable_syslibs(repository_ctx):
+    s = repository_ctx.os.environ.get(_XLS_SYSTEM_LIBS, "").strip()
+    if not _is_windows(repository_ctx) and s != None and s != "":
+        return True
+    return False
+
+def _get_system_lib_list(repository_ctx):
+    """Gets the list of deps that should use the system lib.
+
+    Args:
+      repository_ctx: The repository context.
+
+    Returns:
+      A string version of a python list
+    """
+    if _XLS_SYSTEM_LIBS not in repository_ctx.os.environ:
+        return []
+
+    libenv = repository_ctx.os.environ[_XLS_SYSTEM_LIBS].strip()
+    libs = []
+
+    for lib in list(libenv.split(",")):
+        lib = lib.strip()
+        if lib == "":
+            continue
+        if lib not in VALID_LIBS:
+            auto_configure_fail("Invalid system lib set: %s" % lib)
+            return []
+        libs.append(lib)
+
+    return libs
+
+def _format_system_lib_list(repository_ctx):
+    """Formats the list of deps that should use the system lib.
+
+    Args:
+      repository_ctx: The repository context.
+
+    Returns:
+      A list of the names of deps that should use the system lib.
+    """
+    libs = _get_system_lib_list(repository_ctx)
+    ret = ""
+    for lib in libs:
+        ret += "'%s',\n" % lib
+
+    return ret
+
+def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
+    if not out:
+        out = tpl.replace(":", "")
+    repository_ctx.template(
+        out,
+        Label("//dependency_support/systemlibs%s.tpl" % tpl),
+        substitutions,
+        False,
+    )
+
+def _create_dummy_repository(repository_ctx):
+    """Creates the dummy repository to build with all bundled libraries."""
+
+    _tpl(repository_ctx, ":BUILD")
+    _tpl(
+        repository_ctx,
+        ":build_defs.bzl",
+        {
+            "%{syslibs_enabled}": "False",
+            "%{syslibs_list}": "",
+        },
+    )
+
+def _create_local_repository(repository_ctx):
+    """Creates the repository to build with system libraries."""
+
+    _tpl(repository_ctx, ":BUILD")
+    _tpl(
+        repository_ctx,
+        ":build_defs.bzl",
+        {
+            "%{syslibs_enabled}": "True",
+            "%{syslibs_list}": _format_system_lib_list(repository_ctx),
+        },
+    )
+
+def _syslibs_autoconf_impl(repository_ctx):
+    """Implementation of the syslibs_configure repository rule."""
+    if not _enable_syslibs(repository_ctx):
+        _create_dummy_repository(repository_ctx)
+    else:
+        _create_local_repository(repository_ctx)
+
+syslibs_configure = repository_rule(
+    implementation = _syslibs_autoconf_impl,
+    environ = [
+        _XLS_SYSTEM_LIBS,
+    ],
+)
+
+"""Configures the build to link to system libraries
+instead of using bundled versions.
+
+Add the following to your WORKSPACE FILE:
+
+```python
+syslibs_configure(name = "local_config_syslibs")
+```
+
+Args:
+  name: A unique name for this workspace rule.
+"""

--- a/dependency_support/systemlibs/z3.BUILD
+++ b/dependency_support/systemlibs/z3.BUILD
@@ -1,0 +1,63 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"]) # MIT license
+
+package(default_visibility = ["//visibility:public"])
+
+_Z3_HEADERS = [
+    "z3.h",
+    "z3_algebraic.h",
+    "z3_api.h",
+    "z3_ast_containers.h",
+    "z3_fixedpoint.h",
+    "z3_fpa.h",
+    "z3++.h",
+    "z3_macros.h",
+    "z3_optimization.h",
+    "z3_polynomial.h",
+    "z3_rcf.h",
+    "z3_spacer.h",
+    "z3_v1.h",
+    "z3_version.h",
+]
+
+_Z3_PREFIXED_HEADERS = ["src/api/" + hdr for hdr in _Z3_HEADERS]
+
+# In order to limit the damage from the `includes` propagation
+# via `:z3`, copy the public headers to a subdirectory and
+# expose those.
+genrule(
+    name = "copy_public_headers",
+    outs = _Z3_PREFIXED_HEADERS,
+    cmd = """
+      for i in $(OUTS); do
+        f=$${i#$(@D)/src/api/}
+        mkdir -p $(@D)
+        ln -sf /usr/include/z3/$$f $(@D)/src/api/$$f
+      done
+    """,
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "z3lib",
+    linkopts = ["-lz3"],
+)
+
+cc_library(
+    name = "api",
+    hdrs = _Z3_PREFIXED_HEADERS,
+    deps = [":z3lib"],
+)

--- a/dependency_support/systemlibs/zlib.BUILD
+++ b/dependency_support/systemlibs/zlib.BUILD
@@ -1,0 +1,26 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # BSD/MIT-like license (for zlib)
+
+filegroup(
+    name = "zlib.h",
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
+    name = "zlib",
+    linkopts = ["-lz"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This PR adds a framework enabling builds of XLS with unbundled external dependency.

It is inspired form tensorflow's prooven way of unbundle things: https://github.com/tensorflow/tensorflow/pull/20284

Features implemented are **optional** and by default original build system behaviour is kept.

---

For now, within this initial PR, it is possible to enable these features:

   - **com_grail_bazel_toolchain**  -> bypass download bazel's toolchain bundle
   - **llvm_toolchain** -> bypass download llvm's clang toolchain binary bundle (use system's local ```clang``` instead)
   - **llvm** -> bypass bundle build of llvm-project (use system installed ```LLVM``` shared library, works with **11.0.0-rc3** too)
   - **zlib** -> bypass bundle build of zlib (use system installed ```zlib``` shared library)
   - **z3** -> bypass bundle build of z3 (use system installed ```z3``` shared library)
   - **org_gnu_m4** -> bypass bundle build of m4 (use system installed ```m4``` binary tool)

---

Currently it allows build by this way:

```
export LOCAL_LIBS="com_grail_bazel_toolchain,llvm_toolchain,llvm,zlib,z3,org_gnu_m4"

export XLS_SYSTEM_LIBS=$LOCAL_LIBS

bazel build -c opt \
    --action_env XLS_SYSTEM_LIBS=$LOCAL_LIBS \
    ...
```

Make sure you have system installed bits, e.g. on fedora box:
```
$ rpm -q clang llvm-devel m4 z3-devel zlib-devel
clang-11.0.0-0.4.rc3.fc34.x86_64
llvm-devel-11.0.0-0.8.rc3.fc34.x86_64
m4-1.4.18-15.fc33.x86_64
z3-devel-4.8.9-2.fc34.x86_64
zlib-devel-1.2.11-22.fc33.x86_64
$ rpm -qf /usr/bin/clang-format
clang-tools-extra-11.0.0-0.4.rc3.fc34.x86_64
```


---

Thank You !
~/Cristian.
