### PR TITLE
Enable place_and_route targets

### DIFF
--- a/dependency_support/boost/add_python.patch
+++ b/dependency_support/boost/add_python.patch
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-diff --git BUILD.boost BUILD.boost
-index e6b28cf..99470c5 100644
---- BUILD.boost
-+++ BUILD.boost
-@@ -2268,3 +2268,41 @@ boost_library(
-         ":utility",
+diff --git boost.BUILD boost.BUILD
+index e5d0b60..4f52d3c 100644
+--- boost.BUILD
++++ boost.BUILD
+@@ -2642,3 +2642,41 @@ boost_library(
+         ":variant2",
      ],
  )
 +

--- a/dependency_support/boost/workspace.bzl
+++ b/dependency_support/boost/workspace.bzl
@@ -21,9 +21,9 @@ def repo():
     maybe(
         http_archive,
         name = "com_github_nelhage_rules_boost",
-        url = "https://github.com/nelhage/rules_boost/archive/1e3a69bf2d5cd10c34b74f066054cd335d033d71.tar.gz",
-        strip_prefix = "rules_boost-1e3a69bf2d5cd10c34b74f066054cd335d033d71",
-        sha256 = "b3cbdceaa95b8cfe3a69ff37f8ad0e53a77937433234f6b9a6add2eff5bde333",
+        url = "https://github.com/nelhage/rules_boost/archive/1217caae292dc9f14e8109777ba43c988cf89c5b.tar.gz",
+        strip_prefix = "rules_boost-1217caae292dc9f14e8109777ba43c988cf89c5b",
+        sha256 = "b3280ba677fb53c08dfe9fc3d77504c53efd31288c3b8445711c2e7b82281315",
         patches = [
             # rules_boost does not include Boost Python, see
             # https://github.com/nelhage/rules_boost/issues/67

--- a/dependency_support/rules_hdl/workspace.bzl
+++ b/dependency_support/rules_hdl/workspace.bzl
@@ -29,9 +29,9 @@ def repo():
         ],
     )
 
-    # Commit on 2023-04-12, current as of 2023-04-12.
-    git_hash = "be231cf9a8449a70304adc44c5c2655d2ba4069c"
-    git_sha256 = "1b57afa043a47b39dfecb6f6158683674ded46e8e53a3afce6ba9a1fc087ddfb"
+    # Commit on 2023-06-13, current as of 2023-06-13.
+    git_hash = "e6540a5bccbfb124aec0b19deaa9cf855781b3a5"
+    git_sha256 = "21307b0c14a036f1b4879c8f1d4d50a115053eb87c428307d4d6569c3e7ba859"
 
     maybe(
         http_archive,

--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -31,8 +31,7 @@ load(
 )
 load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load("@rules_hdl//synthesis:build_defs.bzl", "synthesize_rtl")
-# TODO(cdleary): 2022-05-09 Re-enable use of this rule.
-# load("@rules_hdl//place_and_route:build_defs.bzl", "place_and_route")
+load("@rules_hdl//place_and_route:build_defs.bzl", "place_and_route")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -569,14 +568,12 @@ verilog_library(
     srcs = [":constraint.sv"],
 )
 
-# TODO(cdleary): 2022-05-09 Get this target working as well, requires
-# addressing the dependence on openmp runtime.
-# place_and_route(
-#     name = "find_index_place_and_route",
-#     # ~64 MhZ
-#     clock_period = "15.42857143",
-#     core_padding_microns = 30,
-#     placement_density = "0.8",
-#     synthesized_rtl = ":find_index_5000ps_model_unit_verilog_synth",
-#     target_die_utilization_percentage = "30",
-# )
+place_and_route(
+    name = "find_index_place_and_route",
+    # ~64 MhZ
+    clock_period = "15.42857143",
+    core_padding_microns = 30,
+    placement_density = "0.8",
+    synthesized_rtl = ":find_index_5000ps_model_unit_verilog_synth",
+    target_die_utilization_percentage = "30",
+)


### PR DESCRIPTION
Fixes https://github.com/google/xls/issues/975

This PR:
* bumps boost dependency to v1.82
* uncomments existing place_and_route target under `xls/examples`
* bumps bazel_rules_hdl

In https://github.com/google/xls/commit/f18ad88c7c248e6873fc74c401c8395e03b3296c instead of bumping bazel_rules_hdl I temporarily replaced upstream bazel_rules_hdl with forked repository with branch that includes changes from 3 pending PRs:
* https://github.com/hdl/bazel_rules_hdl/pull/167
* https://github.com/hdl/bazel_rules_hdl/pull/164
* https://github.com/hdl/bazel_rules_hdl/pull/165

Those PRs passed CI tests and are ready for final review. As soon as those will be merged I will remove temporary link to forked bazel_rules_hdl, bump this dependency to the latest version and convert PR from draft to regular one.

CC @proppy 


**EDIT:**

`bazel_rules_hdl` PRs are merged. https://github.com/google/xls/commit/f18ad88c7c248e6873fc74c401c8395e03b3296c was replaced with https://github.com/google/xls/pull/1025/commits/019fcad70d4185c556e84d4a12330d1f91062a9c which bumps bazel_rules_hdl to the latest revision from the upstream repository.