### PR TITLE
Necessary-but-not-sufficient changes to successfully build on OSX.

### DIFF
--- a/xls/common/subprocess.cc
+++ b/xls/common/subprocess.cc
@@ -46,10 +46,12 @@ struct Pipe {
   // Opens a Unix pipe with a C++ friendly interface.
   static absl::StatusOr<Pipe> Open() {
     int descriptors[2];
-    if (pipe2(descriptors, O_CLOEXEC) == -1) {
+    if(pipe(descriptors) || fcntl(descriptors[0], F_SETFD, FD_CLOEXEC) ||
+       fcntl(descriptors[1], F_SETFD, FD_CLOEXEC)) {
       return absl::InternalError(
-          absl::StrCat("Failed to pipe: ", Strerror(errno)));
+          absl::StrCat("Failed to initialize pipe:", Strerror(errno)));
     }
+
     return Pipe(FileDescriptor(descriptors[0]), FileDescriptor(descriptors[1]));
   }
 

--- a/xls/ir/caret.cc
+++ b/xls/ir/caret.cc
@@ -95,7 +95,9 @@ std::string PrintCaret(
     int64_t slack =
         terminal_width - (line_contents_owned.size() + line_number_width + 3);
     int64_t size =
-        std::max(0l, static_cast<int64_t>(line_contents_owned.size()) + slack);
+        std::max(
+          static_cast<int64_t>(0),
+          static_cast<int64_t>(line_contents_owned.size()) + slack);
     line_contents_owned = line_contents_owned.substr(0, size - 1);
     absl::StrAppend(&line_contents_owned, "…");
   }
@@ -114,7 +116,8 @@ std::string PrintCaret(
     // to the width of the terminal.
     int64_t slack = terminal_width - prefix.size();
     if (slack < 30) {
-      int64_t size = std::max(0l, static_cast<int64_t>(prefix.size()) + slack);
+      int64_t size = std::max(
+          static_cast<int64_t>(0), static_cast<int64_t>(prefix.size()) + slack);
       prefix = prefix.substr(0, size);
     }
     absl::StrAppend(&result, PrintWordWrappedWithLinePrefix(

--- a/xls/tools/ice40_device_rpc_strategy.cc
+++ b/xls/tools/ice40_device_rpc_strategy.cc
@@ -209,7 +209,9 @@ absl::Status Ice40DeviceRpcStrategy::Connect(int64_t device_ordinal) {
   t.c_cc[VEOF] = 0;
   t.c_cc[VTIME] = 0;
   t.c_cc[VMIN] = 1;  // blocking read until 1 character arrives
+#ifdef VSWTC
   t.c_cc[VSWTC] = 0;
+#endif
   t.c_cc[VSTART] = 0;
   t.c_cc[VSTOP] = 0;
   t.c_cc[VSUSP] = 0;
@@ -240,7 +242,9 @@ absl::Status Ice40DeviceRpcStrategy::Connect(int64_t device_ordinal) {
   XLS_VLOG(1) << "control modes: " << ControlModesToString(t.c_cflag);
   XLS_VLOG(1) << "local modes:   " << LocalModesToString(t.c_lflag);
 
+#ifdef LINUX
   XLS_VLOG(1) << "c_line: " << std::hex << static_cast<int>(t.c_line);
+#endif
   for (int i = 0; i < NCCS; ++i) {
     XLS_VLOG(3) << "c_cc[" << i << "]: " << std::hex
                 << static_cast<int>(t.c_cc[i]);


### PR DESCRIPTION
Found while attempting to build on an M1 Mac. Tested in that environment, but not on Linux and/or x86.

I don't love the `#ifdef LINUX`, but I wasn't able to find another way to specialize that the  non-POSIX `c_line` field. I'd be just as happy to drop it. WDYT?