### PR TITLE
Revert "Remove uses of `incompatible_use_toolchain_transition` now th…

### DIFF
--- a/dependency_support/embedded_python_interpreter/cc_so_library.bzl
+++ b/dependency_support/embedded_python_interpreter/cc_so_library.bzl
@@ -43,5 +43,6 @@ cc_so_library = rule(
         "src": attr.label(allow_single_file = True),
         "_cc_toolchain": attr.label(default = "@bazel_tools//tools/cpp:current_cc_toolchain"),
     },
+    incompatible_use_toolchain_transition = True,
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
 )


### PR DESCRIPTION
…at it is enabled by default."

This is still needed for bazel 4.x compatibility, and it a no-op in
Bazel 5.x, so it should be kept.

The API will be removed in Bazel 6.0.

Part of bazelbuild/bazel#14127.

This reverts commit e1ab8bab9d8cac72c61e80d0f1a6a67f3beda8d8.