### PR TITLE
Don't use hardcoded paths to /bin/bash /usr/bin/python

### DIFF
--- a/xls/build_rules/tests/has_clk.sh
+++ b/xls/build_rules/tests/has_clk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # Copyright 2021 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/build_rules/tests/is_block_ir.sh
+++ b/xls/build_rules/tests/is_block_ir.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # Copyright 2022 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/build_rules/tests/not_has_clk.sh
+++ b/xls/build_rules/tests/not_has_clk.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # Copyright 2021 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/build_rules/xls_codegen_rules.bzl
+++ b/xls/build_rules/xls_codegen_rules.bzl
@@ -424,7 +424,7 @@ def _xls_benchmark_verilog_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             cmd,
             "exit 0",

--- a/xls/build_rules/xls_dslx_rules.bzl
+++ b/xls/build_rules/xls_dslx_rules.bzl
@@ -418,7 +418,7 @@ def _xls_dslx_test_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             "\n".join(cmds),
             "exit 0",

--- a/xls/build_rules/xls_ir_rules.bzl
+++ b/xls/build_rules/xls_ir_rules.bzl
@@ -746,7 +746,7 @@ def _xls_ir_equivalence_test_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             cmd,
             "exit 0",
@@ -852,7 +852,7 @@ def _xls_eval_ir_test_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             cmd,
             "exit 0",
@@ -950,7 +950,7 @@ def _xls_benchmark_ir_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             cmd,
             "exit 0",

--- a/xls/build_rules/xls_rules.bzl
+++ b/xls/build_rules/xls_rules.bzl
@@ -192,7 +192,7 @@ def _xls_dslx_opt_ir_test_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             "set -e",
             dslx_test_cmd,
             ir_equivalence_test_cmd,

--- a/xls/build_rules/xls_utilities.bzl
+++ b/xls/build_rules/xls_utilities.bzl
@@ -36,7 +36,7 @@ def _check_sha256sum_test_impl(ctx):
     ctx.actions.write(
         output = executable_file,
         content = "\n".join([
-            "#!/bin/bash",
+            "#!/usr/bin/env bash",
             # Note two spaces is required between the sha256sum and filename to
             # comply with the sha256sum input format.
             "echo \"{}  {}\" | sha256sum -c -".format(

--- a/xls/dslx/ir_converter_test.sh
+++ b/xls/dslx/ir_converter_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/fuzzer/run_crasher.sh
+++ b/xls/fuzzer/run_crasher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/netlist/parse_netlist_main_test.sh
+++ b/xls/netlist/parse_netlist_main_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/benchmark_eval_test.sh
+++ b/xls/tools/benchmark_eval_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/benchmark_test.sh
+++ b/xls/tools/benchmark_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/check_ir_equivalence.sh
+++ b/xls/tools/check_ir_equivalence.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash -ex
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/generate_vvp_runner.py
+++ b/xls/tools/generate_vvp_runner.py
@@ -34,7 +34,7 @@ def main(argv):
   # bazel-out/k8-fastbuild/bin/xls/[...]
   path = '/'.join(path.split('/')[3:])
 
-  print("""#!/bin/bash
+  print("""#!/usr/bin/env bash
 
 temp=$(mktemp)
 stdout="${{temp}}.stdout"

--- a/xls/tools/make_release.py
+++ b/xls/tools/make_release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2020 The XLS Authors
 #

--- a/xls/tools/package_bazel_build_test.sh
+++ b/xls/tools/package_bazel_build_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/bazel-bin/package_test
+++ b/xls/tools/package_bazel_build_testdata/bazel-bin/package_test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/c/copied_dep.sh
+++ b/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/c/copied_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/copied_dep.sh
+++ b/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/copied_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/s/src_dep.sh
+++ b/xls/tools/package_bazel_build_testdata/bazel-bin/package_test.runfiles/s/src_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/hash/execroot/com_google_xls/execroot_dep.sh
+++ b/xls/tools/package_bazel_build_testdata/hash/execroot/com_google_xls/execroot_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/package_bazel_build_testdata/hash/external/outputroot_dep.sh
+++ b/xls/tools/package_bazel_build_testdata/hash/external/outputroot_dep.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/xls/tools/parse_ir_test.sh
+++ b/xls/tools/parse_ir_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2020 The XLS Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
In more pure environments (such as nixos), these paths do not exist.
In general, the recommended way in the unix environment is to use /usr/bin/env to resolve binaries, so

  * `#!/usr/bin/env bash`
  * `#!/usr/bin/env python`

Signed-off-by: Henner Zeller <h.zeller@acm.org>