### PR TITLE
Generic integration interfaces

### DIFF
--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -106,3 +106,14 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "ichannel",
+    hdrs = [
+        "ichannel.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -18,6 +18,16 @@ package(
 )
 
 cc_library(
+    name = "common",
+    hdrs = [
+        "common.h",
+    ],
+    deps = [
+        "//xls/common/logging",
+    ],
+)
+
+cc_library(
     name = "iconnection",
     hdrs = [
         "iconnection.h",
@@ -113,6 +123,7 @@ cc_library(
         "ichannel.h",
     ],
     deps = [
+        ":common",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -17,6 +17,16 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
+)
+
+cc_proto_library(
+    name = "cc_config_proto",
+    deps = [":config_proto"],
+)
+
 cc_library(
     name = "common",
     hdrs = [
@@ -24,6 +34,41 @@ cc_library(
     ],
     deps = [
         "//xls/common/logging",
+    ],
+)
+
+cc_library(
+    name = "config",
+    srcs = [
+        "config.cc",
+    ],
+    hdrs = [
+        "config.h",
+    ],
+    deps = [
+        ":cc_config_proto",
+        "//xls/common/file:filesystem",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "config_test",
+    srcs = [
+        "config_test.cc",
+    ],
+    deps = [
+        ":config",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -80,3 +80,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "byteops",
+    hdrs = [
+        "byteops.h",
+    ],
+    deps = [
+        "//xls/common/logging",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "byteops_test",
+    size = "small",
+    srcs = [
+        "byteops_test.cc",
+    ],
+    deps = [
+        ":byteops",
+        "//xls/common/status:matchers",
+        "//xls/common:xls_gunit_main",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -28,3 +28,29 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "iactive",
+    hdrs = [
+        "iactive.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "iactive_test",
+    srcs = [
+        "iactive_stub.cc",
+        "iactive_stub.h",
+        "iactive_test.cc",
+    ],
+    deps = [
+        ":iactive",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_library(
+    name = "iconnection",
+    hdrs = [
+        "iconnection.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -54,3 +54,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iirq",
+    hdrs = [
+        "iirq.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "iirq_test",
+    srcs = [
+        "iirq_stub.cc",
+        "iirq_stub.h",
+        "iirq_test.cc",
+    ],
+    deps = [
+        ":iirq",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -269,3 +269,37 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "ichannelmanager",
+    hdrs = [
+        "ichannelmanager.h",
+    ],
+    deps = [
+        ":ichannel",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ichannelmanager_stub_test",
+    srcs = [
+        "ichannelmanager_stub.cc",
+        "ichannelmanager_stub.h",
+        "ichannelmanager_stub_test.cc",
+    ],
+    deps = [
+        ":ichannel",
+        ":ichannelmanager",
+        ":istream_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -128,3 +128,72 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "iregister",
+    hdrs = [
+        "iregister.h",
+    ],
+    deps = [
+        ":ichannel",
+    ],
+)
+
+cc_library(
+    name = "iregister_stub",
+    srcs = [
+        "iregister_stub.cc",
+    ],
+    hdrs = [
+        "iregister_stub.h",
+    ],
+    deps = [
+        ":iregister",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "iregister_stub_test",
+    size = "small",
+    srcs = [
+        "iregister_stub_test.cc",
+    ],
+    deps = [
+        ":iregister_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "iregister_mock",
+    hdrs = [
+        "iregister_mock.h",
+    ],
+    deps = [
+        ":byteops",
+        ":iregister",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "iregister_mock_test",
+    size = "small",
+    srcs = [
+        "iregister_mock_test.cc",
+    ],
+    deps = [
+        ":iregister_mock",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -197,3 +197,75 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "istream",
+    hdrs = [
+        "istream.h",
+    ],
+    deps = [
+        ":ichannel",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
+    name = "istream_stub",
+    srcs = [
+        "istream_stub.cc",
+    ],
+    hdrs = [
+        "istream_stub.h",
+    ],
+    deps = [
+        ":istream",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "istream_stub_test",
+    size = "small",
+    srcs = [
+        "istream_stub_test.cc",
+    ],
+    deps = [
+        ":istream_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "istream_mock",
+    hdrs = [
+        "istream_mock.h",
+    ],
+    deps = [
+        ":iregister_mock",
+        ":istream",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "istream_mock_test",
+    size = "small",
+    srcs = [
+        "istream_mock_test.cc",
+    ],
+    deps = [
+        ":istream_mock",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -348,3 +348,40 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iaxistreamlike",
+    hdrs = [
+        "iaxistreamlike.h",
+    ],
+    deps = [
+        ":istream",
+    ],
+)
+
+cc_library(
+    name = "iaxistreamlike_stub",
+    srcs = [
+        "iaxistreamlike_stub.cc",
+    ],
+    hdrs = [
+        "iaxistreamlike_stub.h",
+    ],
+    deps = [
+        ":iaxistreamlike",
+        "//xls/common/logging",
+    ],
+)
+
+cc_test(
+    name = "iaxistreamlike_stub_test",
+    srcs = [
+        "iaxistreamlike_stub_test.cc",
+    ],
+    deps = [
+        ":iaxistreamlike_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -385,3 +385,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iperipheral",
+    hdrs = [
+        "iperipheral.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "iperipheral_stub",
+    srcs = [
+        "iperipheral_stub.cc",
+    ],
+    hdrs = [
+        "iperipheral_stub.h",
+    ],
+    deps = [
+        ":iperipheral",
+        "//xls/common/logging",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -73,11 +73,24 @@ cc_test(
 )
 
 cc_library(
+    name = "imasterport",
+    hdrs = [
+        "imasterport.h",
+    ],
+    deps = [
+        ":common",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
     name = "iconnection",
     hdrs = [
         "iconnection.h",
     ],
     deps = [
+        ":imasterport",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
@@ -392,6 +405,7 @@ cc_library(
         "iperipheral.h",
     ],
     deps = [
+        ":common",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -425,3 +425,14 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+
+cc_library(
+    name = "idmaendpoint",
+    hdrs = [
+        "idmaendpoint.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/byteops.h
+++ b/xls/simulation/generic/byteops.h
@@ -1,0 +1,76 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_BYTEOPS_H_
+#define XLS_SIMULATION_GENERIC_BYTEOPS_H_
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic::byteops {
+
+// Given a span of bytes, reads Size bytes starting from a specified
+// offset and assembles them into a value of integer type T following
+// little-endian byte order
+template <typename Word, uint64_t Size = sizeof(Word)>
+absl::StatusOr<Word> bytes_read_word(absl::Span<const uint8_t> bytes,
+                                     uint64_t offset) {
+  static_assert(Size >= 1, "Size should be positive");
+  static_assert(std::numeric_limits<Word>::is_integer,
+                "Word must be an integer");
+  static_assert(sizeof(Word) >= Size, "Word is too small for specified Size");
+  Word ret = 0;
+  if (bytes.size() == 0 || bytes.size() - 1 < offset)
+    return absl::InternalError("Offset: " + std::to_string(offset) +
+                               " is outside byte array");
+  // Assume little-endian order
+  for (uint64_t i = 0; i < Size; i++) {
+    if (offset + Size - 1 - i >= bytes.size()) continue;
+    if (i > 0) ret <<= 8;
+    ret |= bytes[offset + Size - 1 - i];
+  }
+  return ret;
+}
+
+// Given a span of bytes, takes value of integer T and writes it to the
+// span at a specified offset following little-endian byte order
+template <typename Word, uint64_t Size = sizeof(Word)>
+absl::Status bytes_write_word(absl::Span<uint8_t> bytes, uint64_t offset,
+                              Word value) {
+  static_assert(Size >= 1, "Size should be positive");
+  static_assert(std::numeric_limits<Word>::is_integer,
+                "Word must be an integer");
+  static_assert(sizeof(Word) >= Size, "Word is too small for specified Size");
+  using UWord = std::make_unsigned_t<Word>;
+  if (bytes.size() == 0 || bytes.size() - 1 < offset)
+    return absl::InternalError("Offset: " + std::to_string(offset) +
+                               " is outside byte array");
+  UWord uval = value;
+  // Assume little-endian order
+  for (uint64_t i = 0; i < Size && offset + i < bytes.size(); i++) {
+    bytes[offset + i] = uval & 0xFF;
+    uval >>= 8;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic::byteops
+
+#endif  // XLS_SIMULATION_GENERIC_BYTEOPS_H_

--- a/xls/simulation/generic/byteops_test.cc
+++ b/xls/simulation/generic/byteops_test.cc
@@ -1,0 +1,151 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/byteops.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic::byteops {
+namespace {
+
+using testing::ElementsAre;
+
+class ByteopsTest : public ::testing::Test {};
+
+TEST_F(ByteopsTest, BytesReadWord8) {
+  std::vector<uint8_t> data{{1, 2, 3}};
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x01));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x02));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x03));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 3),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 4),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord16) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5}};
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x0201));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 3),
+              xls::status_testing::IsOkAndHolds(0x0504));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 4),
+              xls::status_testing::IsOkAndHolds(0x05));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord32) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5}};
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x04030201));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x05040302));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x050403));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord64) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x0807060504030201ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x0908070605040302ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x09080706050403ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 9),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord8) {
+  std::vector<uint8_t> data(3);
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 0, 1),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 1, 2),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 0));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 2, 3),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 3));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 1, 4),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 4, 3));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord16) {
+  std::vector<uint8_t> data(3);
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 0, 0x0201),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 0));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 1, 0x0403),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 3, 4));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 0, 0x0506),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(6, 5, 4));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 2, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(6, 5, 0));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord32) {
+  std::vector<uint8_t> data(5);
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 0, 0x03020100),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 1, 2, 3, 0));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 1, 0x07060504),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 4, 5, 6, 7));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 4, 5, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 5, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord64) {
+  std::vector<uint8_t> data(9);
+  EXPECT_THAT(
+      bytes_write_word<uint64_t>(absl::MakeSpan(data), 0, 0x0102030405060708LL),
+      xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 7, 6, 5, 4, 3, 2, 1, 0));
+  EXPECT_THAT(
+      bytes_write_word<uint64_t>(absl::MakeSpan(data), 1, 0x0102030405060708LL),
+      xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 8, 7, 6, 5, 4, 3, 2, 1));
+  EXPECT_THAT(bytes_write_word<uint64_t>(absl::MakeSpan(data), 4, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 8, 7, 6, 0, 0, 0, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint64_t>(absl::MakeSpan(data), 9, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic::byteops

--- a/xls/simulation/generic/common.h
+++ b/xls/simulation/generic/common.h
@@ -1,0 +1,32 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_COMMON_H_
+#define XLS_SIMULATION_GENERIC_COMMON_H_
+
+#include <cstdint>
+
+#include "xls/common/logging/logging.h"
+
+inline uint64_t BytesToBits(uint64_t byte_count) {
+  XLS_DCHECK_GE(byte_count, 0);
+  XLS_DCHECK_LE(byte_count, 8);
+  return byte_count << 3;
+}
+
+inline uint64_t BitsToBytes(uint64_t bit_count) {
+  return (bit_count & 0x7) ? (bit_count >> 3) + 1 : (bit_count >> 3);
+}
+
+#endif  // XLS_SIMULATION_GENERIC_COMMON_H_

--- a/xls/simulation/generic/common.h
+++ b/xls/simulation/generic/common.h
@@ -19,6 +19,10 @@
 
 #include "xls/common/logging/logging.h"
 
+enum class AccessWidth : uint8_t { BYTE, WORD, DWORD, QWORD };
+
+enum class IRQEnum : uint8_t { NoChange, SetIRQ, UnsetIRQ };
+
 inline uint64_t BytesToBits(uint64_t byte_count) {
   XLS_DCHECK_GE(byte_count, 0);
   XLS_DCHECK_LE(byte_count, 8);

--- a/xls/simulation/generic/config.cc
+++ b/xls/simulation/generic/config.cc
@@ -1,0 +1,400 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/config.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+
+ABSL_FLAG(
+    std::string, config_type, "binproto",
+    "Configuration file format, can be either: 'textproto', or 'binproto'");
+
+namespace xls::simulation::generic {
+
+absl::StatusOr<ConfigType> ResolveConfigType() {
+  std::string config_type_str = absl::GetFlag(FLAGS_config_type);
+  absl::StatusOr<ConfigType> config_type;
+  if (config_type_str == "textproto") {
+    config_type = ConfigType::kTextproto;
+  } else if (config_type_str == "binproto") {
+    config_type = ConfigType::kBinproto;
+  } else {
+    return absl::InvalidArgumentError(
+        "Invalid -config_type flag: " + config_type_str +
+        "; must be one of textproto|binproto");
+  }
+
+  return config_type;
+}
+
+absl::StatusOr<std::unique_ptr<ConfigProto>> MakeProtoForConfigFile(
+    std::string_view config_file_path, ConfigType config_type) {
+  absl::Status success;
+  absl::StatusOr<std::unique_ptr<ConfigProto>> design_config =
+      std::make_unique<ConfigProto>();
+
+  if (config_type == ConfigType::kNone) {
+    ConfigType& temp(config_type);
+    XLS_ASSIGN_OR_RETURN(temp, ResolveConfigType());
+  }
+  if (config_type == ConfigType::kTextproto) {
+    success = ParseTextProtoFile(config_file_path, design_config.value().get());
+  } else {
+    success = ParseProtobinFile(config_file_path, design_config.value().get());
+  }
+  if (!success.ok()) {
+    design_config = success;
+  }
+  return design_config;
+}
+
+Config::Config(std::unique_ptr<ConfigProto> proto, SimulationType sim_type)
+    : proto_(std::move(proto)), sim_type_(sim_type) {}
+
+std::vector<std::filesystem::path> Config::GetImportPaths() const {
+  std::vector<std::filesystem::path> import_paths;
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    import_paths.reserve(this->proto_->import_path_size());
+    for (int i = 0; i < this->proto_->import_path_size(); ++i) {
+      import_paths.push_back(
+          std::filesystem::path(this->proto_->import_path(i)));
+    }
+  }
+  return import_paths;
+}
+
+absl::StatusOr<std::filesystem::path> Config::GetDesignPath() const {
+  std::string type("DSLX");
+  if (this->sim_type_ == SimulationType::kIR) type = std::string("IR");
+  absl::StatusOr<std::filesystem::path> result =
+      absl::NotFoundError("Config has no value for " + type + " file path");
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    if (this->proto_->has_path_to_dslx_design())
+      result = std::filesystem::path(this->proto_->path_to_dslx_design());
+  } else if (this->sim_type_ == SimulationType::kIR) {
+    if (this->proto_->has_path_to_ir_design())
+      result = std::filesystem::path(this->proto_->path_to_ir_design());
+  } else {
+    return absl::InvalidArgumentError("Invalid sim type");
+  }
+  return result;
+}
+
+absl::StatusOr<std::string> Config::GetDesignName() const {
+  std::string type("DSLX");
+  if (this->sim_type_ == SimulationType::kIR) type = std::string("IR");
+  absl::StatusOr<std::string> result =
+      absl::NotFoundError("Config has no value for " + type + " file path");
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    if (this->proto_->has_dslx_top_level_process())
+      result = this->proto_->dslx_top_level_process();
+  } else if (this->sim_type_ == SimulationType::kIR) {
+    if (this->proto_->has_ir_top_level_process())
+      result = this->proto_->ir_top_level_process();
+  }
+  return result;
+}
+
+absl::StatusOr<uint64_t> Config::GetAddressMask() const {
+  uint64_t value = this->proto_->address_mask();
+  absl::StatusOr<uint64_t> result = value;
+  char hex_result_[100];
+  snprintf(hex_result_, sizeof(hex_result_) - 1, "%" PRIx64, value);
+  std::string hex_result(hex_result_);
+  value += 1;
+  if ((value & (value >> 1)) != 0)
+    result = absl::InvalidArgumentError("Address Mask " + hex_result +
+                                        " is not continous");
+  return result;
+}
+
+absl::StatusOr<std::optional<ConfigSingleValueManager>>
+Config::GetSingleValueManagerConfig() const {
+  if (!this->proto_->has_svm_config()) {
+    return std::nullopt;
+  }
+  auto svm_config_ = this->proto_->svm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(svm_config_.single_value_channels_size());
+  for (int i = 0; i < svm_config_.single_value_channels_size(); ++i) {
+    auto channel_config = svm_config_.single_value_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigSingleValueManager(svm_config_.base_address(),
+                                  svm_config_.runtime_status_offset(),
+                                  channels_);
+}
+
+absl::StatusOr<std::optional<ConfigStreamManager>>
+Config::GetStreamManagerConfig() const {
+  if (!this->proto_->has_sm_config()) {
+    return std::nullopt;
+  }
+  auto sm_config_ = this->proto_->sm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(sm_config_.stream_channels_size());
+  for (int i = 0; i < sm_config_.stream_channels_size(); ++i) {
+    auto channel_config = sm_config_.stream_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigStreamManager(sm_config_.base_address(), channels_);
+}
+
+absl::StatusOr<std::optional<ConfigStreamManager>>
+Config::GetDmaStreamManagerConfig() const {
+  if (!this->proto_->has_dma_sm_config()) {
+    return std::nullopt;
+  }
+  auto dma_sm_config_ = this->proto_->dma_sm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(dma_sm_config_.stream_channels_size());
+  for (int i = 0; i < dma_sm_config_.stream_channels_size(); ++i) {
+    auto channel_config = dma_sm_config_.stream_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigStreamManager(dma_sm_config_.base_address(), channels_);
+}
+
+ConfigDmaAxiStreamLikeManager::ConfigDmaAxiStreamLikeManager(
+    uint64_t base_address, std::vector<ConfigAxiStreamLikeChannel> channels)
+    : base_address_(base_address), channels_(channels) {}
+
+uint64_t ConfigDmaAxiStreamLikeManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+const std::vector<ConfigAxiStreamLikeChannel>&
+ConfigDmaAxiStreamLikeManager::GetChannels() const {
+  return this->channels_;
+}
+
+absl::StatusOr<std::optional<ConfigDmaAxiStreamLikeManager>>
+Config::GetDmaAxiStreamLikeManagerConfig() const {
+  if (!this->proto_->has_dma_axi_sm_config()) {
+    return std::nullopt;
+  }
+  auto dma_axi_sm_config_ = this->proto_->dma_axi_sm_config();
+  std::vector<ConfigAxiStreamLikeChannel> channels_;
+  channels_.reserve(dma_axi_sm_config_.axi_channels_size());
+  for (int i = 0; i < dma_axi_sm_config_.axi_channels_size(); ++i) {
+    auto axi_config = dma_axi_sm_config_.axi_channels(i);
+    auto base_config = axi_config.base_config();
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!base_config.has_dslx_name()) continue;
+      name = base_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!base_config.has_ir_name()) continue;
+      name = base_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (base_config.has_in_manager_offset())
+      ba_ = base_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (base_config.has_dma_id()) id_ = base_config.dma_id();
+
+    std::vector<uint64_t> data_idxs_;
+    data_idxs_.reserve(axi_config.dataidxs_size());
+    for (int j = 0; j < axi_config.dataidxs_size(); ++j) {
+      data_idxs_.push_back(axi_config.dataidxs(j));
+    }
+
+    std::optional<uint64_t> keep_ = std::nullopt;
+    if (axi_config.has_keepidx()) keep_ = axi_config.keepidx();
+    std::optional<uint64_t> last_ = std::nullopt;
+    if (axi_config.has_lastidx()) last_ = axi_config.lastidx();
+
+    XLS_ASSIGN_OR_RETURN(
+        ConfigAxiStreamLikeChannel channel_,
+        ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+            name, data_idxs_, ba_, id_, keep_, last_));
+    channels_.push_back(channel_);
+  }
+  return ConfigDmaAxiStreamLikeManager(dma_axi_sm_config_.base_address(),
+                                       channels_);
+}
+
+/* static */ absl::StatusOr<ConfigChannel> ConfigChannel::MakeConfigChannel(
+    std::string name, std::optional<uint64_t> offset,
+    std::optional<uint64_t> dma_id) {
+  absl::StatusOr<ConfigChannel> result = absl::InvalidArgumentError(
+      "Channel \"" + name + "\" has invalid config!");
+  if (offset.has_value() || dma_id.has_value())
+    result = ConfigChannel(name, offset, dma_id);
+  XLS_LOG_IF(ERROR, !result.ok())
+      << "Channel \"" << name << "\" does not define offset or DMA ID";
+  return result;
+}
+
+ConfigChannel::ConfigChannel(std::string name, std::optional<uint64_t> offset,
+                             std::optional<uint64_t> dma_id)
+    : name_(name), offset_(offset), dma_id_(dma_id) {}
+
+std::string_view ConfigChannel::GetName() const { return this->name_; }
+
+absl::StatusOr<uint64_t> ConfigChannel::GetOffset() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define offset.");
+  if (this->offset_.has_value()) result = this->offset_.value();
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigChannel::GetDMAID() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define DMA ID.");
+  if (this->dma_id_.has_value()) result = this->dma_id_.value();
+  return result;
+}
+
+ConfigSingleValueManager::ConfigSingleValueManager(
+    uint64_t base_address, uint64_t runtime_status_offset,
+    std::vector<ConfigChannel> channels)
+    : base_address_(base_address),
+      runtime_status_offset_(runtime_status_offset),
+      channels_(channels) {}
+
+uint64_t ConfigSingleValueManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+uint64_t ConfigSingleValueManager::GetRuntimeStatusOffset() const {
+  return this->runtime_status_offset_;
+}
+
+const std::vector<ConfigChannel>& ConfigSingleValueManager::GetChannels()
+    const {
+  return this->channels_;
+}
+
+ConfigStreamManager::ConfigStreamManager(uint64_t base_address,
+                                         std::vector<ConfigChannel> channels)
+    : base_address_(base_address), channels_(channels) {}
+
+uint64_t ConfigStreamManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+const std::vector<ConfigChannel>& ConfigStreamManager::GetChannels() const {
+  return this->channels_;
+}
+
+/* static */ absl::StatusOr<ConfigAxiStreamLikeChannel>
+ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+    std::string name, std::vector<uint64_t> data_idxs,
+    std::optional<uint64_t> base_address, std::optional<uint64_t> dma_id,
+    std::optional<uint64_t> keep_idx, std::optional<uint64_t> last_idx) {
+  absl::StatusOr<ConfigAxiStreamLikeChannel> result =
+      absl::InvalidArgumentError(name + " has invalid config!");
+  bool has_address = base_address.has_value() || dma_id.has_value();
+  bool has_data = data_idxs.size() > 0;
+  if (has_address && has_data)
+    result = ConfigAxiStreamLikeChannel(name, data_idxs, base_address, dma_id,
+                                        keep_idx, last_idx);
+
+  XLS_LOG_IF(ERROR, !has_address)
+      << name << " doesn't define base address nor DMA ID";
+
+  XLS_LOG_IF(ERROR, !has_data)
+      << "Channel \"" << name << "\" does not define any data indices";
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigAxiStreamLikeChannel::GetLastIdx() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define last index.");
+  if (this->last_idx_.has_value()) result = this->last_idx_.value();
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigAxiStreamLikeChannel::GetKeepIdx() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define keep index.");
+  if (this->keep_idx_.has_value()) result = this->keep_idx_.value();
+  return result;
+}
+
+const std::vector<uint64_t>& ConfigAxiStreamLikeChannel::GetDataIdxs() const {
+  return this->data_idxs_;
+}
+
+ConfigAxiStreamLikeChannel::ConfigAxiStreamLikeChannel(
+    std::string name, std::vector<uint64_t> data_idxs,
+    std::optional<uint64_t> offset, std::optional<uint64_t> dma_id,
+    std::optional<uint64_t> keep_idx, std::optional<uint64_t> last_idx)
+    : ConfigChannel(name, offset, dma_id),
+      keep_idx_(keep_idx),
+      last_idx_(last_idx),
+      data_idxs_(data_idxs) {}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/config.h
+++ b/xls/simulation/generic/config.h
@@ -1,0 +1,168 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_CONFIG_H_
+#define XLS_SIMULATION_GENERIC_CONFIG_H_
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/flags/declare.h"
+#include "absl/flags/flag.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/config.pb.h"
+
+ABSL_DECLARE_FLAG(std::string, config_type);
+
+namespace xls::simulation::generic {
+
+enum class ConfigType {
+  kTextproto,
+  kBinproto,
+  kNone,
+};
+
+enum class SimulationType {
+  kDSLX,
+  kIR,
+};
+
+absl::StatusOr<std::unique_ptr<ConfigProto>> MakeProtoForConfigFile(
+    std::string_view, ConfigType = ConfigType::kNone);
+
+absl::StatusOr<ConfigType> ResolveConfigType();
+
+class ConfigSingleValueManager;
+class ConfigStreamManager;
+class ConfigDmaAxiStreamLikeManager;
+
+class Config {
+ public:
+  Config(std::unique_ptr<ConfigProto>, SimulationType);
+
+  std::vector<std::filesystem::path> GetImportPaths() const;
+  absl::StatusOr<std::filesystem::path> GetDesignPath() const;
+  absl::StatusOr<std::string> GetDesignName() const;
+  absl::StatusOr<uint64_t> GetAddressMask() const;
+
+  absl::StatusOr<std::optional<ConfigSingleValueManager>>
+  GetSingleValueManagerConfig() const;
+  absl::StatusOr<std::optional<ConfigStreamManager>> GetStreamManagerConfig()
+      const;
+  absl::StatusOr<std::optional<ConfigStreamManager>> GetDmaStreamManagerConfig()
+      const;
+  absl::StatusOr<std::optional<ConfigDmaAxiStreamLikeManager>>
+  GetDmaAxiStreamLikeManagerConfig() const;
+
+ private:
+  Config();
+  std::unique_ptr<ConfigProto> proto_;
+  SimulationType sim_type_;
+};
+
+class ConfigChannel {
+ public:
+  static absl::StatusOr<ConfigChannel> MakeConfigChannel(
+      std::string, std::optional<uint64_t> = std::nullopt,
+      std::optional<uint64_t> = std::nullopt);
+
+  std::string_view GetName() const;
+  absl::StatusOr<uint64_t> GetOffset() const;
+  absl::StatusOr<uint64_t> GetDMAID() const;
+
+ protected:
+  ConfigChannel();
+  ConfigChannel(std::string, std::optional<uint64_t> = std::nullopt,
+                std::optional<uint64_t> = std::nullopt);
+
+  std::string name_;
+  std::optional<uint64_t> offset_;
+  std::optional<uint64_t> dma_id_;
+};
+
+class ConfigSingleValueManager {
+ public:
+  ConfigSingleValueManager(uint64_t, uint64_t, std::vector<ConfigChannel>);
+
+  uint64_t GetBaseAddress() const;
+  uint64_t GetRuntimeStatusOffset() const;
+  const std::vector<ConfigChannel>& GetChannels() const;
+
+ private:
+  ConfigSingleValueManager();
+  uint64_t base_address_;
+  uint64_t runtime_status_offset_;
+  std::vector<ConfigChannel> channels_;
+};
+
+class ConfigStreamManager {
+ public:
+  ConfigStreamManager(uint64_t, std::vector<ConfigChannel>);
+
+  uint64_t GetBaseAddress() const;
+  const std::vector<ConfigChannel>& GetChannels() const;
+
+ private:
+  ConfigStreamManager();
+  uint64_t base_address_;
+  std::vector<ConfigChannel> channels_;
+};
+
+class ConfigAxiStreamLikeChannel : public ConfigChannel {
+ public:
+  static absl::StatusOr<ConfigAxiStreamLikeChannel>
+      MakeConfigAxiStreamLikeChannel(std::string, std::vector<uint64_t>,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt);
+
+  absl::StatusOr<uint64_t> GetKeepIdx() const;
+  absl::StatusOr<uint64_t> GetLastIdx() const;
+  const std::vector<uint64_t>& GetDataIdxs() const;
+
+ private:
+  ConfigAxiStreamLikeChannel();
+  ConfigAxiStreamLikeChannel(std::string, std::vector<uint64_t>,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt);
+
+  std::optional<uint64_t> keep_idx_;
+  std::optional<uint64_t> last_idx_;
+  std::vector<uint64_t> data_idxs_;
+};
+
+class ConfigDmaAxiStreamLikeManager {
+ public:
+  ConfigDmaAxiStreamLikeManager(uint64_t,
+                                std::vector<ConfigAxiStreamLikeChannel>);
+
+  uint64_t GetBaseAddress() const;
+  const std::vector<ConfigAxiStreamLikeChannel>& GetChannels() const;
+
+ private:
+  ConfigDmaAxiStreamLikeManager();
+  uint64_t base_address_;
+  std::vector<ConfigAxiStreamLikeChannel> channels_;
+};
+
+}  // namespace xls::simulation::generic
+#endif  // XLS_SIMULATION_GENERIC_CONFIG_H_

--- a/xls/simulation/generic/config.proto
+++ b/xls/simulation/generic/config.proto
@@ -1,0 +1,60 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package xls.simulation.generic;
+
+message ConfigProto {
+  repeated string import_path = 1;
+  optional string path_to_dslx_design = 2;
+  optional string dslx_top_level_process = 3;
+  optional string path_to_ir_design = 4;
+  optional string ir_top_level_process = 5;
+  uint64 address_mask = 6;
+
+  message Channel {
+    optional string dslx_name = 1;
+    optional string ir_name = 2;
+    optional uint64 in_manager_offset = 3;
+    optional uint64 DMA_ID = 4;
+  }
+
+  message SingleValueManager {
+    uint64 base_address = 1;
+    uint64 runtime_status_offset = 2;
+    repeated Channel single_value_channels = 3;
+  }
+  optional SingleValueManager svm_config = 7;
+
+  message StreamManager {
+    uint64 base_address = 1;
+    repeated Channel stream_channels = 2;
+  }
+  optional StreamManager sm_config = 8;
+  optional StreamManager dma_sm_config = 9;
+
+  message AXIStreamLikeChannel {
+    Channel base_config = 1;
+    repeated uint64 dataIdxs = 2;
+    optional uint64 keepIdx = 3;
+    optional uint64 lastIdx = 4;
+  }
+
+  message DMAAXIStreamLikeManager {
+    uint64 base_address = 1;
+    repeated AXIStreamLikeChannel axi_channels = 2;
+  }
+  optional DMAAXIStreamLikeManager dma_axi_sm_config = 10;
+}

--- a/xls/simulation/generic/config_test.cc
+++ b/xls/simulation/generic/config_test.cc
@@ -1,0 +1,766 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/config.h"
+
+#include <fcntl.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class ConfigChannelTest : public ::testing::Test {
+ protected:
+  ConfigChannelTest() : name("name"), offset(0xDEADBEEF), dma_id(0) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+
+  absl::StatusOr<ConfigChannel> cfg;
+  std::string name;
+  uint64_t offset;
+  uint64_t dma_id;
+};
+
+TEST_F(ConfigChannelTest, MakeConfigChannel) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, offset, dma_id));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetOffset(), offset);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetDMAID(), dma_id);
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelOffsetNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, std::nullopt, dma_id));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetOffset().status()));
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetDMAID(), dma_id);
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelDmaIdNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, offset, std::nullopt));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetOffset(), offset);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetDMAID().status()));
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelDmaIdAndOffsetNullopt) {
+  ::testing::internal::CaptureStderr();
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      ConfigChannel::MakeConfigChannel(name, std::nullopt, std::nullopt)
+          .status()));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("does not define offset or DMA ID"));
+}
+
+class ConfigAxiStreamLikeChannelTest : public ::testing::Test {
+ protected:
+  ConfigAxiStreamLikeChannelTest()
+      : name("name"),
+        data_idxs({0, 1, 2, 3, 4, 5, 6, 7}),
+        offset(0xDEADBEEF),
+        dma_id(0),
+        keep_idx(0),
+        last_idx(0) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+
+  absl::StatusOr<ConfigAxiStreamLikeChannel> cfg;
+  std::string name;
+  std::vector<uint64_t> data_idxs;
+  uint64_t offset;
+  uint64_t dma_id;
+  uint64_t keep_idx;
+  uint64_t last_idx;
+};
+
+TEST_F(ConfigAxiStreamLikeChannelTest, MakeConfigAxiStreamLikeChannel) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, keep_idx, last_idx));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetKeepIdx(), keep_idx);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetLastIdx(), last_idx);
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetDataIdxsEmpty) {
+  data_idxs = {};
+  ::testing::internal::CaptureStderr();
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+          name, data_idxs, offset, dma_id, keep_idx, last_idx)
+          .status()));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("does not define any data indices"));
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetKeepIdxNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, std::nullopt, last_idx));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetKeepIdx().status()));
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetLastIdx(), last_idx);
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetLastIdxNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, keep_idx, std::nullopt));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetKeepIdx(), keep_idx);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetLastIdx().status()));
+}
+
+class ChannelManagerTest : public ::testing::Test {
+ protected:
+  ChannelManagerTest()
+      : base_address(0xDEADBEEF), channels_num(8), channel_width(64) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+  void SetUp() override { SetupChannels(); }
+  virtual void SetupChannels() = 0;
+
+  uint64_t base_address;
+  uint8_t channels_num;
+  uint8_t channel_width;
+};
+
+class RegularChannelManagerTest : public ChannelManagerTest {
+ protected:
+  void SetupChannels() override {
+    channels.clear();
+    for (uint8_t i = 0; i < channels_num; i++) {
+      auto cfg = ConfigChannel::MakeConfigChannel(
+          "RegularChannel" + std::to_string(i), (channel_width * i), i);
+      channels.push_back(cfg.value());
+    }
+  }
+
+  void CompareChannels(std::vector<ConfigChannel> tested_channels) {
+    uint64_t i = 0;
+    for (auto channel : tested_channels) {
+      EXPECT_EQ(channel.GetName(), channels[i].GetName());
+      EXPECT_EQ(channel.GetOffset(), channels[i].GetOffset());
+      EXPECT_EQ(channel.GetDMAID(), channels[i].GetDMAID());
+      i++;
+    }
+  }
+
+  std::vector<ConfigChannel> channels;
+};
+
+class ConfigSingleValueManagerTest : public RegularChannelManagerTest {
+ protected:
+  ConfigSingleValueManagerTest() : runtime_status_offset(0xFEEBDAED) {}
+
+  uint64_t runtime_status_offset;
+};
+
+TEST_F(ConfigSingleValueManagerTest, ConfigSingleValueManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigSingleValueManager cfg =
+      ConfigSingleValueManager(base_address, runtime_status_offset, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetRuntimeStatusOffset(), runtime_status_offset);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+using ConfigStreamManagerTest = RegularChannelManagerTest;
+
+TEST_F(ConfigStreamManagerTest, ConfigStreamManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigStreamManager cfg = ConfigStreamManager(base_address, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+class ConfigDmaAxiStreamLikeManagerTest : public ChannelManagerTest {
+ protected:
+  void SetupChannels() override {
+    std::vector<uint64_t> data_idxs = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    channels.clear();
+    for (uint8_t i = 0; i < channels_num; i++) {
+      absl::StatusOr<ConfigAxiStreamLikeChannel> cfg =
+          ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+              "AxiStreamLikeChannel" + std::to_string(i), data_idxs,
+              (channel_width * i), i, i, i);
+      channels.push_back(cfg.value());
+    }
+  }
+
+  void CompareChannels(
+      std::vector<ConfigAxiStreamLikeChannel> tested_channels) {
+    uint64_t i = 0;
+    for (auto channel : tested_channels) {
+      EXPECT_EQ(channel.GetName(), channels[i].GetName());
+      EXPECT_EQ(channel.GetOffset(), channels[i].GetOffset());
+      EXPECT_EQ(channel.GetDMAID(), channels[i].GetDMAID());
+      EXPECT_EQ(channel.GetKeepIdx(), channels[i].GetKeepIdx());
+      EXPECT_EQ(channel.GetLastIdx(), channels[i].GetLastIdx());
+      EXPECT_EQ(channel.GetDataIdxs(), channels[i].GetDataIdxs());
+      i++;
+    }
+  }
+
+  std::vector<ConfigAxiStreamLikeChannel> channels;
+};
+
+TEST_F(ConfigDmaAxiStreamLikeManagerTest, ConfigDmaAxiStramLikeManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigDmaAxiStreamLikeManager cfg =
+      ConfigDmaAxiStreamLikeManager(base_address, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+class ConfigWriter {
+ public:
+  inline static const std::vector<std::string> import_path = {
+      "arbitrary/import/path/a", "arbitrary/import/path/b",
+      "arbitrary/import/path/c", "arbitrary/import/path/d"};
+
+  inline static const std::string path_to_dslx_design =
+      "arbitrary/path/to/dslx/design.x";
+  inline static const std::string dslx_top_level_process =
+      "dslx_top_level_process_name";
+  inline static const std::string path_to_ir_design =
+      "arbitrary/path/to/ir/design.ir";
+  inline static const std::string ir_top_level_process =
+      "ir_top_level_process_name";
+
+  static const uint64_t address_mask = 0xFFFFFFFFFFFFFFFF;
+
+  static const uint8_t max_single_value_channels = 64;
+  static const uint64_t example_single_value_channel_width = 64;
+  static const uint64_t svm_base_address = 0;
+  // runtime status is the first channel in single value manager address space
+  static const uint64_t svm_runtime_status_offset = svm_base_address;
+
+  static const uint8_t max_stream_channels = 32;
+  static const uint64_t example_stream_channel_width = 256;
+  static const uint64_t sm_base_address =
+      svm_base_address +
+      (max_single_value_channels * example_single_value_channel_width);
+
+  static const uint8_t max_dma_stream_channels = 16;
+  static const uint64_t example_dma_stream_channel_width = 512;
+  static const uint64_t dma_sm_base_address =
+      sm_base_address + (max_stream_channels * example_stream_channel_width);
+
+  static const uint8_t max_dma_axi_stream_channels = 8;
+  static const uint64_t example_dma_axi_stream_channel_width = 2048;
+  static const uint64_t dma_axi_stream_base_address =
+      dma_sm_base_address +
+      (max_dma_stream_channels * example_dma_stream_channel_width);
+
+  void SetupChannelConfigProto(ConfigProto_Channel* cfg, std::string dslx_name,
+                               std::string ir_name, uint64_t offset,
+                               uint64_t dma_id) {
+    cfg->set_dslx_name(dslx_name);
+    cfg->set_ir_name(ir_name);
+    cfg->set_in_manager_offset(offset);
+    cfg->set_dma_id(dma_id);
+  }
+
+  void SetupAxiStreamLikeChannelConfigProto(
+      ConfigProto_AXIStreamLikeChannel* cfg, std::string dslx_name,
+      std::string ir_name, uint64_t offset, uint64_t dma_id,
+      std::vector<uint64_t> data_idxs, uint64_t keep_idx, uint64_t last_idx) {
+    ConfigProto_Channel* channel = cfg->mutable_base_config();
+    SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    for (auto data_idx : data_idxs) {
+      cfg->add_dataidxs(data_idx);
+    }
+    cfg->set_keepidx(keep_idx);
+    cfg->set_lastidx(last_idx);
+  }
+
+  void SetupSvmConfigProto(ConfigProto_SingleValueManager* cfg, uint64_t ba,
+                           uint64_t runtime_status_offset, uint8_t max_channels,
+                           uint64_t channel_width) {
+    cfg->set_base_address(ba);
+    cfg->set_runtime_status_offset(runtime_status_offset);
+
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxSingleValueChannel" + std::to_string(i);
+      std::string ir_name = "IrSingleValueChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      ConfigProto_Channel* channel = cfg->add_single_value_channels();
+      SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    }
+  }
+
+  void SetupSmConfigProto(ConfigProto_StreamManager* cfg, uint64_t ba,
+                          uint8_t max_channels, uint64_t channel_width) {
+    cfg->set_base_address(ba);
+
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxStreamChannel" + std::to_string(i);
+      std::string ir_name = "IrStreamChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      ConfigProto_Channel* channel = cfg->add_stream_channels();
+      SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    }
+  }
+
+  void SetupDmaAxiSmConfigProto(ConfigProto_DMAAXIStreamLikeManager* cfg,
+                                uint64_t ba, uint8_t max_channels,
+                                uint64_t channel_width) {
+    cfg->set_base_address(ba);
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxAxiStreamLikeChannel" + std::to_string(i);
+      std::string ir_name = "IrAxiStreamLikeChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      std::vector<uint64_t> data_idxs = {0, 1, 2, 3, 4, 5, 6, 7};
+      uint64_t keep_idx = i;
+      uint64_t last_idx = i;
+      ConfigProto_AXIStreamLikeChannel* channel = cfg->add_axi_channels();
+      SetupAxiStreamLikeChannelConfigProto(channel, dslx_name, ir_name, offset,
+                                           dma_id, data_idxs, keep_idx,
+                                           last_idx);
+    }
+  }
+
+  ConfigProto& SetupConfigProto() {
+    for (auto path : import_path) {
+      cfg_proto.add_import_path(path);
+    }
+
+    cfg_proto.set_path_to_dslx_design(path_to_dslx_design);
+    cfg_proto.set_dslx_top_level_process(dslx_top_level_process);
+    cfg_proto.set_path_to_ir_design(path_to_ir_design);
+    cfg_proto.set_ir_top_level_process(ir_top_level_process);
+    cfg_proto.set_address_mask(address_mask);
+
+    svm_config = cfg_proto.mutable_svm_config();
+    SetupSvmConfigProto(svm_config, svm_base_address, svm_runtime_status_offset,
+                        max_single_value_channels,
+                        example_single_value_channel_width);
+
+    sm_config = cfg_proto.mutable_sm_config();
+    SetupSmConfigProto(sm_config, sm_base_address, max_stream_channels,
+                       example_stream_channel_width);
+
+    dma_sm_config = cfg_proto.mutable_dma_sm_config();
+    SetupSmConfigProto(dma_sm_config, dma_sm_base_address,
+                       max_dma_stream_channels,
+                       example_dma_stream_channel_width);
+
+    dma_axi_sm_config = cfg_proto.mutable_dma_axi_sm_config();
+    SetupDmaAxiSmConfigProto(dma_axi_sm_config, dma_axi_stream_base_address,
+                             max_dma_axi_stream_channels,
+                             example_dma_axi_stream_channel_width);
+
+    return cfg_proto;
+  }
+
+  void WriteBinaryConfigProto(std::string filename) {
+    std::fstream output(filename,
+                        std::ios::out | std::ios::trunc | std::ios::binary);
+    if (!cfg_proto.SerializeToOstream(&output)) {
+      XLS_LOG(ERROR) << "Failed to write binary config file";
+    }
+    output.close();
+  }
+
+  void WriteTextConfigProto(std::string filename) {
+    int fd = open(filename.c_str(), O_CREAT | O_WRONLY | O_TRUNC,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+    google::protobuf::io::FileOutputStream output =
+        google::protobuf::io::FileOutputStream(fd);
+    if (!google::protobuf::TextFormat::Print(cfg_proto, &output)) {
+      XLS_LOG(ERROR) << "Failed to write text config file";
+    }
+    output.Close();
+    close(fd);
+  }
+
+  ConfigProto cfg_proto;
+  ConfigProto_SingleValueManager* svm_config;
+  ConfigProto_StreamManager* sm_config;
+  ConfigProto_StreamManager* dma_sm_config;
+  ConfigProto_DMAAXIStreamLikeManager* dma_axi_sm_config;
+};
+
+class MakeProtoForConfigFileTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+  explicit MakeProtoForConfigFileTest(std::string cfg_proto_file_path)
+      : cfg_proto_file_path(cfg_proto_file_path) {
+    cfg_writer.SetupConfigProto();
+  }
+
+  absl::StatusOr<std::unique_ptr<ConfigProto>> status_or_cfg_proto;
+  ConfigWriter cfg_writer;
+  ConfigType cfg_type;
+  std::string cfg_proto_file_path;
+};
+
+class MakeProtoForConfigFileBinaryTest
+    : public MakeProtoForConfigFileTest,
+      public testing::WithParamInterface<ConfigType> {
+ protected:
+  MakeProtoForConfigFileBinaryTest()
+      : MakeProtoForConfigFileTest("/tmp/cfg_proto.bin") {
+    cfg_writer.WriteBinaryConfigProto(cfg_proto_file_path);
+  }
+};
+
+TEST_P(MakeProtoForConfigFileBinaryTest, RoundTripCheck) {
+  cfg_type = GetParam();
+
+  ::testing::internal::CaptureStderr();
+  status_or_cfg_proto = MakeProtoForConfigFile(cfg_proto_file_path, cfg_type);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  if (cfg_type == ConfigType::kNone) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else if (cfg_type == ConfigType::kBinproto) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else if (cfg_type == ConfigType::kTextproto) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MakeProtoForConfigFileBinaryTestParametrized,
+                         MakeProtoForConfigFileBinaryTest,
+                         testing::Values(ConfigType::kNone,
+                                         ConfigType::kBinproto,
+                                         ConfigType::kTextproto));
+
+class MakeProtoForConfigFileTextTest
+    : public MakeProtoForConfigFileTest,
+      public testing::WithParamInterface<ConfigType> {
+ protected:
+  MakeProtoForConfigFileTextTest()
+      : MakeProtoForConfigFileTest("/tmp/cfg_proto.txtpb") {
+    cfg_writer.WriteTextConfigProto(cfg_proto_file_path);
+  }
+};
+
+TEST_P(MakeProtoForConfigFileTextTest, RoundTripCheck) {
+  cfg_type = GetParam();
+
+  ::testing::internal::CaptureStderr();
+  status_or_cfg_proto = MakeProtoForConfigFile(cfg_proto_file_path, cfg_type);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  // Expected to fail because MakeProtoForConfigFile() with ConfigType::kNone
+  // calls ResolveConfigType() which resolves the config type based on
+  // absl flag 'FLAGS_config_type' which has default value set to 'binproto'.
+  // This causes Text Proto file to be incorrectly parsed as Binary Proto file
+  if (cfg_type == ConfigType::kNone) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else if (cfg_type == ConfigType::kBinproto) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else if (cfg_type == ConfigType::kTextproto) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MakeProtoForConfigFileTextTestParametrized,
+                         MakeProtoForConfigFileTextTest,
+                         testing::Values(ConfigType::kNone,
+                                         ConfigType::kBinproto,
+                                         ConfigType::kTextproto));
+
+class ResolveConfigTypeTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<std::string> {
+ protected:
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_P(ResolveConfigTypeTest, ResolveConfigType) {
+  std::string cfg_type_str = GetParam();
+  if (cfg_type_str != "default_cfg_type")
+    absl::SetFlag(&FLAGS_config_type, cfg_type_str);
+  ::testing::internal::CaptureStderr();
+  absl::StatusOr<ConfigType> cfg_type = ResolveConfigType();
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  if (cfg_type_str == "textproto") {
+    XLS_EXPECT_OK(cfg_type);
+  } else if (cfg_type_str == "binproto") {
+    XLS_EXPECT_OK(cfg_type);
+  } else if (cfg_type_str == "default_cfg_type") {
+    XLS_EXPECT_OK(cfg_type);  // cfg_type flag defaults to 'binproto'
+  } else if (cfg_type_str == "") {
+    EXPECT_TRUE(absl::IsInvalidArgument(cfg_type.status()));
+  } else {
+    EXPECT_TRUE(absl::IsInvalidArgument(cfg_type.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ResolveConfigTypeTestParametrized,
+                         ResolveConfigTypeTest,
+                         testing::Values("default_cfg_type", "",
+                                         "not_recognized", "textproto",
+                                         "binproto"));
+
+class ConfigTest : public MakeProtoForConfigFileTest,
+                   public testing::WithParamInterface<SimulationType> {
+ protected:
+  ConfigTest() : MakeProtoForConfigFileTest("/tmp/cfg_proto.bin") {
+    cfg_writer.WriteBinaryConfigProto(cfg_proto_file_path);
+    cfg_type = ConfigType::kNone;
+  }
+
+  void compare_channels(ConfigChannel* channel,
+                        const ConfigProto_Channel& ref_channel,
+                        SimulationType sim_type) {
+    if (sim_type == SimulationType::kDSLX)
+      EXPECT_EQ(channel->GetName(), ref_channel.dslx_name());
+    else if (sim_type == SimulationType::kIR)
+      EXPECT_EQ(channel->GetName(), ref_channel.ir_name());
+    else
+      FAIL() << "Unexpected SimulationType";
+
+    XLS_EXPECT_OK_AND_EQ(channel->GetOffset(), ref_channel.in_manager_offset());
+    XLS_EXPECT_OK_AND_EQ(channel->GetDMAID(), ref_channel.dma_id());
+  }
+
+  void compare_axi_stream_like_channels(
+      ConfigAxiStreamLikeChannel* channel,
+      const ConfigProto_AXIStreamLikeChannel& ref_channel,
+      SimulationType sim_type) {
+    compare_channels(channel, ref_channel.base_config(), sim_type);
+
+    XLS_EXPECT_OK_AND_EQ(channel->GetKeepIdx(), ref_channel.keepidx());
+    XLS_EXPECT_OK_AND_EQ(channel->GetLastIdx(), ref_channel.lastidx());
+
+    auto data_idxs = channel->GetDataIdxs();
+    EXPECT_GT(data_idxs.size(), 0);
+    EXPECT_EQ(data_idxs.size(), ref_channel.dataidxs_size());
+    for (int i = 0; i < data_idxs.size(); i++) {
+      EXPECT_EQ(data_idxs[i], ref_channel.dataidxs(i));
+    }
+  }
+
+  SimulationType sim_type;
+};
+
+TEST_P(ConfigTest, GetImportPaths) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  std::vector<std::filesystem::path> import_paths =
+      cfg_wrapper.GetImportPaths();
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_GT(import_paths.size(), 0);
+    EXPECT_EQ(import_paths.size(), reference.import_path_size());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(import_paths.size(), 0);
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+  for (int i = 0; i < import_paths.size(); i++) {
+    EXPECT_EQ(import_paths[i].string(), reference.import_path(i));
+  }
+}
+
+TEST_P(ConfigTest, GetDesignPath) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::filesystem::path design_path,
+                           cfg_wrapper.GetDesignPath());
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_EQ(design_path.string(), reference.path_to_dslx_design());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(design_path.string(), reference.path_to_ir_design());
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+}
+
+TEST_P(ConfigTest, GetDesignName) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::string design_name,
+                           cfg_wrapper.GetDesignName());
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_EQ(design_name, reference.dslx_top_level_process());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(design_name, reference.ir_top_level_process());
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+}
+
+TEST_P(ConfigTest, GetAddressMask) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_EXPECT_OK_AND_EQ(cfg_wrapper.GetAddressMask(), reference.address_mask());
+}
+
+TEST_P(ConfigTest, GetSingleValueManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_svm_cfg = reference.svm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto svm_cfg,
+                           cfg_wrapper.GetSingleValueManagerConfig());
+  EXPECT_EQ(svm_cfg->GetBaseAddress(), ref_svm_cfg.base_address());
+  EXPECT_EQ(svm_cfg->GetRuntimeStatusOffset(),
+            ref_svm_cfg.runtime_status_offset());
+  auto channels = svm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_svm_cfg.single_value_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_svm_cfg.single_value_channels(i),
+                     sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetStreamManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_sm_cfg = reference.sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto sm_cfg, cfg_wrapper.GetStreamManagerConfig());
+  EXPECT_EQ(sm_cfg->GetBaseAddress(), ref_sm_cfg.base_address());
+  auto channels = sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_sm_cfg.stream_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_sm_cfg.stream_channels(i), sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetDmaStreamManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_dma_sm_cfg = reference.dma_sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto dma_sm_cfg,
+                           cfg_wrapper.GetDmaStreamManagerConfig());
+  EXPECT_EQ(dma_sm_cfg->GetBaseAddress(), ref_dma_sm_cfg.base_address());
+  auto channels = dma_sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_dma_sm_cfg.stream_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_dma_sm_cfg.stream_channels(i), sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetDmaAxiStreamLikeManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_dma_axi_sm_cfg = reference.dma_axi_sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto dma_axi_sm_cfg,
+                           cfg_wrapper.GetDmaAxiStreamLikeManagerConfig());
+  EXPECT_EQ(dma_axi_sm_cfg->GetBaseAddress(),
+            ref_dma_axi_sm_cfg.base_address());
+  auto channels = dma_axi_sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_dma_axi_sm_cfg.axi_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_axi_stream_like_channels(
+        &channels[i], ref_dma_axi_sm_cfg.axi_channels(i), sim_type);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ConfigTestParametrized, ConfigTest,
+                         testing::Values(SimulationType::kDSLX,
+                                         SimulationType::kIR));
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iactive.h
+++ b/xls/simulation/generic/iactive.h
@@ -1,0 +1,30 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IACTIVE_H_
+#define XLS_SIMULATION_GENERIC_IACTIVE_H_
+
+#include "absl/status/status.h"
+
+namespace xls::simulation::generic {
+
+class IActive {
+ public:
+  virtual ~IActive() = default;
+  virtual absl::Status Update() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IACTIVE_H_

--- a/xls/simulation/generic/iactive_stub.cc
+++ b/xls/simulation/generic/iactive_stub.cc
@@ -1,0 +1,35 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iactive_stub.h"
+
+#include "absl/status/status.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IActiveStub::IActiveStub() : cnt_(0) {}
+
+absl::Status IActiveStub::Update() {
+  XLS_LOG(INFO) << "IActiveStub tick: " << this->cnt_;
+
+  ++this->cnt_;
+  return absl::OkStatus();
+}
+
+int IActiveStub::getCnt() { return this->cnt_; }
+
+void IActiveStub::setCnt(int cnt) { this->cnt_ = cnt; }
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iactive_stub.h
+++ b/xls/simulation/generic/iactive_stub.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_
+#define XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iactive.h"
+
+namespace xls::simulation::generic {
+
+class IActiveStub : public IActive {
+ public:
+  IActiveStub();
+  virtual ~IActiveStub() = default;
+
+  int getCnt();
+  void setCnt(int cnt);
+
+  absl::Status Update() override;
+
+ private:
+  int cnt_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_

--- a/xls/simulation/generic/iactive_test.cc
+++ b/xls/simulation/generic/iactive_test.cc
@@ -1,0 +1,37 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iactive_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IActiveStubTest : public ::testing::Test {
+ protected:
+  IActiveStub stub;
+};
+
+TEST_F(IActiveStubTest, Init) { ASSERT_EQ(stub.getCnt(), 0); }
+
+TEST_F(IActiveStubTest, Update) {
+  for (auto i = 0; i < 100; ++i) {
+    ASSERT_EQ(stub.getCnt(), i);
+    XLS_EXPECT_OK(stub.Update());
+  }
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iaxistreamlike.h
+++ b/xls/simulation/generic/iaxistreamlike.h
@@ -1,0 +1,47 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_
+#define XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+// IAxiStreamLike - extension to IStream interface that provides methods
+// for managing AXI-Stream-like bits of data payload.
+class IAxiStreamLike : public IStream {
+ public:
+  virtual uint64_t GetNumSymbols() const = 0;
+  // Get the width of the underlying XLS channel symbol in bits.
+  // In the CPU-facing interface (IChannel), implementation must pad symbols
+  // with zero MSB bits to align them on 8/16/32..-bit boundaries.
+  virtual uint64_t GetSymbolWidth() const = 0;
+  // Get number of bytes occupied by a single symbol in the IChannel interface.
+  virtual uint64_t GetSymbolSize() const = 0;
+
+  // Number of data valid (TKEEP) flags must match the number of symbols.
+  virtual void SetDataValid(std::vector<bool> dataValid) = 0;
+  virtual std::vector<bool> GetDataValid() const = 0;
+
+  virtual void SetLast(bool last) = 0;
+  virtual bool GetLast() const = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_

--- a/xls/simulation/generic/iaxistreamlike_stub.cc
+++ b/xls/simulation/generic/iaxistreamlike_stub.cc
@@ -1,0 +1,127 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iaxistreamlike_stub.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+uint64_t IAxiStreamLikeStub::GetNumSymbols() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetNumSymbols()";
+  return 2;
+}
+
+uint64_t IAxiStreamLikeStub::GetSymbolWidth() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetSymbolWidth()";
+  return 14;
+}
+
+uint64_t IAxiStreamLikeStub::GetSymbolSize() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetSymbolSize()";
+  return 2;
+}
+
+uint64_t IAxiStreamLikeStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetChannelWidth()";
+  return 32;
+}
+
+void IAxiStreamLikeStub::SetDataValid(std::vector<bool> dataValid) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetDataValid()";
+}
+
+std::vector<bool> IAxiStreamLikeStub::GetDataValid() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetDataValid()";
+  return {true, true};
+}
+
+void IAxiStreamLikeStub::SetLast(bool last) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetLast()";
+}
+
+bool IAxiStreamLikeStub::GetLast() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetLast()";
+  return true;
+}
+
+bool IAxiStreamLikeStub::IsReadStream() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::IsReadStream()";
+  return true;
+}
+
+bool IAxiStreamLikeStub::IsReady() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::IsReady()";
+  return true;
+}
+
+absl::Status IAxiStreamLikeStub::Transfer() {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::Transfer()";
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IAxiStreamLikeStub::GetPayloadData8(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IAxiStreamLikeStub::GetPayloadData16(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IAxiStreamLikeStub::GetPayloadData32(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IAxiStreamLikeStub::GetPayloadData64(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData8(uint64_t offset,
+                                                 uint8_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData16(uint64_t offset,
+                                                  uint16_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData32(uint64_t offset,
+                                                  uint32_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData64(uint64_t offset,
+                                                  uint64_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iaxistreamlike_stub.h
+++ b/xls/simulation/generic/iaxistreamlike_stub.h
@@ -1,0 +1,56 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_
+#define XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/iaxistreamlike.h"
+
+namespace xls::simulation::generic {
+
+class IAxiStreamLikeStub : public IAxiStreamLike {
+ public:
+  // IAxiStreamLike
+
+  uint64_t GetNumSymbols() const override;
+  uint64_t GetSymbolWidth() const override;
+  uint64_t GetSymbolSize() const override;
+  void SetDataValid(std::vector<bool> dataValid) override;
+  std::vector<bool> GetDataValid() const override;
+  void SetLast(bool last) override;
+  bool GetLast() const override;
+  // IStream
+  bool IsReadStream() const override;
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+  // IChannel
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_

--- a/xls/simulation/generic/iaxistreamlike_stub_test.cc
+++ b/xls/simulation/generic/iaxistreamlike_stub_test.cc
@@ -1,0 +1,180 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iaxistreamlike_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IAxiStreamLikeStubTest : public ::testing::Test {
+ protected:
+  IAxiStreamLikeStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IAxiStreamLikeStubTest, GetSymbolWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetSymbolWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetSymbolWidth"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetDataValid) {
+  ::testing::internal::CaptureStderr();
+  stub.SetDataValid({true, false});
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::SetDataValid"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetDataValid) {
+  ::testing::internal::CaptureStderr();
+  stub.GetDataValid();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::GetDataValid"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetLast) {
+  ::testing::internal::CaptureStderr();
+  stub.SetLast(true);
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::SetLast"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetLast) {
+  ::testing::internal::CaptureStderr();
+  stub.GetLast();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::GetLast"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, IsReadStream) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReadStream();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::IsReadStream"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, IsReady) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReady();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::IsReady"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, Transfer) {
+  ::testing::internal::CaptureStderr();
+  auto result = stub.Transfer();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  XLS_EXPECT_OK(result);
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::Transfer"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetChannelWidth"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData8"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData16"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData32"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData64"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData8"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData16"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData32"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannel.h
+++ b/xls/simulation/generic/ichannel.h
@@ -1,0 +1,43 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNEL_H_
+#define XLS_SIMULATION_GENERIC_ICHANNEL_H_
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+class IChannel {
+ public:
+  virtual absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const = 0;
+  virtual absl::Status SetPayloadData8(uint64_t offset, uint8_t data) = 0;
+  virtual absl::Status SetPayloadData16(uint64_t offset, uint16_t data) = 0;
+  virtual absl::Status SetPayloadData32(uint64_t offset, uint32_t data) = 0;
+  virtual absl::Status SetPayloadData64(uint64_t offset, uint64_t data) = 0;
+
+  virtual uint64_t GetChannelWidth() const = 0;
+
+  virtual ~IChannel() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNEL_H_

--- a/xls/simulation/generic/ichannel.h
+++ b/xls/simulation/generic/ichannel.h
@@ -19,6 +19,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
 
 namespace xls::simulation::generic {
 
@@ -36,6 +37,8 @@ class IChannel {
   virtual uint64_t GetChannelWidth() const = 0;
 
   virtual ~IChannel() = default;
+
+  uint64_t GetChannelWidthInBytes() { return BitsToBytes(GetChannelWidth()); }
 };
 
 }  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannelmanager.h
+++ b/xls/simulation/generic/ichannelmanager.h
@@ -1,0 +1,62 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_
+#define XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+class IChannelManager {
+ public:
+  using channel_addr_t = uint64_t;
+
+  virtual absl::Status WriteU8AtAddress(channel_addr_t, uint8_t) = 0;
+  virtual absl::Status WriteU16AtAddress(channel_addr_t, uint16_t) = 0;
+  virtual absl::Status WriteU32AtAddress(channel_addr_t, uint32_t) = 0;
+  virtual absl::Status WriteU64AtAddress(channel_addr_t, uint64_t) = 0;
+  virtual absl::StatusOr<uint8_t> ReadU8AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint16_t> ReadU16AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint32_t> ReadU32AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint64_t> ReadU64AtAddress(channel_addr_t) = 0;
+
+  // range: [base_address, base_address+address_range_end_)
+  explicit IChannelManager(uint64_t base_address)
+      : base_address_(base_address), address_range_end_(0) {}
+  IChannelManager(uint64_t base_address, uint64_t address_range_end)
+      : base_address_(base_address), address_range_end_(address_range_end) {}
+
+  uint64_t GetBaseAddress() const { return this->base_address_; }
+
+  bool InRange(uint64_t address) const {
+    return this->base_address_ <= address &&
+           address < (this->base_address_ + this->address_range_end_);
+  }
+
+  virtual ~IChannelManager() = default;
+
+ protected:
+  uint64_t base_address_;
+  uint64_t address_range_end_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_

--- a/xls/simulation/generic/ichannelmanager_stub.cc
+++ b/xls/simulation/generic/ichannelmanager_stub.cc
@@ -1,0 +1,87 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ichannelmanager_stub.h"
+
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+IChannelManagerStub::IChannelManagerStub(uint64_t base_address,
+                                         uint64_t address_range_end)
+    : IChannelManager(base_address, address_range_end) {}
+
+IChannelManagerStub::~IChannelManagerStub() = default;
+
+absl::Status IChannelManagerStub::WriteU8AtAddress(uint64_t address,
+                                                   uint8_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU8AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU16AtAddress(uint64_t address,
+                                                    uint16_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU16AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU32AtAddress(uint64_t address,
+                                                    uint32_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU32AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU64AtAddress(uint64_t address,
+                                                    uint64_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU64AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IChannelManagerStub::ReadU8AtAddress(uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU8AtAddress()";
+
+  return 0xDE;
+}
+
+absl::StatusOr<uint16_t> IChannelManagerStub::ReadU16AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU16AtAddress()";
+
+  return 0xDEAD;
+}
+
+absl::StatusOr<uint32_t> IChannelManagerStub::ReadU32AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU32AtAddress()";
+
+  return 0xDEADBEEF;
+}
+
+absl::StatusOr<uint64_t> IChannelManagerStub::ReadU64AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU64AtAddress()";
+
+  return 0xDEADBEEFFEEBDAED;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannelmanager_stub.h
+++ b/xls/simulation/generic/ichannelmanager_stub.h
@@ -1,0 +1,45 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_
+#define XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/ichannel.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+
+namespace xls::simulation::generic {
+
+class IChannelManagerStub : public IChannelManager {
+ public:
+  absl::Status WriteU8AtAddress(uint64_t address, uint8_t value) override;
+  absl::Status WriteU16AtAddress(uint64_t address, uint16_t value) override;
+  absl::Status WriteU32AtAddress(uint64_t address, uint32_t value) override;
+  absl::Status WriteU64AtAddress(uint64_t address, uint64_t value) override;
+  absl::StatusOr<uint8_t> ReadU8AtAddress(uint64_t address) override;
+  absl::StatusOr<uint16_t> ReadU16AtAddress(uint64_t address) override;
+  absl::StatusOr<uint32_t> ReadU32AtAddress(uint64_t address) override;
+  absl::StatusOr<uint64_t> ReadU64AtAddress(uint64_t address) override;
+
+  IChannelManagerStub(uint64_t base_address, uint64_t max_offset);
+  virtual ~IChannelManagerStub();
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_

--- a/xls/simulation/generic/ichannelmanager_stub_test.cc
+++ b/xls/simulation/generic/ichannelmanager_stub_test.cc
@@ -1,0 +1,112 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ichannelmanager_stub.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/istream_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IChannelManagerStubTest : public ::testing::Test {
+ protected:
+  IChannelManagerStub* stub;
+
+  IChannelManagerStubTest() { stub = new IChannelManagerStub(0x0, 0x200); }
+  ~IChannelManagerStubTest() { delete stub; }
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IChannelManagerStubTest, GetBaseAddress) {
+  EXPECT_EQ(stub->GetBaseAddress(), 0x0);
+}
+
+TEST_F(IChannelManagerStubTest, InRange) {
+  EXPECT_FALSE(stub->InRange(-1));
+  EXPECT_TRUE(stub->InRange(0x0));
+  EXPECT_TRUE(stub->InRange(0x1));
+  EXPECT_TRUE(stub->InRange(0x8));
+  EXPECT_FALSE(stub->InRange(0x200));
+  EXPECT_FALSE(stub->InRange(0x201));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU8AtAddress(0x0, 0xDE));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU8AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU16AtAddress(0x0, 0xDEAD));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU16AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU32AtAddress(0x0, 0xDEADBEEF));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU32AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU64AtAddress(0x0, 0xDEADBEEFFEEBDAED));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU64AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU8AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU8AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU16AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU16AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU32AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU32AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU64AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU64AtAddress()"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iconnection.h
+++ b/xls/simulation/generic/iconnection.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICONNECTION_H_
+#define XLS_SIMULATION_GENERIC_ICONNECTION_H_
+
+#include <string_view>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IConnection is used in conjunction with IPeripheral and provides methods for
+// XLS-initiated communication with Renode:
+//  - SendResponse() is used to send a response for a request received via
+//  IPeripheral::HandleRequest().
+//  - SendRequest() is used to send peripheral-initiated requests (e.g. IRQ).
+//  - ReceiveResponse() is used to receive a response for a request transmitted
+//  via SendRequest.
+//  - Log() allows to push messages to the Renode's logging subsystem.
+class IConnection {
+ public:
+  virtual absl::Status Log(absl::LogSeverity level, std::string_view msg) = 0;
+  virtual ~IConnection() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICONNECTION_H_

--- a/xls/simulation/generic/iconnection.h
+++ b/xls/simulation/generic/iconnection.h
@@ -20,6 +20,7 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/imasterport.h"
 
 namespace xls::simulation::generic {
 
@@ -33,6 +34,7 @@ namespace xls::simulation::generic {
 //  - Log() allows to push messages to the Renode's logging subsystem.
 class IConnection {
  public:
+  virtual IMasterPort* GetMasterPort() = 0;
   virtual absl::Status Log(absl::LogSeverity level, std::string_view msg) = 0;
   virtual ~IConnection() = default;
 };

--- a/xls/simulation/generic/idmaendpoint.h
+++ b/xls/simulation/generic/idmaendpoint.h
@@ -1,0 +1,55 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_
+#define XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_
+
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IDmaEndpoint represents a peripheral end of a 1D DMA channel.
+//
+// It allows to transfer a stream of fixed-size elements, and supports framing
+// those elements into packets by flagging the last element of the transfer.
+// User can query the size of a single element, as well as a maximum number of
+// elements that a single transfer can fit. In general, transferring any number
+// of elements between 0 and maximum should be supported by the implementation.
+//
+// Transfers with number of bytes not divisible by the element size, are deemed
+// as erroneous. Empty transfers (zero bytes) are supported by the interface,
+// however, an implemnentation is allowed to ignore them.
+class IDmaEndpoint {
+ public:
+  struct Payload {
+    std::vector<uint8_t> data;
+    bool last;
+  };
+
+  virtual ~IDmaEndpoint() = default;
+
+  virtual uint64_t GetElementSize() const = 0;
+  virtual uint64_t GetMaxElementsPerTransfer() const = 0;
+  virtual bool IsReadStream() const = 0;
+  virtual bool IsReady() const = 0;
+  virtual absl::Status Write(Payload payload) = 0;
+  virtual absl::StatusOr<Payload> Read() = 0;
+};
+
+};  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_

--- a/xls/simulation/generic/iirq.h
+++ b/xls/simulation/generic/iirq.h
@@ -1,0 +1,31 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IIRQ_H_
+#define XLS_SIMULATION_GENERIC_IIRQ_H_
+
+#include "absl/status/status.h"
+
+namespace xls::simulation::generic {
+
+class IIRQ {
+ public:
+  virtual ~IIRQ() = default;
+  virtual bool GetIRQ() = 0;
+  virtual absl::Status UpdateIRQ() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IIRQ_H_

--- a/xls/simulation/generic/iirq_stub.cc
+++ b/xls/simulation/generic/iirq_stub.cc
@@ -1,0 +1,41 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iirq_stub.h"
+
+#include <functional>
+
+#include "absl/status/status.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IIRQStub::IIRQStub() : status_(false), policy_([] { return true; }) {}
+
+bool IIRQStub::GetIRQ() {
+  XLS_LOG(INFO) << "IIRQStub::GetIRQ()";
+  return this->status_;
+}
+
+absl::Status IIRQStub::UpdateIRQ() {
+  XLS_LOG(INFO) << "IIRQStub::UpdateIRQ()";
+  this->status_ = this->policy_();
+  return absl::OkStatus();
+}
+
+void IIRQStub::SetPolicy(std::function<bool(void)> policy) {
+  this->policy_ = policy;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iirq_stub.h
+++ b/xls/simulation/generic/iirq_stub.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IIRQ_STUB_H_
+#define XLS_SIMULATION_GENERIC_IIRQ_STUB_H_
+
+#include <functional>
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iirq.h"
+
+namespace xls::simulation::generic {
+
+class IIRQStub : public IIRQ {
+ public:
+  IIRQStub();
+  virtual ~IIRQStub() = default;
+
+  bool GetIRQ() override;
+  absl::Status UpdateIRQ() override;
+
+  void SetPolicy(std::function<bool(void)> policy);
+
+ private:
+  bool status_;
+  std::function<bool(void)> policy_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IIRQ_STUB_H_

--- a/xls/simulation/generic/iirq_test.cc
+++ b/xls/simulation/generic/iirq_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iirq_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IIRQStubTest : public ::testing::Test {
+ protected:
+  IIRQStub stub;
+};
+
+TEST_F(IIRQStubTest, Init) {
+  // stub should not request any interrupt after initialization
+  ASSERT_EQ(stub.GetIRQ(), false);
+}
+
+TEST_F(IIRQStubTest, UpdateIRQ) {
+  // with the default stub implementation,
+  // UpdateIRQ should change the internal interrupt state from false to true
+  ASSERT_EQ(stub.GetIRQ(), false);
+  XLS_EXPECT_OK(stub.UpdateIRQ());
+  EXPECT_EQ(stub.GetIRQ(), true);
+}
+
+TEST_F(IIRQStubTest, GetIRQ) {
+  // consecutive reads using GetIRQ should have the same value
+  ASSERT_EQ(stub.GetIRQ(), false);
+  EXPECT_EQ(stub.GetIRQ(), false);
+  EXPECT_EQ(stub.GetIRQ(), false);
+  XLS_EXPECT_OK(stub.UpdateIRQ());
+  EXPECT_EQ(stub.GetIRQ(), true);
+  EXPECT_EQ(stub.GetIRQ(), true);
+  EXPECT_EQ(stub.GetIRQ(), true);
+}
+
+TEST_F(IIRQStubTest, SetPolicy) {
+  // stub should be able to change the existing policy
+  bool prev = false;
+  std::function<bool(void)> alternate_policy = [&prev] {
+    prev = !prev;
+    return prev;
+  };
+
+  stub.SetPolicy(alternate_policy);
+  bool prev_policy = stub.GetIRQ();
+  for (int i = 0; i < 100; ++i) {
+    XLS_EXPECT_OK(stub.UpdateIRQ());
+    EXPECT_EQ(stub.GetIRQ(), !prev_policy);
+    prev_policy = stub.GetIRQ();
+  }
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/imasterport.h
+++ b/xls/simulation/generic/imasterport.h
@@ -1,0 +1,36 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IMASTERPORT_H_
+#define XLS_SIMULATION_GENERIC_IMASTERPORT_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
+
+namespace xls::simulation::generic {
+
+class IMasterPort {
+ public:
+  virtual absl::Status RequestWrite(uint64_t address, uint64_t value,
+                                    AccessWidth type) = 0;
+  virtual absl::StatusOr<uint64_t> RequestRead(uint64_t address,
+                                               AccessWidth type) = 0;
+
+  virtual ~IMasterPort() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IMASTERPORT_H_

--- a/xls/simulation/generic/iperipheral.h
+++ b/xls/simulation/generic/iperipheral.h
@@ -1,0 +1,52 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IPERIPHERAL_H_
+#define XLS_SIMULATION_GENERIC_IPERIPHERAL_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IPeripheral is used in conjunction with IConnection,
+// and implements callbacks for:
+// - read/write operations,
+// - reset,
+// - IRQ and
+// - simulation tick.
+// Calls:
+//  - CheckRequest() checks if address is mapped to channel manager
+//  - HandleRead() reads data from address `addr`
+//  - HandleWrite() writes data starting ad address `addr`
+//  - HandleIRQ() checks if any IRQ is ready
+//  - HandleTick() advances simulation
+//  - Reset() is used to reset a peripheral.
+class IPeripheral {
+ public:
+  virtual absl::Status CheckRequest(uint64_t addr, AccessWidth width) = 0;
+  virtual absl::StatusOr<uint64_t> HandleRead(uint64_t addr,
+                                              AccessWidth width) = 0;
+  virtual absl::Status HandleWrite(uint64_t addr, AccessWidth width,
+                                   uint64_t payload) = 0;
+  virtual absl::StatusOr<IRQEnum> HandleIRQ() = 0;
+  virtual absl::Status HandleTick() = 0;
+
+  virtual absl::Status Reset() = 0;
+  virtual ~IPeripheral() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IPERIPHERAL_H_

--- a/xls/simulation/generic/iperipheral.h
+++ b/xls/simulation/generic/iperipheral.h
@@ -17,6 +17,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
 
 namespace xls::simulation::generic {
 

--- a/xls/simulation/generic/iperipheral_stub.cc
+++ b/xls/simulation/generic/iperipheral_stub.cc
@@ -1,0 +1,64 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iperipheral_stub.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IPeripheralStub::IPeripheralStub() {
+  XLS_LOG(INFO) << "IPeripheralStub::IPeripheralStub()";
+}
+
+absl::Status IPeripheralStub::CheckRequest(uint64_t addr, AccessWidth width) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::CheckRequest(addr=%lu, width=%d)", addr, width);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint64_t> IPeripheralStub::HandleRead(uint64_t addr,
+                                                     AccessWidth width) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::HandleRead(addr=%lu, width=%d), returns 0", addr,
+      width);
+  return 0;
+}
+
+absl::Status IPeripheralStub::HandleWrite(uint64_t addr, AccessWidth width,
+                                          uint64_t payload) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::HandleWrite(addr=%lu, width=%d, payload=%lu)", addr,
+      width, payload);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<IRQEnum> IPeripheralStub::HandleIRQ() {
+  XLS_LOG(INFO) << absl::StreamFormat("IPeripheralStub::HandleIRQ()");
+  return IRQEnum::NoChange;
+}
+
+absl::Status IPeripheralStub::HandleTick() {
+  XLS_LOG(INFO) << absl::StreamFormat("IPeripheralStub::HandleTick()");
+  return absl::OkStatus();
+}
+
+absl::Status IPeripheralStub::Reset() {
+  XLS_LOG(INFO) << "IPeripheralStub::Reset()";
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iperipheral_stub.h
+++ b/xls/simulation/generic/iperipheral_stub.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_
+#define XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iperipheral.h"
+
+namespace xls::simulation::generic {
+
+class IPeripheralStub : public IPeripheral {
+ public:
+  IPeripheralStub();
+  absl::Status CheckRequest(uint64_t addr, AccessWidth width) override;
+  absl::StatusOr<uint64_t> HandleRead(uint64_t addr,
+                                      AccessWidth width) override;
+  absl::Status HandleWrite(uint64_t addr, AccessWidth width,
+                           uint64_t payload) override;
+  absl::StatusOr<IRQEnum> HandleIRQ() override;
+  absl::Status HandleTick() override;
+
+  absl::Status Reset() override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_

--- a/xls/simulation/generic/iregister.h
+++ b/xls/simulation/generic/iregister.h
@@ -1,0 +1,26 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_H_
+
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+class IRegister : public IChannel {};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_H_

--- a/xls/simulation/generic/iregister_mock.h
+++ b/xls/simulation/generic/iregister_mock.h
@@ -1,0 +1,103 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_
+
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/simulation/generic/byteops.h"
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+// Mock implementation of IRegister interface for tests
+// Exposes normal IRegister interface, as well as test-only
+// methods to access underlying data bytes as std::vector
+template <uint64_t WidthBits>
+class IRegisterMock : public IRegister {
+ public:
+  constexpr static uint64_t WidthBytes = (WidthBits + 7) / 8;
+  constexpr static uint64_t LastByte = (WidthBits - 1) / 8;
+  constexpr static uint64_t LastByteBitmask =
+      (1 << (WidthBits - 8 * LastByte)) - 1;
+  using ByteArray = std::array<uint8_t, WidthBytes>;
+
+  IRegisterMock() = default;
+  explicit IRegisterMock(ByteArray init_bytes) : bytes_{init_bytes} {
+    bytes_[LastByte] &= LastByteBitmask;
+  };
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint8_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint16_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint32_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint64_t>(bytes_, offset);
+  }
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  uint64_t GetChannelWidth() const override { return WidthBits; }
+
+  const ByteArray& bytes() const { return bytes_; }
+  ByteArray& bytes() { return bytes_; }
+
+ private:
+  ByteArray bytes_{};
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_

--- a/xls/simulation/generic/iregister_mock_test.cc
+++ b/xls/simulation/generic/iregister_mock_test.cc
@@ -1,0 +1,141 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_mock.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using testing::ElementsAre;
+
+class IRegisterMockTest : public ::testing::Test {};
+
+TEST_F(IRegisterMockTest, Init1) {
+  IRegisterMock<17> mock;
+  ASSERT_THAT(mock.bytes(), ElementsAre(0, 0, 0));
+}
+
+TEST_F(IRegisterMockTest, Init2) {
+  IRegisterMock<31> mock{{1, 2, 3, 4}};
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 2, 3, 4));
+}
+
+TEST_F(IRegisterMockTest, SetBytes) {
+  IRegisterMock<31> mock{};
+  mock.bytes() = {3, 4, 5, 6};
+  ASSERT_THAT(mock.bytes(), ElementsAre(3, 4, 5, 6));
+}
+
+TEST_F(IRegisterMockTest, GetChannelWidth) {
+  IRegisterMock<31> mock{};
+  ASSERT_EQ(mock.GetChannelWidth(), 31);
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData8) {
+  IRegisterMock<17> mock{{1, 2, 3}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData8(1));
+  EXPECT_EQ(data, 0x02);
+  EXPECT_THAT(mock.GetPayloadData8(3),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData16) {
+  IRegisterMock<35> mock{{1, 2, 3, 4, 5}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData16(3));
+  EXPECT_EQ(data, 0x0504);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(4));
+  EXPECT_EQ(data, 0x05);
+  EXPECT_THAT(mock.GetPayloadData16(5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData32) {
+  IRegisterMock<35> mock{{1, 2, 3, 4, 5}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData32(1));
+  EXPECT_EQ(data, 0x05040302);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData32(2));
+  EXPECT_EQ(data, 0x050403);
+  EXPECT_THAT(mock.GetPayloadData32(5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData64) {
+  IRegisterMock<70> mock{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData64(1));
+  EXPECT_EQ(data, 0x0908070605040302LL);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData64(4));
+  EXPECT_EQ(data, 0x0908070605LL);
+  EXPECT_THAT(mock.GetPayloadData64(9),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, CheckBitmasking) {
+  IRegisterMock<3> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 1));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 7));
+  ASSERT_THAT(mock.bytes(), ElementsAre(7));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 8));
+  ASSERT_THAT(mock.bytes(), ElementsAre(0));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 9));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData8) {
+  IRegisterMock<17> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 2));
+  XLS_EXPECT_OK(mock.SetPayloadData8(2, 3));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 2, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 4));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 4, 1));
+  EXPECT_THAT(mock.SetPayloadData8(3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData16) {
+  IRegisterMock<17> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData16(1, 0x0503));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0506));
+  ASSERT_THAT(mock.bytes(), ElementsAre(6, 5, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData16(2, 0));
+  ASSERT_THAT(mock.bytes(), ElementsAre(6, 5, 0));
+  EXPECT_THAT(mock.SetPayloadData16(3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData32) {
+  IRegisterMock<33> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData32(0, 0x03020100));
+  XLS_EXPECT_OK(mock.SetPayloadData32(1, 0x07060504));
+  ASSERT_THAT(mock.bytes(), ElementsAre(0, 4, 5, 6, 1));
+  EXPECT_THAT(mock.SetPayloadData32(5, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData64) {
+  IRegisterMock<70> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData64(0, 0x0102030405060708LL));
+  XLS_EXPECT_OK(mock.SetPayloadData64(1, 0x0102030405060708LL));
+  ASSERT_THAT(mock.bytes(), ElementsAre(8, 8, 7, 6, 5, 4, 3, 2, 1));
+  EXPECT_THAT(mock.SetPayloadData64(9, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iregister_stub.cc
+++ b/xls/simulation/generic/iregister_stub.cc
@@ -1,0 +1,73 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_stub.h"
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+absl::StatusOr<uint8_t> IRegisterStub::GetPayloadData8(uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IRegisterStub::GetPayloadData16(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IRegisterStub::GetPayloadData32(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IRegisterStub::GetPayloadData64(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IRegisterStub::SetPayloadData8(uint64_t offset, uint8_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData16(uint64_t offset, uint16_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData32(uint64_t offset, uint32_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData64(uint64_t offset, uint64_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+uint64_t IRegisterStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IRegisterStub::GetChannelWidth()";
+  return 17;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iregister_stub.h
+++ b/xls/simulation/generic/iregister_stub.h
@@ -1,0 +1,40 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_
+
+#include <cstdint>
+
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+class IRegisterStub : public IRegister {
+ public:
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_

--- a/xls/simulation/generic/iregister_stub_test.cc
+++ b/xls/simulation/generic/iregister_stub_test.cc
@@ -1,0 +1,105 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IRegisterStubTest : public ::testing::Test {
+ protected:
+  IRegisterStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IRegisterStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetChannelWidth"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData8"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData16"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData32"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData64"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData8"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData16"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData32"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream.h
+++ b/xls/simulation/generic/istream.h
@@ -1,0 +1,53 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+// IStream - interface to the FIFO-like XLS streams (see xls::StreamingChannel)
+//
+// Contains internal holding register which stores a single data item. Holding
+// register can be accessed via methods provided by IChannel.
+class IStream : public IChannel {
+ public:
+  // Returns 'true' if the device reads from this stream, 'false' if it writes
+  // to it.
+  virtual bool IsReadStream() const = 0;
+
+  // Returns 'true' if the stream is ready to perform a single transfer:
+  //  - For a read stream to be ready, the underlying stream implementation
+  //    must have at least one data item available for reading, and must be
+  //    ready to transfer it into the holding register when Transfer() is
+  //    called.
+  //  - For a write stream to be ready, the underlying stream implementation
+  //    must be ready to accept at least a single data item whenever
+  //    Transfer() is called.
+  virtual bool IsReady() const = 0;
+
+  // Performs a single transfer on the stream:
+  //  - For read streams, this extracts a single data item from the stream
+  //    and places it into a holding register.
+  //  - For write streams, this takes a data item from the holding
+  //    register and sends it to the stream.
+  virtual absl::Status Transfer() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_H_

--- a/xls/simulation/generic/istream_mock.h
+++ b/xls/simulation/generic/istream_mock.h
@@ -1,0 +1,106 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_
+
+#include <array>
+#include <cstdint>
+#include <queue>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+#include "xls/simulation/generic/iregister_mock.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+// Mock implementation of IStream interface backed by std::deque queue.
+// Provides usual IStream methods as well as access to the queues.
+template <uint64_t WidthBits, bool IsReadStream_>
+class IStreamMock : public IStream {
+ public:
+  using Register = IRegisterMock<WidthBits>;
+  constexpr static uint64_t WidthBytes = Register::WidthBytes;
+  using Bytes = std::array<uint8_t, WidthBytes>;
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData8(offset);
+  }
+
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData16(offset);
+  }
+
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData32(offset);
+  }
+
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData64(offset);
+  }
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override {
+    return holding_reg_.SetPayloadData8(offset, data);
+  }
+
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override {
+    return holding_reg_.SetPayloadData16(offset, data);
+  }
+
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override {
+    return holding_reg_.SetPayloadData32(offset, data);
+  }
+
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override {
+    return holding_reg_.SetPayloadData64(offset, data);
+  }
+
+  uint64_t GetChannelWidth() const override { return WidthBits; }
+
+  bool IsReadStream() const override { return IsReadStream_; }
+
+  bool IsReady() const override {
+    if (IsReadStream_)
+      return !fifo_.empty();
+    else
+      return true;
+  }
+
+  absl::Status Transfer() override {
+    if (IsReadStream_) {
+      if (fifo_.empty()) return absl::InternalError("FIFO is empty");
+      holding_reg_ = IRegisterMock<WidthBits>{fifo_.front()};
+      fifo_.pop();
+    } else {
+      fifo_.push(holding_reg_.bytes());
+    }
+    return absl::OkStatus();
+  }
+
+  Register& holding_reg() { return holding_reg_; }
+  const Register& holding_reg() const { return holding_reg_; }
+
+  std::queue<Bytes>& fifo() { return fifo_; }
+  const std::queue<Bytes>& fifo() const { return fifo_; }
+
+ private:
+  Register holding_reg_;
+  std::queue<Bytes> fifo_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_

--- a/xls/simulation/generic/istream_mock_test.cc
+++ b/xls/simulation/generic/istream_mock_test.cc
@@ -1,0 +1,123 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_mock.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using absl::StatusCode;
+using ::testing::_;
+using testing::ElementsAre;
+using ::xls::status_testing::StatusIs;
+
+class IStreamMockTest : public ::testing::Test {};
+
+TEST_F(IStreamMockTest, InitRead) {
+  IStreamMock<17, true> mock;
+  ASSERT_EQ(mock.IsReadStream(), true);
+  ASSERT_EQ(mock.GetChannelWidth(), 17);
+  ASSERT_EQ(mock.IsReady(), false);
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  ASSERT_EQ(mock.fifo().empty(), true);
+}
+
+TEST_F(IStreamMockTest, InitWrite) {
+  IStreamMock<17, false> mock;
+  ASSERT_EQ(mock.IsReadStream(), false);
+  ASSERT_EQ(mock.GetChannelWidth(), 17);
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  ASSERT_EQ(mock.fifo().empty(), true);
+}
+
+TEST_F(IStreamMockTest, HoldingRegSet8) {
+  IStreamMock<17, true> mock;
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 5));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 5, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 6));
+  XLS_EXPECT_OK(mock.SetPayloadData8(2, 7));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(6, 5, 1));
+}
+
+TEST_F(IStreamMockTest, HoldingRegGet8) {
+  IStreamMock<17, true> mock;
+  mock.holding_reg().bytes() = {1, 2, 3};
+  uint8_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(0));
+  EXPECT_EQ(data, 1);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(1));
+  EXPECT_EQ(data, 2);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(2));
+  EXPECT_EQ(data, 3);
+}
+
+TEST_F(IStreamMockTest, HoldingRegSet16) {
+  IStreamMock<17, true> mock;
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0203));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(3, 2, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData16(1, 0x0505));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(3, 5, 1));
+}
+
+TEST_F(IStreamMockTest, HoldingRegGet16) {
+  IStreamMock<17, true> mock;
+  mock.holding_reg().bytes() = {1, 2, 3};
+  uint16_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0201);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(1));
+  EXPECT_EQ(data, 0x0302);
+}
+
+TEST_F(IStreamMockTest, Write) {
+  IStreamMock<16, false> mock;
+  ASSERT_EQ(mock.IsReady(), true);
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0302));
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0504));
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  ASSERT_EQ(mock.fifo().size(), 2);
+  ASSERT_THAT(mock.fifo().front(), ElementsAre(2, 3));
+  mock.fifo().pop();
+  ASSERT_THAT(mock.fifo().front(), ElementsAre(4, 5));
+}
+
+TEST_F(IStreamMockTest, Read) {
+  IStreamMock<16, true> mock;
+  ASSERT_EQ(mock.IsReady(), false);
+  mock.fifo().push({{2, 3}});
+  mock.fifo().push({{4, 5}});
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  uint16_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0302);
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0504);
+  ASSERT_EQ(mock.IsReady(), false);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream_stub.cc
+++ b/xls/simulation/generic/istream_stub.cc
@@ -1,0 +1,85 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_stub.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+// IStreamStub
+
+bool IStreamStub::IsReadStream() const {
+  XLS_LOG(INFO) << "IStreamStub::IsReadStream()";
+  return true;
+}
+
+bool IStreamStub::IsReady() const {
+  XLS_LOG(INFO) << "IStreamStub::IsReady()";
+  return true;
+}
+
+absl::Status IStreamStub::Transfer() {
+  XLS_LOG(INFO) << "IStreamStub::Transfer()";
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IStreamStub::GetPayloadData8(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IStreamStub::GetPayloadData16(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IStreamStub::GetPayloadData32(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IStreamStub::GetPayloadData64(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IStreamStub::SetPayloadData8(uint64_t offset, uint8_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData16(uint64_t offset, uint16_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData32(uint64_t offset, uint32_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData64(uint64_t offset, uint64_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+uint64_t IStreamStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IStreamStub::GetChannelWidth()";
+  return 17;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream_stub.h
+++ b/xls/simulation/generic/istream_stub.h
@@ -1,0 +1,46 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+class IStreamStub : public IStream {
+ public:
+  // IStream
+  bool IsReadStream() const override;
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+  // IChannel
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_

--- a/xls/simulation/generic/istream_stub_test.cc
+++ b/xls/simulation/generic/istream_stub_test.cc
@@ -1,0 +1,130 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IStreamStubTest : public ::testing::Test {
+ protected:
+  IStreamStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IStreamStubTest, IsReadStream) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReadStream();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::IsReadStream"));
+}
+
+TEST_F(IStreamStubTest, IsReady) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReady();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::IsReady"));
+}
+
+TEST_F(IStreamStubTest, Transfer) {
+  ::testing::internal::CaptureStderr();
+  auto result = stub.Transfer();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  XLS_EXPECT_OK(result);
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::Transfer"));
+}
+
+TEST_F(IStreamStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetChannelWidth"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData8"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData16"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData32"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData64"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData8"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData16"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData32"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic


### PR DESCRIPTION
Generic integration creates memory mapped device.

This is the first PR in the series of 3.
It adds interfaces that are used in the generic integration.
