### PR TITLE
Added fpldexp and cast from float to fixed-point.

### DIFF
--- a/xls/dslx/stdlib/bfloat16.x
+++ b/xls/dslx/stdlib/bfloat16.x
@@ -30,6 +30,12 @@ pub fn bias(unbiased_exponent_in: u9) -> u8 {
 }
 pub fn flatten(f: BF16) -> u16 { apfloat::flatten<u32:8, u32:7>(f) }
 pub fn unflatten(f: u16) -> BF16 { apfloat::unflatten<u32:8, u32:7>(f) }
+pub fn cast_from_fixed<NUM_SRC_BITS:u32>(s: sN[NUM_SRC_BITS]) -> BF16 {
+  apfloat::cast_from_fixed<u32:8, u32:7>(s)
+}
+pub fn cast_to_fixed<NUM_DST_BITS:u32>(to_cast: BF16) -> sN[NUM_DST_BITS] {
+  apfloat::cast_from_fixed(to_cast)
+}
 pub fn subnormals_to_zero(f: BF16) -> BF16 {
   apfloat::subnormals_to_zero<u32:8, u32:7>(f)
 }

--- a/xls/dslx/stdlib/float32.x
+++ b/xls/dslx/stdlib/float32.x
@@ -35,6 +35,12 @@ pub fn bias(unbiased_exponent_in: u9) -> u8 {
 }
 pub fn flatten(f: F32) -> u32 { apfloat::flatten<u32:8, u32:23>(f) }
 pub fn unflatten(f: u32) -> F32 { apfloat::unflatten<u32:8, u32:23>(f) }
+pub fn cast_from_fixed<NUM_SRC_BITS:u32>(s: sN[NUM_SRC_BITS]) -> F32 {
+  apfloat::cast_from_fixed<u32:8, u32:23>(s)
+}
+pub fn cast_to_fixed<NUM_DST_BITS:u32>(to_cast: F32) -> sN[NUM_DST_BITS] {
+  apfloat::cast_from_fixed(to_cast)
+}
 pub fn subnormals_to_zero(f: F32) -> F32 {
   apfloat::subnormals_to_zero<u32:8, u32:23>(f)
 }

--- a/xls/dslx/stdlib/float64.x
+++ b/xls/dslx/stdlib/float64.x
@@ -38,6 +38,12 @@ pub fn bias(unbiased_exponent_in: u12) -> u11 {
 }
 pub fn flatten(f: F64) -> u64 { apfloat::flatten<u32:11, u32:52>(f) }
 pub fn unflatten(f: u64) -> F64 { apfloat::unflatten<u32:11, u32:52>(f) }
+pub fn cast_from_fixed<NUM_SRC_BITS:u32>(s: sN[NUM_SRC_BITS]) -> F64 {
+  apfloat::cast_from_fixed<u32:11, u32:52>(s)
+}
+pub fn cast_to_fixed<NUM_DST_BITS:u32>(to_cast: F64) -> sN[NUM_DST_BITS] {
+  apfloat::cast_from_fixed(to_cast)
+}
 pub fn subnormals_to_zero(f: F64) -> F64 {
   apfloat::subnormals_to_zero<u32:11, u32:52>(f)
 }

--- a/xls/dslx/tests/local_const_value_as_nested_loop_bound.x
+++ b/xls/dslx/tests/local_const_value_as_nested_loop_bound.x
@@ -1,0 +1,29 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main(input: u32) -> u32 {
+  const FOO = u32:2;
+  for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+    for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+      for(idx, acc): (u32, u32) in range(u32:0, FOO) {
+        acc + input
+      }(acc)
+    }(acc)
+  }(u32:0)
+}
+
+#![test]
+fn local_test() {
+  assert_eq(u32:8, main(u32:1))
+}

--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -75,6 +75,28 @@ cc_binary(
 )
 
 dslx_test(
+    name = "dot_product",
+    srcs = ["dot_product.x"],
+    deps = ["//xls/modules:apfloat_add_2.x",
+            "//xls/modules:fpadd_2x32.x",
+            "//xls/modules:apfloat_mul_2.x",
+            "//xls/modules:fpmul_2x32.x"],
+    # No meaningful entry point to convert.
+    convert_ir = False,
+)
+
+dslx_test(
+    name = "fir_filter",
+    srcs = ["fir_filter.x"],
+    deps = ["//xls/modules:apfloat_add_2.x",
+            "//xls/modules:fpadd_2x32.x",
+            "//xls/modules:apfloat_mul_2.x",
+            "//xls/modules:fpmul_2x32.x"],
+    # No meaningful entry point to convert.
+    convert_ir = False,
+)
+
+dslx_test(
     name = "riscv_simple",
     srcs = ["riscv_simple.x"],
     # TODO(hjmontero): run_instruction segfaults.

--- a/xls/examples/dot_product.x
+++ b/xls/examples/dot_product.x
@@ -1,0 +1,74 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Paramterized fixed and floating point dot product
+// implementations.
+
+import std
+import float32
+import xls.modules.fpadd_2x32
+import xls.modules.fpmul_2x32
+
+type F32 = float32::F32;
+
+// Caluclates the dot product of fixed-point vectors a and b.
+pub fn dot_product_fixed<BITCOUNT: u32, VECTOR_LENGTH: u32>
+  (a: sN[BITCOUNT][VECTOR_LENGTH], b: sN[BITCOUNT][VECTOR_LENGTH])
+  -> sN[BITCOUNT]{
+
+  for(idx, acc): (u32, sN[BITCOUNT])
+    in range (u32:0, VECTOR_LENGTH) {
+      
+    let partial_product = a[idx] * b[idx];
+    acc + partial_product
+  } (sN[BITCOUNT]:0)
+}
+
+// Caluclates the dot product of 32-bit floating-pont 
+// vectors a and b.
+pub fn dot_product_float32<VECTOR_LENGTH: u32>
+  (a: F32[VECTOR_LENGTH], b: F32[VECTOR_LENGTH])
+  -> F32{
+
+  for(idx, acc): (u32, F32)
+    in range (u32:0, VECTOR_LENGTH) {
+    let partial_product = fpmul_2x32::fpmul_2x32(a[idx], b[idx]);
+    fpadd_2x32::fpadd_2x32(acc, partial_product)
+  } (float32::zero(u1:0))
+}
+
+#![test]
+fn dot_product_fixed_test() {
+   let a = s32[4]:[1, 2, 3, 4];
+   let b = s32[4]:[5, 6, 7, 8];
+   let result = dot_product_fixed<u32:32, u32:4>(a, b);
+   let _ = assert_eq(result, s32:70);
+
+   let a = s8[2]:[1, 2];
+   let b = s8[2]:[5, 6];
+   let result = dot_product_fixed<u32:8, u32:2>(a, b);
+   let _ = assert_eq(result, s8:17);
+   ()
+}
+
+#![test]
+fn dot_product_float32_test() {
+   let a = map(s32[4]:[1, 2, 3, 4], float32::cast_from_fixed);
+   let b = map(s32[4]:[5, 6, 7, 8], float32::cast_from_fixed);
+   let result = dot_product_float32(a, b);
+   let _ = assert_eq(result, float32::cast_from_fixed(s32:70));
+   ()
+
+}
+

--- a/xls/examples/fir_filter.x
+++ b/xls/examples/fir_filter.x
@@ -1,0 +1,98 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Paramterized fixed and floating point fir filter
+// implementations.  A fir filter, used in signal
+// processing, is essentially a convolution of a
+// filter of a series of samples.
+
+import std
+import float32
+import xls.modules.fpadd_2x32
+import xls.modules.fpmul_2x32
+
+type F32 = float32::F32;
+
+
+pub fn fir_filter_fixed<NUM_TAPS:u32, NUM_SAMPLES:u32, 
+  NUM_OUTPUTS:u32 = NUM_SAMPLES - NUM_TAPS + u32:1>
+  (samples: s32[NUM_SAMPLES], coefficients: s32[NUM_TAPS]) 
+  -> s32[NUM_OUTPUTS] {
+
+  // Convolve filter coefficients over sample array.
+  for(out_idx, fir_output): (u32, s32[NUM_OUTPUTS]) 
+    in range(u32:0, NUM_OUTPUTS) {
+
+    // Compute a single output datapoint.
+    // There's probably a way to reuse dot-product here
+    // (flatten sample array, bitslice, reverse, repack as array,
+    // then pass to dot product?), but it seems like more 
+    // trouble than it's worth.
+    let point_output = for(tap_idx, acc): (u32, s32) 
+      in range(u32:0, NUM_TAPS) {
+
+      let sample_idx = out_idx + NUM_TAPS - tap_idx - u32:1;
+      let product = coefficients[tap_idx] * samples[sample_idx];
+      acc + product
+
+    }(s32:0);
+
+    update(fir_output, out_idx, point_output)
+
+  }(s32[NUM_OUTPUTS]:[0,...])
+}
+
+pub fn fir_filter_float32<NUM_TAPS:u32, NUM_SAMPLES:u32, 
+  NUM_OUTPUTS:u32 = NUM_SAMPLES - NUM_TAPS + u32:1>
+  (samples: F32[NUM_SAMPLES], coefficients: F32[NUM_TAPS]) 
+  -> F32[NUM_OUTPUTS] {
+
+  // Convolve filter coefficients over sample array.
+  for(out_idx, fir_output): (u32, F32[NUM_OUTPUTS]) 
+    in range(u32:0, NUM_OUTPUTS) {
+
+    // Compute a single output datapoint.
+    let point_output = for(tap_idx, acc): (u32, F32) 
+      in range(u32:0, NUM_TAPS) {
+
+      let sample_idx = out_idx + NUM_TAPS - tap_idx - u32:1;
+      let product = fpmul_2x32::fpmul_2x32(coefficients[tap_idx], 
+                                           samples[sample_idx]);
+      fpadd_2x32::fpadd_2x32(acc, product)
+
+    }(float32::zero(u1:0));
+
+    update(fir_output, out_idx, point_output)
+
+  }(F32[NUM_OUTPUTS]:[float32::zero(u1:0),...])
+}
+
+#![test]
+fn fir_filter_fixed_test() {
+   let samples = s32[6]:[1, 2, 3, 4, 5, 6];
+   let coefficients = s32[4]:[10, 11, -12, -13];
+   let result = fir_filter_fixed(samples, coefficients);
+   let _ = assert_eq(result, s32[3]:[36, 32, 28]);
+   ()
+}
+
+#![test]
+fn fir_filter_float32_test() {
+   let samples = map(s32[6]:[1, 2, 3, 4, 5, 6], float32::cast_from_fixed);
+   let coefficients= map(s32[4]:[10, 11, -12, -13], float32::cast_from_fixed);
+   let result = fir_filter_float32(samples, coefficients);
+   let expected = map(s32[3]:[36, 32, 28], float32::cast_from_fixed);
+   let _ = assert_eq(result, expected);
+   ()
+}

--- a/xls/modules/BUILD
+++ b/xls/modules/BUILD
@@ -140,6 +140,37 @@ dslx_test(
 )
 
 dslx_test(
+    name = "fpldexp_32",
+    srcs = ["fpldexp_32.x"],
+)
+
+dslx_jit_wrapper(
+    name = "fpldexp_32_jit_wrapper",
+    dslx_name = "fpldexp_32",
+    deps = [":fpldexp_32_opt_ir"],
+)
+
+cc_test(
+    name = "fpldexp_32_test",
+    srcs = ["fpldexp_32_test.cc"],
+    data = [":fpldexp_32_all_ir"],
+    tags = ["optonly"],
+    deps = [
+        ":fpldexp_32_jit_wrapper",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/status",
+        "//xls/common:init_xls",
+        "//xls/common:math_util",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "//xls/ir:value_helpers",
+        "//xls/ir:value_view_helpers",
+        "//xls/tools:testbench",
+    ],
+)
+
+dslx_test(
     name = "fpmul_2x32",
     srcs = ["fpmul_2x32.x"],
     # 2021-03-08: Takes too long (> 15 minutes).


### PR DESCRIPTION
 These will be used for an exp() function (currently blocked float division is not checked in).
 
I planned to base fpldexp on the go implementation on of ldexp.  However, I ended up just writing it myself once I understood what the function was supposed to do.  So, I don't think lisence / attribution is necessary.