### PR TITLE
[DSLX] Propagating type_info through proc frames

### DIFF
--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -1503,7 +1503,8 @@ absl::Status ProcConfigBytecodeInterpreter::EvalSpawn(
       std::unique_ptr<BytecodeInterpreter> next_interpreter,
       CreateUnique(import_data, next_bf.get(), full_next_args, options));
   proc_instances->push_back(ProcInstance{proc, std::move(next_interpreter),
-                                         std::move(next_bf), full_next_args});
+                                         std::move(next_bf), full_next_args,
+                                         type_info});
   return absl::OkStatus();
 }
 
@@ -1526,7 +1527,7 @@ absl::StatusOr<ProcRunResult> ProcInstance::Run() {
     }
 
     XLS_RETURN_IF_ERROR(interpreter_->InitFrame(next_fn_.get(), next_args_,
-                                                /*type_info=*/nullptr));
+                                                type_info_));
     return ProcRunResult{.execution_state = ProcExecutionState::kCompleted,
                          .blocked_channel_name = std::nullopt,
                          .progress_made = progress_made};

--- a/xls/dslx/bytecode/bytecode_interpreter.h
+++ b/xls/dslx/bytecode/bytecode_interpreter.h
@@ -269,11 +269,13 @@ class ProcInstance {
  public:
   ProcInstance(Proc* proc, std::unique_ptr<BytecodeInterpreter> interpreter,
                std::unique_ptr<BytecodeFunction> next_fn,
-               std::vector<InterpValue> next_args)
+               std::vector<InterpValue> next_args,
+               const TypeInfo* type_info)
       : proc_(proc),
         interpreter_(std::move(interpreter)),
         next_fn_(std::move(next_fn)),
-        next_args_(std::move(next_args)) {}
+        next_args_(std::move(next_args)),
+        type_info_(type_info) {}
 
   // Executes a single "tick" of the ProcInstance.
   absl::StatusOr<ProcRunResult> Run();
@@ -283,6 +285,7 @@ class ProcInstance {
   std::unique_ptr<BytecodeInterpreter> interpreter_;
   std::unique_ptr<BytecodeFunction> next_fn_;
   std::vector<InterpValue> next_args_;
+  const TypeInfo* type_info_;
 };
 
 }  // namespace xls::dslx


### PR DESCRIPTION
This commit fixes internal error when testing DSLX procs using `#test_proc()`.
Issue was that only first evaluated frame had `type_info` defined, and all following frames had it undefined. This made ConcreteType lookup fail.

Fixes #981