### PR TITLE
github/workflows/ci: fail-fast=false

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,6 +19,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - runner: ubuntu-20.04-64core


### PR DESCRIPTION
as we do not want linux ci jobs to be interrupted by macos failure.