### PR TITLE
Add simple RLE stream muxer

### DIFF
--- a/xls/modules/AXI4DMA/address_generator.x
+++ b/xls/modules/AXI4DMA/address_generator.x
@@ -1,0 +1,33 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct RawAddressData<ADDR_WIDTH: u32> {
+  base_address: bits[ADDR_WIDTH],
+  burst_length: bits[8],
+  burst_size: bits[3],
+  burst_type: bits[2],
+}
+
+struct AlignedAddress<ADDR_wIDTH: u32, DATA_WIDTH: u32, DATA_BYTE_WIDTH = DATA_WIDTH / u32:8> {
+  aligned_address: bits[ADDR_WIDTH],
+  active_bytes: bits[DATA_BYTE_WIDTH],
+}
+
+struct 
+
+pub proc AddressGenerationAndSlicing<ADDR_WIDTH: u32, DATA_WIDTH: u32> {
+  input_r: chan<RawAddressData> in;
+  output_r: chan<AlignedAddress> out;
+  init{()}
+}

--- a/xls/modules/rle/BUILD
+++ b/xls/modules/rle/BUILD
@@ -107,6 +107,75 @@ xls_benchmark_ir(
 )
 
 xls_dslx_library(
+    name = "rle_mux_dslx",
+    srcs = [
+        "muxer.x",
+    ],
+    deps = [
+        ":rle_common_dslx"
+    ],
+)
+
+xls_dslx_test(
+    name = "rle_mux_dslx_test",
+    dslx_test_args = {
+        "compare": "none",
+    },
+    library = "rle_mux_dslx",
+)
+
+xls_dslx_test(
+    name = "rle_mux_dslx_ir_test",
+    dslx_test_args = {
+        "compare": "interpreter",
+    },
+    library = "rle_mux_dslx",
+)
+
+xls_dslx_test(
+    name = "rle_mux_dslx_jit_test",
+    dslx_test_args = {
+        "compare": "jit",
+    },
+    library = "rle_mux_dslx",
+)
+
+xls_dslx_ir(
+    name = "rle_mux_ir",
+    dslx_top = "StreamMuxerSimple32",
+    library = "rle_mux_dslx",
+    ir_file = "rle_mux.ir",
+)
+
+xls_ir_opt_ir(
+    name = "rle_mux_opt_ir",
+    src = "rle_mux.ir",
+    top = "__muxer__StreamMuxerSimple32__StreamMuxerSimple_0__32_next",
+)
+
+xls_ir_verilog(
+    name = "rle_mux_verilog",
+    src = ":rle_mux_opt_ir.opt.ir",
+    verilog_file = "rle_mux.v",
+    codegen_args = {
+        "module_name": "rle_mux",
+        "delay_model": "unit",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+)
+
+xls_benchmark_ir(
+    name = "rle_mux_ir_benchmark",
+    src = ":rle_mux_opt_ir.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "unit",
+    }
+)
+
+xls_dslx_library(
     name = "rle_dec_dslx",
     srcs = [
         "rle_dec.x",

--- a/xls/modules/rle/muxer.x
+++ b/xls/modules/rle/muxer.x
@@ -1,0 +1,198 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file implements a parametric RLE encoder
+//
+// The encoder uses Run Length Encoding (RLE) to compress the input stream
+// with symbol (data to compress). The output contains packets of data with
+// the symbol and the number of their occurrences in the input stream.
+
+import std
+import xls.modules.rle.rle_common as rle_interface
+
+type EncData = rle_interface::CompressedData;
+type MixData = rle_interface::MixedData;
+
+// Structure to preserve state of the RLEEnc for the next iteration
+struct StreamMuxerState<WORD_WIDTH: u32> {
+    counter: bits[WORD_WIDTH],  // symbol count
+    read: bool,                 // read <symbol, count> pair
+    last: bool,                 // last word
+}
+
+pub proc StreamMuxerSimple<WORD_WIDTH: u32> {
+    data_r: chan<EncData<WORD_WIDTH, WORD_WIDTH>> in;
+    word_s: chan<MixData<WORD_WIDTH>> out;
+
+    init {(StreamMuxerState<WORD_WIDTH> {
+            counter: bits[WORD_WIDTH]:0,
+            read:    bool:true,
+            last:    bool:false,
+        }
+    )}
+
+    config(
+        data_r: chan<EncData<WORD_WIDTH, WORD_WIDTH>> in,
+        word_s: chan<MixData<WORD_WIDTH>> out
+    ) {(data_r, word_s)}
+
+    next (tok: token, state: StreamMuxerState<WORD_WIDTH>) {
+        let (tok, words) = recv_if(tok, data_r, state.read,
+            EncData<WORD_WIDTH> {
+                symbol: state.counter,
+                count:  bits[WORD_WIDTH]:0,
+                last:   bool:false,
+            });
+        let last = state.last & !state.read;
+        let tok = send(tok, word_s, MixData<WORD_WIDTH> {
+            word: words.symbol,
+            last: last,
+        });
+        StreamMuxerState<WORD_WIDTH> {
+            counter: words.count,
+            read:    !state.read,
+            last:    words.last,
+        }
+    }
+}
+
+// Stream Muxer specialization for the codegen
+proc StreamMuxerSimple32 {
+    init {()}
+
+    config (
+        data_r: chan<EncData<32, 32>> in,
+        word_s: chan<MixData<32>> out,
+    ) {
+        spawn StreamMuxerSimple<u32:32>(data_r, word_s);
+        ()
+    }
+    next (tok: token, state: ()) {
+        ()
+    }
+}
+
+// Tests
+
+type TestEncData = EncData<32, 32>;
+type TestMixData = MixData<32>;
+
+const TEST_SEND_DATA_LOOKUP = TestEncData[10]:[
+    TestEncData{symbol: bits[32]:0xA, count: bits[32]:0x3, last: bool:false},
+    TestEncData{symbol: bits[32]:0xB, count: bits[32]:0x2, last: bool:false},
+    TestEncData{symbol: bits[32]:0x1, count: bits[32]:0x1, last: bool:false},
+    TestEncData{symbol: bits[32]:0xC, count: bits[32]:0x3, last: bool:true},
+    TestEncData{symbol: bits[32]:0xC, count: bits[32]:0x3, last: bool:false},
+    TestEncData{symbol: bits[32]:0x3, count: bits[32]:0x3, last: bool:true},
+    TestEncData{symbol: bits[32]:0x2, count: bits[32]:0x2, last: bool:true},
+    TestEncData{symbol: bits[32]:0x1, count: bits[32]:0x1, last: bool:false},
+    TestEncData{symbol: bits[32]:0x2, count: bits[32]:0x1, last: bool:false},
+    TestEncData{symbol: bits[32]:0x3, count: bits[32]:0x1, last: bool:true},
+];
+
+const TEST_RECV_WORD_LOOKUP = TestMixData[20]:[
+    TestMixData{word: bits[32]:0xA, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:false},
+    TestMixData{word: bits[32]:0xB, last: bool:false},
+    TestMixData{word: bits[32]:0x2, last: bool:false},
+    TestMixData{word: bits[32]:0x1, last: bool:false},
+    TestMixData{word: bits[32]:0x1, last: bool:false},
+    TestMixData{word: bits[32]:0xC, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:true},
+    TestMixData{word: bits[32]:0xC, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:true},
+    TestMixData{word: bits[32]:0x2, last: bool:false},
+    TestMixData{word: bits[32]:0x2, last: bool:true},
+    TestMixData{word: bits[32]:0x1, last: bool:false},
+    TestMixData{word: bits[32]:0x1, last: bool:false},
+    TestMixData{word: bits[32]:0x2, last: bool:false},
+    TestMixData{word: bits[32]:0x1, last: bool:false},
+    TestMixData{word: bits[32]:0x3, last: bool:false},
+    TestMixData{word: bits[32]:0x1, last: bool:true},
+];
+
+const TEST_SEND_DATA_LEN = array_size(TEST_SEND_DATA_LOOKUP);
+const TEST_RECV_WORD_LEN = array_size(TEST_RECV_WORD_LOOKUP);
+
+// structure to preserve state of the RLE encoder tester for the next iteration
+pub struct StreamMuxerSimpleTesterState {
+    recv_count: u32,                   // number of received transactions
+}
+
+// auxiliary proc for sending data to the tested Stream Muxer
+proc StreamMuxerTestSender {
+    data_s: chan<EncData<32, 32>> out;  // symbol sent to the tested module
+    init {(u32:0)}
+    config ( data_s: chan<EncData<32, 32>> out) { (data_s,) }
+    next (tok: token, count: u32) {
+        if count < TEST_SEND_DATA_LEN {
+            let test_data = TEST_SEND_DATA_LOOKUP[count];
+            let send_tok  = send(tok, data_s, test_data);
+            trace_fmt!("Sent {} transactions, symbol: 0x{:x}, last: {}",
+                test_data.count, test_data.symbol, test_data.last);
+            count + u32:1
+         } else {
+            count
+         }
+    }
+}
+
+// main proc used to test the MixSimple
+#[test_proc]
+proc StreamMuxerSimpleTester {
+    terminator: chan<bool> out;     // test termination request
+    word_r: chan<TestMixData> in;   // data read from the tested MixSimple
+
+    init {(zero!<StreamMuxerSimpleTesterState>())}
+
+    config(terminator: chan<bool> out) {
+        let (data_s, data_r) = chan<TestEncData>;
+        let (word_s, word_r) = chan<TestMixData>;
+
+        spawn StreamMuxerTestSender(data_s);
+        spawn StreamMuxerSimple<u32:32>(data_r, word_s);
+        (terminator, word_r)
+    }
+
+    next(tok: token, state: StreamMuxerSimpleTesterState) {
+        let (recv_tok, test_word) = recv(tok, word_r);
+
+        let recv_count = state.recv_count + u32:1;
+
+        trace_fmt!(
+            "Received {} transactions, word: 0x{:x}, total of {} words",
+            recv_count, test_word.word, recv_count
+        );
+
+        // checks for expected values
+
+        let exp_word = TEST_RECV_WORD_LOOKUP[state.recv_count];
+        assert_eq(exp_word, test_word);
+
+        // check the total count after the last expected receive matches
+        // with the expected value
+
+        if (recv_count == TEST_RECV_WORD_LEN) {
+            send(recv_tok, terminator, true);
+        } else {()};
+
+        // state for the next iteration
+
+        StreamMuxerSimpleTesterState {
+            recv_count: recv_count,
+        }
+    }
+}

--- a/xls/modules/rle/rle_common.x
+++ b/xls/modules/rle/rle_common.x
@@ -32,3 +32,10 @@ pub struct CompressedData<SYMBOL_WIDTH: u32, COUNT_WIDTH: u32> {
     count: bits[COUNT_WIDTH],   // symbol counter
     last: bool,                 // flush RLE
 }
+
+// structure containing output data from a Stream Mixer
+// and input to a Bus interface
+pub struct MixedData<WORD_WIDTH: u32> {
+    word: bits[WORD_WIDTH], // word
+    last: bool,             // flush RLE
+}


### PR DESCRIPTION
This PR:
* adds implementation for a simple stream muxer,
* test and gen verilog rules for this muxer,
* adds intra RLE interface specification,
* moves rle.x to rle_enc.x

Stream muxer is responsible for converting RLE encoder 
(symbol, count) pair stream into stream of words.

This PR depends on:
- [ ] #974 

Related: #994

CC @proppy 