### PR TITLE
Make boost libbacktrace dependency hermetic.

### DIFF
--- a/dependency_support/boost/backtrace_from_rule.patch
+++ b/dependency_support/boost/backtrace_from_rule.patch
@@ -1,0 +1,29 @@
+--- boost.BUILD	2023-07-22 21:40:32.570049258 -0700
++++ boost.BUILD	2023-07-23 07:33:08.760174104 -0700
+@@ -1901,18 +1901,6 @@
+         "//conditions:default": [],
+     }),
+     exclude_src = ["libs/stacktrace/src/*.cpp"],
+-    linkopts = select({
+-        ":linux_ppc": [
+-            "-lbacktrace -ldl",
+-        ],
+-        ":linux_x86_64": [
+-            "-lbacktrace -ldl",
+-        ],
+-        ":linux_aarch64": [
+-            "-lbacktrace -ldl",
+-        ],
+-        "//conditions:default": [],
+-    }),
+     deps = [
+         ":array",
+         ":config",
+@@ -1922,6 +1910,7 @@
+         ":predef",
+         ":static_assert",
+         ":type_traits",
++        "@com_github_libbacktrace//:libbacktrace",
+     ],
+ )
+ 

--- a/dependency_support/boost/workspace.bzl
+++ b/dependency_support/boost/workspace.bzl
@@ -32,5 +32,6 @@ def repo():
             # toolchain. The patch below selects the same Python headers
             # that the rest of XLS uses.
             "@com_google_xls//dependency_support/boost:add_python.patch",
+            "@com_google_xls//dependency_support/boost:backtrace_from_rule.patch",
         ],
     )


### PR DESCRIPTION
This uses Ethans [libbacktrace support in bazel_rules_hdl](https://github.com/hdl/bazel_rules_hdl/commit/196706dee7fdfeb0ddf916f8a8bd125e0ed0ab45) (that we already depend on).

Without, XLS compilation will fail if the libbacktrace doesn't happen to be part of the local compiler set-up:

```
external/boost/libs/stacktrace/include/boost/stacktrace/detail/libbacktrace_impls.hpp:23:13: fatal error: backtrace.h: No such file or directory
   23 | #   include <backtrace.h>
      |             ^~~~~~~~~~~~~
compilation terminated.
```