### PR TITLE
Move XLS_EXPECT_OK_AND_EQ to matchers

### DIFF
--- a/xls/common/status/matchers.h
+++ b/xls/common/status/matchers.h
@@ -570,6 +570,12 @@ IsOkAndHolds(InnerMatcher&& inner_matcher) {
                        xls::status_testing::internal_status::AddFatalFailure( \
                            #rexpr, _))
 
+// Executes an expression that returns a absl::StatusOr, and compares the
+// contained variable to rexpr if the error code is OK.
+// If the Status is non-OK it generates a nonfatal test failure
+#define XLS_EXPECT_OK_AND_EQ(lhs, rexpr) \
+  EXPECT_THAT(lhs, status_testing::IsOkAndHolds(rexpr));
+
 }  // namespace status_testing
 }  // namespace xls
 

--- a/xls/noc/simulation/indexer_test.cc
+++ b/xls/noc/simulation/indexer_test.cc
@@ -21,10 +21,6 @@
 #include "xls/noc/config/network_config.pb.h"
 #include "xls/noc/config/network_config_proto_builder.h"
 
-// TODO(tedhong): 2021-01-10 Move this to xls/common
-#define XLS_EXPECT_OK_AND_EQ(lhs, rexpr) \
-  EXPECT_THAT(lhs, status_testing::IsOkAndHolds(rexpr));
-
 namespace xls {
 namespace noc {
 namespace {


### PR DESCRIPTION
Fixes https://github.com/google/xls/issues/1112

This PR moves macro `XLS_EXPECT_OK_AND_EQ` which was previously defined in [xls/noc/simulation/indexer_test.cc](https://github.com/antmicro/xls/blob/main/xls/noc/simulation/indexer_test.cc) to [xls/common/status/matchers.h](https://github.com/antmicro/xls/blob/main/xls/common/status/matchers.h) so that it is now widely available.

CC @proppy 