### PR TITLE
Fix typo in README.md install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ installed](https://docs.bazel.build/versions/master/install-ubuntu.html).
 $ bazel --version
 bazel 3.2.0
 
-$ sudo apt install python3-dev python3-distutils python3-dev libtinfo5
+$ sudo apt install python3-distutils python3-dev libtinfo5
 
 # py_binary currently assume they can refer to /usr/bin/env python
 # even though Ubuntu 20.04 has no `python`, only `python3`.


### PR DESCRIPTION
The current version tells the user to install python3-dev twice.
I think the intention is to install both python-dev *and* python3-dev,
but there is a typo here.