### PR TITLE
modules/zstd: build libzstd

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,6 +19,7 @@ build --host_copt "-Wno-comment"
 # https://github.com/google/googletest/issues/4383
 build --define absl=1
 build --incompatible_enable_cc_toolchain_resolution
+build --@llvm_zstd//:llvm_enable_zstd=false
 
 # Settings for --config=asan address sanitizer build
 build:asan --strip=never

--- a/dependency_support/com_github_facebook_zstd/BUILD
+++ b/dependency_support/com_github_facebook_zstd/BUILD
@@ -1,0 +1,15 @@
+# Copyright 2023 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needed to make this a package.

--- a/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
+++ b/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
@@ -42,12 +42,8 @@ cc_library(
         "lib/zstd.h",
     ],
     strip_include_prefix = "lib",
-    linkopts = [
-        "-pthread",
-    ],
     local_defines = [
         "ZSTD_LEGACY_SUPPORT=4",
-        "ZSTD_MULTITHREAD",
         "XXH_NAMESPACE=ZSTD_",
     ],
     visibility = ["//visibility:public"],

--- a/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
+++ b/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
@@ -1,0 +1,54 @@
+# Copyright 2023 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+# Builds everything together similarly to the zstd cmake file:
+# https://github.com/facebook/zstd/blob/dev/build/cmake/lib/CMakeLists.txt
+# but with legacy support and defines as in the zstd BUCK file:
+# https://github.com/facebook/zstd/blob/dev/lib/BUCK
+
+cc_library(
+    name = "zstd",
+    srcs = glob([
+        "lib/common/*.h",
+        "lib/common/*.c",
+        "lib/compress/*.h",
+        "lib/compress/*.c",
+        "lib/decompress/*.h",
+        "lib/decompress/*.c",
+        "lib/decompress/*.S",
+        "lib/deprecated/*.h",
+        "lib/deprecated/*.c",
+        "lib/dictBuilder/*.h",
+        "lib/dictBuilder/*.c",
+        "lib/legacy/*.h",
+        "lib/legacy/*.c",
+    ]),
+    hdrs = [
+        "lib/zstd.h",
+    ],
+    strip_include_prefix = "lib",
+    linkopts = [
+        "-pthread",
+    ],
+    local_defines = [
+        "ZSTD_LEGACY_SUPPORT=4",
+        "ZSTD_MULTITHREAD",
+        "XXH_NAMESPACE=ZSTD_",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -286,3 +286,14 @@ def load_external_repositories():
             "https://github.com/nlohmann/json/archive/refs/tags/v3.10.2.tar.gz",
         ],
     )
+
+    # Version 1.4.7 released on 17.12.2020
+    # https://github.com/facebook/zstd/releases/tag/v1.4.7
+    # Updated 23.11.2023
+    http_archive(
+        name = "com_github_facebook_zstd",
+        sha256 = "192cbb1274a9672cbcceaf47b5c4e9e59691ca60a357f1d4a8b2dfa2c365d757",
+        strip_prefix = "zstd-1.4.7",
+        urls = ["https://github.com/facebook/zstd/releases/download/v1.4.7/zstd-1.4.7.tar.gz"],
+        build_file = "@//dependency_support/com_github_facebook_zstd:bundled.BUILD.bazel",
+    )


### PR DESCRIPTION
This PR adds zstd library to the XLS framework. It exposes the following targets:

    @com_github_facebok_zstd//:libzstd - zstd library itself
    @com_github_facebok_zstd//:zstd - binary for performing zstd compression/decompression
    @com_github_facebok_zstd//:decodecorpus - binary for creating test data for a zstd decoder

Additionally, we remove zstd from llvm build to avoid linking conflicts with newly-added zstd library. It seems that llvm_zstd is not necessary for correct llvm operation.