### PR TITLE
Added ir_integrator

### DIFF
--- a/xls/contrib/integrator/BUILD
+++ b/xls/contrib/integrator/BUILD
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_library(
+    name = "ir_integrator",
+    srcs = ["ir_integrator.cc"],
+    hdrs = ["ir_integrator.h"],
+    deps = [
+        "//xls/ir",
+        "//xls/ir:ir_parser",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ir_integrator_test",
+    srcs = ["ir_integrator_test.cc"],
+    deps = [
+        ":ir_integrator",
+        "//xls/common/status:matchers",
+        "//xls/ir",
+        "//xls/ir:ir_matcher",
+        "//xls/ir:ir_parser",
+        "//xls/ir:ir_test_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+

--- a/xls/contrib/integrator/ir_integrator.cc
+++ b/xls/contrib/integrator/ir_integrator.cc
@@ -1,0 +1,88 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include "xls/contrib/integrator/ir_integrator.h"
+
+#include "xls/ir/ir_parser.h"
+
+namespace xls {
+
+absl::StatusOr<Function*> IntegrationBuilder::CloneFunctionRecursive(
+    const Function* function,
+    absl::flat_hash_map<const Function*, Function*>* call_remapping) {
+  // Collect callee functions.
+  std::vector<const Function*> callee_funcs;
+  for (const Node* node : function->nodes()) {
+    switch (node->op()) {
+      case Op::kCountedFor:
+        callee_funcs.push_back(node->As<CountedFor>()->body());
+        break;
+      case Op::kMap:
+        callee_funcs.push_back(node->As<Map>()->to_apply());
+        break;
+      case Op::kInvoke:
+        callee_funcs.push_back(node->As<Invoke>()->to_apply());
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Clone and call_remapping callees.
+  for (const Function* callee : callee_funcs) {
+    if (!call_remapping->contains(callee)) {
+      XLS_ASSIGN_OR_RETURN(Function * callee_clone,
+                           CloneFunctionRecursive(callee, call_remapping));
+      (*call_remapping)[callee] = callee_clone;
+    }
+  }
+
+  std::string clone_name =
+      function_name_uniquer_.GetSanitizedUniqueName(function->name());
+  return function->Clone(clone_name, package_.get(), *call_remapping);
+}
+
+absl::Status IntegrationBuilder::CopySourcesToIntegrationPackage() {
+  source_functions_.reserve(original_package_source_functions_.size());
+  for (const Function* source : original_package_source_functions_) {
+    absl::flat_hash_map<const Function*, Function*> call_remapping;
+    XLS_ASSIGN_OR_RETURN(Function * clone_func,
+                         CloneFunctionRecursive(source, &call_remapping));
+    source_functions_.push_back(clone_func);
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<IntegrationBuilder>> IntegrationBuilder::Build(
+    absl::Span<const Function* const> input_functions) {
+  auto builder = absl::WrapUnique(new IntegrationBuilder(input_functions));
+
+  // Add sources to common package.
+  XLS_RETURN_IF_ERROR(builder->CopySourcesToIntegrationPackage());
+
+  switch (builder->source_functions_.size()) {
+    case 0:
+      return absl::InternalError(
+          "No source functions provided for integration");
+    case 1:
+      builder->integrated_function_ = builder->source_functions_.front();
+      break;
+    default:
+      return absl::InternalError("Integration not yet implemented.");
+  }
+
+  return std::move(builder);
+}
+
+}  // namespace xls

--- a/xls/contrib/integrator/ir_integrator.h
+++ b/xls/contrib/integrator/ir_integrator.h
@@ -1,0 +1,75 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_INTEGRATOR_IR_INTEGRATOR_H_
+#define XLS_INTEGRATOR_IR_INTEGRATOR_H_
+
+#include "absl/status/statusor.h"
+#include "xls/ir/function.h"
+#include "xls/ir/package.h"
+
+namespace xls {
+
+// Class used to integrate separate functions into a combined, reprogrammable
+// circuit that can be configured to have the same functionality as the
+// input functions. The builder will attempt to construct the integrated
+// function such that hardware common to the input functions is consolidated.
+// Note that this is distinct from function inlining. With inlining, a function
+// call is replaced by the body of the function that is called.  With function
+// integration, we take separate functions that do not call each other and
+// combine the hardware used to implement the functions.
+class IntegrationBuilder {
+ public:
+  // Creates an IntegrationBuilder and uses it to produce an integrated function
+  // implementing all functions in source_functions_.
+  static absl::StatusOr<std::unique_ptr<IntegrationBuilder>> Build(
+      absl::Span<const Function* const> input_functions);
+
+  Package* package() { return package_.get(); }
+  Function* integrated_function() { return integrated_function_; }
+
+ private:
+  IntegrationBuilder(absl::Span<const Function* const> input_functions) {
+    original_package_source_functions_.insert(
+        original_package_source_functions_.end(), input_functions.begin(),
+        input_functions.end());
+    // TODO(jbaileyhandle): Make package name an optional argument.
+    package_ = std::move(absl::make_unique<Package>("IntegrationPackage"));
+  }
+
+  // Copy the source functions into a common package.
+  absl::Status CopySourcesToIntegrationPackage();
+
+  // Recursively copy a function into the common package_.
+  absl::StatusOr<Function*> CloneFunctionRecursive(
+      const Function* function,
+      absl::flat_hash_map<const Function*, Function*>* call_remapping);
+
+  NameUniquer function_name_uniquer_ = NameUniquer(/*separator=*/"__");
+
+  // Common package for to-be integrated functions
+  // and integrated function.
+  std::unique_ptr<Package> package_;
+
+  Function* integrated_function_;
+
+  // Functions to be integrated, in the integration package.
+  std::vector<Function*> source_functions_;
+  // Functions to be integrated, in their original packages.
+  std::vector<const Function*> original_package_source_functions_;
+};
+
+}  // namespace xls
+
+#endif  // XLS_INTEGRATOR_IR_INTEGRATOR_H_

--- a/xls/contrib/integrator/ir_integrator_test.cc
+++ b/xls/contrib/integrator/ir_integrator_test.cc
@@ -1,0 +1,125 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/integrator/ir_integrator.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/package.h"
+
+namespace xls {
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+class IntegratorTest : public IrTestBase {};
+
+TEST_F(IntegratorTest, NoSourceFunctions) {
+  EXPECT_FALSE(IntegrationBuilder::Build({}).ok());
+}
+
+TEST_F(IntegratorTest, OneSourceFunction) {
+  auto p = CreatePackage();
+
+  FunctionBuilder fb_body("body", p.get());
+  fb_body.Param("index", p->GetBitsType(2));
+  fb_body.Param("acc", p->GetBitsType(2));
+  fb_body.Literal(UBits(0b11, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * body_func, fb_body.Build());
+
+  FunctionBuilder fb_double("double", p.get());
+  auto double_in = fb_double.Param("in1", p->GetBitsType(2));
+  fb_double.Add(double_in, double_in);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * double_func, fb_double.Build());
+
+  FunctionBuilder fb_main("main", p.get());
+  auto main_in1 = fb_main.Param("in1", p->GetBitsType(2));
+  auto main_in_arr =
+      fb_main.Param("in_arr", p->GetArrayType(2, p->GetBitsType(2)));
+  fb_main.Map(main_in_arr, double_func, /*loc=*/std::nullopt, "map");
+  fb_main.CountedFor(main_in1, /*trip_count=*/4, /*stride=*/1, body_func,
+                     /*invariant_args=*/{}, /*loc=*/std::nullopt,
+                     "counted_for");
+  fb_main.Invoke(/*args=*/{main_in1}, double_func, /*loc=*/std::nullopt,
+                 "invoke");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main_func, fb_main.Build());
+
+  auto get_function_names = [](Package* p) {
+    std::vector<std::string> names;
+    for (const auto& func : p->functions()) {
+      names.push_back(func->name());
+    }
+    return names;
+  };
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<IntegrationBuilder> builder,
+                           IntegrationBuilder::Build({main_func}));
+
+  // Original package is unchanged.
+  EXPECT_THAT(get_function_names(p.get()),
+              UnorderedElementsAre("body", "double", "main"));
+
+  // Original CountedFor
+  CountedFor* counted_original =
+      FindNode("counted_for", main_func)->As<CountedFor>();
+  EXPECT_EQ(counted_original->body(), body_func);
+  EXPECT_EQ(counted_original->body()->name(), "body");
+  EXPECT_EQ(counted_original->body()->package(), p.get());
+
+  // Original Map
+  Map* map_original = FindNode("map", main_func)->As<Map>();
+  EXPECT_EQ(map_original->to_apply(), double_func);
+  EXPECT_EQ(map_original->to_apply()->name(), "double");
+  EXPECT_EQ(map_original->to_apply()->package(), p.get());
+
+  // Original Invoke
+  Invoke* invoke_original = FindNode("invoke", main_func)->As<Invoke>();
+  EXPECT_EQ(invoke_original->to_apply(), double_func);
+  EXPECT_EQ(invoke_original->to_apply()->name(), "double");
+  EXPECT_EQ(invoke_original->to_apply()->package(), p.get());
+
+  // builder package has copies of functions.
+  EXPECT_THAT(get_function_names(builder->package()),
+              UnorderedElementsAre("body", "double", "main"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * clone_body_func,
+                           builder->package()->GetFunction("body"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * clone_double_func,
+                           builder->package()->GetFunction("double"));
+
+  // Clone CountedFor
+  Function* main_clone_func = builder->integrated_function();
+  CountedFor* counted_clone =
+      FindNode("counted_for", main_clone_func)->As<CountedFor>();
+  EXPECT_EQ(counted_clone->body(), clone_body_func);
+  EXPECT_EQ(counted_clone->body()->name(), "body");
+  EXPECT_EQ(counted_clone->body()->package(), builder->package());
+
+  // Clone Map
+  Map* map_clone = FindNode("map", main_clone_func)->As<Map>();
+  EXPECT_EQ(map_clone->to_apply(), clone_double_func);
+  EXPECT_EQ(map_clone->to_apply()->name(), "double");
+  EXPECT_EQ(map_clone->to_apply()->package(), builder->package());
+
+  // Clone Invoke
+  Invoke* invoke_clone = FindNode("invoke", main_clone_func)->As<Invoke>();
+  EXPECT_EQ(invoke_clone->to_apply(), clone_double_func);
+  EXPECT_EQ(invoke_clone->to_apply()->name(), "double");
+  EXPECT_EQ(invoke_clone->to_apply()->package(), builder->package());
+}
+
+}  // namespace
+}  // namespace xls

--- a/xls/ir/function.h
+++ b/xls/ir/function.h
@@ -51,9 +51,15 @@ class Function : public FunctionBase {
   //   This is only useful when dumping individual functions, and not packages.
   std::string DumpIr(bool recursive = false) const override;
 
-  // Creates a clone of the function with the new name 'new_name'. FunctionBase
-  // is owned by the same package.
-  absl::StatusOr<Function*> Clone(absl::string_view new_name) const;
+  // Creates a clone of the function with the new name 'new_name'. Function is
+  // owned by targt_package.  call_remapping specifies any function
+  // substitutions to be used in the cloned function, e.g. If call_remapping
+  // holds {funcA, funcB}, any references to funcA in the function will be
+  // references to funcB in the cloned function.
+  absl::StatusOr<Function*> Clone(
+      absl::string_view new_name, Package* target_package = nullptr,
+      const absl::flat_hash_map<const Function*, Function*>& call_remapping =
+          {}) const;
 
   // Returns true if analysis indicates that this function always produces the
   // same value as 'other' when run with the same arguments. The analysis is

--- a/xls/ir/function_base.h
+++ b/xls/ir/function_base.h
@@ -90,6 +90,11 @@ class FunctionBase {
     return xabsl::make_range(MakeUnwrappingIterator(nodes_.begin()),
                              MakeUnwrappingIterator(nodes_.end()));
   }
+  xabsl::iterator_range<UnwrappingIterator<NodeList::const_iterator>> nodes()
+      const {
+    return xabsl::make_range(MakeUnwrappingIterator(nodes_.begin()),
+                             MakeUnwrappingIterator(nodes_.end()));
+  }
 
   // Adds a node to the set owned by this function.
   template <typename T>

--- a/xls/ir/function_test.cc
+++ b/xls/ir/function_test.cc
@@ -19,6 +19,7 @@
 #include "xls/common/status/matchers.h"
 #include "xls/ir/function_builder.h"
 #include "xls/ir/ir_test_base.h"
+#include "xls/ir/node_util.h"
 
 namespace xls {
 namespace {
@@ -41,6 +42,23 @@ ret add.3: bits[32] = add(x, y)
   EXPECT_EQ(func_clone->name(), "foobar");
   EXPECT_EQ(func_clone->node_count(), 3);
   EXPECT_EQ(func_clone->return_value()->op(), Op::kAdd);
+}
+
+TEST_F(FunctionTest, CloneSimpleFunctionToDifferentPackage) {
+  auto p = CreatePackage();
+  FunctionBuilder b("f", p.get());
+  auto x = b.Param("x", p->GetBitsType(32));
+  auto y = b.Param("y", p->GetBitsType(32));
+  auto arr = b.Array({x, y}, x.GetType());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func, b.BuildWithReturnValue(arr));
+
+  auto new_package = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_clone,
+                           func->Clone("newbar", new_package.get()));
+  EXPECT_EQ(func_clone->name(), "newbar");
+  EXPECT_EQ(func_clone->node_count(), 3);
+  EXPECT_EQ(func_clone->return_value()->op(), Op::kArray);
+  EXPECT_EQ(func_clone->package(), new_package.get());
 }
 
 TEST_F(FunctionTest, DumpIrWhenParamIsRetval) {
@@ -164,6 +182,125 @@ fn id(x: bits[16], y: bits[32]) -> bits[16] {
       StatusIs(absl::StatusCode::kInternal,
                HasSubstr("Type of operand 1 (bits[32] via y) does not "
                          "match type of xor")));
+}
+
+TEST_F(FunctionTest, IsLiteralMask) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+  auto seven_3b = fb.Literal(UBits(0b111, 3));
+  auto two_3b = fb.Literal(UBits(0b011, 3));
+  auto one_1b = fb.Literal(UBits(0b1, 1));
+  auto zero_1b = fb.Literal(UBits(0b0, 1));
+  auto zero_0b = fb.Literal(UBits(0b0, 0));
+
+  int64 leading_zeros, trailing_ones;
+  EXPECT_TRUE(IsLiteralMask(seven_3b.node(), &leading_zeros, &trailing_ones));
+  EXPECT_EQ(0, leading_zeros);
+  EXPECT_EQ(3, trailing_ones);
+
+  EXPECT_TRUE(IsLiteralMask(two_3b.node(), &leading_zeros, &trailing_ones));
+  EXPECT_EQ(1, leading_zeros);
+  EXPECT_EQ(2, trailing_ones);
+
+  EXPECT_TRUE(IsLiteralMask(one_1b.node(), &leading_zeros, &trailing_ones));
+  EXPECT_EQ(0, leading_zeros);
+  EXPECT_EQ(1, trailing_ones);
+
+  EXPECT_FALSE(IsLiteralMask(zero_1b.node(), &leading_zeros, &trailing_ones));
+  EXPECT_FALSE(IsLiteralMask(zero_0b.node(), &leading_zeros, &trailing_ones));
+}
+
+TEST_F(FunctionTest, CloneCountedForRemap) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_body("body_a", p.get());
+  fb_body.Param("index", p->GetBitsType(2));
+  fb_body.Param("acc", p->GetBitsType(2));
+  fb_body.Literal(UBits(0b11, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * body_a, fb_body.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * body_b, body_a->Clone("body_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * body_c, body_a->Clone("body_c"));
+
+  FunctionBuilder fb_main("main", p.get());
+  auto init = fb_main.Param("init_acc", p->GetBitsType(2));
+  fb_main.CountedFor(init, /*trip_count=*/4, /*stride=*/1, body_a,
+                     /*invariant_args=*/{}, /*loc=*/std::nullopt, "counted_a");
+  fb_main.CountedFor(init, /*trip_count=*/4, /*stride=*/1, body_b,
+                     /*invariant_args=*/{}, /*loc=*/std::nullopt, "counted_b");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main, fb_main.Build());
+
+  absl::flat_hash_map<const Function*, Function*> remap;
+  remap[body_a] = body_c;
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Function * main_clone,
+      main->Clone("main_clone", /*package=*/p.get(), remap));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_a_clone,
+                           main_clone->GetNode("counted_a"));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_b_clone,
+                           main_clone->GetNode("counted_b"));
+  CountedFor* counted_a_clone = node_a_clone->As<CountedFor>();
+  CountedFor* counted_b_clone = node_b_clone->As<CountedFor>();
+  EXPECT_EQ(counted_a_clone->body(), body_c);
+  EXPECT_EQ(counted_b_clone->body(), body_b);
+}
+
+TEST_F(FunctionTest, CloneMapRemap) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_body("apply_a", p.get());
+  fb_body.Param("in", p->GetBitsType(2));
+  fb_body.Literal(UBits(0b11, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_a, fb_body.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_b, apply_a->Clone("apply_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_c, apply_a->Clone("apply_c"));
+
+  FunctionBuilder fb_main("main", p.get());
+  auto input = fb_main.Param("input", p->GetArrayType(2, p->GetBitsType(2)));
+  fb_main.Map(input, apply_a, /*loc=*/std::nullopt, "map_a");
+  fb_main.Map(input, apply_b, /*loc=*/std::nullopt, "map_b");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main, fb_main.Build());
+
+  absl::flat_hash_map<const Function*, Function*> remap;
+  remap[apply_a] = apply_c;
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Function * main_clone,
+      main->Clone("main_clone", /*package=*/p.get(), remap));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_a_clone, main_clone->GetNode("map_a"));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_b_clone, main_clone->GetNode("map_b"));
+  Map* map_a_clone = node_a_clone->As<Map>();
+  Map* map_b_clone = node_b_clone->As<Map>();
+  EXPECT_EQ(map_a_clone->to_apply(), apply_c);
+  EXPECT_EQ(map_b_clone->to_apply(), apply_b);
+}
+
+TEST_F(FunctionTest, CloneInvokeForRemap) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_body("body_a", p.get());
+  fb_body.Literal(UBits(0b11, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_a, fb_body.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_b, apply_a->Clone("apply_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * apply_c, apply_a->Clone("apply_c"));
+
+  FunctionBuilder fb_main("main", p.get());
+  // TODO finish
+  fb_main.Invoke(/*args=*/{}, apply_a, /*loc=*/std::nullopt, "invoke_a");
+  fb_main.Invoke(/*args=*/{}, apply_b, /*loc=*/std::nullopt, "invoke_b");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main, fb_main.Build());
+
+  absl::flat_hash_map<const Function*, Function*> remap;
+  remap[apply_a] = apply_c;
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Function * main_clone,
+      main->Clone("main_clone", /*package=*/p.get(), remap));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_a_clone,
+                           main_clone->GetNode("invoke_a"));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * node_b_clone,
+                           main_clone->GetNode("invoke_b"));
+  Invoke* invoke_a_clone = node_a_clone->As<Invoke>();
+  Invoke* invoke_b_clone = node_b_clone->As<Invoke>();
+  EXPECT_EQ(invoke_a_clone->to_apply(), apply_c);
+  EXPECT_EQ(invoke_b_clone->to_apply(), apply_b);
 }
 
 }  // namespace

--- a/xls/ir/nodes_source.tmpl
+++ b/xls/ir/nodes_source.tmpl
@@ -107,6 +107,29 @@ SliceData Concat::GetOperandSliceData(int64 operandno) const {
   return SliceData{start, this->operand(operandno)->BitCountOrDie()};
 }
 
+absl::StatusOr<Node*> Param::CloneInNewFunction(absl::Span<Node* const> new_operands,
+                                           FunctionBase* new_function) const {
+  // TODO(meheff): Choose an appropriate name for the cloned node.
+  XLS_RET_CHECK_EQ(operand_count(), new_operands.size());
+  XLS_ASSIGN_OR_RETURN(Type* new_type, 
+    new_function->package()->MapTypeFromOtherPackage(GetType()));
+  return new_function->MakeNodeWithName<Param>(loc(),
+                                      name_,
+                                      new_type);
+}
+
+absl::StatusOr<Node*> Array::CloneInNewFunction(absl::Span<Node* const> new_operands,
+                                           FunctionBase* new_function) const {
+  // TODO(meheff): Choose an appropriate name for the cloned node.
+  XLS_RET_CHECK_EQ(size(), new_operands.size());
+  XLS_ASSIGN_OR_RETURN(Type* new_element_type, 
+    new_function->package()->MapTypeFromOtherPackage(element_type()));
+  return new_function->MakeNodeWithName<Array>(loc(),
+                                      new_operands,
+                                      new_element_type,
+                                      name_);
+}
+
 absl::StatusOr<Node*> Send::CloneInNewFunction(
     absl::Span<Node* const> new_operands,
     FunctionBase* new_function) const {

--- a/xls/ir/op_specification.py
+++ b/xls/ir/op_specification.py
@@ -391,7 +391,8 @@ OpClass.kinds['ARRAY'] = OpClass(
     attributes=[TypeAttribute('element_type')],
     extra_methods=[Method(name='size',
                           return_cpp_type='int64',
-                          expression='operand_count()')]
+                          expression='operand_count()')],
+    custom_clone_method=True
 )
 
 OpClass.kinds['ARRAY_INDEX'] = OpClass(
@@ -641,7 +642,9 @@ OpClass.kinds['PARAM'] = OpClass(
                           return_cpp_type='absl::string_view',
                           expression='name_')],
     # Params are never equivalent to other nodes.
-    custom_equivalence_expression='false')
+    custom_equivalence_expression='false',
+    custom_clone_method=True
+)
 
 OpClass.kinds['SELECT'] = OpClass(
     name='Select',

--- a/xls/ir/package.h
+++ b/xls/ir/package.h
@@ -67,6 +67,10 @@ class Package {
   FunctionType* GetFunctionType(absl::Span<Type* const> args_types,
                                 Type* return_type);
 
+  // Returns a pointer to a type owned by this package that is of the same
+  // type as 'other_package_type', which may be owned by another package.
+  absl::StatusOr<Type*> MapTypeFromOtherPackage(Type* other_package_type);
+
   // Creates and returned an owned type constructed from the given proto.
   absl::StatusOr<Type*> GetTypeFromProto(const TypeProto& proto);
   absl::StatusOr<FunctionType*> GetFunctionTypeFromProto(


### PR DESCRIPTION
...which will be used to combine multiple functions into a single function capable of implmenting all original functions. The initial code copies the source functions into a new package where they can be combined. Functions to be merged should be in the same package to ensure type compatibility. This required extending Function's clone method to enable call site remapping.  This way, we can recursively copy functions and their callees such that the cloned caller function calls the cloned callee function. Additionally, a GetType(Type*) function is added to Package.  This allows us to take a Type from one package and fetch / construct a corresponding Type in another package. 