### PR TITLE
Add basic string interpolation to assert op

### DIFF
--- a/docs_src/ir_semantics.md
+++ b/docs_src/ir_semantics.md
@@ -1151,6 +1151,7 @@ other side-effecting operations.
 ```
 result = assert(tkn, condition, message=<string>)
 result = assert(tkn, condition, message=<string>, label=<string>)
+result = assert(tkn, condition, message=<string>, data_operands=<operands>, label=<string>)
 ```
 
 **Types**
@@ -1169,8 +1170,27 @@ Value       | Type
 | --------- | ----------------- | -------- | ------- | --------------- |
 | `message` | `string`          | yes      |         | Message to include in raised error |
 | `label`   | `optional string` | yes      |         | Label to associate with the assert statement in the generated (System)Verilog |
+| `data_operands` | array of    | no       | `[]`    | Data operands that are interpolated in the provided message |
 
 <!-- mdformat on -->
+
+The message can interpolate data operands using curly `{}`. Anything that is not
+contained in braces is considered literal text, which is copied unchanged to the
+output. Curly braces can be escaped by doubling up, e.g. `{{` or `}}`. A format
+specifier can be provided within the braces to set how the argument should be
+printed. The valid specifiers are:
+
+* no specifier: Print the argument in its default format.
+* `:x`: Print argument in hex.
+* `:b`: Print argument in binary.
+* `:d`: Print argument in decimal.
+
+Printing a compound type (e.g. tuple or array) will apply the specifier
+recursively to the contained bits.
+
+Invalid interpolation arguments (for example, not enough data operands being
+provided, or an invalid specifier being used) will simply print the unformatted
+message.
 
 #### **`cover`**
 

--- a/xls/common/BUILD
+++ b/xls/common/BUILD
@@ -204,6 +204,30 @@ cc_library(
 )
 
 cc_library(
+    name = "string_interpolation",
+    srcs = ["string_interpolation.cc"],
+    hdrs = ["string_interpolation.h"],
+    deps = [
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/functional:function_ref",
+        "@com_google_absl//absl/strings:str_format",
+        "//xls/common/status:ret_check",
+        "//xls/common/status:status_macros",
+    ],
+)
+
+cc_test(
+    name = "string_interpolation_test",
+    srcs = ["string_interpolation_test.cc"],
+    deps = [
+        ":string_interpolation",
+        ":xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
     name = "string_to_int",
     srcs = ["string_to_int.cc"],
     hdrs = ["string_to_int.h"],

--- a/xls/common/string_interpolation.cc
+++ b/xls/common/string_interpolation.cc
@@ -1,0 +1,72 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/common/string_interpolation.h"
+
+#include "absl/strings/str_format.h"
+#include "xls/common/status/ret_check.h"
+#include "xls/common/status/status_macros.h"
+
+namespace xls {
+
+absl::StatusOr<std::string> InterpolateArgs(absl::string_view s,
+                                            InterpolationCallback print_arg) {
+  std::string result;
+  result.reserve(s.size());
+  int64_t i = 0;
+  int64_t arg_idx = 0;
+  while (i < s.size()) {
+    if (s[i] == '{') {
+      // escaped lcurly - skip over it and continue
+      if (i + 1 < s.size() && s[i + 1] == '{') {
+        result += '{';
+        i += 2;
+        continue;
+      }
+      // not escaped: try and find matching rcurly
+      int64_t j = i + 1;
+      while (j < s.size() && s[j] != '}') {
+        ++j;
+      }
+      // couldn't find a matching rcurly
+      if (j == s.size()) {
+        return absl::InvalidArgumentError(
+            absl::StrFormat("unmatched '{' at index %d", i, s));
+      }
+
+      // found a matching rcurly, format the argument and bump i passed the "}"
+      XLS_ASSIGN_OR_RETURN(std::string formatted_arg,
+                           print_arg(s.substr(i + 1, j - i - 1), arg_idx++));
+      result += formatted_arg;
+      i = j + 1;
+    } else if (s[i] == '}') {
+      // escaped rcurly - skip over it and continue
+      if (i + 1 < s.size() && s[i + 1] == '}') {
+        result += '}';
+        i += 2;
+        continue;
+      }
+      // otherwise this is an error, because matched "}"s would be found after
+      // encountering its corresponding "{" above.
+      return absl::InvalidArgumentError(
+          absl::StrFormat("unmatched '}' at index %d", i, s));
+    } else {
+      result += s[i++];
+    }
+  }
+
+  return result;
+}
+
+}  // namespace xls

--- a/xls/common/string_interpolation.h
+++ b/xls/common/string_interpolation.h
@@ -1,0 +1,46 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_COMMON_STRING_INTERPOLATION_H_
+#define XLS_COMMON_STRING_INTERPOLATION_H_
+
+#include "absl/status/statusor.h"
+
+namespace xls {
+
+// Callback provided by the user for determining how to print individual
+// arguments. It is passed the format spec (the text between braces `{}`), as
+// well as the index of the argument in question (see InterpolateArgs below).
+using InterpolationCallback =
+    absl::FunctionRef<absl::StatusOr<std::string>(absl::string_view, int64_t)>;
+
+// Parses the input string, calling the provided callback on any format
+// arguments and interpolating them into the original string.
+//
+// For example, passing a string of "start {} mid {foo} end" will call the
+// callback with arguments ("", 0) and ("foo", 1), substituting the call results
+// (assuming no failures) into the resulting string. Using javascript syntax,
+// this would be equivalent to the template literal:
+//
+//   `start ${print_arg("", 0)} mid ${print_arg("foo", 1)} end`
+//
+// This function allows escaping by doubling up on curly braces. For example,
+// an input string of "{{}}" will result in an output string of "{}", similar
+// to Python and Rust.
+absl::StatusOr<std::string> InterpolateArgs(absl::string_view s,
+                                            InterpolationCallback print_arg);
+
+}  // namespace xls
+
+#endif  // XLS_COMMON_STRING_INTERPOLATION_H_

--- a/xls/common/string_interpolation_test.cc
+++ b/xls/common/string_interpolation_test.cc
@@ -1,0 +1,78 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/common/string_interpolation.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls {
+namespace {
+
+using ::testing::HasSubstr;
+using xls::status_testing::StatusIs;
+
+// concatenate the format spec and the index so we can check both in the
+// expected output
+absl::StatusOr<std::string> PrintArg(absl::string_view format, int64_t index) {
+  return std::to_string(index) + std::string(format);
+}
+
+TEST(StringInterpolation, ValidStrings) {
+  struct TestCase {
+    std::string input;
+    std::string expected;
+  };
+  auto cases = {
+      TestCase{"{{}}", "{}"},
+      TestCase{"asdf{{", "asdf{"},
+      TestCase{"{}", "0"},
+      TestCase{"start {a} m {b} n {c} end", "start 0a m 1b n 2c end"},
+      TestCase{"{{{x}}}", "{0x}"},
+      TestCase{"{x{d}", "0x{d"},
+  };
+  for (const auto& test_case : cases) {
+    XLS_ASSERT_OK_AND_ASSIGN(std::string result,
+                             InterpolateArgs(test_case.input, PrintArg));
+    EXPECT_EQ(result, test_case.expected);
+  }
+}
+
+TEST(StringInterpolation, InvalidStrings) {
+  EXPECT_THAT(InterpolateArgs("{x}d}", PrintArg),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("unmatched '}' at index 4")));
+  EXPECT_THAT(InterpolateArgs("{{}}}", PrintArg),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("unmatched '}' at index 4")));
+  EXPECT_THAT(InterpolateArgs("{{{}}", PrintArg),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("unmatched '}' at index 4")));
+  EXPECT_THAT(InterpolateArgs("{foo} bar {baz", PrintArg),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("unmatched '{' at index 10")));
+  auto at_most_two_args = [](absl::string_view format,
+                             int64_t index) -> absl::StatusOr<std::string> {
+    if (index >= 2)
+      return absl::InvalidArgumentError("not enough data operands");
+    return "dontcare";
+  };
+  EXPECT_THAT(InterpolateArgs("{foo} {bar} {baz}", at_most_two_args),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("not enough data operands")));
+}
+
+}  // namespace
+}  // namespace xls

--- a/xls/dslx/ir_converter.cc
+++ b/xls/dslx/ir_converter.cc
@@ -1837,7 +1837,7 @@ absl::Status FunctionConverter::HandleFailBuiltin(Invocation* node,
                                           node->span().ToString());
     BValue assert_result_token = function_builder_->Assert(
         implicit_token_data_->entry_token,
-        function_builder_->Not(control_predicate), message);
+        function_builder_->Not(control_predicate), message, /*data_operands=*/{});
     implicit_token_data_->control_tokens.push_back(assert_result_token);
   }
   // The result of the failure call is the argument given; e.g. if we were to

--- a/xls/interpreter/BUILD
+++ b/xls/interpreter/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "//xls/common/logging:log_lines",
         "//xls/common/status:ret_check",
         "//xls/common/status:status_macros",
+        "//xls/common:string_interpolation",
         "//xls/ir",
         "//xls/ir:bits",
         "//xls/ir:bits_ops",

--- a/xls/interpreter/ir_interpreter.h
+++ b/xls/interpreter/ir_interpreter.h
@@ -162,6 +162,9 @@ class IrInterpreter : public DfsVisitor {
   absl::StatusOr<Value> DeepOr(Type* input_type,
                                absl::Span<const Value* const> inputs);
 
+  std::string FormatString(absl::string_view message,
+                           absl::Span<Node* const> data_operands);
+
   // The arguments to the Function being evaluated indexed by parameter name.
   std::vector<Value> args_;
 

--- a/xls/ir/function_builder.cc
+++ b/xls/ir/function_builder.cc
@@ -1137,6 +1137,7 @@ BValue BuilderBase::AddBitwiseReductionOp(Op op, BValue arg,
 
 BValue BuilderBase::Assert(BValue token, BValue condition,
                            absl::string_view message,
+                           absl::Span<const BValue> data_operands,
                            absl::optional<std::string> label,
                            absl::optional<SourceLocation> loc,
                            absl::string_view name) {
@@ -1157,8 +1158,12 @@ BValue BuilderBase::Assert(BValue token, BValue condition,
                         condition.GetType()->ToString()),
         loc);
   }
-  return AddNode<xls::Assert>(loc, token.node(), condition.node(), message,
-                              label, name);
+  std::vector<Node*> data_operand_nodes;
+  for (const BValue& operand : data_operands) {
+    data_operand_nodes.push_back(operand.node());
+  }
+  return AddNode<xls::Assert>(loc, token.node(), condition.node(),
+                              data_operand_nodes, message, label, name);
 }
 
 BValue BuilderBase::Cover(BValue token, BValue condition,
@@ -1304,11 +1309,12 @@ BValue TokenlessProcBuilder::SendIf(Channel* channel, BValue pred, BValue data,
 }
 
 BValue TokenlessProcBuilder::Assert(BValue condition, absl::string_view message,
+                                    absl::Span<const BValue> data_operands,
                                     absl::optional<std::string> label,
                                     absl::optional<SourceLocation> loc,
                                     absl::string_view name) {
-  BValue asrt = BuilderBase::Assert(GetTokenParam(), condition, message, label,
-                                    loc, name);
+  BValue asrt = BuilderBase::Assert(GetTokenParam(), condition, message,
+                                    data_operands, label, loc, name);
   tokens_.push_back(asrt);
   return asrt;
 }

--- a/xls/ir/function_builder.h
+++ b/xls/ir/function_builder.h
@@ -545,6 +545,7 @@ class BuilderBase {
   // Adds an assert op to the function. Assert raises an error containing the
   // given message if the given condition evaluates to false.
   BValue Assert(BValue token, BValue condition, absl::string_view message,
+                absl::Span<const BValue> data_operands,
                 absl::optional<std::string> label = absl::nullopt,
                 absl::optional<SourceLocation> loc = absl::nullopt,
                 absl::string_view name = "");
@@ -737,6 +738,7 @@ class TokenlessProcBuilder : public ProcBuilder {
   // Add an assert operation. Returns the token-typed assert operation.
   using BuilderBase::Assert;
   BValue Assert(BValue condition, absl::string_view message,
+                absl::Span<const BValue> data_operands,
                 absl::optional<std::string> label = absl::nullopt,
                 absl::optional<SourceLocation> loc = absl::nullopt,
                 absl::string_view name = "");

--- a/xls/ir/function_builder_test.cc
+++ b/xls/ir/function_builder_test.cc
@@ -702,7 +702,7 @@ TEST(FunctionBuilderTest, Assert) {
   Package p("p");
   FunctionBuilder b("f", &p);
   b.Assert(b.Param("tkn", p.GetTokenType()), b.Param("cond", p.GetBitsType(1)),
-           /*message=*/"It's about sending a message");
+           /*message=*/"It's about sending a message", /*data_operands=*/{});
   XLS_ASSERT_OK_AND_ASSIGN(Function * f, b.Build());
   EXPECT_THAT(f->return_value(), m::Assert(m::Param("tkn"), m::Param("cond")));
   EXPECT_EQ(f->return_value()->As<Assert>()->message(),
@@ -714,7 +714,8 @@ TEST(FunctionBuilderTest, AssertWrongTypeOperand0) {
   FunctionBuilder b("f", &p);
   b.Assert(b.Param("blah", p.GetBitsType(42)),
            b.Param("cond", p.GetBitsType(1)),
-           /*message=*/"It's about sending a message");
+           /*message=*/"It's about sending a message",
+           /*data_operands=*/{});
   EXPECT_THAT(
       b.Build().status(),
       StatusIs(absl::StatusCode::kInvalidArgument,
@@ -725,7 +726,7 @@ TEST(FunctionBuilderTest, AssertWrongTypeOperand1) {
   Package p("p");
   FunctionBuilder b("f", &p);
   b.Assert(b.Param("blah", p.GetTokenType()), b.Param("cond", p.GetBitsType(2)),
-           /*message=*/"It's about sending a message");
+           /*message=*/"It's about sending a message", /*data_operands=*/{});
   EXPECT_THAT(
       b.Build().status(),
       StatusIs(

--- a/xls/ir/ir_parser.cc
+++ b/xls/ir/ir_parser.cc
@@ -913,6 +913,9 @@ absl::StatusOr<BValue> Parser::ParseNode(
     }
     case Op::kAssert: {
       QuotedString* message = arg_parser.AddKeywordArg<QuotedString>("message");
+      std::optional<std::vector<BValue>>* maybe_operands =
+          arg_parser.AddOptionalKeywordArg<std::vector<BValue>>(
+              "data_operands");
       absl::optional<QuotedString>* label =
           arg_parser.AddOptionalKeywordArg<QuotedString>("label");
       XLS_ASSIGN_OR_RETURN(operands, arg_parser.Run(/*arity=*/2));
@@ -920,8 +923,12 @@ absl::StatusOr<BValue> Parser::ParseNode(
       if (label->has_value()) {
         label_string = label->value().value;
       }
+      std::vector<BValue> data_operands;
+      if (maybe_operands->has_value()) {
+        data_operands = maybe_operands->value();
+      }
       bvalue = fb->Assert(operands[0], operands[1], message->value,
-                          label_string, *loc, node_name);
+                          data_operands, label_string, *loc, node_name);
       break;
     }
     case Op::kCover: {

--- a/xls/ir/ir_parser_test.cc
+++ b/xls/ir/ir_parser_test.cc
@@ -1132,6 +1132,18 @@ fn bar(tkn: token, cond: bits[1]) -> token {
   ParsePackageAndCheckDump(input);
 }
 
+TEST(IrParserTest, ParseAssertWithOperands) {
+  const std::string input = R"(package foobar
+
+fn bar(tkn: token, cond: bits[1]) -> token {
+  literal.1: bits[32] = literal(value=1, id=1)
+  literal.2: bits[32] = literal(value=2, id=2)
+  ret assert.3: token = assert(tkn, cond, message="The {} is {:x}", data_operands=[literal.1, literal.2], label="assert_label", id=3)
+}
+)";
+  ParsePackageAndCheckDump(input);
+}
+
 TEST(IrParserTest, ParseBitSliceUpdate) {
   const std::string input = R"(package foobar
 

--- a/xls/ir/node.cc
+++ b/xls/ir/node.cc
@@ -521,8 +521,17 @@ std::string Node::ToStringInternal(bool include_operand_types) const {
       break;
     }
     case Op::kAssert:
+      args = {operand(0)->GetName(), operand(1)->GetName()};
       args.push_back(
           absl::StrFormat("message=\"%s\"", As<Assert>()->message()));
+      if (!As<Assert>()->data_operands().empty()) {
+        args.push_back(absl::StrFormat(
+            "data_operands=[%s]",
+            absl::StrJoin(As<Assert>()->data_operands(), ", ",
+                          [](std::string* out, const Node* node) {
+                            absl::StrAppend(out, node->GetName());
+                          })));
+      }
       if (As<Assert>()->label().has_value()) {
         args.push_back(
             absl::StrFormat("label=\"%s\"", As<Assert>()->label().value()));

--- a/xls/ir/nodes_source.tmpl
+++ b/xls/ir/nodes_source.tmpl
@@ -203,6 +203,18 @@ absl::StatusOr<Node*> ArrayUpdate::CloneInNewFunction(
                                       name_);
 }
 
+absl::StatusOr<Node*> Assert::CloneInNewFunction(
+    absl::Span<Node* const> new_operands,
+    FunctionBase* new_function) const {
+  return new_function->MakeNodeWithName<Assert>(loc(),
+                                    new_operands[0],
+                                    new_operands[1],
+                                    new_operands.subspan(2),
+                                    message(),
+                                    label(),
+                                    name_);
+}
+
 bool Select::AllCases(std::function<bool(Node*)> p) const {
   for (Node* case_ : cases()) {
     if (!p(case_)) {

--- a/xls/ir/op_specification.py
+++ b/xls/ir/op_specification.py
@@ -481,7 +481,7 @@ OpClass.kinds['ARITH_OP'] = OpClass(
 OpClass.kinds['ASSERT'] = OpClass(
     name='Assert',
     op='Op::kAssert',
-    operands=[Operand('token'), Operand('condition')],
+    operands=[Operand('token'), Operand('condition'), OperandSpan('data_operands')],
     xls_type_expression='function->package()->GetTokenType()',
     extra_methods=[Method(name='token',
                           return_cpp_type='Node*',
@@ -489,8 +489,11 @@ OpClass.kinds['ASSERT'] = OpClass(
                    Method(name='condition',
                           return_cpp_type='Node*',
                           expression='operand(1)'),
-                   ],
-    attributes=[StringAttribute('message'), OptionalStringAttribute('label')]
+                   Method(name='data_operands',
+                          return_cpp_type='absl::Span<Node* const>',
+                          expression='operands().subspan(2)')],
+    attributes=[StringAttribute('message'), OptionalStringAttribute('label')],
+    custom_clone_method=True,
 )
 
 OpClass.kinds['COVER'] = OpClass(

--- a/xls/ir/verifier.cc
+++ b/xls/ir/verifier.cc
@@ -65,7 +65,7 @@ class NodeChecker : public DfsVisitor {
   }
 
   absl::Status HandleAssert(Assert* assert_op) override {
-    XLS_RETURN_IF_ERROR(ExpectOperandCount(assert_op, 2));
+    XLS_RETURN_IF_ERROR(ExpectOperandCountGt(assert_op, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(assert_op, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(assert_op, /*operand_no=*/1,
                                                  /*expected_bit_count=*/1));


### PR DESCRIPTION
This commit adds a `data_operands` field to the Assert node,
and specifies a format string format for interpolating these
operands into the assert message. This format is implemented
in the IR interpreter.

(see #342)