### PR TITLE
Get DSL code to syntax highlight in the mkdocs

### DIFF
--- a/docs_src/contributing.md
+++ b/docs_src/contributing.md
@@ -80,3 +80,18 @@ Note that the `mkvirtualenv` command assumes you're using
 to manage your Python environment. You'll need to adjust these instrutions if
 you're doing something different. That can include explicitly adding `mkdocs` to
 your path, if locally installed Python binaries aren't available by default.
+
+### DSL snippets in documentation
+
+There are a few different language annotations we use in different
+circumstances in the Markdown docs:
+
+* `dslx`: A full code block that should be parsed/typechecked/tested.
+* `dslx-snippet`: A fragment that should be syntax highlighted but not
+  parsed/typechecked/tested.
+* `dslx-bad`: An example of something that we expect to produce an error
+  when parsing/typechecking/testing.
+
+GitHub issue [google/xls#378](https://github.com/google/xls/issues/378) tracks
+a script that does the parse/typecheck/test that ensures our documentation is
+up to date and correct.

--- a/docs_src/fpadd_example.md
+++ b/docs_src/fpadd_example.md
@@ -6,38 +6,36 @@ with a discussion on the algorithm and how it maps to DSLX.
 This document assumes familiarity with floating-point numbers in general
 (layout, precision, error, etc.).
 
-[TOC]
-
 ## Background
 
 Floating-point addition, like any FP operation, is much more complicated than
 integer addition, and has many more steps.
 
-1.  Expand significands: Floating-point operations are computed with bits beyond
+1.  **Expand significands:** Floating-point operations are computed with bits beyond
     that in their normal representations for increased precision. For IEEE 754
     numbers, there are three extra, called the guard, rounding and sticky bits.
     The first two behave normally, but the last, the "sticky" bit, is special.
     During shift operations (below), if a "1" value is ever shifted into the
     sticky bit, it "sticks" - the bit will remain "1" through any further shift
     operations. In this step, the significands are expanded by these three bits.
-1.  Align significands: To ensure that significands are added with appropriate
+1.  **Align significands:** To ensure that significands are added with appropriate
     magnitudes, they must be aligned according to their exponents. To do so, the
     smaller significant needs to be shifted to the right (each right shift is
     equivalent to increasing the exponent by one).
     -   The extra precision bits are populated in this shift.
     -   As part of this step, the leading 1 bit... and a sign bit Note: The
         sticky bit is calculated and applied in this step.
-1.  Sign-adjustment: if the significands differ in sign, then the significand
+1.  **Sign-adjustment:** if the significands differ in sign, then the significand
     with the smaller initial exponent needs to be (two's complement) negated.
-1.  Add the significands and capture the carry bit. Note that, if the signs of
+1.  **Add the significands and capture the carry bit.** Note that, if the signs of
     the significands differs, then this could result in higher bits being
     cleared.
-1.  Normalize the significands: Shift the result so that the leading '1' is
+1.  **Normalize the significands:** Shift the result so that the leading '1' is
     present in the proper space. This means shifting right one place if the
     result set the carry bit, and to the left some number of places if high bits
     were cleared.
     -   The sticky bit must be preserved in any of these shifts!
-1.  Rounding: Here, the extra precision bits are examined to determine if the
+1.  **Rounding:** Here, the extra precision bits are examined to determine if the
     result significand's last bit should be rounded up. IEEE 754 supports five
     rounding modes:
     -   Round towards 0: just chop off the extra precision bits.
@@ -54,8 +52,8 @@ integer addition, and has many more steps.
         -   This is the most commonly-used rounding mode.
         -   This is [currently] the only supported mode by the DSLX
             implementation.
-1.  Special case handling: The results are examined for special cases such as
-    NaNs, infinities, or (optionally) subnormals.
+1.  **Special case handling:** The results are examined for special cases such
+    as NaNs, infinities, or (optionally) subnormals.
 
 ## DSLX implementation
 
@@ -69,7 +67,7 @@ the greater exponent, but there are two extra cases to consider. If the operands
 have the same exponent, then the sign will be that of the greater significand,
 and if the result is 0, then we favor positive 0 vs. negative 0.
 
-```
+```dslx-snippet
   let sfd = (addend_x as s29) + (addend_y as s29);
   let sfd_is_zero = sfd == s29:0;
   let result_sign = match (sfd_is_zero, sfd < s29:0) {
@@ -84,7 +82,7 @@ and if the result is 0, then we favor positive 0 vs. negative 0.
 As complicated as rounding is to describe, its implementation is relatively
 straightforward.
 
-```
+```dslx-snippet
   let normal_chunk = shifted_sfd[0:3];
   let half_way_chunk = shifted_sfd[2:4];
   let do_round_up =

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,3 +49,15 @@ nav:
     - Glossary: 'xls_noc_glossary.md'
 markdown_extensions:
   - mdx_truly_sane_lists
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      extend_pygments_lang:
+        - name: dslx
+          lang: rust
+        # dslx-snippet indicates the code block doesn't need to parse and
+        # typecheck.
+        - name: dslx-snippet
+          lang: rust
+        # dslx-bad indicates the code block is showing something wrong.
+        - name: dslx-bad
+          lang: rust


### PR DESCRIPTION
Introduces three language annotations (all of which map to Rust for
Pygments syntax highlight purposes):

* `dslx`: A full code block that should be parsed/typechecked/tested.
* `dslx-snippet`: A fragment that should be syntax highlighted but not
  parsed/typechecked/tested.
* `dslx-bad`: An example of something that we expect to produce an error
  when parsing/typechecking/testing.

Adds note on language tags to contributing docs.

Towards google/xls#378