### PR TITLE
"Added helper functions to 1) detect when 2 nodes are mapping targets…

### DIFF
--- a/xls/contrib/integrator/BUILD
+++ b/xls/contrib/integrator/BUILD
@@ -18,13 +18,22 @@ package(
 )
 
 cc_library(
+    name = "integration_options",
+    srcs = ["integration_options.cc"],
+    hdrs = ["integration_options.h"],
+    deps = [
+    ],
+)
+
+cc_library(
     name = "ir_integrator",
     srcs = ["ir_integrator.cc"],
     hdrs = ["ir_integrator.h"],
     deps = [
-        "@com_google_absl//absl/status:statusor",
+        ":integration_options",
         "//xls/ir",
         "//xls/ir:ir_parser",
+        "@com_google_absl//absl/status:statusor",
     ],
 )
 
@@ -33,6 +42,33 @@ cc_test(
     srcs = ["ir_integrator_test.cc"],
     deps = [
         ":ir_integrator",
+        "//xls/common/status:matchers",
+        "//xls/ir",
+        "//xls/ir:ir_matcher",
+        "//xls/ir:ir_parser",
+        "//xls/ir:ir_test_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "integration_builder",
+    srcs = ["integration_builder.cc"],
+    hdrs = ["integration_builder.h"],
+    deps = [
+        ":ir_integrator",
+        ":integration_options",
+        "//xls/contrib/integrator/integration_algorithms:basic_integration_algorithm",
+        "//xls/ir",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "integration_builder_test",
+    srcs = ["integration_builder_test.cc"],
+    deps = [
+        ":integration_builder",
         "//xls/common/status:matchers",
         "//xls/ir",
         "//xls/ir:ir_matcher",

--- a/xls/contrib/integrator/integration_algorithms/BUILD
+++ b/xls/contrib/integrator/integration_algorithms/BUILD
@@ -1,0 +1,49 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_library(
+    name = "basic_integration_algorithm",
+    srcs = ["basic_integration_algorithm.cc"],
+    hdrs = ["basic_integration_algorithm.h",
+            "integration_algorithm.h",
+            "integration_algorithm_implementation.h",
+            ],
+    deps = [
+        "//xls/contrib/integrator:integration_options",
+        "//xls/contrib/integrator:ir_integrator",
+        "//xls/ir",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "basic_integration_algorithm_test",
+    srcs = ["basic_integration_algorithm_test.cc"],
+    deps = [
+        ":basic_integration_algorithm",
+        "//xls/contrib/integrator:integration_builder",
+        "//xls/contrib/integrator:integration_options",
+        "//xls/common/status:matchers",
+        "//xls/ir",
+        "//xls/ir:ir_matcher",
+        "//xls/ir:ir_parser",
+        "//xls/ir:ir_test_base",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.cc
+++ b/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.cc
@@ -1,0 +1,100 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+
+#include "xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h"
+
+#include "xls/ir/node_iterator.h"
+
+namespace xls {
+
+void BasicIntegrationAlgorithm::EnqueueNodeIfReady(Node* node) {
+  if (!queued_nodes_.contains(node) &&
+      integration_function_->AllOperandsHaveMapping(node)) {
+    ready_nodes_.push_back(node);
+    queued_nodes_.insert(node);
+  }
+}
+
+absl::Status BasicIntegrationAlgorithm::Initialize() {
+  // Make integration function.
+  XLS_ASSIGN_OR_RETURN(integration_function_, NewIntegrationFunction());
+
+  // ID initial nodes with all operands ready.
+  for (const Function* func : source_functions_) {
+    for (Node* node: func->nodes()) {
+      if(node->op() != Op::kParam) {
+        EnqueueNodeIfReady(node);
+      }
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+BasicIntegrationAlgorithm::Run() {
+  while (!ready_nodes_.empty()) {
+    std::optional<BasicIntegrationMove> move;
+    for (auto node_itr = ready_nodes_.begin(); node_itr != ready_nodes_.end();
+         ++node_itr) {
+      // Check insertion cost.
+      XLS_ASSIGN_OR_RETURN(int64 insert_cost,
+                           integration_function_->GetInsertNodeCost(*node_itr));
+      if (!move.has_value() || insert_cost < move.value().cost) {
+        move = MakeInsertMove(node_itr, insert_cost);
+      }
+
+      // Check merge cost.
+      for (Node* internal_node : integration_function_->function()->nodes()) {
+        // TODO(jbaileyhandle): Relax this requirement so that
+        // it only applies to integration-generated muxes.
+        if (!integration_function_->IsMappingTarget(internal_node)) {
+          continue;
+        }
+
+        // Check if mergeable
+        XLS_ASSIGN_OR_RETURN(
+            std::optional<int64> merge_cost,
+            integration_function_->GetMergeNodesCost(*node_itr, internal_node));
+        if (!merge_cost.has_value()) {
+          continue;
+        }
+
+        // Check if lowest cost.
+        XLS_RET_CHECK(move.has_value());
+        if (merge_cost < move.value().cost) {
+          move = MakeMergeMove(node_itr, internal_node, merge_cost.value());
+        }
+      }
+    }
+
+    // Execute lowest-cost move.
+    XLS_RET_CHECK(move.has_value());
+    XLS_RETURN_IF_ERROR(ExecuteMove(integration_function_.get(), move.value()).status());
+
+    // Update ready_nodes_.
+    ready_nodes_.erase(move.value().node_itr);
+    for (Node* user : move.value().node->users()) {
+      EnqueueNodeIfReady(user);
+    }
+  }
+
+  // Finalize.
+  XLS_RETURN_IF_ERROR(integration_function_->MakeTupleReturnValue().status());
+  return std::move(integration_function_);
+}
+
+// Explicit instantiation.
+template class IntegrationAlgorithm<BasicIntegrationAlgorithm>;
+
+}  // namespace xls

--- a/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h
+++ b/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h
@@ -1,0 +1,98 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// A abstract class for an algorithm to integrate multiple functions.
+
+#ifndef XLS_INTEGRATOR_BASIC_INTEGRATION_ALGORITHM_
+#define XLS_INTEGRATOR_BASIC_INTEGRATION_ALGORITHM_
+
+#include "xls/contrib/integrator/integration_algorithms/integration_algorithm.h"
+
+namespace xls {
+
+// A naive merging algorithm.  A node is eligible to be added to the
+// integration function when all of its operands have already been added.
+// At each step, adds the eligible node for which the cost of adding it to
+// the function (either by inserting or merging with any integeration function
+// node) is the lowest.
+class BasicIntegrationAlgorithm
+    : public IntegrationAlgorithm<BasicIntegrationAlgorithm> {
+ public:
+  BasicIntegrationAlgorithm(const BasicIntegrationAlgorithm& other) = delete;
+  void operator=(const BasicIntegrationAlgorithm& other) = delete;
+
+ private:
+  // IntegrationAlgorithm::IntegrateFunctions needs to be able to call derived
+  // class constructor.
+  friend class IntegrationAlgorithm;
+
+  BasicIntegrationAlgorithm(
+      Package* package, absl::Span<const Function* const> source_functions,
+      const IntegrationOptions& options = IntegrationOptions())
+      : IntegrationAlgorithm(package, source_functions, options) {}
+
+  // Represents a possible modification to the integration function.
+  struct BasicIntegrationMove : IntegrationMove {
+    std::list<Node*>::iterator node_itr;
+  };
+
+  // Make a BasicIntegrationMove for an insert.
+  inline BasicIntegrationMove MakeInsertMove(
+      std::list<Node*>::iterator node_itr, int64 cost) {
+    return BasicIntegrationMove{{.node = *node_itr,
+                                 .move_type = IntegrationMoveType::kInsert,
+                                 .cost = cost},
+                                node_itr};
+  }
+
+  // Make a BasicIntegrationMove for a merge.
+  inline BasicIntegrationMove MakeMergeMove(std::list<Node*>::iterator node_itr,
+                                            Node* merge_node, int64 cost) {
+    return BasicIntegrationMove{{.node = *node_itr,
+                                 .move_type = IntegrationMoveType::kMerge,
+                                 .merge_node = merge_node,
+                                 .cost = cost},
+                                node_itr};
+  }
+
+  // Initialize member fields.
+  absl::Status Initialize();
+
+  // Returns a function that integrates the functions in source_functions_.
+  // Runs after Initialize.
+  absl::StatusOr<std::unique_ptr<IntegrationFunction>> Run();
+
+  // Get the IntegrationOptions::Algorithm value corresponding to
+  // this algoirthm.
+  IntegrationOptions::Algorithm get_corresponding_algorithm_option() {
+    return IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm;
+  }
+
+  // Queue node for processing if all its operands are mapped
+  // and node has not already been queued for processing.
+  void EnqueueNodeIfReady(Node* node);
+
+  // Track nodes for which all operands are already mapped and
+  // are ready to be added to the integration_function_
+  std::list<Node*> ready_nodes_;
+
+  // Track all nodes that have ever been inserted into 'ready_nodes_'.
+  absl::flat_hash_set<Node*> queued_nodes_;
+
+  // Function combining the source functions.
+  std::unique_ptr<IntegrationFunction> integration_function_;
+};
+
+}  // namespace xls
+
+#endif  // XLS_INTEGRATOR_BASIC_INTEGRATION_ALGORITHM_

--- a/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm_test.cc
+++ b/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm_test.cc
@@ -1,0 +1,445 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/contrib/integrator/integration_builder.h"
+#include "xls/contrib/integrator/ir_integrator.h"
+#include "xls/ir/ir_matcher.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/node_iterator.h"
+#include "xls/ir/package.h"
+#include "xls/ir/verifier.h"
+
+namespace m = ::xls::op_matchers;
+
+namespace xls {
+namespace {
+
+using status_testing::IsOkAndHolds;
+using status_testing::StatusIs;
+using ::testing::ElementsAre;
+using ::testing::HasSubstr;
+using ::testing::UnorderedElementsAre;
+
+class BasicIntegrationAlgorithmTest : public IrTestBase {};
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationNodesNotCompatible) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a_in1 = fb_a.Param("a_in1", p->GetBitsType(2));
+  auto a_in2 = fb_a.Param("a_in2", p->GetBitsType(2));
+
+  fb_a.Or(a_in1, a_in2,
+          /*loc=*/absl::nullopt, "a_or");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  auto b_in1 = fb_b.Param("b_in1", p->GetBitsType(2));
+  auto b_in2 = fb_b.Param("b_in2", p->GetBitsType(2));
+
+  fb_b.And(b_in1, b_in2,
+           /*loc=*/absl::nullopt, "b_and");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 10);
+  EXPECT_THAT(
+      builder->integrated_function()->function()->return_value(),
+      m::Tuple(m::Or(m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                     m::TupleIndex(m::Param("func_a_ParamTuple"), 1)),
+               m::And(m::TupleIndex(m::Param("func_b_ParamTuple"), 0),
+                      m::TupleIndex(m::Param("func_b_ParamTuple"), 1))));
+}
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationMergeNotProfitable) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a_in1 = fb_a.Param("a_in1", p->GetBitsType(2));
+  auto a_in2 = fb_a.Param("a_in2", p->GetBitsType(2));
+  auto a_in3 = fb_a.Param("a_in3", p->GetBitsType(2));
+  auto a_in4 = fb_a.Param("a_in4", p->GetBitsType(2));
+
+  fb_a.Or({a_in1, a_in2, a_in3, a_in4},
+          /*loc=*/absl::nullopt, "a_or");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  auto b_in1 = fb_b.Param("b_in1", p->GetBitsType(2));
+  auto b_in2 = fb_b.Param("b_in2", p->GetBitsType(2));
+  auto b_in3 = fb_b.Param("b_in3", p->GetBitsType(2));
+  auto b_in4 = fb_b.Param("b_in4", p->GetBitsType(2));
+
+  fb_b.Or({b_in1, b_in2, b_in3, b_in4},
+          /*loc=*/absl::nullopt, "b_or");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 14);
+  EXPECT_THAT(builder->integrated_function()->function()->return_value(),
+              m::Tuple(m::Or(m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_a_ParamTuple"), 3)),
+                       m::Or(m::TupleIndex(m::Param("func_b_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 3))));
+}
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationIdentical) {
+  auto p = CreatePackage();
+  FunctionBuilder fb("func_a", p.get());
+  auto in1 = fb.Param("in1", p->GetBitsType(2));
+  auto in2 = fb.Param("in2", p->GetBitsType(2));
+  auto in3 = fb.Param("in3", p->GetBitsType(2));
+  auto in4 = fb.Param("in4", p->GetBitsType(2));
+  auto add1 = fb.Add(in1, in2,
+                     /*loc=*/absl::nullopt, "add1");
+  auto add2 = fb.Add(in3, in4,
+                     /*loc=*/absl::nullopt, "add2");
+  fb.UMul(add1, add2,
+          /*loc=*/absl::nullopt, "mul");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 19);
+  EXPECT_THAT(
+      builder->integrated_function()->function()->return_value(),
+      m::Tuple(
+          m::UMul(
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 1)})),
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 2)}),
+                  m::Select(
+                      m::Param("global_mux_select"),
+                      {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                       m::TupleIndex(m::Param("func_b_ParamTuple"), 3)}))),
+          // Duplicate the above.
+          m::UMul(
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 1)})),
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 2)}),
+                  m::Select(
+                      m::Param("global_mux_select"),
+                      {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                       m::TupleIndex(m::Param("func_b_ParamTuple"), 3)})))));
+}
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationDifferentOutput) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a_in1 = fb_a.Param("in1", p->GetBitsType(2));
+  auto a_in2 = fb_a.Param("in2", p->GetBitsType(2));
+  auto a_in3 = fb_a.Param("in3", p->GetBitsType(2));
+  auto a_in4 = fb_a.Param("in4", p->GetBitsType(2));
+  auto a_add1 = fb_a.Add(a_in1, a_in2,
+                         /*loc=*/absl::nullopt, "add1");
+  auto a_add2 = fb_a.Add(a_in3, a_in4,
+                         /*loc=*/absl::nullopt, "add2");
+  fb_a.And(a_add1, a_add2,
+           /*loc=*/absl::nullopt, "and");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  auto b_in1 = fb_b.Param("in1", p->GetBitsType(2));
+  auto b_in2 = fb_b.Param("in2", p->GetBitsType(2));
+  auto b_in3 = fb_b.Param("in3", p->GetBitsType(2));
+  auto b_in4 = fb_b.Param("in4", p->GetBitsType(2));
+  auto b_add1 = fb_b.Add(b_in1, b_in2,
+                         /*loc=*/absl::nullopt, "add1");
+  auto b_add2 = fb_b.Add(b_in3, b_in4,
+                         /*loc=*/absl::nullopt, "add2");
+  fb_b.Or(b_add1, b_add2,
+          /*loc=*/absl::nullopt, "or");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 20);
+  EXPECT_THAT(
+      builder->integrated_function()->function()->return_value(),
+      m::Tuple(
+          m::And(
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 1)})),
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 2)}),
+                  m::Select(
+                      m::Param("global_mux_select"),
+                      {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                       m::TupleIndex(m::Param("func_b_ParamTuple"), 3)}))),
+          m::Or(
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 1)})),
+              m::Add(
+                  m::Select(m::Param("global_mux_select"),
+                            {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                             m::TupleIndex(m::Param("func_b_ParamTuple"), 2)}),
+                  m::Select(
+                      m::Param("global_mux_select"),
+                      {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                       m::TupleIndex(m::Param("func_b_ParamTuple"), 3)})))));
+}
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationDifferentIntermediate) {
+  auto p = CreatePackage();
+  FunctionBuilder fb_a("func_a", p.get());
+  auto a_in1 = fb_a.Param("in1", p->GetBitsType(2));
+  auto a_in2 = fb_a.Param("in2", p->GetBitsType(2));
+  auto a_in3 = fb_a.Param("in3", p->GetBitsType(2));
+  auto a_in4 = fb_a.Param("in4", p->GetBitsType(2));
+  auto a_in5 = fb_a.Param("in5", p->GetBitsType(2));
+  auto a_add1 = fb_a.Add(a_in1, a_in2,
+                         /*loc=*/absl::nullopt, "add1");
+  auto a_add2 = fb_a.Add(a_in3, a_in4,
+                         /*loc=*/absl::nullopt, "add2");
+  auto a_and = fb_a.And(a_add1, a_add2,
+                        /*loc=*/absl::nullopt, "and");
+  fb_a.UMul(a_in5, a_and,
+            /*loc=*/absl::nullopt, "mul");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb_a.Build());
+
+  FunctionBuilder fb_b("func_b", p.get());
+  auto b_in1 = fb_b.Param("in1", p->GetBitsType(2));
+  auto b_in2 = fb_b.Param("in2", p->GetBitsType(2));
+  auto b_in3 = fb_b.Param("in3", p->GetBitsType(2));
+  auto b_in4 = fb_b.Param("in4", p->GetBitsType(2));
+  auto b_in5 = fb_b.Param("in5", p->GetBitsType(2));
+  auto b_add1 = fb_b.Add(b_in1, b_in2,
+                         /*loc=*/absl::nullopt, "add1");
+  auto b_add2 = fb_b.Add(b_in3, b_in4,
+                         /*loc=*/absl::nullopt, "add2");
+  auto b_or = fb_b.Or(b_add1, b_add2,
+                      /*loc=*/absl::nullopt, "or");
+  fb_b.UMul(b_in5, b_or,
+            /*loc=*/absl::nullopt, "mul");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, fb_b.Build());
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 25);
+  EXPECT_THAT(
+      builder->integrated_function()->function()->return_value(),
+      m::Tuple(
+          m::UMul(
+              m::Select(m::Param("global_mux_select"),
+                        {m::TupleIndex(m::Param("func_a_ParamTuple"), 4),
+                         m::TupleIndex(m::Param("func_b_ParamTuple"), 4)}),
+              m::Select(
+                  m::Param("global_mux_select"),
+                  {m::And(
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              0)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              1)})),
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              2)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              3)}))),
+                   m::Or(
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              0)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              1)})),
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              2)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              3)})))})),
+          // Duplicate the above.
+          m::UMul(
+              m::Select(m::Param("global_mux_select"),
+                        {m::TupleIndex(m::Param("func_a_ParamTuple"), 4),
+                         m::TupleIndex(m::Param("func_b_ParamTuple"), 4)}),
+              m::Select(
+                  m::Param("global_mux_select"),
+                  {m::And(
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              0)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              1)})),
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              2)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              3)}))),
+                   m::Or(
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              0)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 1),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              1)})),
+                       m::Add(
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 2),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              2)}),
+                           m::Select(
+                               m::Param("global_mux_select"),
+                               {m::TupleIndex(m::Param("func_a_ParamTuple"), 3),
+                                m::TupleIndex(m::Param("func_b_ParamTuple"),
+                                              3)})))}))));
+}
+
+TEST_F(BasicIntegrationAlgorithmTest, BasicIntegrationLiterals) {
+  auto p = CreatePackage();
+  FunctionBuilder fb("func_a", p.get());
+  auto in1 = fb.Param("in1", p->GetBitsType(2));
+  auto literal1 = fb.Literal(UBits(2,2));
+  fb.Add(in1, literal1,
+                     /*loc=*/absl::nullopt, "add1");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_a, fb.Build());
+  XLS_ASSERT_OK_AND_ASSIGN(Function * func_b, func_a->Clone("func_b"));
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build(
+          {func_a, func_b},
+          IntegrationOptions().algorithm(
+              IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm)));
+
+  Function* function = builder->integrated_function()->function();
+  EXPECT_EQ(function->node_count(), 9);
+  EXPECT_THAT(
+      builder->integrated_function()->function()->return_value(),
+      m::Tuple(
+          m::Add(
+              m::Select(m::Param("global_mux_select"),
+                        {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                         m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+              m::Literal(UBits(2,2))),
+          // Duplicate the above.
+          m::Add(
+              m::Select(m::Param("global_mux_select"),
+                        {m::TupleIndex(m::Param("func_a_ParamTuple"), 0),
+                         m::TupleIndex(m::Param("func_b_ParamTuple"), 0)}),
+              m::Literal(UBits(2,2)))));
+}
+
+}  // namespace
+}  // namespace xls

--- a/xls/contrib/integrator/integration_algorithms/integration_algorithm.h
+++ b/xls/contrib/integrator/integration_algorithms/integration_algorithm.h
@@ -1,0 +1,94 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// A abstract class for an algorithm to integrate multiple functions.
+
+#ifndef XLS_INTEGRATOR_INTEGRATION_ALGORITHM_
+#define XLS_INTEGRATOR_INTEGRATION_ALGORITHM_
+
+#include "absl/status/statusor.h"
+#include "xls/contrib/integrator/integration_options.h"
+#include "xls/contrib/integrator/ir_integrator.h"
+#include "xls/ir/function.h"
+#include "xls/ir/package.h"
+
+namespace xls {
+
+// An abstract class representing an algorithm to merge 2 or more
+// xls ir Functions.
+template <class AlgorithmType>
+class IntegrationAlgorithm {
+ public:
+  IntegrationAlgorithm(const IntegrationAlgorithm& other) = delete;
+  void operator=(const IntegrationAlgorithm& other) = delete;
+
+  // Returns a function that integrates the functions in source_functions.
+  static absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+  IntegrateFunctions(Package* package,
+                     absl::Span<const Function* const> source_functions,
+                     const IntegrationOptions& options = IntegrationOptions());
+
+ protected:
+  IntegrationAlgorithm(Package* package,
+                       absl::Span<const Function* const> source_functions,
+                       const IntegrationOptions& options = IntegrationOptions())
+      : package_(package), integration_options_(options) {
+    source_functions_.reserve(source_functions.size());
+    for (const auto* func : source_functions) {
+      source_functions_.push_back(func);
+    }
+  }
+  virtual ~IntegrationAlgorithm() {}
+
+  // Get the IntegrationOptions::Algorithm value corresponding to
+  // this algoirthm.
+  virtual IntegrationOptions::Algorithm
+  get_corresponding_algorithm_option() = 0;
+
+  // Initialize any member fields.
+  virtual absl::Status Initialize() = 0;
+
+  // Returns a function that integrates the functions in source_functions_.
+  // Runs after Initialize.
+  virtual absl::StatusOr<std::unique_ptr<IntegrationFunction>> Run() = 0;
+
+  // Represents a possible modification to an integration function.
+  enum class IntegrationMoveType { kInsert, kMerge };
+  struct IntegrationMove {
+    Node* node;
+    IntegrationMoveType move_type;
+    Node* merge_node = nullptr;
+    int64 cost;
+  };
+
+  // Perform the modification to 'integration_function' described by 'move'.
+  absl::StatusOr<std::vector<Node*>> ExecuteMove(
+      IntegrationFunction* integration_function, const IntegrationMove& move);
+
+  // Create and return a new IntegrationFunction.
+  absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+  NewIntegrationFunction() {
+    return IntegrationFunction::MakeIntegrationFunctionWithParamTuples(
+        package_, source_functions_, integration_options_);
+  }
+
+  std::vector<const Function*> source_functions_;
+  Package* package_;
+  const IntegrationOptions integration_options_;
+};
+
+}  // namespace xls
+
+#include "xls/contrib/integrator/integration_algorithms/integration_algorithm_implementation.h"
+
+#endif  // XLS_INTEGRATOR_INTEGRATION_ALGORITHM_

--- a/xls/contrib/integrator/integration_algorithms/integration_algorithm_implementation.h
+++ b/xls/contrib/integrator/integration_algorithms/integration_algorithm_implementation.h
@@ -1,0 +1,55 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// A abstract class for an algorithm to integrate multiple functions.
+
+#ifndef XLS_INTEGRATOR_INTEGRATION_ALGORITHM_IMPLEMENTATION_
+#define XLS_INTEGRATOR_INTEGRATION_ALGORITHM_IMPLEMENTATION_
+
+#include "xls/contrib/integrator/integration_algorithms/integration_algorithm.h"
+
+namespace xls {
+
+template <class AlgorithmType>
+absl::StatusOr<std::unique_ptr<IntegrationFunction>>
+IntegrationAlgorithm<AlgorithmType>::IntegrateFunctions(
+    Package* package, absl::Span<const Function* const> source_functions,
+    const IntegrationOptions& options) {
+  // Setup.
+  XLS_RET_CHECK_GT(source_functions.size(), 1);
+  AlgorithmType algorithm(package, source_functions, options);
+  XLS_RETURN_IF_ERROR(algorithm.Initialize());
+  XLS_RET_CHECK_EQ(algorithm.get_corresponding_algorithm_option(),
+                   options.algorithm());
+
+  // Integrate.
+  XLS_ASSIGN_OR_RETURN(std::unique_ptr<IntegrationFunction> integration_func,
+                       algorithm.Run());
+  XLS_RETURN_IF_ERROR(VerifyFunction(integration_func->function()));
+  return integration_func;
+}
+
+template <class AlgorithmType>
+absl::StatusOr<std::vector<Node*>>
+IntegrationAlgorithm<AlgorithmType>::ExecuteMove(
+    IntegrationFunction* integration_function, const IntegrationMove& move) {
+  if (move.move_type == IntegrationMoveType::kInsert) {
+    XLS_ASSIGN_OR_RETURN(Node * node,
+                         integration_function->InsertNode(move.node));
+    return std::vector<Node*>({node});
+  } else {
+    return integration_function->MergeNodes(move.node, move.merge_node);
+  }
+}
+
+}  // namespace xls
+
+#endif  // XLS_INTEGRATOR_INTEGRATION_ALGORITHM_IMPLEMENTATION_

--- a/xls/contrib/integrator/integration_builder.cc
+++ b/xls/contrib/integrator/integration_builder.cc
@@ -1,0 +1,94 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/integrator/integration_builder.h"
+
+#include "xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h"
+
+namespace xls {
+
+absl::StatusOr<Function*> IntegrationBuilder::CloneFunctionRecursive(
+    const Function* function,
+    absl::flat_hash_map<const Function*, Function*>* call_remapping) {
+  // Collect callee functions.
+  std::vector<const Function*> callee_funcs;
+  for (const Node* node : function->nodes()) {
+    switch (node->op()) {
+      case Op::kCountedFor:
+        callee_funcs.push_back(node->As<CountedFor>()->body());
+        break;
+      case Op::kMap:
+        callee_funcs.push_back(node->As<Map>()->to_apply());
+        break;
+      case Op::kInvoke:
+        callee_funcs.push_back(node->As<Invoke>()->to_apply());
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Clone and call_remapping callees.
+  for (const Function* callee : callee_funcs) {
+    if (!call_remapping->contains(callee)) {
+      XLS_ASSIGN_OR_RETURN(Function * callee_clone,
+                           CloneFunctionRecursive(callee, call_remapping));
+      (*call_remapping)[callee] = callee_clone;
+    }
+  }
+
+  std::string clone_name =
+      function_name_uniquer_.GetSanitizedUniqueName(function->name());
+  return function->Clone(clone_name, package_.get(), *call_remapping);
+}
+
+absl::Status IntegrationBuilder::CopySourcesToIntegrationPackage() {
+  source_functions_.reserve(original_package_source_functions_.size());
+  for (const Function* source : original_package_source_functions_) {
+    absl::flat_hash_map<const Function*, Function*> call_remapping;
+    XLS_ASSIGN_OR_RETURN(Function * clone_func,
+                         CloneFunctionRecursive(source, &call_remapping));
+    source_functions_.push_back(clone_func);
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<std::unique_ptr<IntegrationBuilder>> IntegrationBuilder::Build(
+    absl::Span<const Function* const> input_functions,
+    const IntegrationOptions& options) {
+  XLS_RET_CHECK_GT(input_functions.size(), 1);
+
+  // Build builder.
+  auto builder =
+      absl::WrapUnique(new IntegrationBuilder(input_functions, options));
+
+  // Add sources to common package.
+  XLS_RETURN_IF_ERROR(builder->CopySourcesToIntegrationPackage());
+
+  // Integrate the functions.
+  std::unique_ptr<IntegrationFunction> merged_func;
+  switch (options.algorithm()) {
+    case IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm:
+      XLS_ASSIGN_OR_RETURN(merged_func,
+                           BasicIntegrationAlgorithm::IntegrateFunctions(
+                               builder->package(), builder->source_functions(),
+                               *builder->integration_options()));
+      break;
+  }
+  builder->set_integrated_function(std::move(merged_func));
+
+  return std::move(builder);
+}
+
+}  // namespace xls

--- a/xls/contrib/integrator/integration_builder.h
+++ b/xls/contrib/integrator/integration_builder.h
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_INTEGRATOR_INTEGRATION_BUILDER_H_
+#define XLS_INTEGRATOR_INTEGRATION_BUILDER_H_
+
+#include "absl/status/statusor.h"
+#include "xls/contrib/integrator/integration_options.h"
+#include "xls/contrib/integrator/ir_integrator.h"
+#include "xls/ir/function.h"
+#include "xls/ir/package.h"
+
+namespace xls {
+
+// Class used to integrate separate functions into a combined, reprogrammable
+// circuit that can be configured to have the same functionality as the
+// input functions. The builder will attempt to construct the integrated
+// function such that hardware common to the input functions is consolidated.
+// Note that this is distinct from function inlining. With inlining, a function
+// call is replaced by the body of the function that is called.  With function
+// integration, we take separate functions that do not call each other and
+// combine the hardware used to implement the functions.
+class IntegrationBuilder {
+ public:
+  IntegrationBuilder(const IntegrationBuilder& other) = delete;
+  void operator=(const IntegrationBuilder& other) = delete;
+
+  // Creates an IntegrationBuilder and uses it to produce an integrated function
+  // implementing all functions in source_functions_.
+  static absl::StatusOr<std::unique_ptr<IntegrationBuilder>> Build(
+      absl::Span<const Function* const> input_functions,
+      const IntegrationOptions& options = IntegrationOptions());
+
+  // Return functions to be integrated, in the integration package.
+  absl::Span<Function*> source_functions() {
+    return absl::Span<Function*>(source_functions_);
+  }
+
+  Package* package() { return package_.get(); }
+  const IntegrationFunction* integrated_function() {
+    return integrated_function_.get();
+  }
+  const IntegrationOptions* integration_options() {
+    return &integration_options_;
+  }
+
+ private:
+  IntegrationBuilder(absl::Span<const Function* const> input_functions,
+                     const IntegrationOptions& options) {
+    original_package_source_functions_.insert(
+        original_package_source_functions_.end(), input_functions.begin(),
+        input_functions.end());
+    // TODO(jbaileyhandle): Make package name an optional argument.
+    package_ = absl::make_unique<Package>("IntegrationPackage");
+  }
+
+  // Copy the source functions into a common package.
+  absl::Status CopySourcesToIntegrationPackage();
+
+  // Recursively copy a function into the common package_.
+  absl::StatusOr<Function*> CloneFunctionRecursive(
+      const Function* function,
+      absl::flat_hash_map<const Function*, Function*>* call_remapping);
+
+  // Set the integrated_function_.
+  void set_integrated_function(
+      std::unique_ptr<IntegrationFunction> integrated) {
+    integrated_function_ = std::move(integrated);
+  }
+
+  // Uniquer to avoid function name collisions.
+  NameUniquer function_name_uniquer_ = NameUniquer(/*separator=*/"__");
+
+  // Options dictating how to integrate functions.
+  const IntegrationOptions integration_options_;
+
+  // Common package for to-be integrated functions
+  // and integrated function.
+  std::unique_ptr<Package> package_;
+
+  // Function (and metadata) combining the source functions.
+  std::unique_ptr<const IntegrationFunction> integrated_function_;
+
+  // Functions to be integrated, in the integration package.
+  std::vector<Function*> source_functions_;
+  // Functions to be integrated, in their original packages.
+  std::vector<const Function*> original_package_source_functions_;
+};
+
+}  // namespace xls
+
+#endif  // XLS_INTEGRATOR_INTEGRATION_BUILDER_H_

--- a/xls/contrib/integrator/integration_builder_test.cc
+++ b/xls/contrib/integrator/integration_builder_test.cc
@@ -1,0 +1,155 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/integrator/integration_builder.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/ir/ir_matcher.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/node_iterator.h"
+#include "xls/ir/package.h"
+#include "xls/ir/verifier.h"
+
+namespace m = ::xls::op_matchers;
+
+namespace xls {
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+class IntegrationBuilderTest : public IrTestBase {};
+
+TEST_F(IntegrationBuilderTest, IntegrationBuilderNoSourceFunctions) {
+  EXPECT_FALSE(IntegrationBuilder::Build({}).ok());
+}
+
+TEST_F(IntegrationBuilderTest,
+       IntegrationBuilderCopySourceFunctionsIntoPackage) {
+  auto p = CreatePackage();
+
+  FunctionBuilder fb_body("body", p.get());
+  fb_body.Param("index", p->GetBitsType(2));
+  fb_body.Param("acc", p->GetBitsType(2));
+  fb_body.Literal(UBits(0b11, 2));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * body_func, fb_body.Build());
+
+  FunctionBuilder fb_double("double", p.get());
+  auto double_in = fb_double.Param("in1", p->GetBitsType(2));
+  fb_double.Add(double_in, double_in);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * double_func, fb_double.Build());
+
+  FunctionBuilder fb_main("main", p.get());
+  auto main_in1 = fb_main.Param("in1", p->GetBitsType(2));
+  auto main_in_arr =
+      fb_main.Param("in_arr", p->GetArrayType(2, p->GetBitsType(2)));
+  fb_main.Map(main_in_arr, double_func, /*loc=*/std::nullopt, "map");
+  fb_main.CountedFor(main_in1, /*trip_count=*/4, /*stride=*/1, body_func,
+                     /*invariant_args=*/{}, /*loc=*/std::nullopt,
+                     "counted_for");
+  fb_main.Invoke(/*args=*/{main_in1}, double_func, /*loc=*/std::nullopt,
+                 "invoke");
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main_func, fb_main.Build());
+
+  auto diff_package_dummy_p = CreatePackage();
+  FunctionBuilder fb_diff_package_dummy("diff_package_dummy",
+                                        diff_package_dummy_p.get());
+  auto diff_package_dummy_in =
+      fb_diff_package_dummy.Param("in", diff_package_dummy_p->GetBitsType(32));
+  fb_diff_package_dummy.Identity(diff_package_dummy_in);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * diff_package_dummy,
+                           fb_diff_package_dummy.Build());
+
+  auto get_function_names = [](Package* p) {
+    std::vector<std::string> names;
+    for (const auto& func : p->functions()) {
+      names.push_back(func->name());
+    }
+    return names;
+  };
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<IntegrationBuilder> builder,
+      IntegrationBuilder::Build({main_func, diff_package_dummy}));
+
+  // Original packages are unchanged.
+  EXPECT_THAT(get_function_names(p.get()),
+              UnorderedElementsAre("body", "double", "main"));
+  EXPECT_THAT(get_function_names(diff_package_dummy_p.get()),
+              UnorderedElementsAre("diff_package_dummy"));
+
+  // Original CountedFor
+  CountedFor* counted_original =
+      FindNode("counted_for", main_func)->As<CountedFor>();
+  EXPECT_EQ(counted_original->body(), body_func);
+  EXPECT_EQ(counted_original->body()->name(), "body");
+  EXPECT_EQ(counted_original->body()->package(), p.get());
+
+  // Original Map
+  Map* map_original = FindNode("map", main_func)->As<Map>();
+  EXPECT_EQ(map_original->to_apply(), double_func);
+  EXPECT_EQ(map_original->to_apply()->name(), "double");
+  EXPECT_EQ(map_original->to_apply()->package(), p.get());
+
+  // Original Invoke
+  Invoke* invoke_original = FindNode("invoke", main_func)->As<Invoke>();
+  EXPECT_EQ(invoke_original->to_apply(), double_func);
+  EXPECT_EQ(invoke_original->to_apply()->name(), "double");
+  EXPECT_EQ(invoke_original->to_apply()->package(), p.get());
+
+  // Original diff_package_dummy
+  EXPECT_THAT(diff_package_dummy->return_value(), m::Identity(m::Param("in")));
+
+  // builder package has copies of functions.
+  EXPECT_THAT(
+      get_function_names(builder->package()),
+      UnorderedElementsAre("body", "double", "main", "diff_package_dummy"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * main_clone_func,
+                           builder->package()->GetFunction("main"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * clone_body_func,
+                           builder->package()->GetFunction("body"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * clone_double_func,
+                           builder->package()->GetFunction("double"));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Function * clone_diff_package_dummy,
+      builder->package()->GetFunction("diff_package_dummy"));
+
+  // Clone CountedFor
+  CountedFor* counted_clone =
+      FindNode("counted_for", main_clone_func)->As<CountedFor>();
+  EXPECT_EQ(counted_clone->body(), clone_body_func);
+  EXPECT_EQ(counted_clone->body()->name(), "body");
+  EXPECT_EQ(counted_clone->body()->package(), builder->package());
+
+  // Clone Map
+  Map* map_clone = FindNode("map", main_clone_func)->As<Map>();
+  EXPECT_EQ(map_clone->to_apply(), clone_double_func);
+  EXPECT_EQ(map_clone->to_apply()->name(), "double");
+  EXPECT_EQ(map_clone->to_apply()->package(), builder->package());
+
+  // Clone Invoke
+  Invoke* invoke_clone = FindNode("invoke", main_clone_func)->As<Invoke>();
+  EXPECT_EQ(invoke_clone->to_apply(), clone_double_func);
+  EXPECT_EQ(invoke_clone->to_apply()->name(), "double");
+  EXPECT_EQ(invoke_clone->to_apply()->package(), builder->package());
+
+  // Clone diff_package_dummy
+  EXPECT_THAT(clone_diff_package_dummy->return_value(),
+              m::Identity(m::Param("in")));
+}
+
+}  // namespace
+}  // namespace xls

--- a/xls/contrib/integrator/integration_options.cc
+++ b/xls/contrib/integrator/integration_options.cc
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// A abstract class for an algorithm to integrate multiple functions.
+
+#include "xls/contrib/integrator/integration_options.h"
+
+#include <iostream>
+
+namespace xls {
+
+std::ostream& operator<<(std::ostream& os,
+                         const IntegrationOptions::Algorithm& alg) {
+  switch (alg) {
+    case IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm:
+      os << "kBasicIntegrationAlgorithm";
+      break;
+  }
+  return os;
+}
+
+}  // namespace xls

--- a/xls/contrib/integrator/integration_options.h
+++ b/xls/contrib/integrator/integration_options.h
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// A abstract class for an algorithm to integrate multiple functions.
+
+#ifndef XLS_INTEGRATOR_INTEGRATION_OPTIONS_
+#define XLS_INTEGRATOR_INTEGRATION_OPTIONS_
+
+#include <iostream>
+
+namespace xls {
+
+class IntegrationOptions {
+ public:
+  // Used to specify different integration algorithms.
+  enum class Algorithm {
+    kBasicIntegrationAlgorithm,
+  };
+
+  // Which algorithm to use to merge functions.
+  IntegrationOptions& algorithm(Algorithm value) {
+    algorithm_ = value;
+    return *this;
+  }
+  Algorithm algorithm() const { return algorithm_; }
+
+  // Whether we can program individual muxes with unique select signals
+  // or if we can configure the entire graph to match one of the input
+  // functions using a single select signal.
+  IntegrationOptions& unique_select_signal_per_mux(bool value) {
+    unique_select_signal_per_mux_ = value;
+    return *this;
+  }
+  bool unique_select_signal_per_mux() const {
+    return unique_select_signal_per_mux_;
+  }
+
+ private:
+  bool unique_select_signal_per_mux_ = false;
+  Algorithm algorithm_ = Algorithm::kBasicIntegrationAlgorithm;
+};
+
+// Convert IntegrationOptions::Algorithm to human-readable text.
+std::ostream& operator<<(std::ostream& os,
+                         const IntegrationOptions::Algorithm& alg);
+
+}  // namespace xls
+
+#endif  // XLS_INTEGRATOR_INTEGRATION_OPTIONS_


### PR DESCRIPTION
… of a common source function 2) check if all of a node's operands have a mapping and 3) for an integration node, set as the return value a tuple of the mappings of the source function return values. Added a basic integration algorithm. Split up ir_integration into multiple files / build targets, moving the IntegrationBuilder and IntegrationOptions into their own files (This was necessary at some point.  Thought doing the split in the this PR would make review easier but in retrospect... probably not).  Note that we have a virtual IntegrationAlgorithm class. This class is a template because one of its functions must be able to create an object of a child class. Because the class is a template, it exists only as a header rather than an independent build target (actually, we have a .h and an *_implementation.h that mimics what we would put in a .cc file if the class was its own build target)."