### PR TITLE
Added floating point square root and fast (approximate) inverse square root.

### DIFF
--- a/xls/common/math_util.h
+++ b/xls/common/math_util.h
@@ -118,12 +118,16 @@ bool ZeroOrSubnormal(T value) {
   return value == 0 || std::fpclassify(value) == FP_SUBNORMAL;
 }
 
-// Returns 0 if the given floating-point value is subnormal or the original
-// value otherwise.
+// Returns +/-0 if the given floating-point value is subnormal (sign is
+// preserved) or the original value otherwise.
 template <typename T>
 T FlushSubnormal(T value) {
   if (std::fpclassify(value) == FP_SUBNORMAL) {
-    return 0;
+    if (value < 0) {
+      return -0.0;
+    } else {
+      return 0.0;
+    }
   }
 
   return value;

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -222,6 +222,11 @@ pub fn is_nan<EXP_SZ:u32, SFD_SZ:u32>(x: APFloat<EXP_SZ, SFD_SZ>) -> u1 {
   (x.bexp == std::mask_bits<EXP_SZ>() && x.sfd != bits[SFD_SZ]:0)
 }
 
+// Returns true if x == 0 or x is a subnormal number.
+pub fn is_zero_or_subnormal<EXP_SZ: u32, SFD_SZ: u32>(x: APFloat<EXP_SZ, SFD_SZ>) -> u1 {
+  x.bexp == uN[EXP_SZ]:0
+}
+
 // TODO(rspringer): Create a broadly-applicable normalize test, that
 // could be used for multiple type instantiations (without needing
 // per-specialization data to be specified by a user).

--- a/xls/dslx/stdlib/bfloat16.x
+++ b/xls/dslx/stdlib/bfloat16.x
@@ -36,6 +36,9 @@ pub fn subnormals_to_zero(f: BF16) -> BF16 {
 
 pub fn is_inf(f: BF16) -> u1 { apfloat::is_inf<u32:8, u32:7>(f) }
 pub fn is_nan(f: BF16) -> u1 { apfloat::is_nan<u32:8, u32:7>(f) }
+pub fn is_zero_or_subnormal(f: BF16) -> u1 {
+  apfloat::is_zero_or_subnormal<u32:8, u32:7>(f)
+}
 
 pub fn normalize(sign:u1, exp: u8, sfd_with_hidden: u8) -> BF16 {
   apfloat::normalize<u32:8, u32:7>(sign, exp, sfd_with_hidden)

--- a/xls/dslx/stdlib/float32.x
+++ b/xls/dslx/stdlib/float32.x
@@ -41,6 +41,9 @@ pub fn subnormals_to_zero(f: F32) -> F32 {
 
 pub fn is_inf(f: F32) -> u1 { apfloat::is_inf<u32:8, u32:23>(f) }
 pub fn is_nan(f: F32) -> u1 { apfloat::is_nan<u32:8, u32:23>(f) }
+pub fn is_zero_or_subnormal(f: F32) -> u1 {
+  apfloat::is_zero_or_subnormal<u32:8, u32:23>(f)
+}
 
 pub fn normalize(sign:u1, exp: u8, sfd_with_hidden: u24) -> F32 {
   apfloat::normalize<u32:8, u32:23>(sign, exp, sfd_with_hidden)

--- a/xls/dslx/stdlib/float64.x
+++ b/xls/dslx/stdlib/float64.x
@@ -44,6 +44,9 @@ pub fn subnormals_to_zero(f: F64) -> F64 {
 
 pub fn is_inf(f: F64) -> u1 { apfloat::is_inf<u32:11, u32:52>(f) }
 pub fn is_nan(f: F64) -> u1 { apfloat::is_nan<u32:11, u32:52>(f) }
+pub fn is_zero_or_subnormal(f: F64) -> u1 {
+  apfloat::is_zero_or_subnormal<u32:11, u32:52>(f)
+}
 
 pub fn normalize(sign:u1, exp: u11, sfd_with_hidden: u53) -> F64 {
   apfloat::normalize<u32:11, u32:52>(sign, exp, sfd_with_hidden)

--- a/xls/modules/BUILD
+++ b/xls/modules/BUILD
@@ -216,4 +216,74 @@ cc_test(
     ],
 )
 
+dslx_test(
+    name = "fp_fast_rsqrt_32",
+    srcs = ["fp_fast_rsqrt_32.x"],
+    # 2021-03-22 Takes too long.
+    prove_unopt_eq_opt = False,
+    deps = [":fpadd_2x32.x",
+            ":apfloat_add_2.x",
+            ":fpmul_2x32.x",
+            ":apfloat_mul_2.x"],
+)
+
+dslx_jit_wrapper(
+    name = "fp_fast_rsqrt_32_jit_wrapper",
+    dslx_name = "fp_fast_rsqrt_32",
+    deps = [":fp_fast_rsqrt_32_opt_ir"],
+)
+
+cc_test(
+    name = "fp_fast_rsqrt_32_test",
+    srcs = ["fp_fast_rsqrt_32_test.cc"],
+    data = [":fp_fast_rsqrt_32_all_ir"],
+    tags = ["optonly"],
+    deps = [
+        ":fp_fast_rsqrt_32_jit_wrapper",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/status",
+        "//xls/common:init_xls",
+        "//xls/common:math_util",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "//xls/ir:value_helpers",
+        "//xls/ir:value_view_helpers",
+        "//xls/tools:testbench",
+    ],
+)
+
+dslx_test(
+    name = "fpsqrt_32",
+    # 2021-03-22 Takes too long.
+    prove_unopt_eq_opt = False,
+    srcs = ["fpsqrt_32.x"],
+)
+
+dslx_jit_wrapper(
+    name = "fpsqrt_32_jit_wrapper",
+    dslx_name = "fpsqrt_32",
+    deps = [":fpsqrt_32_opt_ir"],
+)
+
+cc_test(
+    name = "fpsqrt_32_test",
+    srcs = ["fpsqrt_32_test.cc"],
+    data = [":fpsqrt_32_all_ir"],
+    tags = ["optonly"],
+    deps = [
+        ":fpsqrt_32_jit_wrapper",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/status",
+        "//xls/common:init_xls",
+        "//xls/common:math_util",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "//xls/ir:value_helpers",
+        "//xls/ir:value_view_helpers",
+        "//xls/tools:testbench",
+    ],
+)
+
 exports_files(glob(["*.x"]))

--- a/xls/modules/fp_fast_rsqrt_32.x
+++ b/xls/modules/fp_fast_rsqrt_32.x
@@ -1,0 +1,114 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements floating point fast (approximate)
+// inverse square root. This should be able to compute
+// 1.0 / sqrt(x) using fewer hardware resources than
+// using a sqrt and division module, although this hasn't
+// been benchmarked yet. Latency is expected to be lower
+// as well. The tradeoff is that this offers slighlty less
+// precision (error is < 0.2% in worst case). The
+// accuracy-resources tradeoff can be adjusted by changing
+// the number of Newton's method iterations (default 1).
+//
+// Note:
+//  - Input denormals are treated as/flushed to 0.
+//      (denormals-are-zero / DAZ).
+//  - Only round-to-nearest mode is supported.
+//  - No exception flags are raised/reported.
+//  - We emit a single, canonical representation for 
+//      NaN (qnan) but accept all NaN respresentations 
+//      as input.
+
+import float32
+import xls.modules.fpadd_2x32
+import xls.modules.fpmul_2x32
+import xls.dslx.stdlib.apfloat
+
+type F32 = float32::F32;
+
+// Computes an approximation of 1.0 / sqrt(x).
+// NUM_REFINEMENTS can be increased to tradeoff more
+// hardware resources for more accuracy.
+pub fn fp_fast_rsqrt_32_config_refinements<NUM_REFINEMENTS: u32 = u32:1>(x: F32) -> F32 {
+  const zero_point_five = F32 {sign: u1:0,
+                               bexp: u8:0x7e,
+                               sfd:  u23:0};
+  const one_point_five  = F32 {sign: u1:0,
+                               bexp: u8:0x7f,
+                               sfd:  u1:1 ++ u22:0};
+  const magic_number = u32:0x5f3759df;
+
+  // Flush subnormal input.
+  let x = float32::subnormals_to_zero(x);
+
+  let approx = float32::unflatten(
+                  magic_number - (float32::flatten(x) >> u32:1));
+  let half_x = fpmul_2x32::fpmul_2x32(x, zero_point_five);
+
+  // Refine solution w/ Newton's method.
+  let result = for (idx, approx): (u32, F32) in range (u32:0, NUM_REFINEMENTS) {
+    let prod = fpmul_2x32::fpmul_2x32(half_x, approx);
+    let prod = fpmul_2x32::fpmul_2x32(prod, approx);
+    let nprod = F32{sign: !prod.sign, bexp: prod.bexp, sfd: prod.sfd};
+    let diff = fpadd_2x32::fpadd_2x32(one_point_five, nprod);
+    fpmul_2x32::fpmul_2x32(approx, diff)
+  } (approx);
+
+  // I don't *think* it is possible to underflow / have a subnormal result
+  // here. In order to have a subnormal result, x would have to be so large
+  // that it overflows to infinity (handled below).
+
+  // Special cases.
+  // 1/sqrt(inf) -> 0, 1/sqrt(-inf) -> NaN (handled below along
+  // with other negative numbers).
+  let result = float32::zero(x.sign) if float32::is_inf(x) else result;
+  // 1/sqrt(x < 0) -> NaN
+  let result = float32::qnan() if x.sign == u1:1 else result;
+  // 1/sqrt(NaN) -> NaN.
+  let result = x if float32::is_nan(x) else result;
+  // 1/sqrt(0) -> inf, 1/sqrt(-0) -> -inf
+  let result = float32::inf(x.sign) if float32::is_zero_or_subnormal(x) 
+                                    else result;
+  result 
+}
+
+pub fn fp_fast_rsqrt_32(x: F32) -> F32 {
+  fp_fast_rsqrt_32_config_refinements<u32:1>(x)
+}
+
+#![test]
+fn fast_sqrt_test() {
+  // Test Special cases.
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::zero(u1:0)), 
+    float32::inf(u1:0));
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::zero(u1:1)), 
+    float32::inf(u1:1));
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::inf(u1:0)), 
+    float32::zero(u1:0));
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::inf(u1:1)), 
+    float32::qnan());
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::qnan()), 
+    float32::qnan());
+  let _ = assert_eq(fp_fast_rsqrt_32(float32::one(u1:1)), 
+    float32::qnan());
+  let pos_denormal = F32{sign: u1:0, bexp: u8:0, sfd: u23:99};
+  let _ = assert_eq(fp_fast_rsqrt_32(pos_denormal),
+    float32::inf(u1:0));
+  let neg_denormal = F32{sign: u1:1, bexp: u8:0, sfd: u23:99};
+  let _ = assert_eq(fp_fast_rsqrt_32(neg_denormal),
+    float32::inf(u1:1));
+  ()
+}
+

--- a/xls/modules/fp_fast_rsqrt_32_test.cc
+++ b/xls/modules/fp_fast_rsqrt_32_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Random-sampling test for DSLX 32-bit floating-point fast, approximate
+// inverse sqrt.
+#include <cmath>
+#include <limits>
+
+#include "absl/random/random.h"
+#include "absl/status/status.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/init_xls.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/math_util.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/ir/value_view_helpers.h"
+#include "xls/modules/fp_fast_rsqrt_32_jit_wrapper.h"
+#include "xls/tools/testbench.h"
+
+ABSL_FLAG(bool, use_opt_ir, true, "Use optimized IR.");
+ABSL_FLAG(int, num_threads, 0,
+          "Number of threads to use. Set to 0 to use all.");
+ABSL_FLAG(int64_t, num_samples, 1024 * 1024,
+          "Number of random samples to test.");
+
+namespace xls {
+
+constexpr const char kOptIrPath[] = "xls/modules/fp_fast_rsqrt_32.opt.ir";
+constexpr const char kIrPath[] = "xls/modules/fp_fast_rsqrt_32.ir";
+
+// Generates a float with reasonably unformly random bit patterns.
+float IndexToInput(uint64_t index) {
+  thread_local absl::BitGen bitgen;
+  uint32_t a = absl::Uniform(bitgen, 0u, std::numeric_limits<uint32_t>::max());
+  return absl::bit_cast<float>(a);
+}
+
+// The DSLX implementation uses the "round to nearest (half to even)"
+// rounding mode, which is the default on most systems, hence we don't need
+// to call fesetround().
+// The DSLX implementation also flushes input subnormals to 0, so we do that
+// here as well.
+float ComputeExpected(float input) {
+  float x = FlushSubnormal(input);
+  return 1.0 / sqrtf(x);
+}
+
+// Computes FP sqrt via DSLX & the JIT.
+float ComputeActual(FpFastRsqrt32* jit_wrapper, float input) {
+  return jit_wrapper->Run(input).value();
+}
+
+// Compares expected vs. actual results, taking into account two special cases.
+bool CompareResults(float a, float b) {
+  // DSLX flushes subnormal outputs, while regular FP addition does not, so
+  // just check for that here.
+  // We only check that results are approximately equal. Percent error
+  // is used rather than simple difference because the input may vary
+  // by many orders of magnitude.
+  float percent_error = (a - b) / a;
+  return a == b || percent_error < 0.01 || (std::isnan(a) && std::isnan(b)) ||
+         (ZeroOrSubnormal(a) && ZeroOrSubnormal(b));
+}
+
+void LogMismatch(uint64_t index, float input, float expected, float actual) {
+  XLS_LOG(ERROR) << absl::StrFormat(
+      "Value mismatch at index %d, input %f:\n"
+      "  Input:  0x%x\n"
+      "  Expected (approx.): 0x%x\n"
+      "  Actual  : 0x%x",
+      index, input, absl::bit_cast<uint32_t>(input),
+      absl::bit_cast<uint32_t>(expected), absl::bit_cast<uint32_t>(actual));
+}
+
+absl::Status RealMain(bool use_opt_ir, uint64_t num_samples, int num_threads) {
+  Testbench<FpFastRsqrt32, float, float> testbench(
+      0, num_samples,
+      /*max_failures=*/1, IndexToInput, ComputeExpected, ComputeActual,
+      CompareResults, LogMismatch);
+  if (num_threads != 0) {
+    XLS_RETURN_IF_ERROR(testbench.SetNumThreads(num_threads));
+  }
+  return testbench.Run();
+}
+
+}  // namespace xls
+
+int main(int argc, char** argv) {
+  xls::InitXls(argv[0], argc, argv);
+  XLS_QCHECK_OK(xls::RealMain(absl::GetFlag(FLAGS_use_opt_ir),
+                              absl::GetFlag(FLAGS_num_samples),
+                              absl::GetFlag(FLAGS_num_threads)));
+  return 0;
+}

--- a/xls/modules/fpsqrt_32.x
+++ b/xls/modules/fpsqrt_32.x
@@ -1,0 +1,239 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code is based on the go double sqrt implementation,
+// available at https://golang.org/src/math/sqrt.go
+// This implementation is in turn based on 
+// FreeBSD's /usr/src/lib/msun/src/e_sqrt.c
+// The lisence for both sources along with comment from
+// the BSD source describing the implementation are
+// reproduced below:
+
+// ====================================================
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+// ====================================================
+
+// ====================================================
+// Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+//
+// Developed at SunPro, a Sun Microsystems, Inc. business.
+// Permission to use, copy, modify, and distribute this
+// software is freely granted, provided that this notice
+// is preserved.
+// ====================================================
+//
+// __ieee754_sqrt(x)
+// Return correctly rounded sqrt.
+//           -----------------------------------------
+//           | Use the hardware sqrt if you have one |
+//           -----------------------------------------
+// Method:
+//   Bit by bit method using integer arithmetic. (Slow, but portable)
+//   1. Normalization
+//      Scale x to y in [1,4) with even powers of 2:
+//      find an integer k such that  1 <= (y=x*2**(2k)) < 4, then
+//              sqrt(x) = 2**k * sqrt(y)
+//   2. Bit by bit computation
+//      Let q  = sqrt(y) truncated to i bit after binary point (q = 1),
+//           i                                                   0
+//                                     i+1         2
+//          s  = 2*q , and      y  =  2   * ( y - q  ).          (1)
+//           i      i            i                 i
+//
+//      To compute q    from q , one checks whether
+//                  i+1       i
+//
+//                            -(i+1) 2
+//                      (q + 2      )  <= y.                     (2)
+//                        i
+//                                                            -(i+1)
+//      If (2) is false, then q   = q ; otherwise q   = q  + 2      .
+//                             i+1   i             i+1   i
+//
+//      With some algebraic manipulation, it is not difficult to see
+//      that (2) is equivalent to
+//                             -(i+1)
+//                      s  +  2       <= y                       (3)
+//                       i                i
+//
+//      The advantage of (3) is that s  and y  can be computed by
+//                                    i      i
+//      the following recurrence formula:
+//          if (3) is false
+//
+//          s     =  s  ,       y    = y   ;                     (4)
+//           i+1      i          i+1    i
+//
+//      otherwise,
+//                         -i                      -(i+1)
+//          s     =  s  + 2  ,  y    = y  -  s  - 2              (5)
+//           i+1      i          i+1    i     i
+//
+//      One may easily use induction to prove (4) and (5).
+//      Note. Since the left hand side of (3) contain only i+2 bits,
+//            it is not necessary to do a full (53-bit) comparison
+//            in (3).
+//   3. Final rounding
+//      After generating the 53 bits result, we compute one more bit.
+//      Together with the remainder, we can decide whether the
+//      result is exact, bigger than 1/2ulp, or less than 1/2ulp
+//      (it will never equal to 1/2ulp).
+//      The rounding mode can be detected by checking whether
+//      huge + tiny is equal to huge, and whether huge - tiny is
+//      equal to huge for some floating point number "huge" and "tiny".
+//
+// Notes:  Rounding mode detection omitted.
+
+// This file implements [most of] IEEE 754 single-precision
+// floating point square-root, with the following exceptions:
+//  - Input denormals are treated as/flushed to 0.
+//      (denormals-are-zero / DAZ).
+//  - Only round-to-nearest mode is supported.
+//  - No exception flags are raised/reported.
+// In all other cases, results should be identical to other
+// conforming implementations, modulo exact significand
+// values in the NaN case (we emit a single, canonical 
+// representation for NaN (qnan) but accept all NaN 
+// respresentations as input).
+
+import float32
+import xls.dslx.stdlib.apfloat
+
+type F32 = float32::F32;
+
+pub fn fpsqrt_32(x: F32) -> F32 {
+  // Flush subnormal input.
+  let x = float32::subnormals_to_zero(x);
+
+  let exp = float32::unbiased_exponent(x);
+
+  let scaled_fixed_point_x = u1:0 ++ u8:1 ++ x.sfd;
+  // If odd exp, double x to make it even.
+  let scaled_fixed_point_x = scaled_fixed_point_x << u32:1 if exp[0:1] else scaled_fixed_point_x;
+  // exp = exp / 2, exponent of square root
+  let exp = exp >> u8:1;
+
+  // Generate sqrt(x) bit by bit.
+  let scaled_fixed_point_x = scaled_fixed_point_x << u32:1;
+
+  // s is scaled version of the square root calculated down to a
+  let (scaled_fixed_point_x, sqrt_in_progress, _) = 
+    for (idx, (scaled_fixed_point_x,
+               sqrt_in_progress,
+               shifting_bit_mask)):
+        (u32, (u32,
+               u32,
+               u32))
+        in range(u32:0, u32:23 + u32:2) {
+
+    let temp = (sqrt_in_progress << u32:1) | shifting_bit_mask;
+
+    // Would be nice to have dslx if-blocks that can desugar
+    // down to something like this automatically...
+    let (sqrt_in_progress, scaled_fixed_point_x) =
+      (sqrt_in_progress | shifting_bit_mask,
+      scaled_fixed_point_x - temp)
+    if temp <= scaled_fixed_point_x else
+      (sqrt_in_progress, scaled_fixed_point_x);
+
+    let scaled_fixed_point_x = scaled_fixed_point_x << u32:1;
+    let shifting_bit_mask = shifting_bit_mask >> u32:1;
+
+    (scaled_fixed_point_x, 
+     sqrt_in_progress,
+     shifting_bit_mask)
+
+  } ((scaled_fixed_point_x,      // scaled_fixed_point_x
+      u32:0,                     // sqrt_in_progress
+      u32:1 << u32:23 + u32:1)); // shifting_bit_mask 
+
+  // Final rounding.
+  let sqrt_in_progress = sqrt_in_progress + (u31:0 ++ sqrt_in_progress[0:1]) if scaled_fixed_point_x != u32:0 else sqrt_in_progress;
+  let scaled_fixed_point_x = (sqrt_in_progress >> u32:1) + 
+           ((float32::bias(exp - u9:1)) as u32 << u32:23);
+  let result = float32::unflatten(scaled_fixed_point_x);
+
+  // I don't *think* it is possible to underflow / have a subnormal result
+  // here. In order to have a subnormal result, x would have to be
+  // subnormal with x << sqrt(x). In this case, x would have been flushed
+  // to 0. x==0 is handled below as a special case.
+
+  // Special cases.
+  // sqrt(inf) -> inf, sqrt(-inf) -> NaN (handled below along
+  // with other negative numbers).
+  let result = x if float32::is_inf(x) else result;
+  // sqrt(x < 0) -> NaN
+  let result = float32::qnan() if x.sign == u1:1 else result;
+  // sqrt(NaN) -> NaN.
+  let result = float32::qnan() if float32::is_nan(x) else result;
+  // x == -0 returns x rather than NaN.
+  let result = x if float32::is_zero_or_subnormal(x) else result;
+  result 
+}
+
+#![test]
+fn sqrt_test() {
+  // Test Special cases.
+  let _ = assert_eq(fpsqrt_32(float32::zero(u1:0)), 
+    float32::zero(u1:0));
+  let _ = assert_eq(fpsqrt_32(float32::zero(u1:1)), 
+    float32::zero(u1:1));
+  let _ = assert_eq(fpsqrt_32(float32::inf(u1:0)), 
+    float32::inf(u1:0));
+  let _ = assert_eq(fpsqrt_32(float32::inf(u1:1)), 
+    float32::qnan());
+  let _ = assert_eq(fpsqrt_32(float32::qnan()), 
+    float32::qnan());
+  let _ = assert_eq(fpsqrt_32(float32::one(u1:1)), 
+    float32::qnan());
+  let pos_denormal = F32{sign: u1:0, bexp: u8:0, sfd: u23:99};
+  let _ = assert_eq(fpsqrt_32(pos_denormal),
+    float32::zero(u1:0));
+  let neg_denormal = F32{sign: u1:1, bexp: u8:0, sfd: u23:99};
+  let _ = assert_eq(fpsqrt_32(neg_denormal),
+    float32::zero(u1:1));
+
+  // Try some simple numbers.
+  // sqrt(1).
+  let _ = assert_eq(fpsqrt_32(float32::one(u1:0)), 
+    fpsqrt_32(float32::one(u1:0)));
+  // sqrt(4).
+  let four = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:2), 
+                  sfd: u23:0};
+  let two = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:1), 
+                  sfd: u23:0};
+  let _ = assert_eq(fpsqrt_32(four), two);
+  // sqrt(9).
+  let nine = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:3), 
+                  sfd: u2:0 ++ u1:1 ++ u20:0};
+  let three = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:1), 
+                  sfd: u1:1 ++ u22:0};
+  let _ = assert_eq(fpsqrt_32(nine), three);
+  // sqrt(25).
+  let twenty_five = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:4), 
+                  sfd: u4:0x9 ++ u19:0};
+  let five = F32 {sign: u1:0, bexp: 
+                  float32::bias(u9:2), 
+                  sfd: u2:1 ++ u21:0};
+  let _ = assert_eq(fpsqrt_32(twenty_five), five);
+  ()
+}
+

--- a/xls/modules/fpsqrt_32_test.cc
+++ b/xls/modules/fpsqrt_32_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Random-sampling test for the DSLX 32-bit floating-point sqrt.
+#include <cmath>
+#include <limits>
+
+#include "absl/random/random.h"
+#include "absl/status/status.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/init_xls.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/math_util.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/ir/value_view_helpers.h"
+#include "xls/modules/fpsqrt_32_jit_wrapper.h"
+#include "xls/tools/testbench.h"
+
+ABSL_FLAG(bool, use_opt_ir, true, "Use optimized IR.");
+ABSL_FLAG(int, num_threads, 0,
+          "Number of threads to use. Set to 0 to use all.");
+ABSL_FLAG(int64_t, num_samples, 1024 * 1024,
+          "Number of random samples to test.");
+
+namespace xls {
+
+constexpr const char kOptIrPath[] = "xls/modules/fpsqrt_32.opt.ir";
+constexpr const char kIrPath[] = "xls/modules/fpsqrt_32.ir";
+
+// Generates a float with reasonably unformly random bit patterns.
+float IndexToInput(uint64_t index) {
+  thread_local absl::BitGen bitgen;
+  uint32_t a = absl::Uniform(bitgen, 0u, std::numeric_limits<uint32_t>::max());
+  return absl::bit_cast<float>(a);
+}
+
+// The DSLX implementation uses the "round to nearest (half to even)"
+// rounding mode, which is the default on most systems, hence we don't need
+// to call fesetround().
+// The DSLX implementation also flushes input subnormals to 0, so we do that
+// here as well.
+float ComputeExpected(float input) {
+  float x = FlushSubnormal(input);
+  return sqrtf(x);
+}
+
+// Computes FP sqrt via DSLX & the JIT.
+float ComputeActual(Fpsqrt32* jit_wrapper, float input) {
+  return jit_wrapper->Run(input).value();
+}
+
+// Compares expected vs. actual results, taking into account two special cases.
+bool CompareResults(float a, float b) {
+  // DSLX flushes subnormal outputs, while regular FP addition does not, so
+  // just check for that here.
+  return a == b || (std::isnan(a) && std::isnan(b)) ||
+         (ZeroOrSubnormal(a) && ZeroOrSubnormal(b));
+}
+
+void LogMismatch(uint64_t index, float input, float expected,
+                 float actual) {
+  XLS_LOG(ERROR) << absl::StrFormat(
+      "Value mismatch at index %d, input %f:\n"
+      "  Input:  0x%x\n"
+      "  Expected: 0x%x\n"
+      "  Actual  : 0x%x",
+      index, input,
+      absl::bit_cast<uint32_t>(input),
+      absl::bit_cast<uint32_t>(expected), 
+      absl::bit_cast<uint32_t>(actual));
+}
+
+absl::Status RealMain(bool use_opt_ir, uint64_t num_samples, int num_threads) {
+  Testbench<Fpsqrt32, float, float> testbench(
+      0, num_samples,
+      /*max_failures=*/1, IndexToInput, ComputeExpected, ComputeActual,
+      CompareResults, LogMismatch);
+  if (num_threads != 0) {
+    XLS_RETURN_IF_ERROR(testbench.SetNumThreads(num_threads));
+  }
+  return testbench.Run();
+}
+
+}  // namespace xls
+
+int main(int argc, char** argv) {
+  xls::InitXls(argv[0], argc, argv);
+  XLS_QCHECK_OK(xls::RealMain(absl::GetFlag(FLAGS_use_opt_ir),
+                              absl::GetFlag(FLAGS_num_samples),
+                              absl::GetFlag(FLAGS_num_threads)));
+  return 0;
+}


### PR DESCRIPTION
Square root implementation is based on the go implementation, which is based on a FreeBSD implementation (see file for license / references).
Fast inverse square root is based on a widley publicized algorithm that was popularized by it's use in the game Quake.  However, its actual provenance seems to be pretty fuzzy.  Given that the algorithm is very well-known / widespread, that there is not an obvious license associated with the concept, and that implementing the algorithm in DSLX necessarily results in different code than sources available online, I'm inclined to think we don't have to do anything re licensing here, but I'm no expert.