### PR TITLE
[DSLX] frontend/parser_test.cc: Fix RoundTrip

### DIFF
--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -53,7 +53,7 @@ class ParserTest : public ::testing::Test {
                     [&](std::string_view path) -> absl::StatusOr<std::string> {
                       return program;
                     });
-      XLS_EXPECT_OK(module_or);
+      XLS_EXPECT_OK(module_or) << module_or.status();
       return nullptr;
     }
     std::unique_ptr<Module> module = std::move(module_or).value();


### PR DESCRIPTION
`XLS_EXPECT_OK` introduced in f2341af did
cause `TestRoundTripFailsOnSyntaxError` to fail,
although `EXPECT_NONFATAL_FAILURE` was used to catch the `XLS_EXPECT_OK` error.

Issue was that `EXPECT_NONFATAL_FAILURE` expected "ParseError:" in error message, but no error message was given.
I've added `module_or.status()` string conversion as error message.
It was enough to get this test passing.