### PR TITLE
[DSLX] Allow for fifo_depth to be specified as second param

### DIFF
--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -740,7 +740,13 @@ std::string ChannelDecl::ToString() const {
     }
   }
 
-  return absl::StrFormat("chan<%s>%s", type_->ToString(),
+  std::vector<std::string> params;
+  params.push_back(ToAstNode(type_)->ToString());
+  if (depth_.has_value()) {
+    params.push_back(depth_.value()->ToString());
+  }
+
+  return absl::StrFormat("chan<%s>%s", absl::StrJoin(params, ","),
                          absl::StrJoin(dims, ""));
 }
 
@@ -2051,11 +2057,13 @@ bool BuiltinTypeAnnotation::GetSignedness() const {
 
 ChannelTypeAnnotation::ChannelTypeAnnotation(
     Module* owner, Span span, ChannelDirection direction,
-    TypeAnnotation* payload, std::optional<std::vector<Expr*>> dims)
+    ExprOrType payload, std::optional<std::vector<Expr*>> dims,
+    std::optional<Expr*> depth)
     : TypeAnnotation(owner, std::move(span)),
       direction_(direction),
       payload_(payload),
-      dims_(dims) {}
+      dims_(dims),
+      depth_(depth) {}
 
 ChannelTypeAnnotation::~ChannelTypeAnnotation() = default;
 
@@ -2066,7 +2074,15 @@ std::string ChannelTypeAnnotation::ToString() const {
       dims.push_back(absl::StrCat("[", dim->ToString(), "]"));
     }
   }
-  return absl::StrFormat("chan<%s>%s %s", payload_->ToString(),
+
+
+  std::vector<std::string> params;
+  params.push_back(ToAstNode(payload_)->ToString());
+  if (depth_.has_value()) {
+    params.push_back(depth_.value()->ToString());
+  }
+
+  return absl::StrFormat("chan<%s>%s %s", absl::StrJoin(params, ","),
                          absl::StrJoin(dims, ""),
                          direction_ == ChannelDirection::kIn ? "in" : "out");
 }

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -144,9 +144,20 @@ class AstCloner : public AstNodeVisitor {
       new_dims = std::move(new_dims_vector);
     }
 
+    std::optional<Expr*> new_depth;
+    if (n->depth().has_value()) {
+      new_depth = down_cast<Expr*>(old_to_new_.at(n->depth().value()));
+    }
+
+    ExprOrType type_old = n->type();
+    ExprOrType type_new;
+    if (std::holds_alternative<Expr*>(type_old))
+      type_new = down_cast<Expr*>(old_to_new_.at(std::get<Expr*>(type_old)));
+    else
+      type_new = down_cast<TypeAnnotation*>(old_to_new_.at(std::get<TypeAnnotation*>(type_old)));
+
     old_to_new_[n] = module_->Make<ChannelDecl>(
-        n->span(), down_cast<TypeAnnotation*>(old_to_new_.at(n->type())),
-        new_dims);
+        n->span(), type_new, new_dims, new_depth);
     return absl::OkStatus();
   }
 
@@ -165,9 +176,22 @@ class AstCloner : public AstNodeVisitor {
       new_dims = new_dims_vector;
     }
 
+    std::optional<Expr*> new_depth;
+    if (n->depth().has_value()) {
+      new_depth = down_cast<Expr*>(old_to_new_.at(n->depth().value()));
+    }
+
+    ExprOrType type_old = n->payload();
+    ExprOrType type_new;
+    if (std::holds_alternative<Expr*>(type_old))
+      type_new = down_cast<Expr*>(old_to_new_.at(std::get<Expr*>(type_old)));
+    else
+      type_new = down_cast<TypeAnnotation*>(old_to_new_.at(std::get<TypeAnnotation*>(type_old)));
+
+
     old_to_new_[n] = module_->Make<ChannelTypeAnnotation>(
         n->span(), n->direction(),
-        down_cast<TypeAnnotation*>(old_to_new_.at(n->payload())), new_dims);
+        type_new, new_dims, new_depth);
     return absl::OkStatus();
   }
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -852,8 +852,7 @@ TEST_F(ParserTest, ZeroMacroSimpleBitsArray) {
   RoundTripExpr("zero!<bits[32][10]>()", {}, /*populate_dslx_builtins=*/true);
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroSimpleStructArray) {
+TEST_F(ParserTest, ZeroMacroSimpleStructArray) {
   const char* text = R"(zero!<MyType[10]>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};
@@ -885,8 +884,7 @@ TEST_F(ParserTest, DISABLED_ZeroMacroSimpleStructArray) {
   ASSERT_TRUE(expr_or.ok());
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroParametricStruct) {
+TEST_F(ParserTest, ZeroMacroParametricStruct) {
   const char* text = R"(zero!<MyType<MyParm0, MyParm1>>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};
@@ -936,8 +934,7 @@ TEST_F(ParserTest, DISABLED_ZeroMacroParametricStruct) {
   ASSERT_TRUE(expr_or.ok());
 }
 
-// TODO: GH-984
-TEST_F(ParserTest, DISABLED_ZeroMacroParametricStructArray) {
+TEST_F(ParserTest, ZeroMacroParametricStructArray) {
   const char* text = R"(zero!<MyType<MyParm0, MyParm1>[10]>())";
   Scanner s{"test.x", std::string{text}};
   Parser p{"test", &s};

--- a/xls/dslx/ir_convert/ir_converter.cc
+++ b/xls/dslx/ir_convert/ir_converter.cc
@@ -198,7 +198,7 @@ absl::Status CreateBoundaryChannels(absl::Span<Param* const> params,
     TypeAnnotation* type = param->type_annotation();
     if (auto* channel_type = dynamic_cast<ChannelTypeAnnotation*>(type);
         type != nullptr) {
-      auto maybe_type = type_info->GetItem(channel_type->payload());
+      auto maybe_type = type_info->GetItem(ToAstNode(channel_type->payload()));
       XLS_RET_CHECK(maybe_type.has_value());
       ConcreteType* ct = maybe_type.value();
       XLS_ASSIGN_OR_RETURN(

--- a/xls/dslx/type_system/concrete_type.h
+++ b/xls/dslx/type_system/concrete_type.h
@@ -646,7 +646,8 @@ class FunctionType : public ConcreteType {
 class ChannelType : public ConcreteType {
  public:
   ChannelType(std::unique_ptr<ConcreteType> payload_type,
-              ChannelDirection direction);
+              ChannelDirection direction,
+              std::optional<int64_t> depth);
 
   absl::Status Accept(ConcreteTypeVisitor& v) const override {
     return v.HandleChannel(*this);
@@ -663,10 +664,12 @@ class ChannelType : public ConcreteType {
 
   const ConcreteType& payload_type() const { return *payload_type_; }
   ChannelDirection direction() const { return direction_; }
+  std::optional<int64_t> depth() const { return depth_; }
 
  private:
   std::unique_ptr<ConcreteType> payload_type_;
   ChannelDirection direction_;
+  std::optional<int64_t> depth_;
 };
 
 // Helper for the case where we have a derived (i.e. non-abstract) ConcreteType,

--- a/xls/dslx/type_system/typecheck.cc
+++ b/xls/dslx/type_system/typecheck.cc
@@ -372,8 +372,16 @@ absl::Status CheckTestProc(const TestProc* test_proc, Module* module,
                                     "Test proc 'config' functions should "
                                     "only take a terminator channel.");
   }
+
+  if (std::holds_alternative<Expr*>(channel_type->payload()))
+    return TypeInferenceErrorStatus(
+        proc->config()->span(), nullptr,
+        "Test proc 'config' terminator channel must be outgoing "
+        "and have boolean payload.");
+  auto type = std::get<TypeAnnotation*>(channel_type->payload());
+
   BuiltinTypeAnnotation* payload_type =
-      dynamic_cast<BuiltinTypeAnnotation*>(channel_type->payload());
+      dynamic_cast<BuiltinTypeAnnotation*>(type);
   if (channel_type->direction() != ChannelDirection::kOut ||
       payload_type == nullptr || payload_type->GetBitCount() != 1) {
     return TypeInferenceErrorStatus(

--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -347,6 +347,7 @@ xls_dslx_opt_ir(
     dslx_top = "main",
     ir_file = "proc_iota.ir",
     opt_ir_file = "proc_iota.opt.ir",
+    top = "__proc_iota__main__producer_0_next",
     tags = ["optonly"],
 )
 

--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -392,10 +392,12 @@ absl::StatusOr<TypedExpr> AstGenerator::GenerateChannelOp(Context* ctx) {
   // Create the channel.
   // TODO(vmirian): 8-22-2022 If payload type exists, create an array of
   // channels.
+  // TODO(mtdudek): 5-26-2023 If payload type exists, consider creating
+  // channel depth.
   ChannelTypeAnnotation* channel_type_annotation =
       module_->Make<ChannelTypeAnnotation>(fake_span_,
                                            chan_op_info.channel_direction,
-                                           channel_type, std::nullopt);
+                                           channel_type, std::nullopt, std::nullopt);
   Param* param = GenerateParam(channel_type_annotation);
   proc_properties_.params.push_back(param);
   NameRef* chan_expr = module_->Make<NameRef>(fake_span_, param->identifier(),
@@ -561,7 +563,8 @@ class FindTokenTypeVisitor : public AstNodeVisitorWithDefault {
     return ContainsTypeRef(array_type->element_type());
   }
   if (auto channel_type = dynamic_cast<const ChannelTypeAnnotation*>(type)) {
-    return ContainsTypeRef(channel_type->payload());
+    return  std::holds_alternative<TypeAnnotation*>(channel_type->payload()) &&
+            ContainsTypeRef(std::get<TypeAnnotation*>(channel_type->payload()));
   }
   XLS_CHECK_NE(dynamic_cast<const BuiltinTypeAnnotation*>(type), nullptr);
   return false;

--- a/xls/fuzzer/sample_generator.cc
+++ b/xls/fuzzer/sample_generator.cc
@@ -211,7 +211,8 @@ GetInputChannelPayloadTypesOfProc(dslx::Proc* proc,
     if (channel_type->direction() != dslx::ChannelDirection::kIn) {
       continue;
     }
-    dslx::TypeAnnotation* payload_type_annotation = channel_type->payload();
+    dslx::TypeAnnotation* payload_type_annotation =
+      std::get<dslx::TypeAnnotation*>(channel_type->payload());
     std::optional<const ConcreteType*> maybe_payload_type =
         proc_type_info->GetItem(payload_type_annotation);
     XLS_RET_CHECK(maybe_payload_type.has_value());

--- a/xls/fuzzer/sample_generator_test.cc
+++ b/xls/fuzzer/sample_generator_test.cc
@@ -67,7 +67,8 @@ TEST(SampleGeneratorTest, GenerateChannelArgument) {
       std::make_unique<dslx::ChannelType>(std::make_unique<dslx::BitsType>(
                                               /*signed=*/true,
                                               /*size=*/4),
-                                          dslx::ChannelDirection::kOut));
+                                          dslx::ChannelDirection::kOut,
+                                          std::nullopt));
 
   std::vector<const dslx::ConcreteType*> param_type_ptrs;
   param_type_ptrs.reserve(param_types.size());


### PR DESCRIPTION
DSLX to IR conversion creates channels with
undefined fifo_depth. This causes proc inlining
to fail as it expects fifo_depth of 0 or 1.

I've modified DSLX, DSLX-to-IR so that fifo depth
can be passed as optional paramiter to channel.

It depends on :
#986 

Signed-off-by: Maciej Dudek <mdudek@antmicro.com>