### PR TITLE
Need to comment out LTS on line 2

### DIFF
--- a/Dockerfile-ubuntu-22.04
+++ b/Dockerfile-ubuntu-22.04
@@ -1,5 +1,5 @@
 # NOTE: We try to support Ubuntu 22.04 environment as it is the latest Ubuntu
-LTS release.
+# LTS release.
 
 # Download base image ubuntu 22.04
 FROM ubuntu:22.04


### PR DESCRIPTION
The comment on line 1 of  Dockerfile-ubuntu-22.04 breaks near the end and leaves an un-commented piece on line two. This also needs to be commented out.