### PR TITLE
Constant loop body paramters converted to loop-internal constants

### DIFF
--- a/xls/dslx/ir_converter.cc
+++ b/xls/dslx/ir_converter.cc
@@ -1062,12 +1062,31 @@ absl::Status FunctionConverter::HandleFor(For* node) {
         dynamic_cast<TypeDef*>(definer) != nullptr) {
       continue;
     }
-    relevant_name_defs.push_back(name_def);
     XLS_VLOG(5) << "Converting freevar name: " << name_def->ToString();
-    XLS_ASSIGN_OR_RETURN(xls::Type * name_def_type, TypeToIr(**type));
-    body_converter.SetNodeToIr(name_def,
-                               body_converter.function_builder_->Param(
-                                   name_def->identifier(), name_def_type));
+
+    absl::optional<IrValue> ir_value = GetNodeToIr(name_def);
+    if (!ir_value.has_value()) {
+      return absl::InternalError(
+          absl::StrFormat("AST node had no associated IR value: %s @ %s",
+                          node->ToString(), SpanToString(node->GetSpan())));
+    }
+
+    // If free variable is a constant, create constant node inside body.
+    // This preserves const-ness of loop body uses (e.g. loop bounds for
+    // a nested loop).
+    if (absl::holds_alternative<CValue>(*ir_value)) {
+      Value constant_value = absl::get<CValue>(*ir_value).ir_value;
+      body_converter.DefConst(name_def, constant_value);
+
+    // Otherwise, pass in the variable to the loop body function as
+    // a parameter.
+    } else {
+      relevant_name_defs.push_back(name_def);
+      XLS_ASSIGN_OR_RETURN(xls::Type * name_def_type, TypeToIr(**type));
+      body_converter.SetNodeToIr(name_def,
+                                 body_converter.function_builder_->Param(
+                                     name_def->identifier(), name_def_type));
+    }
   }
 
   FunctionConverterVisitor visitor(&body_converter);

--- a/xls/dslx/ir_converter_test.cc
+++ b/xls/dslx/ir_converter_test.cc
@@ -883,11 +883,11 @@ fn __test_module__f(x: bits[2]) -> bits[8] {
 TEST(IrConverterTest, CountedForWithLoopInvariants) {
   const char* program =
       R"(
-fn f() -> u32 {
-  let outer_thing: u32 = u32:42;
-  let other_outer_thing: u32 = u32:24;
+fn f(outer_thing_1: u32, outer_thing_2: u32) -> u32 {
+  let outer_thing_3: u32 = u32:42;
+  let outer_thing_4: u32 = u32:24;
   for (i, accum): (u32, u32) in range(u32:0, u32:4) {
-    accum + i + outer_thing + other_outer_thing
+    accum + i + outer_thing_1 + outer_thing_2 + outer_thing_3 + outer_thing_4
   }(u32:0)
 }
 )";

--- a/xls/dslx/testdata/ir_converter_test_CountedForWithLoopInvariants.ir
+++ b/xls/dslx/testdata/ir_converter_test_CountedForWithLoopInvariants.ir
@@ -1,14 +1,18 @@
 package test_module
 
-fn ____test_module__f_counted_for_0_body(i: bits[32], accum: bits[32], other_outer_thing: bits[32], outer_thing: bits[32]) -> bits[32] {
-  add.8: bits[32] = add(accum, i, id=8)
-  add.9: bits[32] = add(add.8, outer_thing, id=9)
-  ret add.10: bits[32] = add(add.9, other_outer_thing, id=10)
+fn ____test_module__f_counted_for_0_body(i: bits[32], accum: bits[32], outer_thing_1: bits[32], outer_thing_2: bits[32]) -> bits[32] {
+  add.12: bits[32] = add(accum, i, id=12)
+  add.13: bits[32] = add(add.12, outer_thing_1, id=13)
+  add.14: bits[32] = add(add.13, outer_thing_2, id=14)
+  literal.10: bits[32] = literal(value=42, id=10)
+  add.15: bits[32] = add(add.14, literal.10, id=15)
+  literal.11: bits[32] = literal(value=24, id=11)
+  ret add.16: bits[32] = add(add.15, literal.11, id=16)
 }
 
-fn __test_module__f() -> bits[32] {
-  literal.3: bits[32] = literal(value=0, id=3)
-  literal.2: bits[32] = literal(value=24, id=2)
-  literal.1: bits[32] = literal(value=42, id=1)
-  ret counted_for.11: bits[32] = counted_for(literal.3, trip_count=4, stride=1, body=____test_module__f_counted_for_0_body, invariant_args=[literal.2, literal.1], id=11)
+fn __test_module__f(outer_thing_1: bits[32], outer_thing_2: bits[32]) -> bits[32] {
+  literal.5: bits[32] = literal(value=0, id=5)
+  literal.3: bits[32] = literal(value=42, id=3)
+  literal.4: bits[32] = literal(value=24, id=4)
+  ret counted_for.17: bits[32] = counted_for(literal.5, trip_count=4, stride=1, body=____test_module__f_counted_for_0_body, invariant_args=[outer_thing_1, outer_thing_2], id=17)
 }

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -190,6 +190,16 @@ dslx_test(
 )
 
 dslx_test(
+    name = "parametric_value_as_nested_loop_bound",
+    srcs = ["parametric_value_as_nested_loop_bound.x"],
+)
+
+dslx_test(
+    name = "derived_parametric_value_as_nested_loop_bound",
+    srcs = ["derived_parametric_value_as_nested_loop_bound.x"],
+)
+
+dslx_test(
     name = "bit_slice",
     srcs = ["bit_slice.x"],
     # Note: no meaningful function to convert.
@@ -437,6 +447,11 @@ dslx_test(
 dslx_test(
     name = "local_const_value",
     srcs = ["local_const_value.x"],
+)
+
+dslx_test(
+    name = "const_value_as_nested_loop_bound",
+    srcs = ["const_value_as_nested_loop_bound.x"],
 )
 
 dslx_test(

--- a/xls/dslx/tests/const_value_as_nested_loop_bound.x
+++ b/xls/dslx/tests/const_value_as_nested_loop_bound.x
@@ -1,0 +1,30 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const FOO = u32:2;
+
+fn main(input: u32) -> u32 {
+  for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+    for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+      for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+        acc + input
+      }(acc)
+    }(acc)
+  }(u32:0)
+}
+
+#![test]
+fn local_test() {
+  assert_eq(u32:8, main(u32:1))
+}

--- a/xls/dslx/tests/derived_parametric_value_as_nested_loop_bound.x
+++ b/xls/dslx/tests/derived_parametric_value_as_nested_loop_bound.x
@@ -1,0 +1,33 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn derived_parametric_main<FOO: u32, BAR: u32, 
+  DERIVED:u32 = FOO + BAR>(input: u32) -> u32 {
+  for(idx, acc): (u32, u32) in range(u32:0, DERIVED) {
+    for(idx, acc): (u32, u32) in range(u32:0, DERIVED) {
+      for(idx, acc): (u32, u32) in range(u32:0, DERIVED) {
+        acc + input
+      }(acc)
+    }(acc)
+  }(u32:0)
+}
+
+fn main(arg: u32) -> u32 {
+  derived_parametric_main<u32:1, u32:1>(u32:1)
+}
+
+#![test]
+fn main_test() {
+  assert_eq(u32:8, main(u32:1))
+}

--- a/xls/dslx/tests/parametric_value_as_nested_loop_bound.x
+++ b/xls/dslx/tests/parametric_value_as_nested_loop_bound.x
@@ -1,0 +1,32 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn parametric_main<FOO: u32>(input: u32) -> u32 {
+  for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+    for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+      for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+        acc + input
+      }(acc)
+    }(acc)
+  }(u32:0)
+}
+
+fn main(arg: u32) -> u32 {
+  parametric_main<u32:2>(arg)
+}
+
+#![test]
+fn main_test() {
+  assert_eq(u32:8, main(u32:1))
+}


### PR DESCRIPTION
For constants used in a loop body but defined outside the loop, reproduce constant nodes in in the loop body instead of passing these nodes to the loop body function as arguments.  This preserves const-ness. Motivating use case was nested loops where the loop bound was defined by a parametric value. Previously, this would not compile because inner loop bounds would appear as non-const parameters of the outer loop body.