### PR TITLE
xls/build_rules: Add `top` to the list of valid opt_ir flags

### DIFF
--- a/xls/build_rules/xls_ir_rules.bzl
+++ b/xls/build_rules/xls_ir_rules.bzl
@@ -197,6 +197,7 @@ def _optimize_ir(ctx, src):
     opt_ir_tool = get_executable_from(get_xls_toolchain_info(ctx).opt_ir_tool)
     opt_ir_args = dict(ctx.attr.opt_ir_args)
     IR_OPT_FLAGS = (
+        "top",
         "ir_dump_path",
         "run_only_passes",
         "skip_passes",


### PR DESCRIPTION
The `top` flag exposed by the `opt_main` was not added to the list of available flags in the bazel rules. This addition allows the `top` flag to be used as an argument of the `opt_ir_args` parameter of the `xls_dslx_verilog` bazel rule.

This may be used to create more concise `BUILD` files. For example, three rules used to build the delay example may be substituted with only one rule:
```
diff --git a/xls/examples/BUILD b/xls/examples/BUILD
index a39c10af..51e5d460 100644
--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -474,22 +474,13 @@ xls_dslx_test(
     library = ":delay_dslx",
 )
 
-xls_dslx_ir(
-    name = "delay_ir",
+xls_dslx_verilog(
+    name = "delay_sv",
     dslx_top = "Delay32x2048_init3",
-    ir_file = "delay.ir",
     library = ":delay_dslx",
-)
-
-xls_ir_opt_ir(
-    name = "delay_opt_ir",
-    src = "delay.ir",
-    top = "__delay__Delay32x2048_init3__Delay__DelayInternal_0__10_32_2048_64_1024_3_next",
-)
-
-xls_ir_verilog(
-    name = "delay_sv",
-    src = ":delay_opt_ir.opt.ir",
+    opt_ir_args = {
+        "top": "__delay__Delay32x2048_init3__Delay__DelayInternal_0__10_32_2048_64_1024_3_next",
+    },
     codegen_args = {
         "module_name": "delay_top",
         "generator": "pipeline",
```

Are `xls_dslx_verilog` and `xls_cc_verilog` the only rules that implement both the `CodegenInfo` and `OptIRInfo` providers used by the `xls_benchmark_verilog` bazel rule? I'm wondering if having this flag isn't the only option to generate Verilog benchmarks for examples that suffer from #959 (e.g., `delay.x` example) or the benchmarks can be somehow generated in other way in this case.