### PR TITLE
Update README to not include how to use system python.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ bazel 5.2.0
 ~/xls$ bazel test -c opt -- //xls/...
 ```
 
-The build needs Python3 to be available. If your python3 binary is at an
-unusual location, you can tell `bazel` by providing a command line flag
-`--repo_env PYTHON_BIN_PATH=/path/to/python3` for `bazel` to find `python3`.
-
 Reference build/test environment setups are also provided via `Dockerfile`s:
 
 ```console


### PR DESCRIPTION
The build downloads external python binaries and this override does not work anymore.

Issues: #1174