### PR TITLE
[public]: add python bindings

### DIFF
--- a/xls/public/python/BUILD
+++ b/xls/public/python/BUILD
@@ -1,0 +1,43 @@
+# Copyright 2021 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pytype tests are present in this file
+load("//dependency_support/pybind11:pybind11.bzl", "xls_pybind_extension")
+
+package(
+    default_visibility = [
+        "//xls:xls_internal",
+    ],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+xls_pybind_extension(
+    name = "runtime_build_actions",
+    srcs = ["runtime_build_actions.cc"],
+    deps = [
+        "//xls/common/status:statusor_pybind_caster",
+        "//xls/public:runtime_build_actions",
+    ],
+)
+
+py_test(
+    name = "runtime_build_actions_test",
+    srcs = ["runtime_build_actions_test.py"],
+    python_version = "PY3",
+    deps = [
+        ":runtime_build_actions",
+        "@com_google_absl_py//absl/testing:absltest",
+        "//xls/common/python:init_xls",
+    ],
+)

--- a/xls/public/python/runtime_build_actions.cc
+++ b/xls/public/python/runtime_build_actions.cc
@@ -27,23 +27,18 @@ PYBIND11_MODULE(runtime_build_actions, m) {
 
   m.def("convert_dslx_to_ir", [](absl::string_view dslx, absl::string_view path, absl::string_view package, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
       return ConvertDslxToIr(dslx, path, package, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
-    });
+    }, py::arg("dslx"), py::arg("path"), py::arg("package"), py::arg("additional_search_paths"));
 
   m.def("convert_dslx_path_to_ir", [](absl::string_view path, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
       return ConvertDslxPathToIr(path, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
-    });
+    }, py::arg("path"), py::arg("additional_search_paths"));
 
-  m.def("optimize_ir", [](absl::string_view ir, absl::string_view entry) -> absl::StatusOr<std::string> {
-      return OptimizeIr(ir, entry);
-    });
+  m.def("optimize_ir", &OptimizeIr, py::arg("ir"), py::arg("entry"));
 
-  m.def("mangle_dslx_name", [](absl::string_view module_name, absl::string_view function_name) -> absl::StatusOr<std::string> {
-      return MangleDslxName(module_name, function_name);
-    });
+  m.def("mangle_dslx_name", &MangleDslxName, py::arg("module_name"), py::arg("function_name"));
 
-  m.def("proto_to_dslx", [](absl::string_view proto_def, absl::string_view message_name, absl::string_view text_proto, absl::string_view binding_name) -> absl::StatusOr<std::string> {
-      return ProtoToDslx(proto_def, message_name, text_proto, binding_name);
-    });
+  m.def("proto_to_dslx", &ProtoToDslx, py::arg("proto_def"), py::arg("message_name"), py::arg("text_proto"), py::arg("binding_name"));
+
 }
 
 }  // namespace xls

--- a/xls/public/python/runtime_build_actions.cc
+++ b/xls/public/python/runtime_build_actions.cc
@@ -27,17 +27,42 @@ PYBIND11_MODULE(runtime_build_actions, m) {
 
   m.def("convert_dslx_to_ir", [](absl::string_view dslx, absl::string_view path, absl::string_view package, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
       return ConvertDslxToIr(dslx, path, package, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
-    }, py::arg("dslx"), py::arg("path"), py::arg("package"), py::arg("additional_search_paths"));
+    }, R"(Converts the specified DSLX text into XLS IR text.
+
+Args:
+ dslx: DSL (module) text to convert to IR.
+ path: Path to use for source location information for the given text.
+   Since text may be generated, an empty string or a pseudo path like
+   "<generated>" is acceptable.
+ module_name: Name of the DSL module, will be used in the name of the
+   converted IR package text.
+ additional_search_paths: Additional filesystem paths to search for imported
+   modules.)", py::arg("dslx"), py::arg("path"), py::arg("package"), py::arg("additional_search_paths"));
 
   m.def("convert_dslx_path_to_ir", [](absl::string_view path, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
       return ConvertDslxPathToIr(path, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
-    }, py::arg("path"), py::arg("additional_search_paths"));
+    }, R"(As convert_dslx_to_ir, but uses a filesystem path to retrieve the DSLX module contents.
+"path" should end with ".x" suffix, the path will determine the module name.)", py::arg("path"), py::arg("additional_search_paths"));
 
-  m.def("optimize_ir", &OptimizeIr, py::arg("ir"), py::arg("entry"));
+  m.def("optimize_ir", &OptimizeIr, R"(Optimizes the generated XLS IR with the given entry point (which should be a
+function present inside the IR text).)", py::arg("ir"), py::arg("entry"));
 
-  m.def("mangle_dslx_name", &MangleDslxName, py::arg("module_name"), py::arg("function_name"));
+  m.def("mangle_dslx_name", &MangleDslxName, R"(Mangles the given DSL module/function name combination so it can be resolved
+as a corresponding symbol in converted IR.)", py::arg("module_name"), py::arg("function_name"));
 
-  m.def("proto_to_dslx", &ProtoToDslx, py::arg("proto_def"), py::arg("message_name"), py::arg("text_proto"), py::arg("binding_name"));
+  m.def("proto_to_dslx", &ProtoToDslx, R"(Converts protocol buffer data into its equivalent DSLX text, as a
+module-level constant.
+
+Note: this currently only supports "standalone" protobuf schemas; i.e. this
+cannot translate schemas that import other `.proto` files. If this limitation
+affects you, please file an issue at `github.com/google/xls/issues`
+
+Args:
+ proto_def: Protobuf schema (e.g. contents of `.proto` file).
+ message_name: Name of the message type (inside the protobuf schema) to emit.
+ text_proto: Protobuf text to translate to DSLX.
+ binding_name: Name of the (const) DSLX binding (i.e. const variable name) to
+   make in the output text.)", py::arg("proto_def"), py::arg("message_name"), py::arg("text_proto"), py::arg("binding_name"));
 
 }
 

--- a/xls/public/python/runtime_build_actions.cc
+++ b/xls/public/python/runtime_build_actions.cc
@@ -1,0 +1,49 @@
+// Copyright 2021 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/runtime_build_actions.h"
+
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+#include "xls/common/status/statusor_pybind_caster.h"
+
+namespace py = pybind11;
+
+namespace xls {
+
+PYBIND11_MODULE(runtime_build_actions, m) {
+  ImportStatusModule();
+
+  m.def("convert_dslx_to_ir", [](absl::string_view dslx, absl::string_view path, absl::string_view package, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
+      return ConvertDslxToIr(dslx, path, package, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
+    });
+
+  m.def("convert_dslx_path_to_ir", [](absl::string_view path, const std::vector<absl::string_view>& additional_search_paths) -> absl::StatusOr<std::string> {
+      return ConvertDslxPathToIr(path, std::vector<std::filesystem::path>(additional_search_paths.begin(), additional_search_paths.end()));
+    });
+
+  m.def("optimize_ir", [](absl::string_view ir, absl::string_view entry) -> absl::StatusOr<std::string> {
+      return OptimizeIr(ir, entry);
+    });
+
+  m.def("mangle_dslx_name", [](absl::string_view module_name, absl::string_view function_name) -> absl::StatusOr<std::string> {
+      return MangleDslxName(module_name, function_name);
+    });
+
+  m.def("proto_to_dslx", [](absl::string_view proto_def, absl::string_view message_name, absl::string_view text_proto, absl::string_view binding_name) -> absl::StatusOr<std::string> {
+      return ProtoToDslx(proto_def, message_name, text_proto, binding_name);
+    });
+}
+
+}  // namespace xls

--- a/xls/public/python/runtime_build_actions_test.py
+++ b/xls/public/python/runtime_build_actions_test.py
@@ -1,0 +1,94 @@
+# Lint as: python3
+#
+# Copyright 2021 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for xls.public.runtime_build_actions."""
+
+import sys
+import tempfile
+
+from xls.public.python import runtime_build_actions
+from xls.common.python import init_xls
+from absl.testing import absltest
+
+
+def setUpModule():
+  # This is required so that module initializers are called including those
+  # which register delay models.
+  init_xls.init_xls(sys.argv)
+
+
+class RuntimeBuildActionsTest(absltest.TestCase):
+
+  def test_convert_dslx_to_ir(self):
+    dslx_text = 'pub fn foo(v:u8) -> u8{ v+u8:1 }'
+    ir_text = runtime_build_actions.convert_dslx_to_ir(
+      dslx_text, '/path/to/foo', 'foo', [])
+    self.assertIn('package foo', ir_text)
+    self.assertIn('bits[8]', ir_text)
+    self.assertIn('add', ir_text)
+    self.assertIn('literal', ir_text)
+
+  def test_convert_dslx_path_to_ir(self):
+    with tempfile.NamedTemporaryFile(prefix='foo', suffix='.x') as f:
+        f.write(b'pub fn foo(v:u8) -> u8{ v+u8:1 }')
+        f.flush()
+        ir_text = runtime_build_actions.convert_dslx_path_to_ir(
+            f.name, [])
+    self.assertIn('package foo', ir_text)
+    self.assertIn('bits[8]', ir_text)
+    self.assertIn('add', ir_text)
+    self.assertIn('literal', ir_text)
+
+  def test_optimize_ir(self):
+    dslx_text = 'pub fn foo(v:u8) -> u8{ v+u8:2-u8:1 }'
+    ir_text = runtime_build_actions.convert_dslx_to_ir(
+      dslx_text, '/path/to/foo', 'foo', [])
+    opt_ir_text = runtime_build_actions.optimize_ir(ir_text, '__foo__foo')
+    self.assertNotEqual(ir_text, opt_ir_text)
+
+  def test_mangle_dslx_name(self):
+    mangled_name = runtime_build_actions.mangle_dslx_name('foo', 'bar')
+    self.assertEqual('__foo__bar', mangled_name)
+
+  def test_proto_to_dslx(self):
+    binding_name = 'MY_TEST_MESSAGE'
+    proto_def = """syntax = "proto2";
+
+package xls_public_test;
+
+message TestMessage {
+  optional int32 test_field = 1;
+}
+
+message TestRepeatedMessage {
+  repeated TestMessage messages = 1;
+}"""
+    text_proto = """messages: {
+  test_field: 42
+}
+messages: {
+  test_field: 64
+}"""
+    message_name = 'xls_public_test.TestRepeatedMessage'
+    dslx_text = runtime_build_actions.proto_to_dslx(proto_def, message_name, text_proto, binding_name)
+    self.assertIn('TestMessage', dslx_text)
+    self.assertIn('message', dslx_text)
+    self.assertIn('test_field', dslx_text)
+    self.assertIn(binding_name, dslx_text)
+
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
This will allow better integration with other python based EDA tools (like `litex`, `migen` and `nmigen`).

/cc @tcal-x who was interesting into discussing ways to ease XLS binary distribution.