### PR TITLE
Adding IntegrationFunction class. This represents an under-constructi…

### DIFF
--- a/xls/contrib/integrator/BUILD
+++ b/xls/contrib/integrator/BUILD
@@ -35,6 +35,7 @@ cc_test(
         ":ir_integrator",
         "//xls/common/status:matchers",
         "//xls/ir",
+        "//xls/ir:ir_matcher",
         "//xls/ir:ir_parser",
         "//xls/ir:ir_test_base",
         "@com_google_googletest//:gtest_main",

--- a/xls/contrib/integrator/ir_integrator.cc
+++ b/xls/contrib/integrator/ir_integrator.cc
@@ -18,6 +18,122 @@
 
 namespace xls {
 
+absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+    Package* package, absl::Span<const Function* const> source_functions) {
+  // Create integration function object.
+  std::unique_ptr<IntegrationFunction> integration_function =
+      absl::make_unique<IntegrationFunction>();
+  integration_function->package_ = package;
+
+  // Create ir function.
+  // TODO(jbaileyhandle): Make function name an optional argument.
+  static int64 integration_functions_count = 0;
+  std::string function_name = std::string("IntegrationFunction") +
+                              std::to_string(integration_functions_count++);
+  integration_function->function_ =
+      absl::make_unique<Function>(function_name, package);
+
+  // Package source function parameters as tuple parameters to integration
+  // function.
+  for (const auto* source_func : source_functions) {
+    // Add tuple paramter for source function.
+    std::vector<Type*> arg_types;
+    for (const Node* param : source_func->params()) {
+      arg_types.push_back(param->GetType());
+    }
+    Type* args_tuple_type = package->GetTupleType(arg_types);
+    std::string tuple_name = source_func->name() + std::string("ParamTuple");
+    XLS_ASSIGN_OR_RETURN(
+        Node * args_tuple,
+        integration_function->function_->MakeNodeWithName<Param>(
+            /*loc=*/std::nullopt, tuple_name, args_tuple_type));
+
+    // Add TupleIndex nodes inside function to unpack tuple parameter.
+    int64 paramter_index = 0;
+    for (const Node* param : source_func->params()) {
+      XLS_ASSIGN_OR_RETURN(
+          Node * tuple_index,
+          integration_function->function_->MakeNode<TupleIndex>(
+              /*loc=*/std::nullopt, args_tuple, paramter_index));
+      XLS_RETURN_IF_ERROR(
+          integration_function->SetNodeMapping(param, tuple_index));
+      paramter_index++;
+    }
+  }
+
+  return std::move(integration_function);
+}
+
+absl::Status IntegrationFunction::SetNodeMapping(const Node* source,
+                                                 Node* map_target) {
+  // Validate map pairing.
+  if (source == map_target) {
+    return absl::InternalError("Tried to map a node to itself");
+  }
+  if (!IntegrationFunctionOwnsNode(map_target)) {
+    return absl::InternalError(
+        "Tried to map to a node not owned by the integration function");
+  }
+  // TODO(jbaileyhandle): Reasonable assumption for short-term use cases.  May
+  // be worth relaxing to enable some optimizations of some sort?
+  if (IntegrationFunctionOwnsNode(source) && !IsMappingTarget(source)) {
+    return absl::InternalError(
+        "Tried to map an integration function node that is not itself a "
+        "mapping target");
+  }
+
+  // 'original' is itself a member of the integrated function.
+  if (IntegrationFunctionOwnsNode(source)) {
+    absl::flat_hash_set<const Node*>& nodes_that_map_to_source =
+        integrated_node_to_original_nodes_map_.at(source);
+
+    // Nodes that previously mapped to original now map to map_target.
+    for (const Node* original_node : nodes_that_map_to_source) {
+      integrated_node_to_original_nodes_map_[map_target].insert(original_node);
+      XLS_RET_CHECK(HasMapping(original_node));
+      original_node_to_integrated_node_map_[original_node] = map_target;
+    }
+
+    // No nodes map to source anymore.
+    integrated_node_to_original_nodes_map_.erase(source);
+
+    // 'source' is an external node.
+  } else {
+    original_node_to_integrated_node_map_[source] = map_target;
+    integrated_node_to_original_nodes_map_[map_target].insert(source);
+  }
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<Node*> IntegrationFunction::GetNodeMapping(
+    const Node* original) const {
+  XLS_RET_CHECK(!IntegrationFunctionOwnsNode(original));
+  if (!HasMapping(original)) {
+    return absl::InternalError("No mapping found for original node");
+  }
+  return original_node_to_integrated_node_map_.at(original);
+}
+
+absl::StatusOr<const absl::flat_hash_set<const Node*>*>
+IntegrationFunction::GetNodesMappedToNode(const Node* map_target) const {
+  XLS_RET_CHECK(IntegrationFunctionOwnsNode(map_target));
+  if (!IsMappingTarget(map_target)) {
+    return absl::InternalError("No mappings found for map target node");
+  }
+  return &integrated_node_to_original_nodes_map_.at(map_target);
+}
+
+bool IntegrationFunction::HasMapping(const Node* node) const {
+  return original_node_to_integrated_node_map_.contains(node);
+}
+
+bool IntegrationFunction::IsMappingTarget(const Node* node) const {
+  return integrated_node_to_original_nodes_map_.find(node) !=
+         integrated_node_to_original_nodes_map_.end();
+}
+
 absl::StatusOr<Function*> IntegrationBuilder::CloneFunctionRecursive(
     const Function* function,
     absl::flat_hash_map<const Function*, Function*>* call_remapping) {

--- a/xls/contrib/integrator/ir_integrator.h
+++ b/xls/contrib/integrator/ir_integrator.h
@@ -22,18 +22,24 @@
 namespace xls {
 
 // Class that represents an integration function i.e. a function combining the
-// IR of other functions. This class tracks which orignal function nodes are
+// IR of other functions. This class tracks which original function nodes are
 // mapped to which integration function nodes. It also provides some utilities
 // that are useful for constructing the integrated function.
 class IntegrationFunction {
  public:
   IntegrationFunction() {}
 
+  IntegrationFunction(const IntegrationFunction& other) = delete;
+  void operator=(const IntegrationFunction& other) = delete;
+
   // Create an IntegrationFunction object that is empty expect for
-  // paramters.
+  // parameters. Each initial parameter of the function is a tuple
+  // which holds inputs corresponding to the paramters of one
+  // of the source_functions.
   static absl::StatusOr<std::unique_ptr<IntegrationFunction>>
   MakeIntegrationFunctionWithParamTuples(
-      Package* package, absl::Span<const Function* const> source_functions);
+      Package* package, absl::Span<const Function* const> source_functions,
+      std::string function_name = "IntegrationFunction");
 
   Function* function() const { return function_.get(); }
 

--- a/xls/contrib/integrator/ir_integrator.h
+++ b/xls/contrib/integrator/ir_integrator.h
@@ -21,6 +21,57 @@
 
 namespace xls {
 
+// Class that represents an integration function i.e. a function combining the
+// IR of other functions. This class tracks which orignal function nodes are
+// mapped to which integration function nodes. It also provides some utilities
+// that are useful for constructing the integrated function.
+class IntegrationFunction {
+ public:
+  IntegrationFunction() {}
+
+  // Create an IntegrationFunction object that is empty expect for
+  // paramters.
+  static absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+  MakeIntegrationFunctionWithParamTuples(
+      Package* package, absl::Span<const Function* const> source_functions);
+
+  Function* function() const { return function_.get(); }
+
+  // Declares that node 'source' from a source function maps
+  // to node 'map_target' in the integrated_function.
+  absl::Status SetNodeMapping(const Node* source, Node* map_target);
+
+  // Returns the integrated node that 'original' maps to, if it
+  // exists. Otherwise, return an error status.
+  absl::StatusOr<Node*> GetNodeMapping(const Node* original) const;
+
+  // Returns the original nodes that map to 'map_target' in the integrated
+  // function.
+  absl::StatusOr<const absl::flat_hash_set<const Node*>*> GetNodesMappedToNode(
+      const Node* map_target) const;
+
+  // Returns true if 'node' is mapped to a node in the integrated function.
+  bool HasMapping(const Node* node) const;
+
+  // Returns true if other nodes map to 'node'
+  bool IsMappingTarget(const Node* node) const;
+
+  // Returns true if 'node' is in the integrated function.
+  bool IntegrationFunctionOwnsNode(const Node* node) const {
+    return function_.get() == node->function_base();
+  }
+
+ private:
+  // Track mapping of original function nodes to integrated function nodes.
+  absl::flat_hash_map<const Node*, Node*> original_node_to_integrated_node_map_;
+  absl::flat_hash_map<const Node*, absl::flat_hash_set<const Node*>>
+      integrated_node_to_original_nodes_map_;
+
+  // Integrated function.
+  std::unique_ptr<Function> function_;
+  Package* package_;
+};
+
 // Class used to integrate separate functions into a combined, reprogrammable
 // circuit that can be configured to have the same functionality as the
 // input functions. The builder will attempt to construct the integrated

--- a/xls/contrib/integrator/ir_integrator_test.cc
+++ b/xls/contrib/integrator/ir_integrator_test.cc
@@ -17,13 +17,17 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
+#include "xls/ir/ir_matcher.h"
 #include "xls/ir/ir_parser.h"
 #include "xls/ir/ir_test_base.h"
 #include "xls/ir/package.h"
 
+namespace m = ::xls::op_matchers;
+
 namespace xls {
 namespace {
 
+using status_testing::IsOkAndHolds;
 using ::testing::UnorderedElementsAre;
 
 class IntegratorTest : public IrTestBase {};
@@ -119,6 +123,345 @@ TEST_F(IntegratorTest, OneSourceFunction) {
   EXPECT_EQ(invoke_clone->to_apply(), clone_double_func);
   EXPECT_EQ(invoke_clone->to_apply()->name(), "double");
   EXPECT_EQ(invoke_clone->to_apply()->package(), builder->package());
+}
+
+TEST_F(IntegratorTest, MappingTestSimple) {
+  auto p = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {})));
+  Function& internal_func = *integration->function();
+  Function external_func("external", p.get());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_1",
+                                            p->GetBitsType(1)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_1,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_1",
+                                            p->GetBitsType(2)));
+
+  // Before mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_FALSE(integration->HasMapping(external_1));
+  EXPECT_FALSE(integration->IsMappingTarget(internal_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(external_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+
+  // Mapping = external_1 -> MapsTo -> internal_1
+  XLS_ASSERT_OK(integration->SetNodeMapping(external_1, internal_1));
+
+  // After mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_TRUE(integration->HasMapping(external_1));
+  EXPECT_TRUE(integration->IsMappingTarget(internal_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  ASSERT_THAT(integration->GetNodeMapping(external_1),
+              IsOkAndHolds(internal_1));
+  auto mapped_to_internal_1 = integration->GetNodesMappedToNode(internal_1);
+  EXPECT_TRUE(mapped_to_internal_1.ok());
+  EXPECT_THAT(*(mapped_to_internal_1.value()),
+              UnorderedElementsAre(external_1));
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+}
+
+TEST_F(IntegratorTest, MappingTestMultipleNodesMapToTarget) {
+  auto p = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {})));
+  Function& internal_func = *integration->function();
+  Function external_func("external", p.get());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_1",
+                                            p->GetBitsType(1)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_1,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_1",
+                                            p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_2,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_1",
+                                            p->GetBitsType(3)));
+
+  // Before mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_2));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_FALSE(integration->HasMapping(external_1));
+  EXPECT_FALSE(integration->HasMapping(external_2));
+  EXPECT_FALSE(integration->IsMappingTarget(internal_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_2));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(external_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(external_2).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_2).ok());
+
+  // Mapping = external_1 && external_2 -> MapsTo -> internal_1
+  XLS_ASSERT_OK(integration->SetNodeMapping(external_1, internal_1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(external_2, internal_1));
+
+  // After mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_2));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_TRUE(integration->HasMapping(external_1));
+  EXPECT_TRUE(integration->HasMapping(external_2));
+  EXPECT_TRUE(integration->IsMappingTarget(internal_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_2));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  ASSERT_THAT(integration->GetNodeMapping(external_1),
+              IsOkAndHolds(internal_1));
+  ASSERT_THAT(integration->GetNodeMapping(external_2),
+              IsOkAndHolds(internal_1));
+  auto mapped_to_internal_1 = integration->GetNodesMappedToNode(internal_1);
+  EXPECT_TRUE(mapped_to_internal_1.ok());
+  EXPECT_THAT(*(mapped_to_internal_1.value()),
+              UnorderedElementsAre(external_1, external_2));
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_2).ok());
+}
+
+TEST_F(IntegratorTest, MappingTestRepeatedMapping) {
+  auto p = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {})));
+  Function& internal_func = *integration->function();
+  Function external_func("external", p.get());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_1",
+                                            p->GetBitsType(1)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_2,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_2",
+                                            p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_1,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_1",
+                                            p->GetBitsType(3)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_2,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_2",
+                                            p->GetBitsType(4)));
+
+  // Before mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_2));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_2));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_FALSE(integration->HasMapping(internal_2));
+  EXPECT_FALSE(integration->HasMapping(external_1));
+  EXPECT_FALSE(integration->HasMapping(external_2));
+  EXPECT_FALSE(integration->IsMappingTarget(internal_1));
+  EXPECT_FALSE(integration->IsMappingTarget(internal_2));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_2));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(internal_2).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(external_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(external_2).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(internal_2).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_2).ok());
+
+  // Mapping = external_1 && external_2 -> MapsTo -> internal_1
+  XLS_ASSERT_OK(integration->SetNodeMapping(external_1, internal_1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(external_2, internal_1));
+
+  // Mapping = external_1 && external_2 -> MapsTo -> internal_1 -> internal_2
+  XLS_ASSERT_OK(integration->SetNodeMapping(internal_1, internal_2));
+
+  // After mapping.
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_1));
+  EXPECT_TRUE(integration->IntegrationFunctionOwnsNode(internal_2));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_1));
+  EXPECT_FALSE(integration->IntegrationFunctionOwnsNode(external_2));
+  EXPECT_FALSE(integration->HasMapping(internal_1));
+  EXPECT_FALSE(integration->HasMapping(internal_2));
+  EXPECT_TRUE(integration->HasMapping(external_1));
+  EXPECT_TRUE(integration->HasMapping(external_2));
+  EXPECT_FALSE(integration->IsMappingTarget(internal_1));
+  EXPECT_TRUE(integration->IsMappingTarget(internal_2));
+  EXPECT_FALSE(integration->IsMappingTarget(external_1));
+  EXPECT_FALSE(integration->IsMappingTarget(external_2));
+  EXPECT_FALSE(integration->GetNodeMapping(internal_1).ok());
+  EXPECT_FALSE(integration->GetNodeMapping(internal_2).ok());
+  ASSERT_THAT(integration->GetNodeMapping(external_1),
+              IsOkAndHolds(internal_2));
+  ASSERT_THAT(integration->GetNodeMapping(external_2),
+              IsOkAndHolds(internal_2));
+  EXPECT_FALSE(integration->GetNodesMappedToNode(internal_1).ok());
+  auto mapped_to_internal_2 = integration->GetNodesMappedToNode(internal_2);
+  EXPECT_TRUE(mapped_to_internal_2.ok());
+  EXPECT_THAT(*(mapped_to_internal_2.value()),
+              UnorderedElementsAre(external_1, external_2));
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_1).ok());
+  EXPECT_FALSE(integration->GetNodesMappedToNode(external_2).ok());
+}
+
+TEST_F(IntegratorTest, MappingTestSetNodeMappingFailureCases) {
+  auto p = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {})));
+  Function& internal_func = *integration->function();
+  Function external_func("external", p.get());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_1",
+                                            p->GetBitsType(1)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_2,
+      internal_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "internal_2",
+                                            p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_1,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_1",
+                                            p->GetBitsType(3)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * external_2,
+      external_func.MakeNodeWithName<Param>(/*loc=*/std::nullopt, "external_2",
+                                            p->GetBitsType(4)));
+
+  // Mapping = external_1 -> MapsTo -> external_1
+  // Mapping target must be internal.
+  EXPECT_FALSE(integration->SetNodeMapping(external_1, external_1).ok());
+
+  // Mapping = external_1 -> MapsTo -> external_2
+  // Mapping target must be internal.
+  EXPECT_FALSE(integration->SetNodeMapping(external_1, external_2).ok());
+
+  // Mapping = internal_1 -> MapsTo -> external_1
+  // Mapping target must be internal.
+  EXPECT_FALSE(integration->SetNodeMapping(internal_1, external_1).ok());
+
+  // Mapping = internal_1 -> MapsTo -> internal_1
+  // Cannot map to self.
+  EXPECT_FALSE(integration->SetNodeMapping(internal_1, internal_1).ok());
+
+  // Mapping = internal_2 -> MapsTo -> internal_1
+  // Cannot map internal nodes that are not mapping targets.
+  EXPECT_FALSE(integration->SetNodeMapping(internal_2, internal_1).ok());
+}
+
+TEST_F(IntegratorTest, ParamterPacking) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  fb_a.Param("a1", p->GetBitsType(2));
+  fb_a.Param("a2", p->GetBitsType(4));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  fb_b.Param("b1", p->GetBitsType(6));
+  fb_b.Param("b2", p->GetBitsType(8));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b})));
+
+  auto GetTupleIndexWithNumBits = [&](long int num_bits) {
+    for (Node* node : integration->function()->nodes()) {
+      if (node->op() == Op::kTupleIndex) {
+        if (node->GetType() == p->GetBitsType(num_bits)) {
+          return absl::optional<Node*>(node);
+        }
+      }
+    }
+    return absl::optional<Node*>(std::nullopt);
+  };
+  auto GetParamWithNumBits = [&p](Function* function, long int num_bits) {
+    for (Node* node : function->nodes()) {
+      if (node->op() == Op::kParam) {
+        if (node->GetType() == p->GetBitsType(num_bits)) {
+          return absl::optional<Node*>(node);
+        }
+      }
+    }
+    return absl::optional<Node*>(std::nullopt);
+  };
+
+  auto a1_index = GetTupleIndexWithNumBits(2);
+  EXPECT_TRUE(a1_index.has_value());
+  EXPECT_TRUE(a1_index.has_value());
+  EXPECT_THAT(a1_index.value(), m::TupleIndex(m::Param("func_aParamTuple"), 0));
+  auto a1_source = GetParamWithNumBits(func_a, 2);
+  EXPECT_TRUE(a1_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(a1_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(a1_source.value()).value(),
+            a1_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(a1_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(a1_index.value()).value()),
+              UnorderedElementsAre(a1_source.value()));
+
+  auto a2_index = GetTupleIndexWithNumBits(4);
+  EXPECT_TRUE(a2_index.has_value());
+  EXPECT_THAT(a2_index.value(), m::TupleIndex(m::Param("func_aParamTuple"), 1));
+  ;
+  auto a2_source = GetParamWithNumBits(func_a, 4);
+  EXPECT_TRUE(a2_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(a2_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(a2_source.value()).value(),
+            a2_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(a2_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(a2_index.value()).value()),
+              UnorderedElementsAre(a2_source.value()));
+
+  auto b1_index = GetTupleIndexWithNumBits(6);
+  EXPECT_TRUE(b1_index.has_value());
+  EXPECT_THAT(b1_index.value(), m::TupleIndex(m::Param("func_bParamTuple"), 0));
+  ;
+  auto b1_source = GetParamWithNumBits(func_b, 6);
+  EXPECT_TRUE(b1_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(b1_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(b1_source.value()).value(),
+            b1_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(b1_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(b1_index.value()).value()),
+              UnorderedElementsAre(b1_source.value()));
+
+  auto b2_index = GetTupleIndexWithNumBits(8);
+  EXPECT_TRUE(b2_index.has_value());
+  EXPECT_THAT(b2_index.value(), m::TupleIndex(m::Param("func_bParamTuple"), 1));
+  ;
+  auto b2_source = GetParamWithNumBits(func_b, 8);
+  EXPECT_TRUE(b2_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(b2_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(b2_source.value()).value(),
+            b2_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(b2_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(b2_index.value()).value()),
+              UnorderedElementsAre(b2_source.value()));
+
+  EXPECT_EQ(integration->function()->node_count(), 6);
 }
 
 }  // namespace

--- a/xls/contrib/integrator/ir_integrator_test.cc
+++ b/xls/contrib/integrator/ir_integrator_test.cc
@@ -129,8 +129,7 @@ TEST_F(IntegratorTest, MappingTestSimple) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      std::move(IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
-          p.get(), {})));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
   Function& internal_func = *integration->function();
   Function external_func("external", p.get());
 


### PR DESCRIPTION
…on merged function and includes bookkeeping to track which original-function nodes map to which integration-function nodes. Currently for an IntegrationFunction, inputs are tuples where each tuple corresponds to the inputs of one of the source functions.