### PR TITLE
[examples] add hsv2rgb

### DIFF
--- a/third_party/xls_colors/BUILD
+++ b/third_party/xls_colors/BUILD
@@ -23,3 +23,31 @@ xls_dslx_test(
     name = "hsv2rgb_dslx_test",
     dep = ":hsv2rgb_dslx_module",
 )
+
+cc_test(
+    name = "hsv2rgb_verilog_test",
+    srcs = ["test.cc"],
+    deps = [
+        "//xls/codegen:combinational_generator",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:matchers",
+        "//xls/dslx:ir_converter",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/ir",
+        "//xls/ir:ir_parser",
+        "//xls/ir:ir_test_base",
+        "@com_google_googletest//:gtest",
+        ":fast_hsv2rgb",
+    ],
+    data = [
+        ":hsv2rgb_dslx_module",
+    ]
+)
+
+cc_library(
+    name = "fast_hsv2rgb",
+    srcs = ["fast_hsv2rgb_32bit.c"],
+    hdrs = ["fast_hsv2rgb.h"],
+)

--- a/third_party/xls_colors/BUILD
+++ b/third_party/xls_colors/BUILD
@@ -1,0 +1,25 @@
+# XLS color library ported from https://www.vagrearg.org/content/hsvrgb
+
+load(
+    "//xls/build_rules:xls_build_defs.bzl",
+    "xls_dslx_module_library",
+    "xls_dslx_test",
+)
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+)
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+xls_dslx_module_library(
+    name = "hsv2rgb_dslx_module",
+    src = "hsv2rgb.x",
+)
+
+xls_dslx_test(
+    name = "hsv2rgb_dslx_test",
+    dep = ":hsv2rgb_dslx_module",
+)

--- a/third_party/xls_colors/LICENSE
+++ b/third_party/xls_colors/LICENSE
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2016  B. Stultiens
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.

--- a/third_party/xls_colors/fast_hsv2rgb.h
+++ b/third_party/xls_colors/fast_hsv2rgb.h
@@ -1,0 +1,197 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016  B. Stultiens
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#ifndef __HSV_FAST_HSV2RGB_H__
+#define __HSV_FAST_HSV2RGB_H__
+
+#include <stdint.h>
+
+#define HSV_HUE_SEXTANT		256
+#define HSV_HUE_STEPS		(6 * HSV_HUE_SEXTANT)
+
+#define HSV_HUE_MIN		0
+#define HSV_HUE_MAX		(HSV_HUE_STEPS - 1)
+#define HSV_SAT_MIN		0
+#define HSV_SAT_MAX		255
+#define HSV_VAL_MIN		0
+#define HSV_VAL_MAX		255
+
+/* Options: */
+#define HSV_USE_SEXTANT_TEST	/* Limit the hue to 0...360 degrees */
+#define HSV_USE_ASSEMBLY	/* Optimize code using assembly */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * The "used" attribute is required in the assembly version because Arduino
+ * uses lto. With lto, the function is inlined into the rest of the code, which
+ * eliminates the pointers to r, g, and b. However, the code requires pointers
+ * because we need to do pointer swapping.
+ * Adding the attribute to the function here forces gcc/linker to add the
+ * function separately to the code and it must be called, just like other
+ * library functions.
+ */
+#ifdef HSV_USE_ASSEMBLY
+#define HSVFUNC_ATTRUSED	__attribute__((used))
+#else
+#define HSVFUNC_ATTRUSED
+#endif
+
+void fast_hsv2rgb_8bit(uint16_t h, uint8_t s, uint8_t v, uint8_t *r, uint8_t *g , uint8_t *b) HSVFUNC_ATTRUSED;
+void fast_hsv2rgb_32bit(uint16_t h, uint8_t s, uint8_t v, uint8_t *r, uint8_t *g , uint8_t *b) HSVFUNC_ATTRUSED;
+
+#ifdef __cplusplus
+}
+#endif
+
+
+/*
+ * Macros that are common to all implementations
+ */
+#define HSV_MONOCHROMATIC_TEST(s,v,r,g,b) \
+	do { \
+		if(!(s)) { \
+			 *(r) = *(g) = *(b) = (v); \
+			return; \
+		} \
+	} while(0)
+
+#ifdef HSV_USE_SEXTANT_TEST
+#define HSV_SEXTANT_TEST(sextant) \
+	do { \
+		if((sextant) > 5) { \
+			(sextant) = 5; \
+		} \
+	} while(0)
+#else
+#define HSV_SEXTANT_TEST(sextant) do { ; } while(0)
+#endif
+
+/*
+ * Pointer swapping:
+ * 	sext.	r g b	r<>b	g<>b	r <> g	result
+ *	0 0 0	v u c			!u v c	u v c
+ *	0 0 1	d v c				d v c
+ *	0 1 0	c v u	u v c			u v c
+ *	0 1 1	c d v	v d c		d v c	d v c
+ *	1 0 0	u c v		u v c		u v c
+ *	1 0 1	v c d		v d c	d v c	d v c
+ *
+ * if(sextant & 2)
+ * 	r <-> b
+ *
+ * if(sextant & 4)
+ * 	g <-> b
+ *
+ * if(!(sextant & 6) {
+ * 	if(!(sextant & 1))
+ * 		r <-> g
+ * } else {
+ * 	if(sextant & 1)
+ * 		r <-> g
+ * }
+ */
+#define HSV_SWAPPTR(a,b)	do { uint8_t *tmp = (a); (a) = (b); (b) = tmp; } while(0)
+#define HSV_POINTER_SWAP(sextant,r,g,b) \
+	do { \
+		if((sextant) & 2) { \
+			HSV_SWAPPTR((r), (b)); \
+		} \
+		if((sextant) & 4) { \
+			HSV_SWAPPTR((g), (b)); \
+		} \
+		if(!((sextant) & 6)) { \
+			if(!((sextant) & 1)) { \
+				HSV_SWAPPTR((r), (g)); \
+			} \
+		} else { \
+			if((sextant) & 1) { \
+				HSV_SWAPPTR((r), (g)); \
+			} \
+		} \
+	} while(0)
+
+
+#if defined(HSV_USE_ASSEMBLY)
+
+#if defined(__AVR_HAVE_MUL__)
+/* Multiply instruction available */
+#define MUL(ra,rb,pfx) \
+		"mul	" ra ", " rb "\n\t"
+#else /* defined(__AVR_HAVE_MUL__) */
+/*
+ * Small AVR cores (f.x. ATtiny and ATmega*u2) do not have a mul instruction.
+ * It is available from the avr4 architecture.
+ *
+ * Multiply: r1:r0 = ra * rb (clobbers r19, r17, r16)
+ * Algorithm:
+ * uint16_t mul(uint8_t ra, uint8_t rb)
+ * {
+ *	r1:r0   = 0
+ *	r19     = ra
+ *	r17:r16 = rb
+ *	do {
+ *		if(r19 & 1)
+ *			r1:r0 += r17:r16
+ *		r17:r16 += r17:r16
+ *		r19 >>= 1;
+ *	} while(r19)
+ *	return r1:r0
+ * }
+ */
+#define MUL(ra,rb,pfx) \
+	"\n" \
+	".L" pfx "mul_" ra "_" rb "_%=:\n\t" \
+		"clr	r0\n\t" \
+		"clr	r1\n\t" \
+		"mov	r19, " ra "\n\t" \
+		"mov	r16, " rb "\n\t" \
+		"clr	r17\n" \
+	".L" pfx "mul_loop_" ra "_" rb "_%=:\n\t" \
+		"sbrc	r19, 0\n\t" \
+		"add	r0, r16\n\t" \
+		"sbrc	r19, 0\n\t" \
+		"adc	r1, r17\n\t" \
+		"add	r16, r16\n\t" \
+		"adc	r17, r17\n\t" \
+		"lsr	r19\n\t" \
+		"brne	.L" pfx "mul_loop_" ra "_" rb "_%=\n\t"
+#endif /* defined(__AVR_HAVE_MUL__) */
+
+#if defined(__AVR_HAVE_MOVW__)
+#define MOVW(rdh,rdl,rsh,rsl) \
+		"movw	" rdl ", " rsl "\n\t"
+#else /* defined(__AVR_HAVE_MOVW__) */
+/*
+ * The avr2 (and avr1) architecture is missing the movw instruction
+ * (ATtiny22/26/1* and AT90s*). All others should have it.
+ */
+#define MOVW(rdh,rdl,rsh,rsl) \
+		"mov	" rdl ", " rsl "\n\t" \
+		"mov	" rdh ", " rsh "\n\t"
+#endif /* defined(__AVR_HAVE_MOVW__) */
+#endif /* defined(HSV_USE_ASSEMBLY) */
+
+#endif

--- a/third_party/xls_colors/fast_hsv2rgb_32bit.c
+++ b/third_party/xls_colors/fast_hsv2rgb_32bit.c
@@ -1,0 +1,238 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016  B. Stultiens
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+#include "fast_hsv2rgb.h"
+
+#if defined(HSV_USE_ASSEMBLY) && !defined(__AVR_ARCH__)
+#warning "Only AVR assembly is implemented. Other architectures use C fallback."
+#undef HSV_USE_ASSEMBLY
+#endif
+
+void fast_hsv2rgb_32bit(uint16_t h, uint8_t s, uint8_t v, uint8_t *r, uint8_t *g , uint8_t *b)
+{
+#ifndef HSV_USE_ASSEMBLY
+	HSV_MONOCHROMATIC_TEST(s, v, r, g, b);	// Exit with grayscale if s == 0
+
+	uint8_t sextant = h >> 8;
+
+	HSV_SEXTANT_TEST(sextant);		// Optional: Limit hue sextants to defined space
+
+	HSV_POINTER_SWAP(sextant, r, g, b);	// Swap pointers depending which sextant we are in
+
+	*g = v;		// Top level
+
+	// Perform actual calculations
+
+	/*
+	 * Bottom level: v * (1.0 - s)
+	 * --> (v * (255 - s) + error_corr + 1) / 256
+	 */
+	uint16_t ww;		// Intermediate result
+	ww = v * (255 - s);	// We don't use ~s to prevent size-promotion side effects
+	ww += 1;		// Error correction
+	ww += ww >> 8;		// Error correction
+	*b = ww >> 8;
+
+	uint8_t h_fraction = h & 0xff;	// 0...255
+	uint32_t d;			// Intermediate result
+
+	if(!(sextant & 1)) {
+		// *r = ...slope_up...;
+		d = v * (uint32_t)((255 << 8) - (uint16_t)(s * (256 - h_fraction)));
+		d += d >> 8;	// Error correction
+		d += v;		// Error correction
+		*r = d >> 16;
+	} else {
+		// *r = ...slope_down...;
+		d = v * (uint32_t)((255 << 8) - (uint16_t)(s * h_fraction));
+		d += d >> 8;	// Error correction
+		d += v;		// Error correction
+		*r = d >> 16;
+	}
+
+#else /* HSV_USE_ASSEMBLY */
+
+#ifdef __AVR_ARCH__
+	/*
+	 * Function arguments passed in registers:
+	 *   h = r25:r24
+	 *   s = r22
+	 *   v = r20
+	 *   *r = r19:r18
+	 *   *g = r17:r16
+	 *   *b = r15:r14
+	 */
+	asm volatile (
+		MOVW("r27", "r26", "r19", "r18")	// r -> X
+		MOVW("r29", "r28", "r17", "r16")	// g -> Y
+		MOVW("r31", "r30", "r15", "r14")	// b -> Z
+
+		"cpse	r22, __zero_reg__\n\t"	// if(!s) --> monochromatic
+		"rjmp	.Lneedcalc%=\n\t"
+
+		"st	X, r20\n\t"		// *r = *g = *b = v;
+		"st	Y, r20\n\t"
+		"st	Z, r20\n\t"
+		"rjmp	.Lendoffunc%=\n"	// return
+
+	".Lneedcalc%=:\n\t"
+
+		"cpi	r25, lo8(6)\n\t"	// if(hi8(h) > 5) hi8(h) = 5;
+		"brlo	.Linrange%=\n\t"
+		"ldi	r25,lo8(5)\n"
+	".Linrange%=:\n\t"
+
+		"sbrs	r25, 1\n\t"		// if(sextant & 2) swapptr(r, b);
+		"rjmp	.Lsextno1%=\n\t"
+		MOVW("r19", "r18", "r27", "r26")
+		MOVW("r27", "r26", "r31", "r30")
+		MOVW("r31", "r30", "r19", "r18")
+	"\n"
+	".Lsextno1%=:\n\t"
+
+		"sbrs	r25, 2\n\t"		// if(sextant & 4) swapptr(g, b);
+		"rjmp	.Lsextno2%=\n\t"
+		MOVW("r19", "r18", "r29", "r28")
+		MOVW("r29", "r28", "r31", "r30")
+		MOVW("r31", "r30", "r19", "r18")
+	"\n"
+	".Lsextno2%=:\n\t"
+
+		"ldi	r18, lo8(6)\n\t"
+		"and	r18, r25\n\t"		// if(!(sextant & 6))
+		"brne	.Lsext2345%=\n\t"
+
+		"sbrc	r25, 0\n\t"		// if(!(sextant & 6) && !(sextant & 1)) --> doswasp
+		"rjmp	.Ldoneswap%=\n"
+	".Lsext0%=:\n\t"
+		MOVW("r19", "r18", "r27", "r26")
+		MOVW("r27", "r26", "r29", "r28")
+		MOVW("r29", "r28", "r19", "r18")
+		"rjmp	.Ldoneswap%=\n"
+
+	".Lsext2345%=:\n\t"
+		"sbrc	r25, 0\n\t"		// if((sextant & 6) && (sextant & 1)) --> doswap
+		"rjmp	.Lsext0%=\n"
+	".Ldoneswap%=:\n\t"
+
+		/* Top level assignment first to free up Y register (r29:r28) */
+		"st	Y, r20\n\t"		// *g = v
+
+		"ldi	r18, 0\n\t"		// Temporary zero reg (r1 is used by mul)
+		"ldi	r19, 1\n\t"		// Temporary one reg
+
+		/*
+		 * Do bottom level next so we may use Z register (r31:r30).
+		 *
+		 *	Bottom level: v * (1.0 - s)
+		 *	--> (v * (255 - s) + error_corr + 1) / 256
+		 *	1 bb = ~s;
+		 *	2 ww = v * bb;
+		 *	3 ww += 1;
+		 *	4 ww += ww >> 8;	// error_corr for division 1/256 instead of 1/255
+		 *	5 *b = ww >> 8;
+		 */
+		"mov	r23, r22\n\t"		// 1 use copy of s
+		"com	r23\n\t"		// 1
+		MUL("r23", "r20", "a")		// 2 r1:r0 = v *  ~s
+		"add	r0, r19\n\t"		// 3 r1:r0 += 1
+		"adc	r1, r18\n\t"		// 3
+		"add	r0, r1\n\t"		// 4 r1:r0 += r1:r0 >> 8
+		"adc	r1, r18\n\t"		// 4
+		"st	Z, r1\n\t"		// 5 *b = r1:r0 >> 8
+
+		/* All that is left are the slopes */
+
+		"sbrc	r25, 0\n\t"		// if(sextant & 1) --> slope down
+		"rjmp	.Lslopedown%=\n\t"
+
+		/* Slope up:
+		 *	d = v * ((255 << 8) - (s * (256 - h_fraction)));
+		 *	d += d >> 8;	// Error correction
+		 *	d += v;		// Error correction
+		 *	*r = d >> 16;
+		 */
+		"ldi	r28, 0\n\t"		// 0 r19:r28 = 256 (0x100)
+		"sub	r28, r24\n\t"		// 0 256 - h_fraction
+		"sbc	r19, r18\n\t"
+		MUL("r22", "r28", "b")		// r1:r0 = s * lo8(256 - h_fraction)
+		"sbrc	r19, 0\n\t"		// if(256 - h_fraction == 0x100)
+		"add	r1, r22\n\t"		//   r1:r0 += s << 8
+		"rjmp	.Lslopecommon%=\n\t"	// r1:r0 holds inner multiplication
+
+		/*
+		 * Slope down:
+		 *	d = v * ((255 << 8) - (s * h_fraction));
+		 *	d += d >> 8;	// Error correction
+		 *	d += v;		// Error correction
+		 *	*r = d >> 16;
+		 */
+	"\n"
+	".Lslopedown%=:\n\t"
+		MUL("r22", "r24", "b")		// r1:r0 = s * h_fraction
+	"\n"
+	".Lslopecommon%=:\n\t"
+		"ldi	r31, 255\n\t"		// Z = 255 << 8
+		"mov	r30, r18\n\t"
+		"sub	r30, r0\n\t"		// Z = (255 << 8) - (s * (...))
+		"sbc	r31, r1\n\t"
+
+		/*
+		 * Multiply r20 * r31:r30:
+		 * r29:r28	= r20 * r31	lo8 * hi8
+		 * r1:r0	= r20 * r30	lo8 * lo8
+		 * Sum:
+		 *	r29 : r28 : (0)
+		 *	(0) : r1  : r0
+		 *	--------------- +
+		 *	r29 : r28 : r0
+		 */
+		MUL("r31", "r20", "c")
+		MOVW("r29", "r28", "r1", "r0")	// Y = hi8(Z) * v
+		MUL("r30", "r20", "d")		// r1:r0 = lo8(Z) * v
+		"add	r28, r1\n\t"
+		"adc	r29, r18\n\t"		// r29:r28:r0 = Y * v
+		"add	r0, r28\n\t"		// Error correction r29:r28:r0 += 0:r29:r28
+		"adc	r28, r29\n\t"
+		"adc	r29, r18\n\t"
+		"add	r0, r20\n\t"		// Error correction r29:r28:r0 += v
+		"adc	r28, r18\n\t"
+		"adc	r29, r18\n\t"
+		"st	X, r29\n\t"		// *r = slope result >> 16
+
+		"clr	__zero_reg__\n"		// Restore zero reg
+
+	".Lendoffunc%=:\n"
+	:
+	:
+	: "r31", "r30", "r29", "r28", "r27", "r26", "r25", "r24", "r23", "r22", "r19", "r18"
+#ifndef __AVR_HAVE_MUL__
+	 , "r17", "r16"
+#endif
+	);
+
+#else /* __AVR_ARCH__ */
+#error "No assembly version implemented for architecture"
+#endif
+#endif
+}

--- a/third_party/xls_colors/hsv2rgb.x
+++ b/third_party/xls_colors/hsv2rgb.x
@@ -1,0 +1,82 @@
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2016  B. Stultiens
+// Copyright 2021 The XLS Authors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+// Fast HSV to RGB conversion.
+//
+// Range:
+//   h: [0, 0x5ff], s: [0, 0xff], v: [0, 0xff]
+//   r: [0,  0xff], g: [0, 0xff], b: [0, 0xff]
+//
+// Ported from https://www.vagrearg.org/content/hsvrgb.
+
+pub fn slope(h_fraction: u16, s: u8, v:u8) -> u8{
+  let u:u32 = (v as u32) * ((u32:255 << 8) - ((s as u16) * h_fraction) as u32);
+  let u:u32 = u + (u >> 8);
+  let u:u32 = u + (v as u32);
+  u[16:24]
+}
+
+pub fn hsv2rgb(h: u16, s: u8, v: u8) -> (u8, u8, u8) {
+  let sextant:u8 = h[8:16];
+  let sextant:u8 = u8:5 if sextant > u8:5 else sextant;
+
+  let ww:u16 = (v as u16) * ((u8:255 - s) as u16);
+  let ww:u16 = ww + u16:1;
+  let ww:u16 = ww + ww >> 8;
+  let c:u8 = ww[8:16];
+
+  let h_fraction:u16 = h[0:8] as u16;
+  let nh_fraction:u16 = u16:256 - h_fraction;
+  let u:u8 = slope(nh_fraction, s, v);
+  let d:u8 = slope(h_fraction, s, v);
+
+  (v, v, v) if s == u8:0 else match sextant {
+    u8:0 => (v, u, c),
+    u8:1 => (d, v, c),
+    u8:2 => (c, v, u),
+    u8:3 => (c, d, v),
+    u8:4 => (u, c, v),
+    u8:5 => (v, c, d),
+    _ => fail!((u8:0, u8:0, u8:0)),
+ }
+}
+
+#![test]
+fn hsv2rgb_test() {
+  let _= assert_eq(hsv2rgb(u16:0, u8:0, u8:0), (u8:0, u8:0, u8:0));
+  let _= assert_eq(hsv2rgb(u16:0, u8:0, u8:255), (u8:255, u8:255, u8:255));  
+  let _= assert_eq(hsv2rgb(u16:300, u8:0, u8:127), (u8:127, u8:127, u8:127));
+  let _= assert_eq(hsv2rgb(u16:0, u8:255, u8:255), (u8:255, u8:0, u8:0));
+  let _= assert_eq(hsv2rgb(u16:128, u8:255, u8:255), (u8:255, u8:127, u8:0));
+  let _= assert_eq(hsv2rgb(u16:256, u8:255, u8:255), (u8:255, u8:255, u8:0));
+  let _= assert_eq(hsv2rgb(u16:384, u8:255, u8:255), (u8:127, u8:255, u8:0));
+  let _= assert_eq(hsv2rgb(u16:512, u8:255, u8:255), (u8:0, u8:255, u8:0));
+  let _= assert_eq(hsv2rgb(u16:640, u8:255, u8:255), (u8:0, u8:255, u8:127));
+  let _= assert_eq(hsv2rgb(u16:768, u8:255, u8:255), (u8:0, u8:255, u8:255));
+  let _= assert_eq(hsv2rgb(u16:896, u8:255, u8:255), (u8:0, u8:127, u8:255));  
+  let _= assert_eq(hsv2rgb(u16:1024, u8:255, u8:255), (u8:0, u8:0, u8:255));
+  let _= assert_eq(hsv2rgb(u16:1152, u8:255, u8:255), (u8:127, u8:0, u8:255));
+  let _= assert_eq(hsv2rgb(u16:1280, u8:255, u8:255), (u8:255, u8:0, u8:255));  
+  _
+}

--- a/third_party/xls_colors/test.cc
+++ b/third_party/xls_colors/test.cc
@@ -1,0 +1,53 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/codegen/combinational_generator.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/ir_converter.h"
+#include "xls/dslx/parse_and_typecheck.h"
+#include "xls/ir/package.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/ir_test_base.h"
+#include "fast_hsv2rgb.h"
+
+using xls::Value;
+using xls::UBits;
+
+class XlsColorsTest : public xls::IrTestBase {};
+
+TEST_F(XlsColorsTest, Hsv2RgbTest) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::filesystem::path path,
+      xls::GetXlsRunfilePath("third_party/xls_colors/hsv2rgb.x"));
+  XLS_ASSERT_OK_AND_ASSIGN(std::string moduleText, xls::GetFileContents(path));
+  xls::dslx::ImportData import_data;
+  XLS_ASSERT_OK_AND_ASSIGN(
+      xls::dslx::TypecheckedModule tm,
+      xls::dslx::ParseAndTypecheck(moduleText, "hsv2rgb.x", "hsv2rgb", &import_data));
+  const xls::dslx::ConvertOptions& options = xls::dslx::ConvertOptions{};
+  XLS_ASSERT_OK_AND_ASSIGN(std::string package_text,
+                           xls::dslx::ConvertModule(tm.module, &import_data, options));
+  const uint8_t s = 255;
+  const uint8_t v = 255;
+  const uint16_t hstep = 8;
+  for (uint16_t h = 0; h < 256 * 6; h+=hstep) {
+    uint8_t r, g, b;
+    fast_hsv2rgb_32bit(h, s, v, &r, &g, &b);
+    RunAndExpectEq({{"h", Value(UBits(h, 16))}, {"s", Value(UBits(s, 8))}, {"v", Value(UBits(v, 8))}},
+                   Value::Tuple({Value(UBits(r, 8)), Value(UBits(g, 8)), Value(UBits(b, 8))}),
+                   package_text, true, true);
+  }
+}

--- a/xls/BUILD
+++ b/xls/BUILD
@@ -22,6 +22,7 @@ package_group(
         "//third_party/xls_berkeley_softfloat/...",
         "//third_party/xls_go_math/...",
         "//third_party/xls_machsuite/...",
+        "//third_party/xls_colors/...",
     ],
 )
 


### PR DESCRIPTION
Fast HSV to RGB conversion.

Ported from https://www.vagrearg.org/content/hsvrgb (MIT license).

- Translated https://www.vagrearg.org/hsvrgb/fast_hsv2rgb_32bit.chttps://www.vagrearg.org/hsvrgb/fast_hsv2rgb_32bit.c to unsafe Rust.
- Converted pointers swap to a match expression.
- Converted `mut`s and statements to let expressions.
- Ported to DSLX.