### PR TITLE
Bump up BoringSSL commit

### DIFF
--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -59,9 +59,9 @@ def load_external_repositories():
 
     git_repository(
         name = "boringssl",
-        commit = "14164f6fef47b7ebd97cdb0cea1624eabd6fe6b8",  # 2018-11-26
+        commit = "4fb158925f7753d80fb858cb0239dff893ef9f15",  # 2021-11-01
         remote = "https://github.com/google/boringssl.git",
-        shallow_since = "1543277914 +0000",
+        shallow_since = "1635790430 +0000",
     )
 
     http_archive(


### PR DESCRIPTION
The listed commit for the boringssl dependency points to a version that doesn't build with GCC 11.1, which means that XLS doesn't build with GCC 11.1. The underlying issue was fixed in boringssl commit [92c6fbfc4c44dc8462d260d836020d2b793e7804](https://boringssl.googlesource.com/boringssl/+/92c6fbfc4c44dc8462d260d836020d2b793e7804) and is currently in boringssl `main`. This updates the commit to `main-with-bazel` of boringssl as of 2021-11-01 and allows XLS to build with GCC 11.1.