### PR TITLE
Force fifo_depth 1 for inter proc channels

### DIFF
--- a/xls/dslx/ir_convert/proc_config_ir_converter.cc
+++ b/xls/dslx/ir_convert/proc_config_ir_converter.cc
@@ -110,7 +110,8 @@ absl::Status ProcConfigIrConverter::HandleChannelDecl(const ChannelDecl* node) {
 
   XLS_ASSIGN_OR_RETURN(
       StreamingChannel * channel,
-      package_->CreateStreamingChannel(name, ChannelOps::kSendReceive, type));
+      package_->CreateStreamingChannel(name, ChannelOps::kSendReceive, type,
+                                       /*initial_values=*/{}, /*fifo_depth=*/1));
   node_to_ir_[node] = channel;
   return absl::OkStatus();
 }

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_HandlesBasicProc.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_HandlesBasicProc.ir
@@ -2,7 +2,7 @@ package test_module
 
 file_number 0 "test_module.x"
 
-chan main_chandecl_test_module_x_33_18_33_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
+chan main_chandecl_test_module_x_33_18_33_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
 
 fn __test_module__producer.init() -> bits[32] {
   ret literal.1: bits[32] = literal(value=0, id=1)

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_HandlesChannelDecls.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_HandlesChannelDecls.ir
@@ -2,10 +2,10 @@ package test_module
 
 file_number 0 "test_module.x"
 
-chan main_chandecl_test_module_x_5_52_5_60(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main_chandecl_test_module_x_6_52_6_60(bits[64], id=1, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main_chandecl_test_module_x_7_84_7_108((bits[64], (bits[64], (bits[64]))), id=2, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main_chandecl_test_module_x_8_20_8_45((bits[64], (bits[64], bits[64][4])), id=3, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
+chan main_chandecl_test_module_x_5_52_5_60(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main_chandecl_test_module_x_6_52_6_60(bits[64], id=1, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main_chandecl_test_module_x_7_84_7_108((bits[64], (bits[64], (bits[64]))), id=2, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main_chandecl_test_module_x_8_20_8_45((bits[64], (bits[64], bits[64][4])), id=3, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
 
 top proc __test_module__main_0_next(__token: token, __state: (), init={()}) {
   literal.3: bits[1] = literal(value=1, id=3)

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_Join.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_Join.ir
@@ -2,11 +2,11 @@ package test_module
 
 file_number 0 "test_module.x"
 
-chan main_chandecl_test_module_x_33_18_33_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main__foo_chandecl_test_module_x_12_20_12_28(bits[32], id=1, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main__foo_chandecl_test_module_x_13_20_13_28(bits[32], id=2, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main__foo_chandecl_test_module_x_14_20_14_28(bits[32], id=3, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
-chan main__foo_chandecl_test_module_x_15_20_15_28(bits[32], id=4, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
+chan main_chandecl_test_module_x_33_18_33_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main__foo_chandecl_test_module_x_12_20_12_28(bits[32], id=1, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main__foo_chandecl_test_module_x_13_20_13_28(bits[32], id=2, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main__foo_chandecl_test_module_x_14_20_14_28(bits[32], id=3, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
+chan main__foo_chandecl_test_module_x_15_20_15_28(bits[32], id=4, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
 
 fn __test_module__foo.init() -> bits[32] {
   ret literal.1: bits[32] = literal(value=0, id=1)

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_SendIfRecvIf.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_SendIfRecvIf.ir
@@ -2,7 +2,7 @@ package test_module
 
 file_number 0 "test_module.x"
 
-chan main_chandecl_test_module_x_38_18_38_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, metadata="""""")
+chan main_chandecl_test_module_x_38_18_38_26(bits[32], id=0, kind=streaming, ops=send_receive, flow_control=ready_valid, fifo_depth=1, metadata="""""")
 
 fn __test_module__producer.init() -> bits[1] {
   ret literal.1: bits[1] = literal(value=0, id=1)

--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -347,6 +347,7 @@ xls_dslx_opt_ir(
     dslx_top = "main",
     ir_file = "proc_iota.ir",
     opt_ir_file = "proc_iota.opt.ir",
+    top = "__proc_iota__main__producer_0_next",
     tags = ["optonly"],
 )
 


### PR DESCRIPTION
DSLX to IR conversion creates channels with
undefined fifo_depth. This causes proc inlining
to fail as it expects fifo_depth of 0 or 1.

I've modified DSLX to IR conversion so that
fifo_depth is always set to 1.