### PR TITLE
Added global mux select signal option.

### DIFF
--- a/xls/contrib/integrator/ir_integrator.cc
+++ b/xls/contrib/integrator/ir_integrator.cc
@@ -21,9 +21,10 @@ namespace xls {
 absl::StatusOr<std::unique_ptr<IntegrationFunction>>
 IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
     Package* package, absl::Span<const Function* const> source_functions,
-    std::string function_name) {
+    const IntegrationOptions& options, std::string function_name) {
   // Create integration function object.
-  auto integration_function = absl::make_unique<IntegrationFunction>();
+  auto integration_function =
+      absl::WrapUnique(new IntegrationFunction(options));
   integration_function->package_ = package;
 
   // Create ir function.
@@ -32,7 +33,12 @@ IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
 
   // Package source function parameters as tuple parameters to integration
   // function.
+  int64 source_function_idx = 0;
   for (const auto* source_func : source_functions) {
+    // Record function index.
+    integration_function->source_function_base_to_index_[source_func] =
+        source_function_idx++;
+
     // Add tuple parameter for source function.
     std::vector<Type*> arg_types;
     for (const Node* param : source_func->params()) {
@@ -56,6 +62,17 @@ IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
           integration_function->SetNodeMapping(param, tuple_index));
       parameter_index++;
     }
+  }
+
+  // Add input for global mux select.
+  if (!integration_function->integration_options_
+           .unique_select_signal_per_mux()) {
+    int64 num_bits = Bits::MinBitCountUnsigned(source_functions.size() - 1);
+    XLS_ASSIGN_OR_RETURN(
+        integration_function->global_mux_select_param_,
+        integration_function->function_->MakeNodeWithName<Param>(
+            /*loc=*/std::nullopt, "global_mux_select",
+            integration_function->package_->GetBitsType(num_bits)));
   }
 
   return std::move(integration_function);
@@ -111,6 +128,43 @@ IntegrationFunction::GetNodesMappedToNode(const Node* map_target) const {
   return &integrated_node_to_original_nodes_map_.at(map_target);
 }
 
+absl::StatusOr<const std::set<int64>*>
+IntegrationFunction::GetGlobalMuxOccupiedCaseIndexes(const Node* node) const {
+  XLS_RET_CHECK(global_mux_to_metadata_.contains(node));
+  return &global_mux_to_metadata_.at(node).occupied_case_indexes;
+}
+
+absl::StatusOr<const std::set<int64>*>
+IntegrationFunction::GetGlobalMuxLastCaseIndexesAdded(const Node* node) const {
+  XLS_RET_CHECK(global_mux_to_metadata_.contains(node));
+  return &global_mux_to_metadata_.at(node).last_case_indexes_added;
+}
+
+int64 IntegrationFunction::GetNumberOfGlobalMuxesTracked() const {
+  return global_mux_to_metadata_.size();
+}
+
+absl::StatusOr<int64> IntegrationFunction::GetSourceFunctionIndexOfNode(
+    const Node* node) const {
+  XLS_RET_CHECK(!IntegrationFunctionOwnsNode(node));
+  XLS_RET_CHECK(source_function_base_to_index_.contains(node->function_base()));
+  return source_function_base_to_index_.at(node->function_base());
+}
+
+absl::StatusOr<std::set<int64>>
+IntegrationFunction::GetSourceFunctionIndexesOfNodesMappedToNode(
+    const Node* map_target) const {
+  XLS_ASSIGN_OR_RETURN(const absl::flat_hash_set<const Node*>* src_nodes,
+                       GetNodesMappedToNode(map_target));
+
+  std::set<int64> source_indexes;
+  for (const auto* node : *src_nodes) {
+    XLS_ASSIGN_OR_RETURN(int64 index, GetSourceFunctionIndexOfNode(node));
+    source_indexes.insert(index);
+  }
+  return source_indexes;
+}
+
 absl::StatusOr<std::vector<Node*>> IntegrationFunction::GetIntegratedOperands(
     const Node* node) const {
   std::vector<Node*> operand_mappings;
@@ -142,9 +196,19 @@ IntegrationFunction::UnifyIntegrationNodes(Node* node_a, Node* node_b) {
 
   // Same node.
   if (node_a == node_b) {
-    return UnifiedNode({node_a, /*new_mux_added=*/false});
+    return UnifiedNode({node_a, /*change=*/UnificationChange::kNoChange});
   }
 
+  if (integration_options_.unique_select_signal_per_mux()) {
+    return UnifyIntegrationNodesWithPerMuxSelect(node_a, node_b);
+  } else {
+    return UnifyIntegrationNodesWithGlobalMuxSelect(node_a, node_b);
+  }
+}
+
+absl::StatusOr<IntegrationFunction::UnifiedNode>
+IntegrationFunction::UnifyIntegrationNodesWithPerMuxSelect(Node* node_a,
+                                                           Node* node_b) {
   // Already created a mux to select between these nodes.
   // Note that we search for (node_a, node_b) but not for
   // (node_b, node_a) because a reversed pair implies
@@ -153,7 +217,8 @@ IntegrationFunction::UnifyIntegrationNodes(Node* node_a, Node* node_b) {
   // this issue.
   std::pair<const Node*, const Node*> key = std::make_pair(node_a, node_b);
   if (node_pair_to_mux_.contains(key)) {
-    return UnifiedNode({node_pair_to_mux_.at(key), /*new_mux_added=*/false});
+    return UnifiedNode(
+        {node_pair_to_mux_.at(key), /*change=*/UnificationChange::kNoChange});
   }
 
   // Create a new mux.
@@ -172,7 +237,141 @@ IntegrationFunction::UnifyIntegrationNodes(Node* node_a, Node* node_b) {
                                        /*default_value=*/std::nullopt));
 
   node_pair_to_mux_[key] = mux;
-  return UnifiedNode({mux, /*new_mux_added=*/true});
+  return UnifiedNode({mux, /*change=*/UnificationChange::kNewMuxAdded});
+}
+
+absl::StatusOr<Node*> IntegrationFunction::ReplaceMuxCases(
+    Node* mux_node,
+    const absl::flat_hash_map<int64, Node*>& source_index_to_case) {
+  XLS_RET_CHECK(IntegrationFunctionOwnsNode(mux_node));
+  XLS_RET_CHECK(!IsMappingTarget(mux_node));
+  Select* mux = mux_node->As<Select>();
+
+  // Add case.
+  std::vector<Node*> new_cases;
+  new_cases.insert(new_cases.end(), mux->cases().begin(), mux->cases().end());
+  for (const auto& index_case : source_index_to_case) {
+    XLS_RET_CHECK(IntegrationFunctionOwnsNode(index_case.second));
+    new_cases[index_case.first] = index_case.second;
+  }
+
+  // Replace mux.
+  XLS_ASSIGN_OR_RETURN(Node * new_mux,
+                       mux->ReplaceUsesWithNew<Select>(
+                           mux->selector(), new_cases,
+                           /*default_value=*/
+                           IsPowerOfTwo(new_cases.size())
+                               ? std::nullopt
+                               : absl::optional<Node*>(mux->default_value())));
+  XLS_RETURN_IF_ERROR(function()->RemoveNode(mux));
+
+  return new_mux;
+}
+
+absl::StatusOr<IntegrationFunction::UnifiedNode>
+IntegrationFunction::UnifyIntegrationNodesWithGlobalMuxSelect(Node* node_a,
+                                                              Node* node_b) {
+  // Determine if node_a or node_b is a mux previously generated by this
+  // function.
+  auto is_unify_generated_mux = [this](Node* node) {
+    if (node->op() != Op::kSel) {
+      return false;
+    }
+    Select* mux = node->As<Select>();
+    Node* selector = mux->selector();
+    return (selector == global_mux_select_param_);
+  };
+  bool a_is_unify_mux = is_unify_generated_mux(node_a);
+  bool b_is_unify_mux = is_unify_generated_mux(node_b);
+  XLS_RET_CHECK(!(a_is_unify_mux && b_is_unify_mux));
+
+  // Neither input is a pre-existing mux.
+  if (!a_is_unify_mux && !b_is_unify_mux) {
+    return UnifyIntegrationNodesWithGlobalMuxSelectNoMuxArg(node_a, node_b);
+
+  // One input is already a pre-existing mux.
+  } else {
+    // ID mux and new case for mux.
+    Node* mux = a_is_unify_mux ? node_a : node_b;
+    Node* case_node = !a_is_unify_mux ? node_a : node_b;
+
+    return UnifyIntegrationNodesWithGlobalMuxSelectArgIsMux(mux, case_node);
+  }
+}
+
+absl::StatusOr<IntegrationFunction::UnifiedNode>
+IntegrationFunction::UnifyIntegrationNodesWithGlobalMuxSelectNoMuxArg(
+    Node* node_a, Node* node_b) {
+  // Prefer a canonical ordering of arguments to increase debuggability /
+  // reduce arbitrariness.
+  XLS_ASSIGN_OR_RETURN(std::set<int64> init_a_source_indexes,
+                       GetSourceFunctionIndexesOfNodesMappedToNode(node_a));
+  XLS_ASSIGN_OR_RETURN(std::set<int64> init_b_source_indexes,
+                       GetSourceFunctionIndexesOfNodesMappedToNode(node_b));
+  if (*init_a_source_indexes.begin() > *init_b_source_indexes.begin()) {
+    std::swap(node_a, node_b);
+  }
+
+  // Create mux.
+  std::vector<Node*> cases(source_function_base_to_index_.size(), node_a);
+  XLS_ASSIGN_OR_RETURN(
+      Node * init_mux,
+      function_->MakeNode<Select>(
+          /*loc=*/std::nullopt, global_mux_select_param_, cases,
+          /*default_value=*/
+          IsPowerOfTwo(cases.size()) ? std::nullopt
+                                     : absl::optional<Node*>(node_a)));
+  // Track assigned cases.
+  XLS_ASSIGN_OR_RETURN(std::set<int64> a_source_indexes,
+                       GetSourceFunctionIndexesOfNodesMappedToNode(node_a));
+  GlobalMuxMetadata& init_metadata = global_mux_to_metadata_[init_mux];
+  init_metadata.occupied_case_indexes = a_source_indexes;
+
+  // Now handle as case where one input is a pre-existing mux.
+  XLS_ASSIGN_OR_RETURN(
+      UnifiedNode new_mux,
+      UnifyIntegrationNodesWithGlobalMuxSelectArgIsMux(init_mux, node_b));
+  new_mux.change = UnificationChange::kNewMuxAdded;
+
+  // Track most recent assigned cases.
+  GlobalMuxMetadata& new_mux_metadata =
+      global_mux_to_metadata_.at(new_mux.node);
+  new_mux_metadata.last_case_indexes_added.insert(a_source_indexes.begin(),
+                                                  a_source_indexes.end());
+  return new_mux;
+}
+
+absl::StatusOr<IntegrationFunction::UnifiedNode>
+IntegrationFunction::UnifyIntegrationNodesWithGlobalMuxSelectArgIsMux(
+    Node* mux, Node* case_node) {
+  // Clear bookkeeping.
+  XLS_RET_CHECK(global_mux_to_metadata_.contains(mux));
+  std::set<int64> occupied =
+      global_mux_to_metadata_.at(mux).occupied_case_indexes;
+  global_mux_to_metadata_.erase(mux);
+
+  // For each source function that maps a node to case_node,
+  // insert case_node as the corresponding mux case.
+  absl::flat_hash_map<int64, Node*> source_index_to_case;
+  XLS_ASSIGN_OR_RETURN(std::set<int64> case_source_indexes,
+                       GetSourceFunctionIndexesOfNodesMappedToNode(case_node));
+  for (int64 index : case_source_indexes) {
+    source_index_to_case[index] = case_node;
+    XLS_RET_CHECK(occupied.find(index) == occupied.end());
+  }
+  XLS_ASSIGN_OR_RETURN(Node * new_mux,
+                       ReplaceMuxCases(mux, source_index_to_case));
+
+  // Update bookkeeping.
+  XLS_RET_CHECK(!global_mux_to_metadata_.contains(new_mux));
+  GlobalMuxMetadata& new_metadata = global_mux_to_metadata_[new_mux];
+  new_metadata.last_case_indexes_added = case_source_indexes;
+  new_metadata.occupied_case_indexes = occupied;
+  new_metadata.occupied_case_indexes.insert(case_source_indexes.begin(),
+                                            case_source_indexes.end());
+
+  return UnifiedNode(
+      {new_mux, /*change=*/UnificationChange::kExistingMuxCasesModified});
 }
 
 absl::StatusOr<IntegrationFunction::UnifiedOperands>
@@ -187,21 +386,33 @@ IntegrationFunction::UnifyNodeOperands(const Node* node_a, const Node* node_b) {
   UnifiedOperands unify_result;
   unify_result.operands.reserve(a_ops.size());
   for (int64 idx = 0; idx < a_ops.size(); ++idx) {
-    XLS_ASSIGN_OR_RETURN(UnifiedNode uni_op,
+    XLS_ASSIGN_OR_RETURN(UnifiedNode uni_operand,
                          UnifyIntegrationNodes(a_ops.at(idx), b_ops.at(idx)));
-    unify_result.operands.push_back(uni_op.node);
-    if (uni_op.new_mux_added) {
-      unify_result.added_muxes.push_back(uni_op.node);
+    unify_result.operands.push_back(uni_operand.node);
+    if (uni_operand.change != UnificationChange::kNoChange) {
+      unify_result.changed_muxes.push_back(uni_operand);
     }
   }
 
   return unify_result;
 }
 
-absl::Status IntegrationFunction::DeUnifyIntegrationNodes(Node* node) {
+absl::StatusOr<Node*> IntegrationFunction::DeUnifyIntegrationNodes(Node* node) {
   XLS_RET_CHECK_EQ(node->op(), Op::kSel);
+  XLS_RET_CHECK(IntegrationFunctionOwnsNode(node));
+  XLS_RET_CHECK(!IsMappingTarget(node));
+
+  if (integration_options_.unique_select_signal_per_mux()) {
+    XLS_RETURN_IF_ERROR(DeUnifyIntegrationNodesWithPerMuxSelect(node));
+    return nullptr;
+  } else {
+    return DeUnifyIntegrationNodesWithGlobalMuxSelect(node);
+  }
+}
+
+absl::Status IntegrationFunction::DeUnifyIntegrationNodesWithPerMuxSelect(
+    Node* node) {
   Select* mux = node->As<Select>();
-  XLS_RET_CHECK(IntegrationFunctionOwnsNode(mux));
   XLS_RET_CHECK_EQ(mux->cases().size(), 2);
   Node* a_in = mux->cases().at(0);
   Node* b_in = mux->cases().at(1);
@@ -223,6 +434,53 @@ absl::Status IntegrationFunction::DeUnifyIntegrationNodes(Node* node) {
   return absl::OkStatus();
 }
 
+absl::StatusOr<Node*>
+IntegrationFunction::DeUnifyIntegrationNodesWithGlobalMuxSelect(Node* node) {
+  Select* mux = node->As<Select>();
+  XLS_RET_CHECK_EQ(mux->cases().size(), source_function_base_to_index_.size());
+
+  // Get bookkeeping.
+  XLS_RET_CHECK(global_mux_to_metadata_.contains(node));
+  GlobalMuxMetadata& metadata = global_mux_to_metadata_.at(node);
+  XLS_RET_CHECK(!metadata.last_case_indexes_added.empty());
+
+  // Clear occupied cases.
+  for (int64 updated_idx : metadata.last_case_indexes_added) {
+    metadata.occupied_case_indexes.erase(updated_idx);
+  }
+
+  // No more occupied cases - remove mux.
+  if (metadata.occupied_case_indexes.empty()) {
+    // Update bookkeeping.
+    global_mux_to_metadata_.erase(node);
+
+    XLS_RETURN_IF_ERROR(function()->RemoveNode(node));
+    return nullptr;
+
+  // Reset last updated cases.
+  } else {
+    Node* reset_value =
+        mux->cases().at(*metadata.occupied_case_indexes.begin());
+    absl::flat_hash_map<int64, Node*> case_updates;
+    for (int64 updated_idx : metadata.last_case_indexes_added) {
+      case_updates[updated_idx] = reset_value;
+    }
+    XLS_ASSIGN_OR_RETURN(Node * new_mux, ReplaceMuxCases(node, case_updates));
+
+    // Update bookkeeping.
+    GlobalMuxMetadata& new_metadata = global_mux_to_metadata_[new_mux];
+    new_metadata = metadata;
+    // Note: DeUnifyIntegrationNodes shouldn't be called repeatedly on
+    // a mux, so we don't need to recover any updates past the update
+    // that was just reversed. So simply clearing last_case_indexes_added
+    // is okay.
+    new_metadata.last_case_indexes_added.clear();
+    global_mux_to_metadata_.erase(node);
+
+    return new_mux;
+  }
+}
+
 bool IntegrationFunction::HasMapping(const Node* node) const {
   return original_node_to_integrated_node_map_.contains(node);
 }
@@ -231,17 +489,21 @@ bool IntegrationFunction::IsMappingTarget(const Node* node) const {
   return integrated_node_to_original_nodes_map_.contains(node);
 }
 
-absl::StatusOr<Node*> IntegrationFunction::InsertNode(const Node* to_insert) {
-  // TODO(jbaileyhandle): Implement this by calling MergeNodes behind
-  // the scenes.
+absl::StatusOr<Node*> IntegrationFunction::InsertNode(Node* to_insert) {
   XLS_RET_CHECK(!IntegrationFunctionOwnsNode(to_insert));
-  XLS_RET_CHECK(!HasMapping(to_insert));
-  XLS_ASSIGN_OR_RETURN(std::vector<Node*> mapped_operands,
-                       GetIntegratedOperands(to_insert));
-  XLS_ASSIGN_OR_RETURN(Node * inserted, to_insert->CloneInNewFunction(
-                                            mapped_operands, function()));
-  XLS_RETURN_IF_ERROR(SetNodeMapping(to_insert, inserted));
-  return inserted;
+  XLS_ASSIGN_OR_RETURN(std::vector<Node*> node_mappings,
+                       MergeNodes(to_insert, to_insert));
+  XLS_RET_CHECK_EQ(node_mappings.size(), 1);
+  return node_mappings.front();
+}
+
+absl::StatusOr<float> IntegrationFunction::GetInsertNodeCost(
+    const Node* to_insert) {
+  XLS_RET_CHECK(!IntegrationFunctionOwnsNode(to_insert));
+  XLS_ASSIGN_OR_RETURN(std::optional<float> insert_cost,
+                       GetMergeNodesCost(to_insert, to_insert));
+  XLS_RET_CHECK(insert_cost.has_value());
+  return insert_cost.value();
 }
 
 absl::StatusOr<IntegrationFunction::MergeNodesBackendResult>
@@ -280,11 +542,12 @@ IntegrationFunction::MergeNodesBackend(const Node* node_a, const Node* node_b) {
         Node * merged,
         node_a->CloneInNewFunction(unified_operands.operands, function()));
 
-    return MergeNodesBackendResult{.can_merge = true,
-                                   .target_a = merged,
-                                   .target_b = merged,
-                                   .added_muxes = unified_operands.added_muxes,
-                                   .other_added_nodes = {merged}};
+    return MergeNodesBackendResult{
+        .can_merge = true,
+        .target_a = merged,
+        .target_b = merged,
+        .changed_muxes = unified_operands.changed_muxes,
+        .other_added_nodes = {merged}};
   } else {
     // TODO(jbaileyhandle): Add logic for nodes that are not identical but
     // may still be merged e.g. different bitwidths for bitwise ops.
@@ -315,8 +578,10 @@ absl::StatusOr<std::optional<int64>> IntegrationFunction::GetMergeNodesCost(
   };
   tabulate_node_elimination_cost(node_a);
   tabulate_node_elimination_cost(node_b);
-  for (Node* new_node : merge_result.added_muxes) {
-    cost += GetNodeCost(new_node);
+  for (UnifiedNode& unified_node : merge_result.changed_muxes) {
+    if (unified_node.change == UnificationChange::kNewMuxAdded) {
+      cost += GetNodeCost(unified_node.node);
+    }
   }
   for (Node* new_node : merge_result.other_added_nodes) {
     cost += GetNodeCost(new_node);
@@ -341,8 +606,9 @@ absl::StatusOr<std::optional<int64>> IntegrationFunction::GetMergeNodesCost(
     XLS_RET_CHECK_GT(nodes_eliminated, initial_eliminated);
   }
 
-  for (Node* new_node : merge_result.added_muxes) {
-    XLS_RETURN_IF_ERROR(DeUnifyIntegrationNodes(new_node));
+  for (UnifiedNode& unified_node : merge_result.changed_muxes) {
+    XLS_RET_CHECK(unified_node.change != UnificationChange::kNoChange);
+    XLS_RETURN_IF_ERROR(DeUnifyIntegrationNodes(unified_node.node).status());
   }
 
   return cost;
@@ -444,8 +710,10 @@ absl::Status IntegrationBuilder::CopySourcesToIntegrationPackage() {
 }
 
 absl::StatusOr<std::unique_ptr<IntegrationBuilder>> IntegrationBuilder::Build(
-    absl::Span<const Function* const> input_functions) {
-  auto builder = absl::WrapUnique(new IntegrationBuilder(input_functions));
+    absl::Span<const Function* const> input_functions,
+    const IntegrationOptions& options) {
+  auto builder =
+      absl::WrapUnique(new IntegrationBuilder(input_functions, options));
 
   // Add sources to common package.
   XLS_RETURN_IF_ERROR(builder->CopySourcesToIntegrationPackage());

--- a/xls/contrib/integrator/ir_integrator.h
+++ b/xls/contrib/integrator/ir_integrator.h
@@ -21,70 +21,111 @@
 
 namespace xls {
 
+class IntegrationOptions {
+ public:
+  // Whether we can program individual muxes with unique select signals
+  // or if we can configure the entire graph to match one of the input
+  // functions using a single select signal.
+  IntegrationOptions& unique_select_signal_per_mux(bool value) {
+    unique_select_signal_per_mux_ = value;
+    return *this;
+  }
+  bool unique_select_signal_per_mux() const {
+    return unique_select_signal_per_mux_;
+  }
+
+ private:
+  bool unique_select_signal_per_mux_ = false;
+};
+
 // Class that represents an integration function i.e. a function combining the
 // IR of other functions. This class tracks which original function nodes are
 // mapped to which integration function nodes. It also provides some utilities
 // that are useful for constructing the integrated function.
 class IntegrationFunction {
  public:
-  IntegrationFunction() {}
-
   IntegrationFunction(const IntegrationFunction& other) = delete;
   void operator=(const IntegrationFunction& other) = delete;
 
   // Create an IntegrationFunction object that is empty expect for
   // parameters. Each initial parameter of the function is a tuple
-  // which holds inputs corresponding to the paramters of one
+  // which holds inputs corresponding to the parameters of one
   // of the source_functions.
   static absl::StatusOr<std::unique_ptr<IntegrationFunction>>
   MakeIntegrationFunctionWithParamTuples(
       Package* package, absl::Span<const Function* const> source_functions,
+      const IntegrationOptions& options = IntegrationOptions(),
       std::string function_name = "IntegrationFunction");
 
   Function* function() const { return function_.get(); }
+  Node* global_mux_select() const { return global_mux_select_param_; }
+
+  // Estimate the cost of inserting the node 'to_insert'.
+  absl::StatusOr<float> GetInsertNodeCost(const Node* to_insert);
 
   // Add the external node 'to_insert' into the integration function. Mapped
   // operands are automatically discovered and connected.
-  absl::StatusOr<Node*> InsertNode(const Node* to_insert);
+  absl::StatusOr<Node*> InsertNode(Node* to_insert);
 
   // Estimate the cost of merging node_a and node_b. If nodes cannot be
   // merged, not value is returned.
   absl::StatusOr<std::optional<int64>> GetMergeNodesCost(const Node* node_a,
                                                          const Node* node_b);
 
-  // Merge node_a and node_b. Returns the nodes that node_a and node_b
-  // map to after merging (vector contains a single node if they map
-  // to the same node).
+  // Merge node_a and node_b. Operands are automatically multiplexed.
+  // Returns the nodes that node_a and node_b map to after merging (vector
+  // contains a single node if they map to the same node).
   absl::StatusOr<std::vector<Node*>> MergeNodes(Node* node_a, Node* node_b);
 
+  enum class UnificationChange {
+    kNoChange,
+    kNewMuxAdded,
+    kExistingMuxCasesModified,
+  };
+  struct UnifiedNode {
+    Node* node;
+    UnificationChange change;
+  };
   // For the integration function nodes node_a and node_b,
   // returns a UnifiedNode. UnifiedNode.node points to a single integration
   // function node that combines the two nodes. This may involve adding a mux
   // and a parameter to serve as the mux select signal.
-  // UnifiedNode.new_mux_added will be be set to true if this call added a new
-  // mux. Otherwise, false.
-  struct UnifiedNode {
-    Node* node;
-    bool new_mux_added;
-  };
+  // UnifiedNode.change will indicate if the ir graph is unchaged, if a new
+  // mux was added by this call, or if an existing mux was modified by this
+  // call.
   absl::StatusOr<UnifiedNode> UnifyIntegrationNodes(Node* node_a, Node* node_b);
 
   // Return a UnifiedOperands struct in which the 'operands' vector holds nodes
   // where each node unifies the corresponding operands of 'node_a' and
-  // 'node_b'.  The 'added_muxes' field lists all new muxes created by this
-  // call.
+  // 'node_b'.  The 'changed_muxes' field lists all muxes created by or modified
+  // by this call.
   struct UnifiedOperands {
     std::vector<Node*> operands;
-    std::vector<Node*> added_muxes;
+    std::vector<UnifiedNode> changed_muxes;
   };
   absl::StatusOr<UnifiedOperands> UnifyNodeOperands(const Node* node_a,
                                                     const Node* node_b);
 
-  // For a mux produced by UnifyIntegrationNodes, remove the mux and
-  // the select paramter. Updates internal unification / mux book-keeping
-  // accordingly. This function should only be called if the mux has no users
-  // and mux's select signal is only used by the mux.
-  absl::Status DeUnifyIntegrationNodes(Node* node);
+  // Return the case indexes which are in active use for a mux
+  // whose selector is global_mux_select_param_;
+  absl::StatusOr<const std::set<int64>*> GetGlobalMuxOccupiedCaseIndexes(
+      const Node* node) const;
+
+  // Return the case indices which were most recently added to a mux
+  // whose selector is global_mux_select_param_;
+  absl::StatusOr<const std::set<int64>*> GetGlobalMuxLastCaseIndexesAdded(
+      const Node* node) const;
+
+  // Returns how many muxes whose selector is global_mux_select_param_
+  // we track metadata for.
+  int64 GetNumberOfGlobalMuxesTracked() const;
+
+  // For a mux produced by UnifyIntegrationNodes, undoes the previous
+  // call to UnifyIntegrationNodes. Also updates
+  // internal unification / mux book-keeping accordingly. If the mux was
+  // modified / replaced, the new mux is returned. If the mux was removed,
+  // nullptr is returned.
+  absl::StatusOr<Node*> DeUnifyIntegrationNodes(Node* node);
 
   // Declares that node 'source' from a source function maps
   // to node 'map_target' in the integrated_function.
@@ -97,6 +138,13 @@ class IntegrationFunction {
   // Returns the original nodes that map to 'map_target' in the integrated
   // function.
   absl::StatusOr<const absl::flat_hash_set<const Node*>*> GetNodesMappedToNode(
+      const Node* map_target) const;
+
+  // Returns the source function index for the given node.
+  absl::StatusOr<int64> GetSourceFunctionIndexOfNode(const Node* node) const;
+
+  // Returns the source function index of all nodes that map to 'map_target'.
+  absl::StatusOr<std::set<int64>> GetSourceFunctionIndexesOfNodesMappedToNode(
       const Node* map_target) const;
 
   // Returns a vector of Nodes to which the operands of the node
@@ -122,6 +170,9 @@ class IntegrationFunction {
   int64 GetNodeCost(const Node* node) const;
 
  private:
+  IntegrationFunction(const IntegrationOptions& options)
+      : integration_options_(options) {}
+
   // Helper function that implements the logic for merging nodes,
   // allowing for either the merge to be performed or for the cost
   // of the merge to be estimated.  A MergeNodesBackendResult struct is
@@ -131,13 +182,14 @@ class IntegrationFunction {
   // (note: these will not necessarily point to the same merged node e.g. if the
   // merge node has a wider bitwidth than one of the original nodes, the target
   // pointer may instead point to a bitslice that takes in the wider node as an
-  // operand). New muxes created by this call are placed in 'added_muxes'. Other
-  // nodes created by this call are placed in 'other_added_nodes'.
+  // operand). New muxes created or muxes modified by this call are placed in
+  // 'changed_muxes'. Other nodes created by this call are placed in
+  // 'other_added_nodes'.
   struct MergeNodesBackendResult {
     bool can_merge;
     Node* target_a = nullptr;
     Node* target_b = nullptr;
-    std::vector<Node*> added_muxes;
+    std::vector<UnifiedNode> changed_muxes;
     // We use a list rather than a vector here because
     // we will later want to remove elements in a (currently)
     // unknown order.  This would involve wastefule data copying
@@ -146,6 +198,54 @@ class IntegrationFunction {
   };
   absl::StatusOr<MergeNodesBackendResult> MergeNodesBackend(const Node* node_a,
                                                             const Node* node_b);
+
+  // For the integration function nodes node_a and node_b,
+  // returns a single integration function node that combines the two
+  // nodes. If a node combining node_a and node_b does not already
+  // exist, a new mux and a per-mux select parameter are added.
+  // If provided, the bool pointed to  by 'new_mux_added' will be
+  // set to true if this call added a new mux.  Otherwise, false.
+  absl::StatusOr<UnifiedNode> UnifyIntegrationNodesWithPerMuxSelect(
+      Node* node_a, Node* node_b);
+
+  // For the integration function nodes node_a and node_b,
+  // returns a single integration function node that combines the two
+  // nodes. If neither node_a or node_b is a mux added by a previous call,
+  // a new mux is added whose select signal global_mux_select_param_.
+  // If one of the nodes is such a mux, the other node is added as an
+  // input to the mux.
+  absl::StatusOr<UnifiedNode> UnifyIntegrationNodesWithGlobalMuxSelect(
+      Node* node_a, Node* node_b);
+
+  // Helper function for UnifyIntegrationNodesWithGlobalMuxSelect that handles
+  // the case that neither input is a pre-existing mux.
+  absl::StatusOr<UnifiedNode> UnifyIntegrationNodesWithGlobalMuxSelectArgIsMux(
+      Node* node_a, Node* node_b);
+
+  // Helper function for UnifyIntegrationNodesWithGlobalMuxSelect that handles
+  // the cases that one of the input nodes is a pre-existing mux. The other
+  // input is a node that will be added as a case(s) to the mux.
+  absl::StatusOr<UnifiedNode> UnifyIntegrationNodesWithGlobalMuxSelectNoMuxArg(
+      Node* mux, Node* case_node);
+
+  // For a mux produced by UnifyIntegrationNodesWithPerMuxSelect, remove the mux
+  // and the select parameter. Updates internal unification / mux book-keeping
+  // accordingly. This function should only be called if the mux has no users
+  // and mux's select signal is only used by the mux.
+  absl::Status DeUnifyIntegrationNodesWithPerMuxSelect(Node* node);
+
+  // For a mux produced by UnifyIntegrationNodesWithGlobalMuxSelect,
+  // remove the most recently added cases. If no cases are in use after this,
+  // then the mux is removed. Otherwise, the revert mux is returned. Also
+  // updates internal unification / mux book-keeping.
+  absl::StatusOr<Node*> DeUnifyIntegrationNodesWithGlobalMuxSelect(Node* node);
+
+  // Replaces 'mux' with a new mux which is identical except that
+  // the the cases at the indexes in 'source_index_to_case'
+  // are replaced with the nodes specified.
+  absl::StatusOr<Node*> ReplaceMuxCases(
+      Node* mux_node,
+      const absl::flat_hash_map<int64, Node*>& source_index_to_case);
 
   // Track mapping of original function nodes to integrated function nodes.
   absl::flat_hash_map<const Node*, Node*> original_node_to_integrated_node_map_;
@@ -156,8 +256,38 @@ class IntegrationFunction {
   absl::flat_hash_map<std::pair<const Node*, const Node*>, Node*>
       node_pair_to_mux_;
 
+  // If integration_options_ does not specify that each mux has a unique
+  // select signal, this shared parameter is the select for all integration
+  // muxes.
+  Node* global_mux_select_param_ = nullptr;
+
+  struct GlobalMuxMetadata {
+    // Prefer to use sets rather than flat_hash_sets so that
+    // the order of indexes reflects the order of the mux inputs.
+
+    // Track which select arms map meaningful nodes for muxes
+    // using the global_mux_select_param_ select signal.
+    std::set<int64> occupied_case_indexes;
+
+    // Track which select arms were most recently added for muxes
+    // using the global_mux_select_param_ select signal. Note that
+    // we only need to preserve enough history to call DeUnifyIntegrationNodes
+    // after calling UnifyIntegrationNodes, with no other calls to
+    // UnifyIntegrationNodes for a given mux inbetween. Further, there should
+    // not be repeated calls to DeUnifyIntegrationNodes for a given node.
+    std::set<int64> last_case_indexes_added;
+  };
+  // Track information about muxes that use global_mux_select_param_ as their
+  // select signal.
+  absl::flat_hash_map<Node*, GlobalMuxMetadata> global_mux_to_metadata_;
+
+  // Maps each source function to a unique index.
+  absl::flat_hash_map<const FunctionBase*, int64>
+      source_function_base_to_index_;
+
   // Integrated function.
   std::unique_ptr<Function> function_;
+  const IntegrationOptions integration_options_;
   Package* package_;
 };
 
@@ -174,13 +304,18 @@ class IntegrationBuilder {
   // Creates an IntegrationBuilder and uses it to produce an integrated function
   // implementing all functions in source_functions_.
   static absl::StatusOr<std::unique_ptr<IntegrationBuilder>> Build(
-      absl::Span<const Function* const> input_functions);
+      absl::Span<const Function* const> input_functions,
+      const IntegrationOptions& options = IntegrationOptions());
 
   Package* package() { return package_.get(); }
   Function* integrated_function() { return integrated_function_; }
+  const IntegrationOptions* integration_options() {
+    return &integration_options_;
+  }
 
  private:
-  IntegrationBuilder(absl::Span<const Function* const> input_functions) {
+  IntegrationBuilder(absl::Span<const Function* const> input_functions,
+                     const IntegrationOptions& options) {
     original_package_source_functions_.insert(
         original_package_source_functions_.end(), input_functions.begin(),
         input_functions.end());
@@ -188,7 +323,6 @@ class IntegrationBuilder {
     package_ = absl::make_unique<Package>("IntegrationPackage");
   }
 
- private:
   // Copy the source functions into a common package.
   absl::Status CopySourcesToIntegrationPackage();
 
@@ -198,6 +332,8 @@ class IntegrationBuilder {
       absl::flat_hash_map<const Function*, Function*>* call_remapping);
 
   NameUniquer function_name_uniquer_ = NameUniquer(/*separator=*/"__");
+
+  const IntegrationOptions integration_options_;
 
   // Common package for to-be integrated functions
   // and integrated function.

--- a/xls/contrib/integrator/ir_integrator_test.cc
+++ b/xls/contrib/integrator/ir_integrator_test.cc
@@ -385,7 +385,8 @@ TEST_F(IntegratorTest, ParamterPacking) {
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
       IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
-          p.get(), {func_a, func_b}));
+          p.get(), {func_a, func_b},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   auto GetTupleIndexWithNumBits = [&](int64 num_bits) {
     for (Node* node : integration->function()->nodes()) {
@@ -460,6 +461,103 @@ TEST_F(IntegratorTest, ParamterPacking) {
   EXPECT_EQ(integration->function()->node_count(), 6);
 }
 
+TEST_F(IntegratorTest, ParamterPackingUniversalMuxSelect) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  fb_a.Param("a1", p->GetBitsType(2));
+  fb_a.Param("a2", p->GetBitsType(4));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  fb_b.Param("b1", p->GetBitsType(6));
+  fb_b.Param("b2", p->GetBitsType(8));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  auto GetTupleIndexWithNumBits = [&](long int num_bits) {
+    for (Node* node : integration->function()->nodes()) {
+      if (node->op() == Op::kTupleIndex) {
+        if (node->GetType() == p->GetBitsType(num_bits)) {
+          return absl::optional<Node*>(node);
+        }
+      }
+    }
+    return absl::optional<Node*>(std::nullopt);
+  };
+  auto GetParamWithNumBits = [&p](Function* function, long int num_bits) {
+    for (Node* node : function->nodes()) {
+      if (node->op() == Op::kParam) {
+        if (node->GetType() == p->GetBitsType(num_bits)) {
+          return absl::optional<Node*>(node);
+        }
+      }
+    }
+    return absl::optional<Node*>(std::nullopt);
+  };
+
+  auto a1_index = GetTupleIndexWithNumBits(2);
+  EXPECT_TRUE(a1_index.has_value());
+  EXPECT_TRUE(a1_index.has_value());
+  EXPECT_THAT(a1_index.value(), m::TupleIndex(m::Param("func_aParamTuple"), 0));
+  auto a1_source = GetParamWithNumBits(func_a, 2);
+  EXPECT_TRUE(a1_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(a1_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(a1_source.value()).value(),
+            a1_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(a1_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(a1_index.value()).value()),
+              UnorderedElementsAre(a1_source.value()));
+
+  auto a2_index = GetTupleIndexWithNumBits(4);
+  EXPECT_TRUE(a2_index.has_value());
+  EXPECT_THAT(a2_index.value(), m::TupleIndex(m::Param("func_aParamTuple"), 1));
+  ;
+  auto a2_source = GetParamWithNumBits(func_a, 4);
+  EXPECT_TRUE(a2_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(a2_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(a2_source.value()).value(),
+            a2_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(a2_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(a2_index.value()).value()),
+              UnorderedElementsAre(a2_source.value()));
+
+  auto b1_index = GetTupleIndexWithNumBits(6);
+  EXPECT_TRUE(b1_index.has_value());
+  EXPECT_THAT(b1_index.value(), m::TupleIndex(m::Param("func_bParamTuple"), 0));
+  ;
+  auto b1_source = GetParamWithNumBits(func_b, 6);
+  EXPECT_TRUE(b1_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(b1_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(b1_source.value()).value(),
+            b1_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(b1_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(b1_index.value()).value()),
+              UnorderedElementsAre(b1_source.value()));
+
+  auto b2_index = GetTupleIndexWithNumBits(8);
+  EXPECT_TRUE(b2_index.has_value());
+  EXPECT_THAT(b2_index.value(), m::TupleIndex(m::Param("func_bParamTuple"), 1));
+  ;
+  auto b2_source = GetParamWithNumBits(func_b, 8);
+  EXPECT_TRUE(b2_source.has_value());
+  EXPECT_TRUE(integration->HasMapping(b2_source.value()));
+  EXPECT_EQ(integration->GetNodeMapping(b2_source.value()).value(),
+            b2_index.value());
+  EXPECT_TRUE(integration->IsMappingTarget(b2_index.value()));
+  EXPECT_THAT(*(integration->GetNodesMappedToNode(b2_index.value()).value()),
+              UnorderedElementsAre(b2_source.value()));
+
+  EXPECT_EQ(integration->function()->node_count(), 7);
+  auto global_mux_select =
+      FindNode("global_mux_select", integration->function());
+  EXPECT_EQ(global_mux_select->GetType(), p->GetBitsType(1));
+}
+
 TEST_F(IntegratorTest, GetIntegratedOperandsExternalNode) {
   auto p = CreatePackage();
   FunctionBuilder fb_a("func_a", p.get());
@@ -515,7 +613,9 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesSameNode) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -535,7 +635,9 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesSameNodeCheckMuxAdded) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -547,7 +649,7 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesSameNodeCheckMuxAdded) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedNode unity,
       integration->UnifyIntegrationNodes(internal_1, internal_1));
-  EXPECT_FALSE(unity.new_mux_added);
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNoChange);
   EXPECT_EQ(unity.node, internal_1);
   EXPECT_EQ(initial_node_count, integration->function()->node_count());
 }
@@ -556,7 +658,9 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesDifferentNodes) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -589,7 +693,9 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesDifferentNodesRepeated) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -626,7 +732,9 @@ TEST_F(IntegratorTest,
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -642,12 +750,12 @@ TEST_F(IntegratorTest,
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedNode unity,
       integration->UnifyIntegrationNodes(internal_1, internal_2));
-  EXPECT_TRUE(unity.new_mux_added);
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNewMuxAdded);
 
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedNode unity2,
       integration->UnifyIntegrationNodes(internal_1, internal_2));
-  EXPECT_FALSE(unity2.new_mux_added);
+  EXPECT_EQ(unity2.change, IntegrationFunction::UnificationChange::kNoChange);
 
   std::string select_name =
       internal_1->GetName() + "_" + internal_2->GetName() + "_mux_sel";
@@ -666,7 +774,9 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesDifferentNodesFailureCases) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
   Function external_func("external", p.get());
 
@@ -689,6 +799,657 @@ TEST_F(IntegratorTest, UnifyIntegrationNodesDifferentNodesFailureCases) {
 
   // Unifying types must match.
   EXPECT_FALSE(integration->UnifyIntegrationNodes(internal_2, internal_1).ok());
+}
+
+TEST_F(IntegratorTest, UnifyIntegrationGlobalSelectCreateMux) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* c_add_node = FindNode("add", func_c);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+
+  EXPECT_EQ(integration->function()->node_count(), 9);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+
+  // Check added mux.
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(integration->function()->node_count(), 10);
+  EXPECT_EQ(unity.node->op(), Op::kSel);
+  Select* mux = unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), a_add_internal);
+  EXPECT_THAT(mux->cases(),
+              ElementsAre(a_add_internal, a_add_internal, c_add_internal));
+
+  // Check bookkeeping.
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* occupied,
+                           integration->GetGlobalMuxOccupiedCaseIndexes(mux));
+  EXPECT_THAT(*occupied, ElementsAre(0, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* last_assigned,
+                           integration->GetGlobalMuxLastCaseIndexesAdded(mux));
+  EXPECT_THAT(*last_assigned, ElementsAre(0, 2));
+}
+
+TEST_F(IntegratorTest, UnifyIntegrationGlobalSelectModifyMux) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_add_node = FindNode("add", func_d);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_add_internal,
+                           integration->InsertNode(b_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * d_add_internal,
+                           integration->InsertNode(d_add_node));
+
+  EXPECT_EQ(integration->function()->node_count(), 13);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      unity, integration->UnifyIntegrationNodes(unity.node, d_add_internal));
+
+  // Create another mux separate from the one we're modifying.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode other,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      unity, integration->UnifyIntegrationNodes(unity.node, b_add_internal));
+
+  // Check modified mux.
+  EXPECT_EQ(unity.change,
+            IntegrationFunction::UnificationChange::kExistingMuxCasesModified);
+  EXPECT_EQ(integration->function()->node_count(), 15);
+  // Modified mux.
+  EXPECT_EQ(unity.node->op(), Op::kSel);
+  Select* mux = unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, b_add_internal,
+                                        c_add_internal, d_add_internal));
+  // Other mux.
+  EXPECT_EQ(other.node->op(), Op::kSel);
+  Select* other_mux = other.node->As<Select>();
+  EXPECT_EQ(other_mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(other_mux->default_value(), std::nullopt);
+  EXPECT_THAT(other_mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                              c_add_internal, a_add_internal));
+
+  // Check bookkeeping.
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+  // Modified mux.
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* occupied,
+                           integration->GetGlobalMuxOccupiedCaseIndexes(mux));
+  EXPECT_THAT(*occupied, ElementsAre(0, 1, 2, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* last_assigned,
+                           integration->GetGlobalMuxLastCaseIndexesAdded(mux));
+  EXPECT_THAT(*last_assigned, ElementsAre(1));
+  // Other mux.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* other_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(other_mux));
+  EXPECT_THAT(*other_occupied, ElementsAre(0, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* other_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(other_mux));
+  EXPECT_THAT(*other_last_assigned, ElementsAre(0, 2));
+}
+
+TEST_F(IntegratorTest, UnifyIntegrationGlobalSelectUnifyMultiMappedNodes) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_add_node = FindNode("add", func_d);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_add_node, a_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+  XLS_ASSERT_OK(integration->SetNodeMapping(d_add_node, c_add_internal));
+
+  EXPECT_EQ(integration->function()->node_count(), 11);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+
+  // Check added mux.
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(integration->function()->node_count(), 12);
+  EXPECT_EQ(unity.node->op(), Op::kSel);
+  Select* mux = unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        c_add_internal, c_add_internal));
+
+  // Check bookkeeping.
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* occupied,
+                           integration->GetGlobalMuxOccupiedCaseIndexes(mux));
+  EXPECT_THAT(*occupied, ElementsAre(0, 1, 2, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* last_assigned,
+                           integration->GetGlobalMuxLastCaseIndexesAdded(mux));
+  EXPECT_THAT(*last_assigned, ElementsAre(0, 1, 2, 3));
+}
+
+TEST_F(IntegratorTest, UnifyIntegrationGlobalSelectErrorCases) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add2");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* a_add2_node = FindNode("add2", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_add_node = FindNode("add", func_d);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add2_internal,
+                           integration->InsertNode(a_add2_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_add_internal,
+                           integration->InsertNode(b_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * d_add_internal,
+                           integration->InsertNode(d_add_node));
+
+  // Try to unify two muxes.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity1,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity2,
+      integration->UnifyIntegrationNodes(b_add_internal, d_add_internal));
+  auto unify_mux_result =
+      integration->UnifyIntegrationNodes(unity1.node, unity2.node);
+  EXPECT_FALSE(unify_mux_result.ok());
+
+  // Conflicting case assignments
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity3,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  auto conflicitng_case_mux_result =
+      integration->UnifyIntegrationNodes(unity3.node, a_add2_internal);
+  EXPECT_FALSE(conflicitng_case_mux_result.ok());
+
+  // Try to unify w/ node that is not a map target.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity4,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      integration->function()->MakeNodeWithName<Param>(
+          /*loc=*/std::nullopt, "internal_1", p->GetBitsType(2)));
+  auto no_map_mux_result =
+      integration->UnifyIntegrationNodes(unity4.node, internal_1);
+  EXPECT_FALSE(no_map_mux_result.ok());
+}
+
+TEST_F(IntegratorTest, DeUnifyIntegrationGlobalSelectRemoveMux) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_add_internal,
+                           integration->InsertNode(b_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+
+  EXPECT_EQ(integration->function()->node_count(), 10);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode inner_unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  EXPECT_EQ(inner_unity.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(integration->function()->node_count(), 11);
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode outer_unity,
+      integration->UnifyIntegrationNodes(a_add_internal, b_add_internal));
+  EXPECT_EQ(outer_unity.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(integration->function()->node_count(), 12);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+
+  // Check inner mux.
+  EXPECT_EQ(inner_unity.node->op(), Op::kSel);
+  Select* mux = inner_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), a_add_internal);
+  EXPECT_THAT(mux->cases(),
+              ElementsAre(a_add_internal, a_add_internal, c_add_internal));
+
+  // Check outer mux.
+  EXPECT_EQ(outer_unity.node->op(), Op::kSel);
+  mux = outer_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), a_add_internal);
+  EXPECT_THAT(mux->cases(),
+              ElementsAre(a_add_internal, b_add_internal, a_add_internal));
+
+  // Check inner bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* inner_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(inner_unity.node));
+  EXPECT_THAT(*inner_occupied, ElementsAre(0, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* inner_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(inner_unity.node));
+  EXPECT_THAT(*inner_last_assigned, ElementsAre(0, 2));
+
+  // Check outer bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* outer_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(outer_unity.node));
+  EXPECT_THAT(*outer_occupied, ElementsAre(0, 1));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* outer_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(outer_unity.node));
+  EXPECT_THAT(*outer_last_assigned, ElementsAre(0, 1));
+
+  // Remove inner mux.
+  auto inner_deunify_result =
+      integration->DeUnifyIntegrationNodes(inner_unity.node);
+  EXPECT_TRUE(inner_deunify_result.ok());
+  EXPECT_EQ(inner_deunify_result.value(), static_cast<Node*>(nullptr));
+  EXPECT_EQ(integration->function()->node_count(), 11);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+
+  // Check outer mux.
+  EXPECT_EQ(outer_unity.node->op(), Op::kSel);
+  mux = outer_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), a_add_internal);
+  EXPECT_THAT(mux->cases(),
+              ElementsAre(a_add_internal, b_add_internal, a_add_internal));
+
+  // Check outer bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(outer_unity.node));
+  EXPECT_THAT(*outer_occupied, ElementsAre(0, 1));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(outer_unity.node));
+  EXPECT_THAT(*outer_last_assigned, ElementsAre(0, 1));
+
+  // Remove outer mux.
+  auto outer_deunify_result =
+      integration->DeUnifyIntegrationNodes(outer_unity.node);
+  EXPECT_TRUE(outer_deunify_result.ok());
+  EXPECT_EQ(outer_deunify_result.value(), static_cast<Node*>(nullptr));
+  EXPECT_EQ(integration->function()->node_count(), 10);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 0);
+}
+
+TEST_F(IntegratorTest, DeUnifyIntegrationGlobalSelectRevertMuxCases) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_add_node = FindNode("add", func_d);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_add_internal,
+                           integration->InsertNode(b_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * d_add_internal,
+                           integration->InsertNode(d_add_node));
+
+  EXPECT_EQ(integration->function()->node_count(), 13);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode outer_unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(outer_unity, integration->UnifyIntegrationNodes(
+                                            outer_unity.node, d_add_internal));
+  EXPECT_EQ(outer_unity.change,
+            IntegrationFunction::UnificationChange::kExistingMuxCasesModified);
+  EXPECT_EQ(integration->function()->node_count(), 14);
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode inner_unity,
+      integration->UnifyIntegrationNodes(a_add_internal, d_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(inner_unity, integration->UnifyIntegrationNodes(
+                                            inner_unity.node, b_add_internal));
+  EXPECT_EQ(inner_unity.change,
+            IntegrationFunction::UnificationChange::kExistingMuxCasesModified);
+  EXPECT_EQ(integration->function()->node_count(), 15);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+
+  // Check inner mux.
+  EXPECT_EQ(inner_unity.node->op(), Op::kSel);
+  Select* mux = inner_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, b_add_internal,
+                                        a_add_internal, d_add_internal));
+
+  // Check outer mux.
+  EXPECT_EQ(outer_unity.node->op(), Op::kSel);
+  mux = outer_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        c_add_internal, d_add_internal));
+
+  // Check inner bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* inner_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(inner_unity.node));
+  EXPECT_THAT(*inner_occupied, ElementsAre(0, 1, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* inner_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(inner_unity.node));
+  EXPECT_THAT(*inner_last_assigned, ElementsAre(1));
+
+  // Check outer bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* outer_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(outer_unity.node));
+  EXPECT_THAT(*outer_occupied, ElementsAre(0, 2, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      const std::set<int64>* outer_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(outer_unity.node));
+  EXPECT_THAT(*outer_last_assigned, ElementsAre(3));
+
+  // Revert inner mux.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      inner_unity.node, integration->DeUnifyIntegrationNodes(inner_unity.node));
+  EXPECT_EQ(integration->function()->node_count(), 15);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+
+  // Check inner mux.
+  EXPECT_EQ(inner_unity.node->op(), Op::kSel);
+  mux = inner_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        a_add_internal, d_add_internal));
+
+  // Check outer mux.
+  EXPECT_EQ(outer_unity.node->op(), Op::kSel);
+  mux = outer_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        c_add_internal, d_add_internal));
+
+  // Check inner bookkeeping.
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      inner_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(inner_unity.node));
+  EXPECT_THAT(*inner_occupied, ElementsAre(0, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      inner_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(inner_unity.node));
+  EXPECT_TRUE(inner_last_assigned->empty());
+
+  // Check outer bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(outer_unity.node));
+  EXPECT_THAT(*outer_occupied, ElementsAre(0, 2, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(outer_unity.node));
+  EXPECT_THAT(*outer_last_assigned, ElementsAre(3));
+
+  // Revert outer mux.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_unity.node, integration->DeUnifyIntegrationNodes(outer_unity.node));
+  EXPECT_EQ(integration->function()->node_count(), 15);
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+
+  // Check inner mux.
+  EXPECT_EQ(inner_unity.node->op(), Op::kSel);
+  mux = inner_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        a_add_internal, d_add_internal));
+
+  // Check outer mux.
+  EXPECT_EQ(outer_unity.node->op(), Op::kSel);
+  mux = outer_unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        c_add_internal, a_add_internal));
+
+  // Check inner bookkeeping.
+  muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 2);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      inner_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(inner_unity.node));
+  EXPECT_THAT(*inner_occupied, ElementsAre(0, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      inner_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(inner_unity.node));
+  EXPECT_TRUE(inner_last_assigned->empty());
+
+  // Check outer bookkeeping.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_occupied,
+      integration->GetGlobalMuxOccupiedCaseIndexes(outer_unity.node));
+  EXPECT_THAT(*outer_occupied, ElementsAre(0, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      outer_last_assigned,
+      integration->GetGlobalMuxLastCaseIndexesAdded(outer_unity.node));
+  EXPECT_TRUE(outer_last_assigned->empty());
+
+  // Can't do repeated reversions.
+  auto inner_unity_repeated_revert_result =
+      integration->DeUnifyIntegrationNodes(inner_unity.node);
+  EXPECT_FALSE(inner_unity_repeated_revert_result.ok());
+  auto outer_unity_repeated_revert_result =
+      integration->DeUnifyIntegrationNodes(outer_unity.node);
+  EXPECT_FALSE(outer_unity_repeated_revert_result.ok());
+}
+
+TEST_F(IntegratorTest, DeUnifyIntegrationGlobalSelectMultiMappedNodes) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_add_node = FindNode("add", func_d);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_add_node, a_add_internal));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+  XLS_ASSERT_OK(integration->SetNodeMapping(d_add_node, c_add_internal));
+
+  EXPECT_EQ(integration->function()->node_count(), 11);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedNode unity,
+      integration->UnifyIntegrationNodes(a_add_internal, c_add_internal));
+
+  // Check added mux.
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(integration->function()->node_count(), 12);
+  EXPECT_EQ(unity.node->op(), Op::kSel);
+  Select* mux = unity.node->As<Select>();
+  EXPECT_EQ(mux->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux->default_value(), std::nullopt);
+  EXPECT_THAT(mux->cases(), ElementsAre(a_add_internal, a_add_internal,
+                                        c_add_internal, c_add_internal));
+
+  // Check bookkeeping.
+  int64 muxes_tracked = integration->GetNumberOfGlobalMuxesTracked();
+  EXPECT_EQ(muxes_tracked, 1);
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* occupied,
+                           integration->GetGlobalMuxOccupiedCaseIndexes(mux));
+  EXPECT_THAT(*occupied, ElementsAre(0, 1, 2, 3));
+  XLS_ASSERT_OK_AND_ASSIGN(const std::set<int64>* last_assigned,
+                           integration->GetGlobalMuxLastCaseIndexesAdded(mux));
+  EXPECT_THAT(*last_assigned, ElementsAre(0, 1, 2, 3));
+
+  // Remove mux.
+  XLS_ASSERT_OK(integration->DeUnifyIntegrationNodes(unity.node));
+  EXPECT_EQ(integration->function()->node_count(), 11);
+  EXPECT_EQ(integration->GetNumberOfGlobalMuxesTracked(), 0);
+}
+
+TEST_F(IntegratorTest, DeUnifyIntegrationGlobalSelectMuxNotCreatedByUnifyCall) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(in1, in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_add_node = FindNode("add", func_c);
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_add_internal,
+                           integration->InsertNode(a_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_add_internal,
+                           integration->InsertNode(b_add_node));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_add_internal,
+                           integration->InsertNode(c_add_node));
+
+  std::vector<Node*> cases = {a_add_internal, b_add_internal, c_add_internal};
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * new_mux,
+      integration->function()->MakeNode<Select>(
+          /*loc=*/std::nullopt, integration->global_mux_select(), cases,
+          /*default_value=*/a_add_internal));
+
+  // Remove mux. Shouldn't be able to deunify mux not created
+  // by a unify call.
+  auto deunify_result = integration->DeUnifyIntegrationNodes(new_mux);
+  EXPECT_FALSE(deunify_result.ok());
 }
 
 TEST_F(IntegratorTest, InsertNodeSimple) {
@@ -744,11 +1505,68 @@ TEST_F(IntegratorTest, InsertNodeRepeatedly) {
   EXPECT_FALSE(repeat_result.ok());
 }
 
+TEST_F(IntegratorTest, InsertNodeIntegrationNode) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a1 = fb_a.Param("a1", p->GetBitsType(2));
+  auto a2 = fb_a.Param("a2", p->GetBitsType(2));
+  fb_a.Add(a1, a2);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(),
+                                                                  {func_a}));
+  Node* add_node = func_a->return_value();
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      integration->function()->MakeNodeWithName<Param>(
+          /*loc=*/std::nullopt, "internal_1", p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_cat,
+      integration->function()->MakeNode<Concat>(
+          /*loc=*/std::nullopt, std::vector<Node*>({internal_1, internal_1})));
+
+  auto unmapped_cost_result = integration->GetInsertNodeCost(internal_cat);
+  EXPECT_FALSE(unmapped_cost_result.ok());
+  auto unmapped_merge_result = integration->InsertNode(internal_cat);
+  EXPECT_FALSE(unmapped_merge_result.ok());
+
+  XLS_ASSERT_OK_AND_ASSIGN(Node * map_target,
+                           integration->InsertNode(add_node));
+  auto mapped_cost_result = integration->GetInsertNodeCost(map_target);
+  EXPECT_FALSE(mapped_cost_result.ok());
+  auto mapped_merge_result = integration->InsertNode(map_target);
+  EXPECT_FALSE(mapped_merge_result.ok());
+}
+
+TEST_F(IntegratorTest, GetNodeCost) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a1 = fb_a.Param("a1", p->GetBitsType(2));
+  auto a2 = fb_a.Param("a2", p->GetBitsType(2));
+  fb_a.Add(a1, a2);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(),
+                                                                  {func_a}));
+
+  Node* add_node = func_a->return_value();
+  XLS_ASSERT_OK_AND_ASSIGN(float cost,
+                           integration->GetInsertNodeCost(add_node));
+  EXPECT_EQ(cost, integration->GetNodeCost(add_node));
+}
+
 TEST_F(IntegratorTest, DeUnifyIntegrationNodesExternalNode) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function external_func("external", p.get());
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -778,7 +1596,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesNonUnifyNonMux) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -798,7 +1618,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesNonUnifyMuxDoesNotHaveTwoCases) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -823,7 +1645,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesNonUnifyMuxSameOperands) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -853,7 +1677,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesNonUnifyMuxDifferentOperands) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -891,7 +1717,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesMuxHasUsers) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -917,7 +1745,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesRemoveMuxAndParam) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -934,7 +1764,9 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesRemoveMuxAndParam) {
   Node* sel = unify_mux.node->As<Select>()->selector();
 
   EXPECT_EQ(integration->function()->node_count(), 4);
-  XLS_ASSERT_OK(integration->DeUnifyIntegrationNodes(unify_mux.node));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * result, integration->DeUnifyIntegrationNodes(unify_mux.node));
+  EXPECT_EQ(result, static_cast<Node*>(nullptr));
 
   auto integration_contains = [&integration](Node* target_node) {
     for (Node* node : integration->function()->nodes()) {
@@ -951,14 +1783,16 @@ TEST_F(IntegratorTest, DeUnifyIntegrationNodesRemoveMuxAndParam) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedNode unity,
       integration->UnifyIntegrationNodes(internal_1, internal_2));
-  EXPECT_TRUE(unity.new_mux_added);
+  EXPECT_EQ(unity.change, IntegrationFunction::UnificationChange::kNewMuxAdded);
 }
 
 TEST_F(IntegratorTest, DeUnifyIntegrationNodesParamHasUsers) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   Function& internal_func = *integration->function();
 
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -999,7 +1833,9 @@ TEST_F(IntegratorTest, UnifyNodeOperands) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map, integration->InsertNode(a_in1));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in2_map, integration->InsertNode(a_in2));
   XLS_ASSERT_OK(integration->SetNodeMapping(b_in1, a_in1_map));
@@ -1008,8 +1844,12 @@ TEST_F(IntegratorTest, UnifyNodeOperands) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add, b_add));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 1);
-  Select* mux = unified_operands.added_muxes.at(0)->As<Select>();
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 1);
+  IntegrationFunction::UnifiedNode& unified_node =
+      unified_operands.changed_muxes.at(0);
+  EXPECT_EQ(unified_node.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  Select* mux = unified_node.node->As<Select>();
   EXPECT_THAT(mux->cases(), ElementsAre(a_in2_map, b_in2_map));
   EXPECT_THAT(unified_operands.operands, ElementsAre(a_in1_map, mux));
 }
@@ -1031,7 +1871,9 @@ TEST_F(IntegratorTest, UnifyNodeOperandsMultipleMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map, integration->InsertNode(a_in1));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in2_map, integration->InsertNode(a_in2));
   XLS_ASSERT_OK_AND_ASSIGN(Node * b_in1_map, integration->InsertNode(b_in1));
@@ -1040,15 +1882,23 @@ TEST_F(IntegratorTest, UnifyNodeOperandsMultipleMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add, b_add));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 2);
-  Select* mux1 = unified_operands.added_muxes.at(0)->As<Select>();
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 2);
+  IntegrationFunction::UnifiedNode& unified_node_1 =
+      unified_operands.changed_muxes.at(0);
+  EXPECT_EQ(unified_node_1.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  IntegrationFunction::UnifiedNode& unified_node_2 =
+      unified_operands.changed_muxes.at(1);
+  EXPECT_EQ(unified_node_2.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  Select* mux1 = unified_node_1.node->As<Select>();
   EXPECT_THAT(mux1->cases(), ElementsAre(a_in1_map, b_in1_map));
-  Select* mux2 = unified_operands.added_muxes.at(1)->As<Select>();
+  Select* mux2 = unified_node_2.node->As<Select>();
   EXPECT_THAT(mux2->cases(), ElementsAre(a_in2_map, b_in2_map));
   EXPECT_THAT(unified_operands.operands, ElementsAre(mux1, mux2));
 }
 
-TEST_F(IntegratorTest, UnifyNodeOperandsReapeatedMux) {
+TEST_F(IntegratorTest, UnifyNodeOperandsRepeatedMux) {
   auto p = CreatePackage();
   FunctionBuilder fb("func", p.get());
   auto in1 = fb.Param("in1", p->GetBitsType(2));
@@ -1062,15 +1912,21 @@ TEST_F(IntegratorTest, UnifyNodeOperandsReapeatedMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map, integration->InsertNode(a_in1));
   XLS_ASSERT_OK_AND_ASSIGN(Node * b_in1_map, integration->InsertNode(b_in1));
 
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add, b_add));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 1);
-  Select* mux = unified_operands.added_muxes.at(0)->As<Select>();
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 1);
+  IntegrationFunction::UnifiedNode& unified_node =
+      unified_operands.changed_muxes.at(0);
+  EXPECT_EQ(unified_node.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  Select* mux = unified_node.node->As<Select>();
   EXPECT_THAT(mux->cases(), ElementsAre(a_in1_map, b_in1_map));
   EXPECT_THAT(unified_operands.operands, ElementsAre(mux, mux));
 }
@@ -1092,7 +1948,9 @@ TEST_F(IntegratorTest, UnifyNodeOperandsNoAddedMuxes) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map, integration->InsertNode(a_in1));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in2_map, integration->InsertNode(a_in2));
   XLS_ASSERT_OK(integration->SetNodeMapping(b_in1, a_in1_map));
@@ -1103,8 +1961,95 @@ TEST_F(IntegratorTest, UnifyNodeOperandsNoAddedMuxes) {
       integration->UnifyNodeOperands(a_add, b_add));
   EXPECT_EQ(a_in1_map->users().size(), 0);
   EXPECT_EQ(a_in2_map->users().size(), 0);
-  EXPECT_EQ(unified_operands.added_muxes.size(), 0);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 0);
   EXPECT_THAT(unified_operands.operands, ElementsAre(a_in1_map, a_in2_map));
+}
+
+TEST_F(IntegratorTest, UnifyNodeOperandsGlobalMuxSelect) {
+  auto p = CreatePackage();
+  FunctionBuilder fb("func_a", p.get());
+  auto in1 = fb.Param("in1", p->GetBitsType(2));
+  auto in2 = fb.Param("in2", p->GetBitsType(2));
+  fb.Concat({in1, in2});
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* a_in1 = FindNode("in1", func_a);
+  Node* a_in2 = FindNode("in2", func_a);
+  Node* a_cat = a_in1->users().at(0);
+  Node* b_in1 = FindNode("in1", func_b);
+  Node* b_in2 = FindNode("in2", func_b);
+  Node* b_cat = b_in1->users().at(0);
+  Node* c_in1 = FindNode("in1", func_c);
+  Node* c_in2 = FindNode("in2", func_c);
+  Node* c_cat = c_in1->users().at(0);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map,
+                           integration->GetNodeMapping(a_in1));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_in2_map,
+                           integration->GetNodeMapping(a_in2));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_in1, a_in1_map));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * b_in2_map,
+                           integration->GetNodeMapping(b_in2));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_in1_map,
+                           integration->GetNodeMapping(c_in1));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * c_in2_map,
+                           integration->GetNodeMapping(c_in2));
+
+  // One operand already matched, second operand requires mux insert.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedOperands unified_operands,
+      integration->UnifyNodeOperands(b_cat, a_cat));
+  // Check inserted mux.
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 1);
+  IntegrationFunction::UnifiedNode& mux1_info =
+      unified_operands.changed_muxes.at(0);
+  EXPECT_EQ(mux1_info.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  Select* mux1 = mux1_info.node->As<Select>();
+  EXPECT_EQ(mux1->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux1->default_value(), a_in2_map);
+  EXPECT_THAT(mux1->cases(), ElementsAre(a_in2_map, b_in2_map, a_in2_map));
+  // Check operands.
+  EXPECT_THAT(unified_operands.operands,
+              ElementsAre(a_in1_map, mux1_info.node));
+
+  // One new mux inserted, one mux modified.
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * cat_with_mux,
+      integration->function()->MakeNode<Concat>(
+          /*loc=*/std::nullopt,
+          std::vector<Node*>({a_in1_map, mux1_info.node})));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      IntegrationFunction::UnifiedOperands unified_operands_repeated,
+      integration->UnifyNodeOperands(c_cat, cat_with_mux));
+  EXPECT_EQ(unified_operands_repeated.changed_muxes.size(), 2);
+  // Check inserted mux.
+  IntegrationFunction::UnifiedNode& mux2_info =
+      unified_operands_repeated.changed_muxes.at(0);
+  EXPECT_EQ(mux2_info.change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  Select* mux2 = mux2_info.node->As<Select>();
+  EXPECT_EQ(mux2->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux2->default_value(), a_in1_map);
+  EXPECT_THAT(mux2->cases(), ElementsAre(a_in1_map, a_in1_map, c_in1_map));
+  // Check modified mux.
+  IntegrationFunction::UnifiedNode& mux3_info =
+      unified_operands_repeated.changed_muxes.at(1);
+  EXPECT_EQ(mux3_info.change,
+            IntegrationFunction::UnificationChange::kExistingMuxCasesModified);
+  Select* mux3 = mux3_info.node->As<Select>();
+  EXPECT_EQ(mux3->selector(), integration->global_mux_select());
+  EXPECT_EQ(mux3->default_value(), a_in2_map);
+  EXPECT_THAT(mux3->cases(), ElementsAre(a_in2_map, b_in2_map, c_in2_map));
+  // Check operands.
+  EXPECT_THAT(unified_operands_repeated.operands,
+              ElementsAre(mux2_info.node, mux3_info.node));
 }
 
 TEST_F(IntegratorTest, MergeBackendErrorNonMappedInternal) {
@@ -1120,7 +2065,9 @@ TEST_F(IntegratorTest, MergeBackendErrorNonMappedInternal) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target, integration->InsertNode(a_in1));
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in2_target, integration->InsertNode(a_in2));
@@ -1152,7 +2099,9 @@ TEST_F(IntegratorTest, MergeBackendErrorMappedExternal) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK(integration->InsertNode(a_in1));
   XLS_ASSERT_OK(integration->InsertNode(a_in2));
@@ -1183,7 +2132,9 @@ TEST_F(IntegratorTest, MergeBackendErrorNodesFromSameFunction) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK(integration->InsertNode(a_in1));
   XLS_ASSERT_OK(integration->InsertNode(a_in2));
@@ -1214,7 +2165,9 @@ TEST_F(IntegratorTest, MergeBackendDoNotMergeIncompatible) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK(integration->InsertNode(a_in1_node));
   XLS_ASSERT_OK(integration->InsertNode(a_in2_node));
@@ -1258,7 +2211,9 @@ TEST_F(IntegratorTest, MergeCostExternalExternaTwoMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target,
                            integration->InsertNode(a_in1_node));
@@ -1312,7 +2267,11 @@ TEST_F(IntegratorTest, MergeCostExternalExternaTwoMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add_node, b_add_node));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 2);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 2);
+  EXPECT_EQ(unified_operands.changed_muxes.at(0).change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+  EXPECT_EQ(unified_operands.changed_muxes.at(1).change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
 }
 
 TEST_F(IntegratorTest, MergeCostInternalExternalOneMux) {
@@ -1343,7 +2302,9 @@ TEST_F(IntegratorTest, MergeCostInternalExternalOneMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target,
                            integration->InsertNode(a_in1_node));
@@ -1412,7 +2373,73 @@ TEST_F(IntegratorTest, MergeCostInternalExternalOneMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add_node, b_add_node));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 1);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 1);
+  EXPECT_EQ(unified_operands.changed_muxes.at(0).change,
+            IntegrationFunction::UnificationChange::kNewMuxAdded);
+}
+
+TEST_F(IntegratorTest, MergeCostGlobalMuxSelect) {
+  auto p = CreatePackage();
+  FunctionBuilder fb("func_a", p.get());
+  auto in1 = fb.Param("in1", p->GetBitsType(2));
+  auto in2 = fb.Param("in2", p->GetBitsType(2));
+  auto in3 = fb.Param("in3", p->GetBitsType(2));
+  auto in_sel = fb.Param("in_sel", p->GetBitsType(2));
+  fb.Select(in_sel, {in1, in2, in3},
+            /*default_value=*/in1,
+            /*loc=*/absl::nullopt, "three_input_mux");
+  fb.Add(in1, in2, /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* ref_3_input_mux_node = FindNode("three_input_mux", func_b);
+  Node* a_in1 = FindNode("in1", func_a);
+  Node* a_add = FindNode("add", func_a);
+  Node* b_in1 = FindNode("in1", func_b);
+  Node* b_add = FindNode("add", func_b);
+  Node* c_add = FindNode("add", func_c);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map,
+                           integration->GetNodeMapping(a_in1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_in1, a_in1_map));
+
+  // Get cost.
+  XLS_ASSERT_OK_AND_ASSIGN(auto optional_cost,
+                           integration->GetMergeNodesCost(a_add, b_add));
+  XLS_ASSERT_OK(VerifyFunction(integration->function()));
+
+  // Check cost. One 'add' and one new mux added.
+  EXPECT_TRUE(optional_cost.has_value());
+  float expected_cost = integration->GetNodeCost(ref_3_input_mux_node) +
+                        integration->GetNodeCost(a_add);
+  EXPECT_FLOAT_EQ(optional_cost.value(), expected_cost);
+
+  // Reverse order of merged nodes.
+  XLS_ASSERT_OK_AND_ASSIGN(optional_cost,
+                           integration->GetMergeNodesCost(b_add, a_add));
+  EXPECT_TRUE(optional_cost.has_value());
+  EXPECT_FLOAT_EQ(optional_cost.value(), expected_cost);
+
+  // Add node for 2nd merge cost estimate.
+  XLS_ASSERT_OK_AND_ASSIGN(std::vector<Node*> merged_nodes,
+                           integration->MergeNodes(a_add, b_add));
+  EXPECT_EQ(merged_nodes.size(), 1);
+  Node* merged_add = merged_nodes.front();
+
+  // Get cost.
+  XLS_ASSERT_OK_AND_ASSIGN(optional_cost,
+                           integration->GetMergeNodesCost(c_add, merged_add));
+  XLS_ASSERT_OK(VerifyFunction(integration->function()));
+
+  // Check cost. One mux added, one mux modified (no cost).
+  EXPECT_TRUE(optional_cost.has_value());
+  expected_cost = integration->GetNodeCost(ref_3_input_mux_node);
+  EXPECT_FLOAT_EQ(optional_cost.value(), expected_cost);
 }
 
 TEST_F(IntegratorTest, MergeNodesExternalExternaTwoMux) {
@@ -1438,7 +2465,9 @@ TEST_F(IntegratorTest, MergeNodesExternalExternaTwoMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target,
                            integration->InsertNode(a_in1_node));
@@ -1486,7 +2515,7 @@ TEST_F(IntegratorTest, MergeNodesExternalExternaTwoMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add_node, b_add_node));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 0);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 0);
 }
 
 TEST_F(IntegratorTest, MergeNodesInternalExternalOneMux) {
@@ -1512,7 +2541,9 @@ TEST_F(IntegratorTest, MergeNodesInternalExternalOneMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target,
                            integration->InsertNode(a_in1_node));
@@ -1562,7 +2593,7 @@ TEST_F(IntegratorTest, MergeNodesInternalExternalOneMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(a_add_node, b_add_node));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 0);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 0);
 }
 
 TEST_F(IntegratorTest, MergeNodesExternalInternalOneMux) {
@@ -1588,7 +2619,9 @@ TEST_F(IntegratorTest, MergeNodesExternalInternalOneMux) {
 
   XLS_ASSERT_OK_AND_ASSIGN(
       std::unique_ptr<IntegrationFunction> integration,
-      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(p.get(), {}));
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {},
+          IntegrationOptions().unique_select_signal_per_mux(true)));
 
   XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_target,
                            integration->InsertNode(a_in1_node));
@@ -1638,7 +2671,159 @@ TEST_F(IntegratorTest, MergeNodesExternalInternalOneMux) {
   XLS_ASSERT_OK_AND_ASSIGN(
       IntegrationFunction::UnifiedOperands unified_operands,
       integration->UnifyNodeOperands(b_add_node, a_add_node));
-  EXPECT_EQ(unified_operands.added_muxes.size(), 0);
+  EXPECT_EQ(unified_operands.changed_muxes.size(), 0);
+}
+
+TEST_F(IntegratorTest, MergeNodesGlobalMuxSelect) {
+  auto p = CreatePackage();
+  FunctionBuilder fb("func_a", p.get());
+  auto in1 = fb.Param("in1", p->GetBitsType(2));
+  auto in2 = fb.Param("in2", p->GetBitsType(2));
+  fb.Add(in1, in2, /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  Node* a_in1 = FindNode("in1", func_a);
+  Node* a_add = FindNode("add", func_a);
+  Node* b_in1 = FindNode("in1", func_b);
+  Node* b_add = FindNode("add", func_b);
+  Node* c_add = FindNode("add", func_c);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c},
+          IntegrationOptions().unique_select_signal_per_mux(false)));
+  XLS_ASSERT_OK_AND_ASSIGN(Node * a_in1_map,
+                           integration->GetNodeMapping(a_in1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_in1, a_in1_map));
+
+  // Merge adds with one new mux.
+  XLS_ASSERT_OK_AND_ASSIGN(std::vector<Node*> merged_nodes,
+                           integration->MergeNodes(a_add, b_add));
+  XLS_ASSERT_OK(VerifyFunction(integration->function()));
+  EXPECT_EQ(merged_nodes.size(), 1);
+  Node* merged_add = merged_nodes.front();
+  EXPECT_THAT(
+      merged_add,
+      m::Add(m::TupleIndex(m::Param("func_aParamTuple"), 0),
+             m::Select(m::Param("global_mux_select"),
+                       {m::TupleIndex(m::Param("func_aParamTuple"), 1),
+                        m::TupleIndex(m::Param("func_bParamTuple"), 1),
+                        m::TupleIndex(m::Param("func_aParamTuple"), 1)},
+                       m::TupleIndex(m::Param("func_aParamTuple"), 1))));
+
+  // Merge adds with one new mux and one modified mux.
+  XLS_ASSERT_OK_AND_ASSIGN(std::vector<Node*> merged_nodes_repeated,
+                           integration->MergeNodes(c_add, merged_add));
+  XLS_ASSERT_OK(VerifyFunction(integration->function()));
+  EXPECT_EQ(merged_nodes_repeated.size(), 1);
+  Node* merged_add_repeated = merged_nodes_repeated.front();
+  EXPECT_THAT(
+      merged_add_repeated,
+      m::Add(m::Select(m::Param("global_mux_select"),
+                       {m::TupleIndex(m::Param("func_aParamTuple"), 0),
+                        m::TupleIndex(m::Param("func_aParamTuple"), 0),
+                        m::TupleIndex(m::Param("func_cParamTuple"), 0)},
+                       m::TupleIndex(m::Param("func_aParamTuple"), 0)),
+             m::Select(m::Param("global_mux_select"),
+                       {m::TupleIndex(m::Param("func_aParamTuple"), 1),
+                        m::TupleIndex(m::Param("func_bParamTuple"), 1),
+                        m::TupleIndex(m::Param("func_cParamTuple"), 1)},
+                       m::TupleIndex(m::Param("func_aParamTuple"), 1))));
+}
+
+TEST_F(IntegratorTest, GetSourceFunctionIndexOfNodeTest) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a_in1 = fb_a.Param("in1", p->GetBitsType(2));
+  fb_a.Add(a_in1, a_in1,
+           /*loc=*/absl::nullopt, "add");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_in1_node = FindNode("in1", func_a);
+  Node* a_add_node = FindNode("add", func_a);
+  Node* b_in1_node = FindNode("in1", func_b);
+  Node* b_add_node = FindNode("add", func_b);
+  Node* c_in1_node = FindNode("in1", func_c);
+  Node* c_add_node = FindNode("add", func_c);
+  Node* d_in1_node = FindNode("in1", func_d);
+  Node* d_add_node = FindNode("add", func_d);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c}));
+
+  auto test_idx = [&integration](Node* node, int64 expected_index) {
+    XLS_ASSERT_OK_AND_ASSIGN(int64 idx,
+                             integration->GetSourceFunctionIndexOfNode(node));
+    EXPECT_EQ(idx, expected_index);
+  };
+
+  test_idx(a_in1_node, 0);
+  test_idx(a_add_node, 0);
+  test_idx(b_in1_node, 1);
+  test_idx(b_add_node, 1);
+  test_idx(c_in1_node, 2);
+  test_idx(c_add_node, 2);
+  auto non_source_result =
+      integration->GetSourceFunctionIndexOfNode(d_in1_node);
+  EXPECT_FALSE(non_source_result.ok());
+  non_source_result = integration->GetSourceFunctionIndexOfNode(d_add_node);
+  EXPECT_FALSE(non_source_result.ok());
+}
+
+TEST_F(IntegratorTest, GetSourceFunctionIndexesOfNodesMappedToNodeTest) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  fb_a.Param("in1", p->GetBitsType(2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_c, func_a->Clone("func_c"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_d, func_a->Clone("func_d"));
+  Node* a_in1_node = FindNode("in1", func_a);
+  Node* b_in1_node = FindNode("in1", func_b);
+  Node* c_in1_node = FindNode("in1", func_c);
+  Node* d_in1_node = FindNode("in1", func_d);
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationFunction> integration,
+      IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+          p.get(), {func_a, func_b, func_c, func_d}));
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_1,
+      integration->function()->MakeNodeWithName<Param>(
+          /*loc=*/std::nullopt, "internal_1", p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_2,
+      integration->function()->MakeNodeWithName<Param>(
+          /*loc=*/std::nullopt, "internal_2", p->GetBitsType(2)));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Node * internal_3,
+      integration->function()->MakeNodeWithName<Param>(
+          /*loc=*/std::nullopt, "internal_3", p->GetBitsType(2)));
+
+  XLS_ASSERT_OK(integration->SetNodeMapping(a_in1_node, internal_1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(c_in1_node, internal_1));
+  XLS_ASSERT_OK(integration->SetNodeMapping(b_in1_node, internal_2));
+  XLS_ASSERT_OK(integration->SetNodeMapping(d_in1_node, internal_2));
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::set<int64> internal_1_source_indexes,
+      integration->GetSourceFunctionIndexesOfNodesMappedToNode(internal_1));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::set<int64> internal_2_source_indexes,
+      integration->GetSourceFunctionIndexesOfNodesMappedToNode(internal_2));
+  EXPECT_THAT(internal_1_source_indexes, ElementsAre(0, 2));
+  EXPECT_THAT(internal_2_source_indexes, ElementsAre(1, 3));
+
+  auto non_map_target_result =
+      integration->GetSourceFunctionIndexesOfNodesMappedToNode(internal_3);
+  EXPECT_FALSE(non_map_target_result.ok());
 }
 
 }  // namespace


### PR DESCRIPTION
Added option to configure an entire integrated graph to match one of the source functions using a global select signal.  Useful if we are sure that we only want to execute the source functions on the circuit.  Also helfpul if we wish to merge if/else paths in a single circuit.

Added GetInsertNodeCost function and rewrote InsertNode to call MergeNodesBackend behind the scenes (life will be easier if insert is just a special case of merge instead of being its own operation that we have to think about).