### PR TITLE
Add targets for writing GDS files

### DIFF
--- a/xls/examples/BUILD
+++ b/xls/examples/BUILD
@@ -14,9 +14,10 @@
 
 # Build rules for XLS examples.
 
-load("@rules_hdl//verilog:providers.bzl", "verilog_library")
+load("@rules_hdl//gds_write:build_defs.bzl", "gds_write")
 load("@rules_hdl//place_and_route:build_defs.bzl", "place_and_route")
 load("@rules_hdl//synthesis:build_defs.bzl", "benchmark_synth", "synthesize_rtl")
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load(
     "//xls/build_rules:xls_build_defs.bzl",
     "cc_xls_ir_jit_wrapper",
@@ -454,7 +455,16 @@ verilog_library(
 )
 
 synthesize_rtl(
-    name = "find_index_5000ps_model_unit_verilog_synth",
+    name = "find_index_5000ps_model_unit_verilog_synth_sky130",
+    top_module = "find_index",
+    deps = [
+        ":find_index_5000ps_model_unit_verilog",
+    ],
+)
+
+synthesize_rtl(
+    name = "find_index_5000ps_model_unit_verilog_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_27//:asap7-sc7p5t_rev27_rvt",
     top_module = "find_index",
     deps = [
         ":find_index_5000ps_model_unit_verilog",
@@ -693,13 +703,37 @@ verilog_library(
 )
 
 place_and_route(
-    name = "find_index_place_and_route",
-    # ~64 MhZ
-    clock_period = "15.42857143",
-    core_padding_microns = 30,
-    placement_density = "0.8",
-    synthesized_rtl = ":find_index_5000ps_model_unit_verilog_synth",
-    target_die_utilization_percentage = "30",
+    name = "find_index_place_and_route_sky130",
+    # ~1.43 GHZ
+    clock_period = "0.70", # units of clock period for SKY130 are nanoseconds
+    core_padding_microns = 2,
+    placement_density = "0.95",
+    synthesized_rtl = ":find_index_5000ps_model_unit_verilog_synth_sky130",
+    die_width_microns = 45,
+    die_height_microns = 45,
+    min_pin_distance = "2",
+)
+
+gds_write(
+    name = "find_index_gds_sky130",
+    implemented_rtl = ":find_index_place_and_route_sky130",
+)
+
+place_and_route(
+    name = "find_index_place_and_route_asap7",
+    # ~3 GHz
+    clock_period = "325", # units of clock period for ASAP7 are picoseconds
+    core_padding_microns = 1,
+    placement_density = "0.95",
+    synthesized_rtl = ":find_index_5000ps_model_unit_verilog_synth_asap7",
+    die_width_microns = 7,
+    die_height_microns = 7,
+    min_pin_distance = "0.2",
+)
+
+gds_write(
+    name = "find_index_gds_asap7",
+    implemented_rtl = ":find_index_place_and_route_asap7",
 )
 
 xls_dslx_library(

--- a/xls/modules/rle/BUILD
+++ b/xls/modules/rle/BUILD
@@ -23,6 +23,10 @@ load(
     "xls_ir_opt_ir",
     "xls_ir_verilog",
 )
+load("@rules_hdl//gds_write:build_defs.bzl", "gds_write")
+load("@rules_hdl//place_and_route:build_defs.bzl", "place_and_route")
+load("@rules_hdl//synthesis:build_defs.bzl", "synthesize_rtl")
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -97,6 +101,64 @@ xls_ir_verilog(
     verilog_file = "rle_enc.v",
 )
 
+verilog_library(
+    name = "rle_enc_verilog_lib",
+    srcs = [
+        ":rle_enc.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "rle_enc_synth_sky130",
+    top_module = "rle_enc",
+    deps = [
+        ":rle_enc_verilog_lib",
+    ],
+)
+
+place_and_route(
+    name = "rle_enc_place_and_route_sky130",
+    # ~0.67 GHz
+    clock_period = "1.5",
+    core_padding_microns = 2,
+    placement_density = "0.96",
+    synthesized_rtl = ":rle_enc_synth_sky130",
+    die_width_microns = 120,
+    die_height_microns = 120,
+    min_pin_distance = "2",
+)
+
+gds_write(
+    name = "rle_enc_gds_sky130",
+    implemented_rtl = ":rle_enc_place_and_route_sky130",
+)
+
+synthesize_rtl(
+    name = "rle_enc_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_27//:asap7-sc7p5t_rev27_rvt",
+    top_module = "rle_enc",
+    deps = [
+        ":rle_enc_verilog_lib",
+    ],
+)
+
+place_and_route(
+    name = "rle_enc_place_and_route_asap7",
+    # ~1 GHz
+    clock_period = "750",
+    core_padding_microns = 1,
+    placement_density = "0.95",
+    synthesized_rtl = ":rle_enc_synth_asap7",
+    die_width_microns = 15,
+    die_height_microns = 15,
+    min_pin_distance = "0.2",
+)
+
+gds_write(
+    name = "rle_enc_gds_asap7",
+    implemented_rtl = ":rle_enc_place_and_route_asap7",
+)
+
 xls_benchmark_ir(
     name = "rle_enc_ir_benchmark",
     src = ":rle_enc_opt_ir.opt.ir",
@@ -164,6 +226,64 @@ xls_ir_verilog(
         "use_system_verilog": "false",
     },
     verilog_file = "rle_dec.v",
+)
+
+verilog_library(
+    name = "rle_dec_verilog_lib",
+    srcs = [
+        ":rle_dec.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "rle_dec_synth_sky130",
+    top_module = "rle_dec",
+    deps = [
+        ":rle_dec_verilog_lib",
+    ],
+)
+
+place_and_route(
+    name = "rle_dec_place_and_route_sky130",
+    # ~0.83 GHz
+    clock_period = "1.2",
+    core_padding_microns = 2,
+    placement_density = "0.95",
+    synthesized_rtl = ":rle_dec_synth_sky130",
+    die_width_microns = 120,
+    die_height_microns = 120,
+    min_pin_distance = "2",
+)
+
+gds_write(
+    name = "rle_dec_gds_sky130",
+    implemented_rtl = ":rle_dec_place_and_route_sky130",
+)
+
+synthesize_rtl(
+    name = "rle_dec_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_27//:asap7-sc7p5t_rev27_rvt",
+    top_module = "rle_dec",
+    deps = [
+        ":rle_dec_verilog_lib",
+    ],
+)
+
+place_and_route(
+    name = "rle_dec_place_and_route_asap7",
+    # ~2.5GHz
+    clock_period = "400",
+    core_padding_microns = 1,
+    placement_density = "0.95",
+    synthesized_rtl = ":rle_dec_synth_asap7",
+    die_width_microns = 15,
+    die_height_microns = 15,
+    min_pin_distance = "0.2",
+)
+
+gds_write(
+    name = "rle_dec_gds_asap7",
+    implemented_rtl = ":rle_dec_place_and_route_asap7",
 )
 
 xls_benchmark_ir(


### PR DESCRIPTION
Closes https://github.com/google/xls/issues/1024

This PR bumps `bazel_rules_hdl` in order to:
* Add `gds_write` rule for writing GDS files (see https://github.com/hdl/bazel_rules_hdl/pull/169).
* Add support for ASAP7 PDK (see https://github.com/hdl/bazel_rules_hdl/pull/176)

Additionally:
* https://github.com/google/xls/pull/1031/commits/65a89c31bf9d1d8adedb325dff9e24c807a5fe36 adds target which builds GDS files for `find_index` example based on the results from previous `place_and_route` targets for ASAP7 and SKY130 technologies.
* https://github.com/google/xls/pull/1031/commits/b67d8b02404d1895789ecf7d1bd378c6135fae95 adds targets for generating GDS files for recently added `RLE` encoder and decoder examples, also for ASAP7 and SKY130.

EDIT:
This PR depends on https://github.com/google/xls/pull/1230