### PR TITLE
[DSLX] Improve type handling in parametrics

### DIFF
--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -852,8 +852,7 @@ TEST_F(ParserTest, ZeroMacroSimpleBitsArray) {
   RoundTripExpr("zero!<bits[32][10]>()", {}, /*populate_dslx_builtins=*/true);
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroSimpleStructArray) {
+TEST_F(ParserTest, ZeroMacroSimpleStructArray) {
   const char* text = R"(zero!<MyType[10]>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};
@@ -885,8 +884,7 @@ TEST_F(ParserTest, DISABLED_ZeroMacroSimpleStructArray) {
   ASSERT_TRUE(expr_or.ok());
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroParametricStruct) {
+TEST_F(ParserTest, ZeroMacroParametricStruct) {
   const char* text = R"(zero!<MyType<MyParm0, MyParm1>>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};
@@ -936,8 +934,7 @@ TEST_F(ParserTest, DISABLED_ZeroMacroParametricStruct) {
   ASSERT_TRUE(expr_or.ok());
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroParametricStructArray) {
+TEST_F(ParserTest, ZeroMacroParametricStructArray) {
   const char* text = R"(zero!<MyType<MyParm0, MyParm1>[10]>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};


### PR DESCRIPTION
Some buildins like `zero!` did not work with
parametric structs and with arrays of structs.

ParseParametrics returns TypeAnnotation only if
token is a buildin type. In all other cases
identifiers are expected to resolve to TypeRef or
constant values.

This commit changes ParseParametrics to allow for
parametric structs and struct arrays types.
This change only extends Parser capabiliteis.

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>