### PR TITLE
Generic integration memory peripheral

### DIFF
--- a/xls/modules/rle/rle_common.x
+++ b/xls/modules/rle/rle_common.x
@@ -28,7 +28,7 @@ pub struct PlainData<SYMB_WIDTH: u32> {
 // Structure is used as an output from RLE encoder and
 // as an input to RLE decoder.
 pub struct CompressedData<SYMBOL_WIDTH: u32, COUNT_WIDTH: u32> {
-    symbol: bits[SYMBOL_WIDTH], // symbol
-    count: bits[COUNT_WIDTH],   // symbol counter
+    //                  symbol              symbol counter
+    symbol_count_pair: (bits[SYMBOL_WIDTH], bits[COUNT_WIDTH]),
     last: bool,                 // flush RLE
 }

--- a/xls/modules/rle/rle_enc.x
+++ b/xls/modules/rle/rle_enc.x
@@ -117,8 +117,7 @@ pub proc RunLengthEncoder<SYMBOL_WIDTH: u32, COUNT_WIDTH: u32> {
         };
 
         let data = EncOutData {
-            symbol: state.prev_symbol,
-            count: state.prev_count,
+            symbol_count_pair: (state.prev_symbol, state.prev_count),
             last: state.prev_last
         };
 
@@ -213,11 +212,11 @@ proc RunLengthEncoderCountSymbolTest {
         in enumerate(CountSymbolTestTestOutput) {
       let last = counter == (array_size(CountSymbolTestTestOutput) - u32:1);
       let expected = CountSymbolTestEncOutData{
-          symbol: symbol, count: count, last: last};
+          symbol_count_pair: (symbol, count), last: last};
       let (tok, enc_output) = recv(tok, enc_output_r);
       trace_fmt!(
         "Received {} pairs, symbol: 0x{:x}, count: {}, last: {}",
-        counter, enc_output.symbol, enc_output.count, enc_output.last
+        counter, enc_output.symbol_count_pair.0, enc_output.symbol_count_pair.1, enc_output.last
       );
       assert_eq(enc_output, expected);
       (tok)
@@ -287,11 +286,11 @@ proc RunLengthEncoderOverflowTest {
         in enumerate(OverflowTestOutput) {
       let last = counter == (array_size(OverflowTestOutput) - u32:1);
       let expected = OverflowEncOutData{
-          symbol: symbol, count: count, last: last};
+          symbol_count_pair: (symbol, count), last: last};
       let (tok, enc_output) = recv(tok, enc_output_r);
       trace_fmt!(
         "Received {} pairs, symbol: 0x{:x}, count: {}, last: {}",
-        counter, enc_output.symbol, enc_output.count, enc_output.last
+        counter, enc_output.symbol_count_pair.0, enc_output.symbol_count_pair.1, enc_output.last
       );
       assert_eq(enc_output, expected);
       (tok)
@@ -342,12 +341,10 @@ proc RunLengthEncoderLastAfterLastTest {
     }(tok);
     let LastAfterLastTestOutput: LastAfterLastOutput[2] = [
       LastAfterLastOutput {
-        symbol: LastAfterLastSymbol:0x1,
-        count: LastAfterLastCount:0x1,
+        symbol_count_pair: (LastAfterLastSymbol:0x1, LastAfterLastCount:0x1),
         last:true},
       LastAfterLastOutput {
-        symbol: LastAfterLastSymbol:0x1,
-        count: LastAfterLastCount:0x1,
+        symbol_count_pair: (LastAfterLastSymbol:0x1, LastAfterLastCount:0x1),
         last:true},
     ];
     let tok = for ((counter, expected), tok):
@@ -356,7 +353,7 @@ proc RunLengthEncoderLastAfterLastTest {
       let (tok, enc_output) = recv(tok, enc_output_r);
       trace_fmt!(
         "Received {} pairs, symbol: 0x{:x}, count: {}, last: {}",
-        counter, enc_output.symbol, enc_output.count, enc_output.last
+        counter, enc_output.symbol_count_pair.0, enc_output.symbol_count_pair.1, enc_output.last
       );
       assert_eq(enc_output, expected);
 
@@ -422,11 +419,11 @@ proc RunLengthEncoderOverflowWithLastTest {
         in enumerate(OverflowWithLastTestOutput) {
       let last = counter == (array_size(OverflowWithLastTestOutput) - u32:1);
       let expected = OverflowWithLastEncOutData{
-          symbol: symbol, count: count, last: last};
+          symbol_count_pair: (symbol, count), last: last};
       let (tok, enc_output) = recv(tok, enc_output_r);
       trace_fmt!(
         "Received {} pairs, symbol: 0x{:x}, count: {}, last: {}",
-        counter, enc_output.symbol, enc_output.count, enc_output.last
+        counter, enc_output.symbol_count_pair.0, enc_output.symbol_count_pair.1, enc_output.last
       );
       assert_eq(enc_output, expected);
       (tok)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -510,6 +510,30 @@ cc_test(
 )
 
 cc_library(
+    name = "runtime_manager",
+    srcs = [
+        "runtime_manager.cc",
+        "runtime_status.cc",
+    ],
+    hdrs = [
+        "managed_serial_proc_runtime.h",
+        "runtime_manager.h",
+        "runtime_status.h",
+    ],
+    deps = [
+        ":iactive",
+        ":iregister",
+        "//xls/interpreter:interpreter_proc_runtime",
+        "//xls/ir",
+        "//xls/jit:jit_proc_runtime",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/memory",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
     name = "iaxistreamlike",
     hdrs = [
         "iaxistreamlike.h",

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -730,3 +730,22 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+
+cc_library(
+    name = "axistreamlikedmaendpoint",
+    srcs = [
+        "axi_stream_like_dma_endpoint.cc",
+    ],
+    hdrs = [
+        "axi_stream_like_dma_endpoint.h",
+    ],
+    deps = [
+        ":iaxistreamlike",
+        ":idmaendpoint",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -168,8 +168,8 @@ cc_test(
     ],
     deps = [
         ":byteops",
-        "//xls/common/status:matchers",
         "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
         "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
     ],
@@ -334,6 +334,43 @@ cc_library(
     ],
     deps = [
         ":ichannel",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
+    name = "ir_stream",
+    srcs = [
+        "ir_stream.cc",
+    ],
+    hdrs = [
+        "ir_stream.h",
+    ],
+    deps = [
+        ":ir_value_common",
+        ":istream",
+        "//xls/common/status:status_macros",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir:value",
+        "//xls/ir:value_helpers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ir_stream_test",
+    srcs = [
+        "ir_stream_test.cc",
+    ],
+    deps = [
+        ":ir_stream",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir",
+        "//xls/ir:channel",
+        "//xls/ir:ir_test_base",
         "@com_google_absl//absl/status",
     ],
 )

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -627,3 +627,45 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "singlevaluemanager",
+    srcs = [
+        "singlevaluemanager.cc",
+    ],
+    hdrs = [
+        "singlevaluemanager.h",
+    ],
+    deps = [
+        ":common",
+        ":ichannel",
+        ":ichannelmanager",
+        ":iregister",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "singlevaluemanager_test",
+    srcs = [
+        "singlevaluemanager_test.cc",
+    ],
+    deps = [
+        ":ichannel",
+        ":iregister",
+        ":iregister_mock",
+        ":iregister_stub",
+        ":singlevaluemanager",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -749,3 +749,25 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+
+cc_library(
+    name = "streamdmachannel",
+    srcs = [
+        "streamdmachannel.cc",
+    ],
+    hdrs = [
+        "streamdmachannel.h",
+    ],
+    deps = [
+        ":iactive",
+        ":idmaendpoint",
+        ":iirq",
+        ":imasterport",
+        ":common",
+        "//xls/common:bits_util",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -106,3 +106,14 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "ichannel",
+    hdrs = [
+        "ichannel.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -18,6 +18,16 @@ package(
 )
 
 cc_library(
+    name = "common",
+    hdrs = [
+        "common.h",
+    ],
+    deps = [
+        "//xls/common/logging",
+    ],
+)
+
+cc_library(
     name = "iconnection",
     hdrs = [
         "iconnection.h",
@@ -113,6 +123,7 @@ cc_library(
         "ichannel.h",
     ],
     deps = [
+        ":common",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -198,6 +198,77 @@ cc_library(
 )
 
 cc_library(
+    name = "ir_value_common",
+    srcs = [
+        "ir_value_access_methods.cc",
+    ],
+    hdrs = [
+        "ir_value_access_methods.h",
+    ],
+    deps = [
+        "//xls/common/status:status_macros",
+        "//xls/ir:value",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ir_value_common_test",
+    size = "small",
+    srcs = [
+        "ir_value_access_methods_test.cc",
+    ],
+    deps = [
+        ":ir_value_common",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/ir:bits",
+        "//xls/ir:type",
+        "//xls/ir:value",
+        "//xls/ir:value_helpers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "ir_single_value",
+    srcs = [
+        "ir_single_value.cc",
+    ],
+    hdrs = [
+        "ir_single_value.h",
+    ],
+    deps = [
+        ":ir_value_common",
+        ":iregister",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir:value_helpers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ir_single_value_test",
+    srcs = [
+        "ir_single_value_test.cc",
+    ],
+    deps = [
+        ":ir_single_value",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir",
+        "//xls/ir:channel",
+        "//xls/ir:ir_test_base",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
     name = "iregister_stub",
     srcs = [
         "iregister_stub.cc",

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -17,6 +17,16 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+proto_library(
+    name = "config_proto",
+    srcs = ["config.proto"],
+)
+
+cc_proto_library(
+    name = "cc_config_proto",
+    deps = [":config_proto"],
+)
+
 cc_library(
     name = "common",
     hdrs = [
@@ -24,6 +34,41 @@ cc_library(
     ],
     deps = [
         "//xls/common/logging",
+    ],
+)
+
+cc_library(
+    name = "config",
+    srcs = [
+        "config.cc",
+    ],
+    hdrs = [
+        "config.h",
+    ],
+    deps = [
+        ":cc_config_proto",
+        "//xls/common/file:filesystem",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "config_test",
+    srcs = [
+        "config_test.cc",
+    ],
+    deps = [
+        ":config",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -669,3 +669,21 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "streammanager",
+    srcs = [
+        "streammanager.cc",
+    ],
+    hdrs = [
+        "streammanager.h",
+    ],
+    deps = [
+        ":ichannel",
+        ":ichannelmanager",
+        ":istream",
+        "//xls/common:bits_util",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -80,3 +80,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "byteops",
+    hdrs = [
+        "byteops.h",
+    ],
+    deps = [
+        "//xls/common/logging",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "byteops_test",
+    size = "small",
+    srcs = [
+        "byteops_test.cc",
+    ],
+    deps = [
+        ":byteops",
+        "//xls/common/status:matchers",
+        "//xls/common:xls_gunit_main",
+        "@com_google_absl//absl/types:span",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -711,3 +711,22 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "streamdmaendpoint",
+    srcs = [
+        "stream_dma_endpoint.cc",
+    ],
+    hdrs = [
+        "stream_dma_endpoint.h",
+    ],
+    deps = [
+        ":idmaendpoint",
+        ":istream",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -533,6 +533,26 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "runtime_manager_test",
+    srcs = [
+        "runtime_manager_test.cc",
+    ],
+    data = [
+        "//xls/simulation/generic/testdata:pasthrough_opt_ir",
+    ],
+    deps = [
+        ":runtime_manager",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:matchers",
+        "//xls/ir:ir_parser",
+        "//xls/ir:value",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 cc_library(
     name = "iaxistreamlike",
     hdrs = [

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -28,3 +28,29 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "iactive",
+    hdrs = [
+        "iactive.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "iactive_test",
+    srcs = [
+        "iactive_stub.cc",
+        "iactive_stub.h",
+        "iactive_test.cc",
+    ],
+    deps = [
+        ":iactive",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+cc_library(
+    name = "iconnection",
+    hdrs = [
+        "iconnection.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -54,3 +54,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iirq",
+    hdrs = [
+        "iirq.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_test(
+    name = "iirq_test",
+    srcs = [
+        "iirq_stub.cc",
+        "iirq_stub.h",
+        "iirq_test.cc",
+    ],
+    deps = [
+        ":iirq",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -863,3 +863,32 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "xlsperipheral",
+    srcs = [
+        "xlsperipheral.cc",
+    ],
+    hdrs = [
+        "xlsperipheral.h",
+    ],
+    deps = [
+        ":axistreamlikedmaendpoint",
+        ":config",
+        ":dmastreammanager",
+        ":ichannelmanager",
+        ":iconnection",
+        ":iperipheral",
+        ":ir_axistreamlike",
+        ":ir_single_value",
+        ":ir_stream",
+        ":runtime_manager",
+        ":singlevaluemanager",
+        ":streamdmaendpoint",
+        ":streammanager",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -892,3 +892,17 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+cc_library(
+    name = "peripheral_factory",
+    srcs = [
+        "peripheral_factory.cc",
+    ],
+    hdrs = [
+        "peripheral_factory.h",
+    ],
+    deps = [
+        ":iconnection",
+        ":iperipheral",
+        ":xlsperipheral",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -817,3 +817,26 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_test(
+    name = "dmastreammanager_test",
+    srcs = [
+        "dmastreammanager_test.cc",
+    ],
+    deps = [
+        ":dmastreammanager",
+        ":iconnection",
+        ":iperipheral",
+        ":istream_mock",
+        ":streamdmachannel",
+        ":streamdmaendpoint",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -269,3 +269,37 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "ichannelmanager",
+    hdrs = [
+        "ichannelmanager.h",
+    ],
+    deps = [
+        ":ichannel",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "ichannelmanager_stub_test",
+    srcs = [
+        "ichannelmanager_stub.cc",
+        "ichannelmanager_stub.h",
+        "ichannelmanager_stub_test.cc",
+    ],
+    deps = [
+        ":ichannel",
+        ":ichannelmanager",
+        ":istream_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -128,3 +128,72 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "iregister",
+    hdrs = [
+        "iregister.h",
+    ],
+    deps = [
+        ":ichannel",
+    ],
+)
+
+cc_library(
+    name = "iregister_stub",
+    srcs = [
+        "iregister_stub.cc",
+    ],
+    hdrs = [
+        "iregister_stub.h",
+    ],
+    deps = [
+        ":iregister",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "iregister_stub_test",
+    size = "small",
+    srcs = [
+        "iregister_stub_test.cc",
+    ],
+    deps = [
+        ":iregister_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "iregister_mock",
+    hdrs = [
+        "iregister_mock.h",
+    ],
+    deps = [
+        ":byteops",
+        ":iregister",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "iregister_mock_test",
+    size = "small",
+    srcs = [
+        "iregister_mock_test.cc",
+    ],
+    deps = [
+        ":iregister_mock",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -197,3 +197,75 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "istream",
+    hdrs = [
+        "istream.h",
+    ],
+    deps = [
+        ":ichannel",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
+    name = "istream_stub",
+    srcs = [
+        "istream_stub.cc",
+    ],
+    hdrs = [
+        "istream_stub.h",
+    ],
+    deps = [
+        ":istream",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "istream_stub_test",
+    size = "small",
+    srcs = [
+        "istream_stub_test.cc",
+    ],
+    deps = [
+        ":istream_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "istream_mock",
+    hdrs = [
+        "istream_mock.h",
+    ],
+    deps = [
+        ":iregister_mock",
+        ":istream",
+        "//xls/common/logging",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_test(
+    name = "istream_mock_test",
+    size = "small",
+    srcs = [
+        "istream_mock_test.cc",
+    ],
+    deps = [
+        ":istream_mock",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -687,3 +687,27 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_test(
+    name = "streammanager_test",
+    srcs = [
+        "streammanager_test.cc",
+    ],
+    deps = [
+        ":common",
+        ":ichannel",
+        ":ichannelmanager",
+        ":istream",
+        ":istream_mock",
+        ":streammanager",
+        "//xls/common:bits_util",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -750,6 +750,29 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "axistreamlikedmaendpoint_test",
+    srcs = [
+        "axi_stream_like_dma_endpoint_test.cc",
+    ],
+    deps = [
+        ":axistreamlikedmaendpoint",
+        ":ir_axistreamlike",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir",
+        "//xls/ir:channel",
+        "//xls/ir:ir_test_base",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 cc_library(
     name = "streamdmachannel",
     srcs = [

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -772,6 +772,29 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "streamdmachannel_test",
+    srcs = [
+        "streamdmachannel_test.cc",
+    ],
+    deps = [
+        ":iconnection",
+        ":idmaendpoint",
+        ":iperipheral",
+        ":istream_mock",
+        ":streamdmachannel",
+        ":streamdmaendpoint",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/logging",
+        "//xls/common/logging:log_flags",
+        "//xls/common/status:matchers",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
 cc_library(
     name = "dmastreammanager",
     srcs = [

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -771,3 +771,26 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
     ],
 )
+
+cc_library(
+    name = "dmastreammanager",
+    srcs = [
+        "dmastreammanager.cc",
+    ],
+    hdrs = [
+        "dmastreammanager.h",
+    ],
+    deps = [
+        ":iactive",
+        ":ichannelmanager",
+        ":idmaendpoint",
+        ":iirq",
+        ":imasterport",
+        ":streamdmachannel",
+        "//xls/common:bits_util",
+        "//xls/common/logging",
+        "//xls/common/status:status_macros",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -348,3 +348,40 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iaxistreamlike",
+    hdrs = [
+        "iaxistreamlike.h",
+    ],
+    deps = [
+        ":istream",
+    ],
+)
+
+cc_library(
+    name = "iaxistreamlike_stub",
+    srcs = [
+        "iaxistreamlike_stub.cc",
+    ],
+    hdrs = [
+        "iaxistreamlike_stub.h",
+    ],
+    deps = [
+        ":iaxistreamlike",
+        "//xls/common/logging",
+    ],
+)
+
+cc_test(
+    name = "iaxistreamlike_stub_test",
+    srcs = [
+        "iaxistreamlike_stub_test.cc",
+    ],
+    deps = [
+        ":iaxistreamlike_stub",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -376,6 +376,45 @@ cc_test(
 )
 
 cc_library(
+    name = "ir_axistreamlike",
+    srcs = [
+        "ir_axistreamlike.cc",
+    ],
+    hdrs = [
+        "ir_axistreamlike.h",
+    ],
+    deps = [
+        ":iaxistreamlike",
+        ":ir_stream",
+        ":ir_value_common",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir:value",
+        "//xls/ir:value_helpers",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "ir_axistreamlike_test",
+    srcs = [
+        "ir_axistreamlike_test.cc",
+    ],
+    deps = [
+        ":ir_axistreamlike",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/interpreter:channel_queue",
+        "//xls/ir",
+        "//xls/ir:channel",
+        "//xls/ir:ir_test_base",
+        "@com_google_absl//absl/status",
+    ],
+)
+
+cc_library(
     name = "istream_stub",
     srcs = [
         "istream_stub.cc",

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -385,3 +385,29 @@ cc_test(
         "@com_google_googletest//:gtest",
     ],
 )
+
+cc_library(
+    name = "iperipheral",
+    hdrs = [
+        "iperipheral.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
+    name = "iperipheral_stub",
+    srcs = [
+        "iperipheral_stub.cc",
+    ],
+    hdrs = [
+        "iperipheral_stub.h",
+    ],
+    deps = [
+        ":iperipheral",
+        "//xls/common/logging",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -73,11 +73,24 @@ cc_test(
 )
 
 cc_library(
+    name = "imasterport",
+    hdrs = [
+        "imasterport.h",
+    ],
+    deps = [
+        ":common",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)
+
+cc_library(
     name = "iconnection",
     hdrs = [
         "iconnection.h",
     ],
     deps = [
+        ":imasterport",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
@@ -392,6 +405,7 @@ cc_library(
         "iperipheral.h",
     ],
     deps = [
+        ":common",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
     ],

--- a/xls/simulation/generic/BUILD
+++ b/xls/simulation/generic/BUILD
@@ -425,3 +425,14 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
     ],
 )
+
+cc_library(
+    name = "idmaendpoint",
+    hdrs = [
+        "idmaendpoint.h",
+    ],
+    deps = [
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+    ],
+)

--- a/xls/simulation/generic/axi_stream_like_dma_endpoint.cc
+++ b/xls/simulation/generic/axi_stream_like_dma_endpoint.cc
@@ -1,0 +1,108 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/axi_stream_like_dma_endpoint.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "absl/strings/str_join.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/simulation/generic/idmaendpoint.h"
+
+namespace xls::simulation::generic {
+
+AxiStreamLikeDmaEndpoint::AxiStreamLikeDmaEndpoint(
+    std::unique_ptr<IAxiStreamLike> stream)
+    : stream_(std::move(stream)) {
+  num_symbols_ = stream_->GetNumSymbols();
+  symbol_size_ = stream_->GetSymbolSize();
+  XLS_CHECK(symbol_size_ > 0);
+  XLS_CHECK(num_symbols_ > 0);
+}
+
+absl::Status AxiStreamLikeDmaEndpoint::Write(Payload payload) {
+  XLS_CHECK(!IsReadStream());
+  auto num_symbols_to_write = payload.data.size() / symbol_size_;
+  if (payload.data.size() % symbol_size_) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Invalid transfer size: %u bytes, must be multiple of %u",
+        payload.data.size(), symbol_size_));
+  }
+  if (num_symbols_to_write > num_symbols_) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Transfer too big: %u bytes, max is %u",
+                        payload.data.size(), symbol_size_ * num_symbols_));
+  }
+  // Set TLAST
+  stream_->SetLast(payload.last);
+  // Set TKEEP
+  std::vector<bool> tkeep(num_symbols_, false);
+  for (uint64_t i = 0; i < num_symbols_to_write; i++) {
+    tkeep[i] = true;
+  }
+  stream_->SetDataValid(std::move(tkeep));
+  // Set data
+  for (uint64_t i = 0; i < (num_symbols_ * symbol_size_); i++) {
+    if (i < payload.data.size()) {
+      XLS_RETURN_IF_ERROR(stream_->SetPayloadData8(i, payload.data[i]));
+    } else {
+      XLS_RETURN_IF_ERROR(stream_->SetPayloadData8(i, 0));
+    }
+  }
+  XLS_RETURN_IF_ERROR(stream_->Transfer());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<AxiStreamLikeDmaEndpoint::Payload>
+AxiStreamLikeDmaEndpoint::Read() {
+  XLS_CHECK(IsReadStream());
+  XLS_RETURN_IF_ERROR(stream_->Transfer());
+  Payload payload{};
+  // Get TLAST
+  payload.last = stream_->GetLast();
+  // Get TKEEP
+  auto tkeep = stream_->GetDataValid();
+  XLS_CHECK(tkeep.size() == num_symbols_);
+  // Find the last valid byte
+  int64_t last_valid = -1;
+  bool continuous = true;
+  for (uint64_t i = 0; i < num_symbols_; i++) {
+    if (tkeep[i]) {
+      // Detect holes in TKEEP
+      if (static_cast<uint64_t>(last_valid + 1) != i) {
+        continuous = false;
+      }
+      last_valid = i;
+    }
+  }
+  uint64_t valid_symbols = last_valid + 1;
+  if (!continuous) {
+    XLS_LOG(WARNING) << absl::StreamFormat(
+        "TKEEP returned by the stream is discontinuous: [%s]. Holes are "
+        "ignored, assuming %u valid symbols",
+        absl::StrJoin(tkeep, ", "), valid_symbols);
+  }
+  uint64_t xfer_nbytes = valid_symbols * symbol_size_;
+  payload.data.resize(xfer_nbytes);
+  for (uint64_t i = 0; i < xfer_nbytes; i++) {
+    XLS_ASSIGN_OR_RETURN(payload.data[i], stream_->GetPayloadData8(i));
+  }
+  return payload;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/axi_stream_like_dma_endpoint.h
+++ b/xls/simulation/generic/axi_stream_like_dma_endpoint.h
@@ -1,0 +1,46 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_AXI_STREAM_LIKE_DMA_ENDPOINT_H_
+#define XLS_SIMULATION_GENERIC_AXI_STREAM_LIKE_DMA_ENDPOINT_H_
+
+#include <memory>
+
+#include "xls/simulation/generic/iaxistreamlike.h"
+#include "xls/simulation/generic/idmaendpoint.h"
+
+namespace xls::simulation::generic {
+
+class AxiStreamLikeDmaEndpoint : public IDmaEndpoint {
+ public:
+  explicit AxiStreamLikeDmaEndpoint(std::unique_ptr<IAxiStreamLike> stream);
+
+  uint64_t GetElementSize() const override { return symbol_size_; }
+  uint64_t GetMaxElementsPerTransfer() const override { return num_symbols_; }
+  bool IsReadStream() const override { return stream_->IsReadStream(); }
+  bool IsReady() const override { return stream_->IsReady(); }
+  absl::Status Write(Payload payload) override;
+  absl::StatusOr<Payload> Read() override;
+
+  IAxiStreamLike* GetStream() const { return stream_.get(); }
+
+ private:
+  std::unique_ptr<IAxiStreamLike> stream_;
+  uint64_t num_symbols_;
+  uint64_t symbol_size_;
+};
+
+};  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_AXI_STREAM_LIKE_DMA_ENDPOINT_H_

--- a/xls/simulation/generic/axi_stream_like_dma_endpoint_test.cc
+++ b/xls/simulation/generic/axi_stream_like_dma_endpoint_test.cc
@@ -1,0 +1,342 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/axi_stream_like_dma_endpoint.h"
+
+#include <exception>
+#include <memory>
+#include <new>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/channel.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/package.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/simulation/generic/idmaendpoint.h"
+#include "xls/simulation/generic/ir_axistreamlike.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using ::testing::ElementsAre;
+
+class SingleSymbolReadTest : public IrTestBase {
+ protected:
+  SingleSymbolReadTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),   // padding
+        package_.GetBitsType(11),  // data
+        package_.GetBitsType(1),   // tlast
+        package_.GetBitsType(5),   // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kSendOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    auto stream = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), false, 1, 2, std::nullopt).value());
+    dut_ = std::make_unique<AxiStreamLikeDmaEndpoint>(std::move(stream));
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<AxiStreamLikeDmaEndpoint> dut_;
+};
+
+TEST_F(SingleSymbolReadTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), true);
+}
+
+TEST_F(SingleSymbolReadTest, GetMaxElementsPerTransfer) {
+  EXPECT_EQ(dut_->GetMaxElementsPerTransfer(), 1);
+}
+
+TEST_F(SingleSymbolReadTest, GetElementSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetElementSize(), 2);
+}
+
+TEST_F(SingleSymbolReadTest, Read) {
+  EXPECT_FALSE(dut_->IsReady());
+  // fill the queue
+  XLS_ASSERT_OK(queue_->Write(Value::Tuple({
+      Value(UBits(0, 2)),       // pad
+      Value(UBits(0x567, 11)),  // data
+      Value(UBits(0, 1)),       // tlast
+      Value(UBits(0, 5)),       // pad
+  })));
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(queue_->Write(Value::Tuple({
+      Value(UBits(0, 2)),       // pad
+      Value(UBits(0x765, 11)),  // data
+      Value(UBits(1, 1)),       // tlast
+      Value(UBits(0, 5)),       // pad
+  })));
+  EXPECT_TRUE(this->dut_->IsReady());
+  // read out
+  XLS_ASSERT_OK_AND_ASSIGN(auto payload, dut_->Read());
+  ASSERT_THAT(payload.data, ElementsAre(0x67, 0x05));
+  EXPECT_EQ(payload.last, false);
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK_AND_ASSIGN(payload, dut_->Read());
+  ASSERT_THAT(payload.data, ElementsAre(0x65, 0x07));
+  EXPECT_EQ(payload.last, true);
+  // check handling of underflow
+  EXPECT_FALSE(this->dut_->IsReady());
+  EXPECT_FALSE(dut_->Read().ok());
+}
+
+class SingleSymbolWriteTest : public IrTestBase {
+ protected:
+  SingleSymbolWriteTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),   // padding
+        package_.GetBitsType(11),  // data
+        package_.GetBitsType(1),   // tlast
+        package_.GetBitsType(5),   // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kReceiveOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    auto stream = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), false, 1, 2, std::nullopt).value());
+    dut_ = std::make_unique<AxiStreamLikeDmaEndpoint>(std::move(stream));
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<AxiStreamLikeDmaEndpoint> dut_;
+};
+
+TEST_F(SingleSymbolWriteTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), false);
+}
+
+TEST_F(SingleSymbolWriteTest, GetMaxElementsPerTransfer) {
+  EXPECT_EQ(dut_->GetMaxElementsPerTransfer(), 1);
+}
+
+TEST_F(SingleSymbolWriteTest, GetElementSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetElementSize(), 2);
+}
+
+TEST_F(SingleSymbolWriteTest, Write) {
+  XLS_ASSERT_OK(dut_->Write(IDmaEndpoint::Payload{{0x01, 0x2}, false}));
+  XLS_ASSERT_OK(dut_->Write(IDmaEndpoint::Payload{{0xAB, 0x7}, true}));
+  auto popt = queue_->Read();
+  EXPECT_FALSE(popt->empty());
+  auto payload = *popt;
+  auto payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),       // pad
+      Value(UBits(0x201, 11)),  // data
+      Value(UBits(0, 1)),       // tlast
+      Value(UBits(0, 5)),       // pad
+  });
+  EXPECT_EQ(payload, payload_ref);
+  popt = queue_->Read();
+  EXPECT_FALSE(popt->empty());
+  payload = *popt;
+  payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),       // pad
+      Value(UBits(0x7AB, 11)),  // data
+      Value(UBits(1, 1)),       // tlast
+      Value(UBits(0, 5)),       // pad
+  });
+  EXPECT_EQ(payload, payload_ref);
+}
+
+class MultiSymbolReadTest : public IrTestBase {
+ protected:
+  MultiSymbolReadTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),                             // padding
+        package_.GetArrayType(3, package_.GetBitsType(11)),  // data
+        package_.GetBitsType(3),                             // tkeep
+        package_.GetBitsType(1),                             // tlast
+        package_.GetBitsType(5),                             // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kSendOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    auto stream = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), true, 1, 3, 2).value());
+    dut_ = std::make_unique<AxiStreamLikeDmaEndpoint>(std::move(stream));
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<AxiStreamLikeDmaEndpoint> dut_;
+};
+
+TEST_F(MultiSymbolReadTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), true);
+}
+
+TEST_F(MultiSymbolReadTest, GetMaxElementsPerTransfer) {
+  EXPECT_EQ(dut_->GetMaxElementsPerTransfer(), 3);
+}
+
+TEST_F(MultiSymbolReadTest, GetElementSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetElementSize(), 2);
+}
+
+TEST_F(MultiSymbolReadTest, Read) {
+  EXPECT_FALSE(dut_->IsReady());
+  // fill the queue
+  XLS_ASSERT_OK(queue_->Write(Value::Tuple({
+      Value(UBits(0, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x4CD, 11)),
+                       Value(UBits(0x7AB, 11)),
+                       Value(UBits(0x511, 11)),
+                   })
+          .value(),          // data
+      Value(UBits(0x3, 3)),  // tkeep
+      Value(UBits(0, 1)),    // tlast
+      Value(UBits(0, 5)),    // pad
+  })));
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(queue_->Write(Value::Tuple({
+      Value(UBits(0, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x3AE, 11)),
+                       Value(UBits(0x6BA, 11)),
+                       Value(UBits(0x7CC, 11)),
+                   })
+          .value(),          // data
+      Value(UBits(0x7, 3)),  // tkeep
+      Value(UBits(1, 1)),    // tlast
+      Value(UBits(0, 5)),    // pad
+  })));
+  EXPECT_TRUE(this->dut_->IsReady());
+  // read out
+  XLS_ASSERT_OK_AND_ASSIGN(auto payload, dut_->Read());
+  ASSERT_THAT(payload.data,
+              ElementsAre(0xCD, 0x04, 0xAB, 0x07));  // elements 0 and 1
+  EXPECT_EQ(payload.last, false);
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK_AND_ASSIGN(payload, dut_->Read());
+  ASSERT_THAT(payload.data, ElementsAre(0xAE, 0x03, 0xBA, 0x06, 0xCC,
+                                        0x07));  // elements 0,1,2
+  EXPECT_EQ(payload.last, true);
+  // check handling of underflow
+  EXPECT_FALSE(this->dut_->IsReady());
+  EXPECT_FALSE(dut_->Read().ok());
+}
+
+class MultiSymbolWriteTest : public IrTestBase {
+ protected:
+  MultiSymbolWriteTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),                             // padding
+        package_.GetArrayType(3, package_.GetBitsType(11)),  // data
+        package_.GetBitsType(3),                             // tkeep
+        package_.GetBitsType(1),                             // tlast
+        package_.GetBitsType(5),                             // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kReceiveOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    auto stream = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), true, 1, 3, 2).value());
+    dut_ = std::make_unique<AxiStreamLikeDmaEndpoint>(std::move(stream));
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<AxiStreamLikeDmaEndpoint> dut_;
+};
+
+TEST_F(MultiSymbolWriteTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), false);
+}
+
+TEST_F(MultiSymbolWriteTest, GetMaxElementsPerTransfer) {
+  EXPECT_EQ(dut_->GetMaxElementsPerTransfer(), 3);
+}
+
+TEST_F(MultiSymbolWriteTest, GetElementSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetElementSize(), 2);
+}
+
+TEST_F(MultiSymbolWriteTest, Write) {
+  XLS_ASSERT_OK(
+      dut_->Write(IDmaEndpoint::Payload{{0xCD, 0x04, 0xAB, 0x07}, false}));
+  XLS_ASSERT_OK(dut_->Write(
+      IDmaEndpoint::Payload{{0xAE, 0x03, 0xBA, 0x06, 0xCC, 0x07}, true}));
+  auto popt = queue_->Read();
+  EXPECT_FALSE(popt->empty());
+  auto payload = *popt;
+  auto payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x4CD, 11)),
+                       Value(UBits(0x7AB, 11)),
+                       Value(UBits(0, 11)),
+                   })
+          .value(),          // data
+      Value(UBits(0x3, 3)),  // tkeep
+      Value(UBits(0, 1)),    // tlast
+      Value(UBits(0, 5)),    // pad
+  });
+  EXPECT_EQ(payload, payload_ref);
+  popt = queue_->Read();
+  EXPECT_FALSE(popt->empty());
+  payload = *popt;
+  payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x3AE, 11)),
+                       Value(UBits(0x6BA, 11)),
+                       Value(UBits(0x7CC, 11)),
+                   })
+          .value(),          // data
+      Value(UBits(0x7, 3)),  // tkeep
+      Value(UBits(1, 1)),    // tlast
+      Value(UBits(0, 5)),    // pad
+  });
+  EXPECT_EQ(payload, payload_ref);
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/byteops.h
+++ b/xls/simulation/generic/byteops.h
@@ -1,0 +1,76 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_BYTEOPS_H_
+#define XLS_SIMULATION_GENERIC_BYTEOPS_H_
+
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic::byteops {
+
+// Given a span of bytes, reads Size bytes starting from a specified
+// offset and assembles them into a value of integer type T following
+// little-endian byte order
+template <typename Word, uint64_t Size = sizeof(Word)>
+absl::StatusOr<Word> bytes_read_word(absl::Span<const uint8_t> bytes,
+                                     uint64_t offset) {
+  static_assert(Size >= 1, "Size should be positive");
+  static_assert(std::numeric_limits<Word>::is_integer,
+                "Word must be an integer");
+  static_assert(sizeof(Word) >= Size, "Word is too small for specified Size");
+  Word ret = 0;
+  if (bytes.size() == 0 || bytes.size() - 1 < offset)
+    return absl::InternalError("Offset: " + std::to_string(offset) +
+                               " is outside byte array");
+  // Assume little-endian order
+  for (uint64_t i = 0; i < Size; i++) {
+    if (offset + Size - 1 - i >= bytes.size()) continue;
+    if (i > 0) ret <<= 8;
+    ret |= bytes[offset + Size - 1 - i];
+  }
+  return ret;
+}
+
+// Given a span of bytes, takes value of integer T and writes it to the
+// span at a specified offset following little-endian byte order
+template <typename Word, uint64_t Size = sizeof(Word)>
+absl::Status bytes_write_word(absl::Span<uint8_t> bytes, uint64_t offset,
+                              Word value) {
+  static_assert(Size >= 1, "Size should be positive");
+  static_assert(std::numeric_limits<Word>::is_integer,
+                "Word must be an integer");
+  static_assert(sizeof(Word) >= Size, "Word is too small for specified Size");
+  using UWord = std::make_unsigned_t<Word>;
+  if (bytes.size() == 0 || bytes.size() - 1 < offset)
+    return absl::InternalError("Offset: " + std::to_string(offset) +
+                               " is outside byte array");
+  UWord uval = value;
+  // Assume little-endian order
+  for (uint64_t i = 0; i < Size && offset + i < bytes.size(); i++) {
+    bytes[offset + i] = uval & 0xFF;
+    uval >>= 8;
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic::byteops
+
+#endif  // XLS_SIMULATION_GENERIC_BYTEOPS_H_

--- a/xls/simulation/generic/byteops_test.cc
+++ b/xls/simulation/generic/byteops_test.cc
@@ -1,0 +1,151 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/byteops.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic::byteops {
+namespace {
+
+using testing::ElementsAre;
+
+class ByteopsTest : public ::testing::Test {};
+
+TEST_F(ByteopsTest, BytesReadWord8) {
+  std::vector<uint8_t> data{{1, 2, 3}};
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x01));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x02));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x03));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 3),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+  EXPECT_THAT(bytes_read_word<uint8_t>(data, 4),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord16) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5}};
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x0201));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 3),
+              xls::status_testing::IsOkAndHolds(0x0504));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 4),
+              xls::status_testing::IsOkAndHolds(0x05));
+  EXPECT_THAT(bytes_read_word<uint16_t>(data, 5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord32) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5}};
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x04030201));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x05040302));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x050403));
+  EXPECT_THAT(bytes_read_word<uint32_t>(data, 5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesReadWord64) {
+  std::vector<uint8_t> data{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 0),
+              xls::status_testing::IsOkAndHolds(0x0807060504030201ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 1),
+              xls::status_testing::IsOkAndHolds(0x0908070605040302ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 2),
+              xls::status_testing::IsOkAndHolds(0x09080706050403ULL));
+  EXPECT_THAT(bytes_read_word<uint64_t>(data, 9),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord8) {
+  std::vector<uint8_t> data(3);
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 0, 1),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 1, 2),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 0));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 2, 3),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 3));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 1, 4),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 4, 3));
+  EXPECT_THAT(bytes_write_word<uint8_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord16) {
+  std::vector<uint8_t> data(3);
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 0, 0x0201),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 2, 0));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 1, 0x0403),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(1, 3, 4));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 0, 0x0506),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(6, 5, 4));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 2, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(6, 5, 0));
+  EXPECT_THAT(bytes_write_word<uint16_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord32) {
+  std::vector<uint8_t> data(5);
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 0, 0x03020100),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 1, 2, 3, 0));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 1, 0x07060504),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 4, 5, 6, 7));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 3, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(0, 4, 5, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint32_t>(absl::MakeSpan(data), 5, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(ByteopsTest, BytesWriteWord64) {
+  std::vector<uint8_t> data(9);
+  EXPECT_THAT(
+      bytes_write_word<uint64_t>(absl::MakeSpan(data), 0, 0x0102030405060708LL),
+      xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 7, 6, 5, 4, 3, 2, 1, 0));
+  EXPECT_THAT(
+      bytes_write_word<uint64_t>(absl::MakeSpan(data), 1, 0x0102030405060708LL),
+      xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 8, 7, 6, 5, 4, 3, 2, 1));
+  EXPECT_THAT(bytes_write_word<uint64_t>(absl::MakeSpan(data), 4, 0),
+              xls::status_testing::IsOk());
+  ASSERT_THAT(data, ElementsAre(8, 8, 7, 6, 0, 0, 0, 0, 0));
+  EXPECT_THAT(bytes_write_word<uint64_t>(absl::MakeSpan(data), 9, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic::byteops

--- a/xls/simulation/generic/common.h
+++ b/xls/simulation/generic/common.h
@@ -1,0 +1,32 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_COMMON_H_
+#define XLS_SIMULATION_GENERIC_COMMON_H_
+
+#include <cstdint>
+
+#include "xls/common/logging/logging.h"
+
+inline uint64_t BytesToBits(uint64_t byte_count) {
+  XLS_DCHECK_GE(byte_count, 0);
+  XLS_DCHECK_LE(byte_count, 8);
+  return byte_count << 3;
+}
+
+inline uint64_t BitsToBytes(uint64_t bit_count) {
+  return (bit_count & 0x7) ? (bit_count >> 3) + 1 : (bit_count >> 3);
+}
+
+#endif  // XLS_SIMULATION_GENERIC_COMMON_H_

--- a/xls/simulation/generic/common.h
+++ b/xls/simulation/generic/common.h
@@ -19,6 +19,10 @@
 
 #include "xls/common/logging/logging.h"
 
+enum class AccessWidth : uint8_t { BYTE, WORD, DWORD, QWORD };
+
+enum class IRQEnum : uint8_t { NoChange, SetIRQ, UnsetIRQ };
+
 inline uint64_t BytesToBits(uint64_t byte_count) {
   XLS_DCHECK_GE(byte_count, 0);
   XLS_DCHECK_LE(byte_count, 8);

--- a/xls/simulation/generic/config.cc
+++ b/xls/simulation/generic/config.cc
@@ -1,0 +1,400 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/config.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+
+ABSL_FLAG(
+    std::string, config_type, "binproto",
+    "Configuration file format, can be either: 'textproto', or 'binproto'");
+
+namespace xls::simulation::generic {
+
+absl::StatusOr<ConfigType> ResolveConfigType() {
+  std::string config_type_str = absl::GetFlag(FLAGS_config_type);
+  absl::StatusOr<ConfigType> config_type;
+  if (config_type_str == "textproto") {
+    config_type = ConfigType::kTextproto;
+  } else if (config_type_str == "binproto") {
+    config_type = ConfigType::kBinproto;
+  } else {
+    return absl::InvalidArgumentError(
+        "Invalid -config_type flag: " + config_type_str +
+        "; must be one of textproto|binproto");
+  }
+
+  return config_type;
+}
+
+absl::StatusOr<std::unique_ptr<ConfigProto>> MakeProtoForConfigFile(
+    std::string_view config_file_path, ConfigType config_type) {
+  absl::Status success;
+  absl::StatusOr<std::unique_ptr<ConfigProto>> design_config =
+      std::make_unique<ConfigProto>();
+
+  if (config_type == ConfigType::kNone) {
+    ConfigType& temp(config_type);
+    XLS_ASSIGN_OR_RETURN(temp, ResolveConfigType());
+  }
+  if (config_type == ConfigType::kTextproto) {
+    success = ParseTextProtoFile(config_file_path, design_config.value().get());
+  } else {
+    success = ParseProtobinFile(config_file_path, design_config.value().get());
+  }
+  if (!success.ok()) {
+    design_config = success;
+  }
+  return design_config;
+}
+
+Config::Config(std::unique_ptr<ConfigProto> proto, SimulationType sim_type)
+    : proto_(std::move(proto)), sim_type_(sim_type) {}
+
+std::vector<std::filesystem::path> Config::GetImportPaths() const {
+  std::vector<std::filesystem::path> import_paths;
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    import_paths.reserve(this->proto_->import_path_size());
+    for (int i = 0; i < this->proto_->import_path_size(); ++i) {
+      import_paths.push_back(
+          std::filesystem::path(this->proto_->import_path(i)));
+    }
+  }
+  return import_paths;
+}
+
+absl::StatusOr<std::filesystem::path> Config::GetDesignPath() const {
+  std::string type("DSLX");
+  if (this->sim_type_ == SimulationType::kIR) type = std::string("IR");
+  absl::StatusOr<std::filesystem::path> result =
+      absl::NotFoundError("Config has no value for " + type + " file path");
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    if (this->proto_->has_path_to_dslx_design())
+      result = std::filesystem::path(this->proto_->path_to_dslx_design());
+  } else if (this->sim_type_ == SimulationType::kIR) {
+    if (this->proto_->has_path_to_ir_design())
+      result = std::filesystem::path(this->proto_->path_to_ir_design());
+  } else {
+    return absl::InvalidArgumentError("Invalid sim type");
+  }
+  return result;
+}
+
+absl::StatusOr<std::string> Config::GetDesignName() const {
+  std::string type("DSLX");
+  if (this->sim_type_ == SimulationType::kIR) type = std::string("IR");
+  absl::StatusOr<std::string> result =
+      absl::NotFoundError("Config has no value for " + type + " file path");
+  if (this->sim_type_ == SimulationType::kDSLX) {
+    if (this->proto_->has_dslx_top_level_process())
+      result = this->proto_->dslx_top_level_process();
+  } else if (this->sim_type_ == SimulationType::kIR) {
+    if (this->proto_->has_ir_top_level_process())
+      result = this->proto_->ir_top_level_process();
+  }
+  return result;
+}
+
+absl::StatusOr<uint64_t> Config::GetAddressMask() const {
+  uint64_t value = this->proto_->address_mask();
+  absl::StatusOr<uint64_t> result = value;
+  char hex_result_[100];
+  snprintf(hex_result_, sizeof(hex_result_) - 1, "%" PRIx64, value);
+  std::string hex_result(hex_result_);
+  value += 1;
+  if ((value & (value >> 1)) != 0)
+    result = absl::InvalidArgumentError("Address Mask " + hex_result +
+                                        " is not continous");
+  return result;
+}
+
+absl::StatusOr<std::optional<ConfigSingleValueManager>>
+Config::GetSingleValueManagerConfig() const {
+  if (!this->proto_->has_svm_config()) {
+    return std::nullopt;
+  }
+  auto svm_config_ = this->proto_->svm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(svm_config_.single_value_channels_size());
+  for (int i = 0; i < svm_config_.single_value_channels_size(); ++i) {
+    auto channel_config = svm_config_.single_value_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigSingleValueManager(svm_config_.base_address(),
+                                  svm_config_.runtime_status_offset(),
+                                  channels_);
+}
+
+absl::StatusOr<std::optional<ConfigStreamManager>>
+Config::GetStreamManagerConfig() const {
+  if (!this->proto_->has_sm_config()) {
+    return std::nullopt;
+  }
+  auto sm_config_ = this->proto_->sm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(sm_config_.stream_channels_size());
+  for (int i = 0; i < sm_config_.stream_channels_size(); ++i) {
+    auto channel_config = sm_config_.stream_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigStreamManager(sm_config_.base_address(), channels_);
+}
+
+absl::StatusOr<std::optional<ConfigStreamManager>>
+Config::GetDmaStreamManagerConfig() const {
+  if (!this->proto_->has_dma_sm_config()) {
+    return std::nullopt;
+  }
+  auto dma_sm_config_ = this->proto_->dma_sm_config();
+  std::vector<ConfigChannel> channels_;
+  channels_.reserve(dma_sm_config_.stream_channels_size());
+  for (int i = 0; i < dma_sm_config_.stream_channels_size(); ++i) {
+    auto channel_config = dma_sm_config_.stream_channels(i);
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!channel_config.has_dslx_name()) continue;
+      name = channel_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!channel_config.has_ir_name()) continue;
+      name = channel_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (channel_config.has_in_manager_offset())
+      ba_ = channel_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (channel_config.has_dma_id()) id_ = channel_config.dma_id();
+    XLS_ASSIGN_OR_RETURN(ConfigChannel channel_,
+                         ConfigChannel::MakeConfigChannel(name, ba_, id_));
+    channels_.push_back(channel_);
+  }
+  return ConfigStreamManager(dma_sm_config_.base_address(), channels_);
+}
+
+ConfigDmaAxiStreamLikeManager::ConfigDmaAxiStreamLikeManager(
+    uint64_t base_address, std::vector<ConfigAxiStreamLikeChannel> channels)
+    : base_address_(base_address), channels_(channels) {}
+
+uint64_t ConfigDmaAxiStreamLikeManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+const std::vector<ConfigAxiStreamLikeChannel>&
+ConfigDmaAxiStreamLikeManager::GetChannels() const {
+  return this->channels_;
+}
+
+absl::StatusOr<std::optional<ConfigDmaAxiStreamLikeManager>>
+Config::GetDmaAxiStreamLikeManagerConfig() const {
+  if (!this->proto_->has_dma_axi_sm_config()) {
+    return std::nullopt;
+  }
+  auto dma_axi_sm_config_ = this->proto_->dma_axi_sm_config();
+  std::vector<ConfigAxiStreamLikeChannel> channels_;
+  channels_.reserve(dma_axi_sm_config_.axi_channels_size());
+  for (int i = 0; i < dma_axi_sm_config_.axi_channels_size(); ++i) {
+    auto axi_config = dma_axi_sm_config_.axi_channels(i);
+    auto base_config = axi_config.base_config();
+    std::string name;
+    if (this->sim_type_ == SimulationType::kDSLX) {
+      if (!base_config.has_dslx_name()) continue;
+      name = base_config.dslx_name();
+    } else if (this->sim_type_ == SimulationType::kIR) {
+      if (!base_config.has_ir_name()) continue;
+      name = base_config.ir_name();
+    }
+    std::optional<uint64_t> ba_ = std::nullopt;
+    if (base_config.has_in_manager_offset())
+      ba_ = base_config.in_manager_offset();
+    std::optional<uint64_t> id_ = std::nullopt;
+    if (base_config.has_dma_id()) id_ = base_config.dma_id();
+
+    std::vector<uint64_t> data_idxs_;
+    data_idxs_.reserve(axi_config.dataidxs_size());
+    for (int j = 0; j < axi_config.dataidxs_size(); ++j) {
+      data_idxs_.push_back(axi_config.dataidxs(j));
+    }
+
+    std::optional<uint64_t> keep_ = std::nullopt;
+    if (axi_config.has_keepidx()) keep_ = axi_config.keepidx();
+    std::optional<uint64_t> last_ = std::nullopt;
+    if (axi_config.has_lastidx()) last_ = axi_config.lastidx();
+
+    XLS_ASSIGN_OR_RETURN(
+        ConfigAxiStreamLikeChannel channel_,
+        ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+            name, data_idxs_, ba_, id_, keep_, last_));
+    channels_.push_back(channel_);
+  }
+  return ConfigDmaAxiStreamLikeManager(dma_axi_sm_config_.base_address(),
+                                       channels_);
+}
+
+/* static */ absl::StatusOr<ConfigChannel> ConfigChannel::MakeConfigChannel(
+    std::string name, std::optional<uint64_t> offset,
+    std::optional<uint64_t> dma_id) {
+  absl::StatusOr<ConfigChannel> result = absl::InvalidArgumentError(
+      "Channel \"" + name + "\" has invalid config!");
+  if (offset.has_value() || dma_id.has_value())
+    result = ConfigChannel(name, offset, dma_id);
+  XLS_LOG_IF(ERROR, !result.ok())
+      << "Channel \"" << name << "\" does not define offset or DMA ID";
+  return result;
+}
+
+ConfigChannel::ConfigChannel(std::string name, std::optional<uint64_t> offset,
+                             std::optional<uint64_t> dma_id)
+    : name_(name), offset_(offset), dma_id_(dma_id) {}
+
+std::string_view ConfigChannel::GetName() const { return this->name_; }
+
+absl::StatusOr<uint64_t> ConfigChannel::GetOffset() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define offset.");
+  if (this->offset_.has_value()) result = this->offset_.value();
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigChannel::GetDMAID() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define DMA ID.");
+  if (this->dma_id_.has_value()) result = this->dma_id_.value();
+  return result;
+}
+
+ConfigSingleValueManager::ConfigSingleValueManager(
+    uint64_t base_address, uint64_t runtime_status_offset,
+    std::vector<ConfigChannel> channels)
+    : base_address_(base_address),
+      runtime_status_offset_(runtime_status_offset),
+      channels_(channels) {}
+
+uint64_t ConfigSingleValueManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+uint64_t ConfigSingleValueManager::GetRuntimeStatusOffset() const {
+  return this->runtime_status_offset_;
+}
+
+const std::vector<ConfigChannel>& ConfigSingleValueManager::GetChannels()
+    const {
+  return this->channels_;
+}
+
+ConfigStreamManager::ConfigStreamManager(uint64_t base_address,
+                                         std::vector<ConfigChannel> channels)
+    : base_address_(base_address), channels_(channels) {}
+
+uint64_t ConfigStreamManager::GetBaseAddress() const {
+  return this->base_address_;
+}
+
+const std::vector<ConfigChannel>& ConfigStreamManager::GetChannels() const {
+  return this->channels_;
+}
+
+/* static */ absl::StatusOr<ConfigAxiStreamLikeChannel>
+ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+    std::string name, std::vector<uint64_t> data_idxs,
+    std::optional<uint64_t> base_address, std::optional<uint64_t> dma_id,
+    std::optional<uint64_t> keep_idx, std::optional<uint64_t> last_idx) {
+  absl::StatusOr<ConfigAxiStreamLikeChannel> result =
+      absl::InvalidArgumentError(name + " has invalid config!");
+  bool has_address = base_address.has_value() || dma_id.has_value();
+  bool has_data = data_idxs.size() > 0;
+  if (has_address && has_data)
+    result = ConfigAxiStreamLikeChannel(name, data_idxs, base_address, dma_id,
+                                        keep_idx, last_idx);
+
+  XLS_LOG_IF(ERROR, !has_address)
+      << name << " doesn't define base address nor DMA ID";
+
+  XLS_LOG_IF(ERROR, !has_data)
+      << "Channel \"" << name << "\" does not define any data indices";
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigAxiStreamLikeChannel::GetLastIdx() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define last index.");
+  if (this->last_idx_.has_value()) result = this->last_idx_.value();
+  return result;
+}
+
+absl::StatusOr<uint64_t> ConfigAxiStreamLikeChannel::GetKeepIdx() const {
+  absl::StatusOr<uint64_t> result =
+      absl::NotFoundError(this->name_ + " doesn't define keep index.");
+  if (this->keep_idx_.has_value()) result = this->keep_idx_.value();
+  return result;
+}
+
+const std::vector<uint64_t>& ConfigAxiStreamLikeChannel::GetDataIdxs() const {
+  return this->data_idxs_;
+}
+
+ConfigAxiStreamLikeChannel::ConfigAxiStreamLikeChannel(
+    std::string name, std::vector<uint64_t> data_idxs,
+    std::optional<uint64_t> offset, std::optional<uint64_t> dma_id,
+    std::optional<uint64_t> keep_idx, std::optional<uint64_t> last_idx)
+    : ConfigChannel(name, offset, dma_id),
+      keep_idx_(keep_idx),
+      last_idx_(last_idx),
+      data_idxs_(data_idxs) {}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/config.h
+++ b/xls/simulation/generic/config.h
@@ -1,0 +1,168 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_CONFIG_H_
+#define XLS_SIMULATION_GENERIC_CONFIG_H_
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/flags/declare.h"
+#include "absl/flags/flag.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/config.pb.h"
+
+ABSL_DECLARE_FLAG(std::string, config_type);
+
+namespace xls::simulation::generic {
+
+enum class ConfigType {
+  kTextproto,
+  kBinproto,
+  kNone,
+};
+
+enum class SimulationType {
+  kDSLX,
+  kIR,
+};
+
+absl::StatusOr<std::unique_ptr<ConfigProto>> MakeProtoForConfigFile(
+    std::string_view, ConfigType = ConfigType::kNone);
+
+absl::StatusOr<ConfigType> ResolveConfigType();
+
+class ConfigSingleValueManager;
+class ConfigStreamManager;
+class ConfigDmaAxiStreamLikeManager;
+
+class Config {
+ public:
+  Config(std::unique_ptr<ConfigProto>, SimulationType);
+
+  std::vector<std::filesystem::path> GetImportPaths() const;
+  absl::StatusOr<std::filesystem::path> GetDesignPath() const;
+  absl::StatusOr<std::string> GetDesignName() const;
+  absl::StatusOr<uint64_t> GetAddressMask() const;
+
+  absl::StatusOr<std::optional<ConfigSingleValueManager>>
+  GetSingleValueManagerConfig() const;
+  absl::StatusOr<std::optional<ConfigStreamManager>> GetStreamManagerConfig()
+      const;
+  absl::StatusOr<std::optional<ConfigStreamManager>> GetDmaStreamManagerConfig()
+      const;
+  absl::StatusOr<std::optional<ConfigDmaAxiStreamLikeManager>>
+  GetDmaAxiStreamLikeManagerConfig() const;
+
+ private:
+  Config();
+  std::unique_ptr<ConfigProto> proto_;
+  SimulationType sim_type_;
+};
+
+class ConfigChannel {
+ public:
+  static absl::StatusOr<ConfigChannel> MakeConfigChannel(
+      std::string, std::optional<uint64_t> = std::nullopt,
+      std::optional<uint64_t> = std::nullopt);
+
+  std::string_view GetName() const;
+  absl::StatusOr<uint64_t> GetOffset() const;
+  absl::StatusOr<uint64_t> GetDMAID() const;
+
+ protected:
+  ConfigChannel();
+  ConfigChannel(std::string, std::optional<uint64_t> = std::nullopt,
+                std::optional<uint64_t> = std::nullopt);
+
+  std::string name_;
+  std::optional<uint64_t> offset_;
+  std::optional<uint64_t> dma_id_;
+};
+
+class ConfigSingleValueManager {
+ public:
+  ConfigSingleValueManager(uint64_t, uint64_t, std::vector<ConfigChannel>);
+
+  uint64_t GetBaseAddress() const;
+  uint64_t GetRuntimeStatusOffset() const;
+  const std::vector<ConfigChannel>& GetChannels() const;
+
+ private:
+  ConfigSingleValueManager();
+  uint64_t base_address_;
+  uint64_t runtime_status_offset_;
+  std::vector<ConfigChannel> channels_;
+};
+
+class ConfigStreamManager {
+ public:
+  ConfigStreamManager(uint64_t, std::vector<ConfigChannel>);
+
+  uint64_t GetBaseAddress() const;
+  const std::vector<ConfigChannel>& GetChannels() const;
+
+ private:
+  ConfigStreamManager();
+  uint64_t base_address_;
+  std::vector<ConfigChannel> channels_;
+};
+
+class ConfigAxiStreamLikeChannel : public ConfigChannel {
+ public:
+  static absl::StatusOr<ConfigAxiStreamLikeChannel>
+      MakeConfigAxiStreamLikeChannel(std::string, std::vector<uint64_t>,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt,
+                                     std::optional<uint64_t> = std::nullopt);
+
+  absl::StatusOr<uint64_t> GetKeepIdx() const;
+  absl::StatusOr<uint64_t> GetLastIdx() const;
+  const std::vector<uint64_t>& GetDataIdxs() const;
+
+ private:
+  ConfigAxiStreamLikeChannel();
+  ConfigAxiStreamLikeChannel(std::string, std::vector<uint64_t>,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt,
+                             std::optional<uint64_t> = std::nullopt);
+
+  std::optional<uint64_t> keep_idx_;
+  std::optional<uint64_t> last_idx_;
+  std::vector<uint64_t> data_idxs_;
+};
+
+class ConfigDmaAxiStreamLikeManager {
+ public:
+  ConfigDmaAxiStreamLikeManager(uint64_t,
+                                std::vector<ConfigAxiStreamLikeChannel>);
+
+  uint64_t GetBaseAddress() const;
+  const std::vector<ConfigAxiStreamLikeChannel>& GetChannels() const;
+
+ private:
+  ConfigDmaAxiStreamLikeManager();
+  uint64_t base_address_;
+  std::vector<ConfigAxiStreamLikeChannel> channels_;
+};
+
+}  // namespace xls::simulation::generic
+#endif  // XLS_SIMULATION_GENERIC_CONFIG_H_

--- a/xls/simulation/generic/config.proto
+++ b/xls/simulation/generic/config.proto
@@ -1,0 +1,60 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package xls.simulation.generic;
+
+message ConfigProto {
+  repeated string import_path = 1;
+  optional string path_to_dslx_design = 2;
+  optional string dslx_top_level_process = 3;
+  optional string path_to_ir_design = 4;
+  optional string ir_top_level_process = 5;
+  uint64 address_mask = 6;
+
+  message Channel {
+    optional string dslx_name = 1;
+    optional string ir_name = 2;
+    optional uint64 in_manager_offset = 3;
+    optional uint64 DMA_ID = 4;
+  }
+
+  message SingleValueManager {
+    uint64 base_address = 1;
+    uint64 runtime_status_offset = 2;
+    repeated Channel single_value_channels = 3;
+  }
+  optional SingleValueManager svm_config = 7;
+
+  message StreamManager {
+    uint64 base_address = 1;
+    repeated Channel stream_channels = 2;
+  }
+  optional StreamManager sm_config = 8;
+  optional StreamManager dma_sm_config = 9;
+
+  message AXIStreamLikeChannel {
+    Channel base_config = 1;
+    repeated uint64 dataIdxs = 2;
+    optional uint64 keepIdx = 3;
+    optional uint64 lastIdx = 4;
+  }
+
+  message DMAAXIStreamLikeManager {
+    uint64 base_address = 1;
+    repeated AXIStreamLikeChannel axi_channels = 2;
+  }
+  optional DMAAXIStreamLikeManager dma_axi_sm_config = 10;
+}

--- a/xls/simulation/generic/config_test.cc
+++ b/xls/simulation/generic/config_test.cc
@@ -1,0 +1,766 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/config.h"
+
+#include <fcntl.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+
+#include <cstdint>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "google/protobuf/util/message_differencer.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class ConfigChannelTest : public ::testing::Test {
+ protected:
+  ConfigChannelTest() : name("name"), offset(0xDEADBEEF), dma_id(0) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+
+  absl::StatusOr<ConfigChannel> cfg;
+  std::string name;
+  uint64_t offset;
+  uint64_t dma_id;
+};
+
+TEST_F(ConfigChannelTest, MakeConfigChannel) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, offset, dma_id));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetOffset(), offset);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetDMAID(), dma_id);
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelOffsetNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, std::nullopt, dma_id));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetOffset().status()));
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetDMAID(), dma_id);
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelDmaIdNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigChannel::MakeConfigChannel(name, offset, std::nullopt));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetName(), name);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetOffset(), offset);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetDMAID().status()));
+}
+
+TEST_F(ConfigChannelTest, MakeConfigChannelDmaIdAndOffsetNullopt) {
+  ::testing::internal::CaptureStderr();
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      ConfigChannel::MakeConfigChannel(name, std::nullopt, std::nullopt)
+          .status()));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("does not define offset or DMA ID"));
+}
+
+class ConfigAxiStreamLikeChannelTest : public ::testing::Test {
+ protected:
+  ConfigAxiStreamLikeChannelTest()
+      : name("name"),
+        data_idxs({0, 1, 2, 3, 4, 5, 6, 7}),
+        offset(0xDEADBEEF),
+        dma_id(0),
+        keep_idx(0),
+        last_idx(0) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+
+  absl::StatusOr<ConfigAxiStreamLikeChannel> cfg;
+  std::string name;
+  std::vector<uint64_t> data_idxs;
+  uint64_t offset;
+  uint64_t dma_id;
+  uint64_t keep_idx;
+  uint64_t last_idx;
+};
+
+TEST_F(ConfigAxiStreamLikeChannelTest, MakeConfigAxiStreamLikeChannel) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, keep_idx, last_idx));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetKeepIdx(), keep_idx);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetLastIdx(), last_idx);
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetDataIdxsEmpty) {
+  data_idxs = {};
+  ::testing::internal::CaptureStderr();
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+          name, data_idxs, offset, dma_id, keep_idx, last_idx)
+          .status()));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("does not define any data indices"));
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetKeepIdxNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, std::nullopt, last_idx));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetKeepIdx().status()));
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetLastIdx(), last_idx);
+}
+
+TEST_F(ConfigAxiStreamLikeChannelTest, GetLastIdxNullopt) {
+  ::testing::internal::CaptureStderr();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      cfg, ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+               name, data_idxs, offset, dma_id, keep_idx, std::nullopt));
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.value().GetDataIdxs(), data_idxs);
+  XLS_EXPECT_OK_AND_EQ(cfg.value().GetKeepIdx(), keep_idx);
+  EXPECT_TRUE(absl::IsNotFound(cfg.value().GetLastIdx().status()));
+}
+
+class ChannelManagerTest : public ::testing::Test {
+ protected:
+  ChannelManagerTest()
+      : base_address(0xDEADBEEF), channels_num(8), channel_width(64) {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+  void SetUp() override { SetupChannels(); }
+  virtual void SetupChannels() = 0;
+
+  uint64_t base_address;
+  uint8_t channels_num;
+  uint8_t channel_width;
+};
+
+class RegularChannelManagerTest : public ChannelManagerTest {
+ protected:
+  void SetupChannels() override {
+    channels.clear();
+    for (uint8_t i = 0; i < channels_num; i++) {
+      auto cfg = ConfigChannel::MakeConfigChannel(
+          "RegularChannel" + std::to_string(i), (channel_width * i), i);
+      channels.push_back(cfg.value());
+    }
+  }
+
+  void CompareChannels(std::vector<ConfigChannel> tested_channels) {
+    uint64_t i = 0;
+    for (auto channel : tested_channels) {
+      EXPECT_EQ(channel.GetName(), channels[i].GetName());
+      EXPECT_EQ(channel.GetOffset(), channels[i].GetOffset());
+      EXPECT_EQ(channel.GetDMAID(), channels[i].GetDMAID());
+      i++;
+    }
+  }
+
+  std::vector<ConfigChannel> channels;
+};
+
+class ConfigSingleValueManagerTest : public RegularChannelManagerTest {
+ protected:
+  ConfigSingleValueManagerTest() : runtime_status_offset(0xFEEBDAED) {}
+
+  uint64_t runtime_status_offset;
+};
+
+TEST_F(ConfigSingleValueManagerTest, ConfigSingleValueManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigSingleValueManager cfg =
+      ConfigSingleValueManager(base_address, runtime_status_offset, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetRuntimeStatusOffset(), runtime_status_offset);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+using ConfigStreamManagerTest = RegularChannelManagerTest;
+
+TEST_F(ConfigStreamManagerTest, ConfigStreamManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigStreamManager cfg = ConfigStreamManager(base_address, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+class ConfigDmaAxiStreamLikeManagerTest : public ChannelManagerTest {
+ protected:
+  void SetupChannels() override {
+    std::vector<uint64_t> data_idxs = {0, 1, 2, 3, 4, 5, 6, 7};
+
+    channels.clear();
+    for (uint8_t i = 0; i < channels_num; i++) {
+      absl::StatusOr<ConfigAxiStreamLikeChannel> cfg =
+          ConfigAxiStreamLikeChannel::MakeConfigAxiStreamLikeChannel(
+              "AxiStreamLikeChannel" + std::to_string(i), data_idxs,
+              (channel_width * i), i, i, i);
+      channels.push_back(cfg.value());
+    }
+  }
+
+  void CompareChannels(
+      std::vector<ConfigAxiStreamLikeChannel> tested_channels) {
+    uint64_t i = 0;
+    for (auto channel : tested_channels) {
+      EXPECT_EQ(channel.GetName(), channels[i].GetName());
+      EXPECT_EQ(channel.GetOffset(), channels[i].GetOffset());
+      EXPECT_EQ(channel.GetDMAID(), channels[i].GetDMAID());
+      EXPECT_EQ(channel.GetKeepIdx(), channels[i].GetKeepIdx());
+      EXPECT_EQ(channel.GetLastIdx(), channels[i].GetLastIdx());
+      EXPECT_EQ(channel.GetDataIdxs(), channels[i].GetDataIdxs());
+      i++;
+    }
+  }
+
+  std::vector<ConfigAxiStreamLikeChannel> channels;
+};
+
+TEST_F(ConfigDmaAxiStreamLikeManagerTest, ConfigDmaAxiStramLikeManager) {
+  ::testing::internal::CaptureStderr();
+  ConfigDmaAxiStreamLikeManager cfg =
+      ConfigDmaAxiStreamLikeManager(base_address, channels);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+  EXPECT_EQ(cfg.GetBaseAddress(), base_address);
+  EXPECT_EQ(cfg.GetChannels().size(), channels.size());
+  CompareChannels(cfg.GetChannels());
+}
+
+class ConfigWriter {
+ public:
+  inline static const std::vector<std::string> import_path = {
+      "arbitrary/import/path/a", "arbitrary/import/path/b",
+      "arbitrary/import/path/c", "arbitrary/import/path/d"};
+
+  inline static const std::string path_to_dslx_design =
+      "arbitrary/path/to/dslx/design.x";
+  inline static const std::string dslx_top_level_process =
+      "dslx_top_level_process_name";
+  inline static const std::string path_to_ir_design =
+      "arbitrary/path/to/ir/design.ir";
+  inline static const std::string ir_top_level_process =
+      "ir_top_level_process_name";
+
+  static const uint64_t address_mask = 0xFFFFFFFFFFFFFFFF;
+
+  static const uint8_t max_single_value_channels = 64;
+  static const uint64_t example_single_value_channel_width = 64;
+  static const uint64_t svm_base_address = 0;
+  // runtime status is the first channel in single value manager address space
+  static const uint64_t svm_runtime_status_offset = svm_base_address;
+
+  static const uint8_t max_stream_channels = 32;
+  static const uint64_t example_stream_channel_width = 256;
+  static const uint64_t sm_base_address =
+      svm_base_address +
+      (max_single_value_channels * example_single_value_channel_width);
+
+  static const uint8_t max_dma_stream_channels = 16;
+  static const uint64_t example_dma_stream_channel_width = 512;
+  static const uint64_t dma_sm_base_address =
+      sm_base_address + (max_stream_channels * example_stream_channel_width);
+
+  static const uint8_t max_dma_axi_stream_channels = 8;
+  static const uint64_t example_dma_axi_stream_channel_width = 2048;
+  static const uint64_t dma_axi_stream_base_address =
+      dma_sm_base_address +
+      (max_dma_stream_channels * example_dma_stream_channel_width);
+
+  void SetupChannelConfigProto(ConfigProto_Channel* cfg, std::string dslx_name,
+                               std::string ir_name, uint64_t offset,
+                               uint64_t dma_id) {
+    cfg->set_dslx_name(dslx_name);
+    cfg->set_ir_name(ir_name);
+    cfg->set_in_manager_offset(offset);
+    cfg->set_dma_id(dma_id);
+  }
+
+  void SetupAxiStreamLikeChannelConfigProto(
+      ConfigProto_AXIStreamLikeChannel* cfg, std::string dslx_name,
+      std::string ir_name, uint64_t offset, uint64_t dma_id,
+      std::vector<uint64_t> data_idxs, uint64_t keep_idx, uint64_t last_idx) {
+    ConfigProto_Channel* channel = cfg->mutable_base_config();
+    SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    for (auto data_idx : data_idxs) {
+      cfg->add_dataidxs(data_idx);
+    }
+    cfg->set_keepidx(keep_idx);
+    cfg->set_lastidx(last_idx);
+  }
+
+  void SetupSvmConfigProto(ConfigProto_SingleValueManager* cfg, uint64_t ba,
+                           uint64_t runtime_status_offset, uint8_t max_channels,
+                           uint64_t channel_width) {
+    cfg->set_base_address(ba);
+    cfg->set_runtime_status_offset(runtime_status_offset);
+
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxSingleValueChannel" + std::to_string(i);
+      std::string ir_name = "IrSingleValueChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      ConfigProto_Channel* channel = cfg->add_single_value_channels();
+      SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    }
+  }
+
+  void SetupSmConfigProto(ConfigProto_StreamManager* cfg, uint64_t ba,
+                          uint8_t max_channels, uint64_t channel_width) {
+    cfg->set_base_address(ba);
+
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxStreamChannel" + std::to_string(i);
+      std::string ir_name = "IrStreamChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      ConfigProto_Channel* channel = cfg->add_stream_channels();
+      SetupChannelConfigProto(channel, dslx_name, ir_name, offset, dma_id);
+    }
+  }
+
+  void SetupDmaAxiSmConfigProto(ConfigProto_DMAAXIStreamLikeManager* cfg,
+                                uint64_t ba, uint8_t max_channels,
+                                uint64_t channel_width) {
+    cfg->set_base_address(ba);
+    for (uint8_t i = 0; i < max_channels; i++) {
+      std::string dslx_name = "DslxAxiStreamLikeChannel" + std::to_string(i);
+      std::string ir_name = "IrAxiStreamLikeChannel" + std::to_string(i);
+      uint64_t offset = i * channel_width;
+      uint64_t dma_id = i;
+      std::vector<uint64_t> data_idxs = {0, 1, 2, 3, 4, 5, 6, 7};
+      uint64_t keep_idx = i;
+      uint64_t last_idx = i;
+      ConfigProto_AXIStreamLikeChannel* channel = cfg->add_axi_channels();
+      SetupAxiStreamLikeChannelConfigProto(channel, dslx_name, ir_name, offset,
+                                           dma_id, data_idxs, keep_idx,
+                                           last_idx);
+    }
+  }
+
+  ConfigProto& SetupConfigProto() {
+    for (auto path : import_path) {
+      cfg_proto.add_import_path(path);
+    }
+
+    cfg_proto.set_path_to_dslx_design(path_to_dslx_design);
+    cfg_proto.set_dslx_top_level_process(dslx_top_level_process);
+    cfg_proto.set_path_to_ir_design(path_to_ir_design);
+    cfg_proto.set_ir_top_level_process(ir_top_level_process);
+    cfg_proto.set_address_mask(address_mask);
+
+    svm_config = cfg_proto.mutable_svm_config();
+    SetupSvmConfigProto(svm_config, svm_base_address, svm_runtime_status_offset,
+                        max_single_value_channels,
+                        example_single_value_channel_width);
+
+    sm_config = cfg_proto.mutable_sm_config();
+    SetupSmConfigProto(sm_config, sm_base_address, max_stream_channels,
+                       example_stream_channel_width);
+
+    dma_sm_config = cfg_proto.mutable_dma_sm_config();
+    SetupSmConfigProto(dma_sm_config, dma_sm_base_address,
+                       max_dma_stream_channels,
+                       example_dma_stream_channel_width);
+
+    dma_axi_sm_config = cfg_proto.mutable_dma_axi_sm_config();
+    SetupDmaAxiSmConfigProto(dma_axi_sm_config, dma_axi_stream_base_address,
+                             max_dma_axi_stream_channels,
+                             example_dma_axi_stream_channel_width);
+
+    return cfg_proto;
+  }
+
+  void WriteBinaryConfigProto(std::string filename) {
+    std::fstream output(filename,
+                        std::ios::out | std::ios::trunc | std::ios::binary);
+    if (!cfg_proto.SerializeToOstream(&output)) {
+      XLS_LOG(ERROR) << "Failed to write binary config file";
+    }
+    output.close();
+  }
+
+  void WriteTextConfigProto(std::string filename) {
+    int fd = open(filename.c_str(), O_CREAT | O_WRONLY | O_TRUNC,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH);
+    google::protobuf::io::FileOutputStream output =
+        google::protobuf::io::FileOutputStream(fd);
+    if (!google::protobuf::TextFormat::Print(cfg_proto, &output)) {
+      XLS_LOG(ERROR) << "Failed to write text config file";
+    }
+    output.Close();
+    close(fd);
+  }
+
+  ConfigProto cfg_proto;
+  ConfigProto_SingleValueManager* svm_config;
+  ConfigProto_StreamManager* sm_config;
+  ConfigProto_StreamManager* dma_sm_config;
+  ConfigProto_DMAAXIStreamLikeManager* dma_axi_sm_config;
+};
+
+class MakeProtoForConfigFileTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+  explicit MakeProtoForConfigFileTest(std::string cfg_proto_file_path)
+      : cfg_proto_file_path(cfg_proto_file_path) {
+    cfg_writer.SetupConfigProto();
+  }
+
+  absl::StatusOr<std::unique_ptr<ConfigProto>> status_or_cfg_proto;
+  ConfigWriter cfg_writer;
+  ConfigType cfg_type;
+  std::string cfg_proto_file_path;
+};
+
+class MakeProtoForConfigFileBinaryTest
+    : public MakeProtoForConfigFileTest,
+      public testing::WithParamInterface<ConfigType> {
+ protected:
+  MakeProtoForConfigFileBinaryTest()
+      : MakeProtoForConfigFileTest("/tmp/cfg_proto.bin") {
+    cfg_writer.WriteBinaryConfigProto(cfg_proto_file_path);
+  }
+};
+
+TEST_P(MakeProtoForConfigFileBinaryTest, RoundTripCheck) {
+  cfg_type = GetParam();
+
+  ::testing::internal::CaptureStderr();
+  status_or_cfg_proto = MakeProtoForConfigFile(cfg_proto_file_path, cfg_type);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  if (cfg_type == ConfigType::kNone) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else if (cfg_type == ConfigType::kBinproto) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else if (cfg_type == ConfigType::kTextproto) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MakeProtoForConfigFileBinaryTestParametrized,
+                         MakeProtoForConfigFileBinaryTest,
+                         testing::Values(ConfigType::kNone,
+                                         ConfigType::kBinproto,
+                                         ConfigType::kTextproto));
+
+class MakeProtoForConfigFileTextTest
+    : public MakeProtoForConfigFileTest,
+      public testing::WithParamInterface<ConfigType> {
+ protected:
+  MakeProtoForConfigFileTextTest()
+      : MakeProtoForConfigFileTest("/tmp/cfg_proto.txtpb") {
+    cfg_writer.WriteTextConfigProto(cfg_proto_file_path);
+  }
+};
+
+TEST_P(MakeProtoForConfigFileTextTest, RoundTripCheck) {
+  cfg_type = GetParam();
+
+  ::testing::internal::CaptureStderr();
+  status_or_cfg_proto = MakeProtoForConfigFile(cfg_proto_file_path, cfg_type);
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  // Expected to fail because MakeProtoForConfigFile() with ConfigType::kNone
+  // calls ResolveConfigType() which resolves the config type based on
+  // absl flag 'FLAGS_config_type' which has default value set to 'binproto'.
+  // This causes Text Proto file to be incorrectly parsed as Binary Proto file
+  if (cfg_type == ConfigType::kNone) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else if (cfg_type == ConfigType::kBinproto) {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  } else if (cfg_type == ConfigType::kTextproto) {
+    XLS_EXPECT_OK(status_or_cfg_proto);
+    EXPECT_TRUE(google::protobuf::util::MessageDifferencer::Equivalent(
+        *(status_or_cfg_proto.value()), cfg_writer.cfg_proto));
+  } else {
+    EXPECT_TRUE(absl::IsFailedPrecondition(status_or_cfg_proto.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(MakeProtoForConfigFileTextTestParametrized,
+                         MakeProtoForConfigFileTextTest,
+                         testing::Values(ConfigType::kNone,
+                                         ConfigType::kBinproto,
+                                         ConfigType::kTextproto));
+
+class ResolveConfigTypeTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<std::string> {
+ protected:
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_P(ResolveConfigTypeTest, ResolveConfigType) {
+  std::string cfg_type_str = GetParam();
+  if (cfg_type_str != "default_cfg_type")
+    absl::SetFlag(&FLAGS_config_type, cfg_type_str);
+  ::testing::internal::CaptureStderr();
+  absl::StatusOr<ConfigType> cfg_type = ResolveConfigType();
+  // Expect empty stderr
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(), ::testing::IsEmpty());
+
+  if (cfg_type_str == "textproto") {
+    XLS_EXPECT_OK(cfg_type);
+  } else if (cfg_type_str == "binproto") {
+    XLS_EXPECT_OK(cfg_type);
+  } else if (cfg_type_str == "default_cfg_type") {
+    XLS_EXPECT_OK(cfg_type);  // cfg_type flag defaults to 'binproto'
+  } else if (cfg_type_str == "") {
+    EXPECT_TRUE(absl::IsInvalidArgument(cfg_type.status()));
+  } else {
+    EXPECT_TRUE(absl::IsInvalidArgument(cfg_type.status()));
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ResolveConfigTypeTestParametrized,
+                         ResolveConfigTypeTest,
+                         testing::Values("default_cfg_type", "",
+                                         "not_recognized", "textproto",
+                                         "binproto"));
+
+class ConfigTest : public MakeProtoForConfigFileTest,
+                   public testing::WithParamInterface<SimulationType> {
+ protected:
+  ConfigTest() : MakeProtoForConfigFileTest("/tmp/cfg_proto.bin") {
+    cfg_writer.WriteBinaryConfigProto(cfg_proto_file_path);
+    cfg_type = ConfigType::kNone;
+  }
+
+  void compare_channels(ConfigChannel* channel,
+                        const ConfigProto_Channel& ref_channel,
+                        SimulationType sim_type) {
+    if (sim_type == SimulationType::kDSLX)
+      EXPECT_EQ(channel->GetName(), ref_channel.dslx_name());
+    else if (sim_type == SimulationType::kIR)
+      EXPECT_EQ(channel->GetName(), ref_channel.ir_name());
+    else
+      FAIL() << "Unexpected SimulationType";
+
+    XLS_EXPECT_OK_AND_EQ(channel->GetOffset(), ref_channel.in_manager_offset());
+    XLS_EXPECT_OK_AND_EQ(channel->GetDMAID(), ref_channel.dma_id());
+  }
+
+  void compare_axi_stream_like_channels(
+      ConfigAxiStreamLikeChannel* channel,
+      const ConfigProto_AXIStreamLikeChannel& ref_channel,
+      SimulationType sim_type) {
+    compare_channels(channel, ref_channel.base_config(), sim_type);
+
+    XLS_EXPECT_OK_AND_EQ(channel->GetKeepIdx(), ref_channel.keepidx());
+    XLS_EXPECT_OK_AND_EQ(channel->GetLastIdx(), ref_channel.lastidx());
+
+    auto data_idxs = channel->GetDataIdxs();
+    EXPECT_GT(data_idxs.size(), 0);
+    EXPECT_EQ(data_idxs.size(), ref_channel.dataidxs_size());
+    for (int i = 0; i < data_idxs.size(); i++) {
+      EXPECT_EQ(data_idxs[i], ref_channel.dataidxs(i));
+    }
+  }
+
+  SimulationType sim_type;
+};
+
+TEST_P(ConfigTest, GetImportPaths) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  std::vector<std::filesystem::path> import_paths =
+      cfg_wrapper.GetImportPaths();
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_GT(import_paths.size(), 0);
+    EXPECT_EQ(import_paths.size(), reference.import_path_size());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(import_paths.size(), 0);
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+  for (int i = 0; i < import_paths.size(); i++) {
+    EXPECT_EQ(import_paths[i].string(), reference.import_path(i));
+  }
+}
+
+TEST_P(ConfigTest, GetDesignPath) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::filesystem::path design_path,
+                           cfg_wrapper.GetDesignPath());
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_EQ(design_path.string(), reference.path_to_dslx_design());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(design_path.string(), reference.path_to_ir_design());
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+}
+
+TEST_P(ConfigTest, GetDesignName) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::string design_name,
+                           cfg_wrapper.GetDesignName());
+  if (GetParam() == SimulationType::kDSLX) {
+    EXPECT_EQ(design_name, reference.dslx_top_level_process());
+  } else if (GetParam() == SimulationType::kIR) {
+    EXPECT_EQ(design_name, reference.ir_top_level_process());
+  } else {
+    FAIL() << "Unexpected SimulationType";
+  }
+}
+
+TEST_P(ConfigTest, GetAddressMask) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto cfg_wrapper = Config(std::move(cfg_proto), GetParam());
+
+  XLS_EXPECT_OK_AND_EQ(cfg_wrapper.GetAddressMask(), reference.address_mask());
+}
+
+TEST_P(ConfigTest, GetSingleValueManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_svm_cfg = reference.svm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto svm_cfg,
+                           cfg_wrapper.GetSingleValueManagerConfig());
+  EXPECT_EQ(svm_cfg->GetBaseAddress(), ref_svm_cfg.base_address());
+  EXPECT_EQ(svm_cfg->GetRuntimeStatusOffset(),
+            ref_svm_cfg.runtime_status_offset());
+  auto channels = svm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_svm_cfg.single_value_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_svm_cfg.single_value_channels(i),
+                     sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetStreamManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_sm_cfg = reference.sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto sm_cfg, cfg_wrapper.GetStreamManagerConfig());
+  EXPECT_EQ(sm_cfg->GetBaseAddress(), ref_sm_cfg.base_address());
+  auto channels = sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_sm_cfg.stream_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_sm_cfg.stream_channels(i), sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetDmaStreamManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_dma_sm_cfg = reference.dma_sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto dma_sm_cfg,
+                           cfg_wrapper.GetDmaStreamManagerConfig());
+  EXPECT_EQ(dma_sm_cfg->GetBaseAddress(), ref_dma_sm_cfg.base_address());
+  auto channels = dma_sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_dma_sm_cfg.stream_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_channels(&channels[i], ref_dma_sm_cfg.stream_channels(i), sim_type);
+  }
+}
+
+TEST_P(ConfigTest, GetDmaAxiStreamLikeManagerConfig) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto cfg_proto, MakeProtoForConfigFile(cfg_proto_file_path, cfg_type));
+  ConfigProto reference = *cfg_proto;
+  auto ref_dma_axi_sm_cfg = reference.dma_axi_sm_config();
+  sim_type = GetParam();
+  auto cfg_wrapper = Config(std::move(cfg_proto), sim_type);
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto dma_axi_sm_cfg,
+                           cfg_wrapper.GetDmaAxiStreamLikeManagerConfig());
+  EXPECT_EQ(dma_axi_sm_cfg->GetBaseAddress(),
+            ref_dma_axi_sm_cfg.base_address());
+  auto channels = dma_axi_sm_cfg->GetChannels();
+  EXPECT_GT(channels.size(), 0);
+  EXPECT_EQ(channels.size(), ref_dma_axi_sm_cfg.axi_channels_size());
+  for (int i = 0; i < channels.size(); i++) {
+    compare_axi_stream_like_channels(
+        &channels[i], ref_dma_axi_sm_cfg.axi_channels(i), sim_type);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(ConfigTestParametrized, ConfigTest,
+                         testing::Values(SimulationType::kDSLX,
+                                         SimulationType::kIR));
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/dmastreammanager.cc
+++ b/xls/simulation/generic/dmastreammanager.cc
@@ -1,0 +1,337 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/dmastreammanager.h"
+
+#include <climits>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/bits_util.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/simulation/generic/streamdmachannel.h"
+
+namespace xls::simulation::generic {
+
+DmaStreamManager::DmaStreamManager(uint64_t base_address)
+    : IChannelManager(base_address),
+      highest_channel_id_(-1),
+      dma_channel_irq_mask_reg_size_(sizeof(uint64_t)),
+      dma_channel_irq_reg_size_(sizeof(uint64_t)) {
+  offset_to_first_dma_channel_ = CalculateOffsetToFirstDMAChannel();
+  // No channels registered yet, assign offset to first addresable byte in the
+  // space reserved for the first DMA Channel
+  address_range_end_ = offset_to_first_dma_channel_;
+}
+
+absl::Status DmaStreamManager::RegisterEndpoint(
+    std::unique_ptr<IDmaEndpoint> endpoint, int64_t id,
+    IMasterPort* bus_master_port) {
+  if (id_to_channel_.find(id) != id_to_channel_.end()) {
+    return absl::InvalidArgumentError("Id: " + std::to_string(id) +
+                                      " already in use!");
+  }
+  if (id > highest_channel_id_) {
+    highest_channel_id_ = id;
+    channel_irq_mask_.resize(id + 1, false);
+    active_irq_mask_.resize(id + 1, false);
+    dma_channel_irq_mask_reg_size_ =
+        (1 + (id / (sizeof(uint64_t) * CHAR_BIT))) * sizeof(uint64_t);
+    dma_channel_irq_reg_size_ = dma_channel_irq_mask_reg_size_;
+    offset_to_first_dma_channel_ = CalculateOffsetToFirstDMAChannel();
+    address_range_end_ += kDMAChannelAddressSpace;
+  }
+  id_to_channel_.insert({id, std::make_unique<StreamDmaChannel>(
+                                 std::move(endpoint), bus_master_port)});
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::CheckAddressAlignment(channel_addr_t address,
+                                                     uint64_t bytes_count) {
+  if ((address & (bytes_count - 1)) != 0) {
+    return absl::InvalidArgumentError(
+        "Unaligned access, address: " + std::to_string(address) +
+        " access width: " + std::to_string(bytes_count));
+  }
+  return absl::OkStatus();
+}
+
+uint64_t DmaStreamManager::IRQBitAccess(const std::vector<bool>& bits,
+                                        uint64_t bytes_count,
+                                        uint64_t byte_offset,
+                                        uint64_t mask) const {
+  uint64_t return_payload = 0;
+  uint64_t current_byte = byte_offset;
+  uint64_t current_first_bit = current_byte * CHAR_BIT;
+  // Access IRQ mask
+  for (int byte = 0; (byte < bytes_count) && (current_first_bit < bits.size());
+       ++byte) {
+    for (int bit = 0;
+         (bit < CHAR_BIT) && ((current_first_bit + bit) < bits.size()); ++bit) {
+      uint64_t bits_to_shift = CHAR_BIT * byte + bit;
+      return_payload |= static_cast<int>(bits[current_first_bit + bit])
+                        << bits_to_shift;
+    }
+    current_byte++;
+    current_first_bit += CHAR_BIT;
+  }
+  return return_payload & mask;
+}
+
+uint64_t DmaStreamManager::CalculateOffsetToFirstDMAChannel() const {
+  uint64_t minimal_offset =
+      kNumberOfDMAChannelsRegSize + kOffsetToFirstDMAChannelRegSize +
+      dma_channel_irq_mask_reg_size_ + dma_channel_irq_reg_size_;
+  // Align to 64 bytes
+  return ((minimal_offset + kChannelAlignment - 1) / kChannelAlignment) *
+         kChannelAlignment;
+}
+absl::StatusOr<uint64_t> DmaStreamManager::ReadNumberOfDMAChannels(
+    uint64_t byte_offset, uint64_t mask) const {
+  return ((highest_channel_id_ + 1) >> (CHAR_BIT * byte_offset)) & mask;
+}
+
+absl::StatusOr<uint64_t> DmaStreamManager::ReadOffsetToFirstDMAChannel(
+    uint64_t byte_offset, uint64_t mask) const {
+  return (offset_to_first_dma_channel_ >> (CHAR_BIT * byte_offset)) & mask;
+}
+
+absl::StatusOr<uint64_t> DmaStreamManager::ReadDMAChannelIRQMask(
+    uint64_t bytes_count, uint64_t byte_offset, uint64_t mask) const {
+  return IRQBitAccess(channel_irq_mask_, bytes_count, byte_offset, mask);
+}
+
+absl::StatusOr<uint64_t> DmaStreamManager::ReadDMAChannelIRQ(
+    uint64_t bytes_count, uint64_t byte_offset, uint64_t mask) const {
+  return IRQBitAccess(active_irq_mask_, bytes_count, byte_offset, mask);
+}
+
+absl::StatusOr<uint64_t> DmaStreamManager::ReadDMAChannel(
+    channel_addr_t address, uint64_t bytes_count) {
+  uint64_t byte_offset = address - base_address_ - offset_to_first_dma_channel_;
+  uint64_t id = byte_offset / kChannelAlignment;
+  if (id_to_channel_.find(id) == id_to_channel_.end()) {
+    XLS_LOG(WARNING) << "DMA channel with id:" + std::to_string(id) +
+                            " does not exist.";
+    return 0;
+  }
+
+  const auto& channel = id_to_channel_[id];
+  uint64_t in_channel_address = byte_offset % kChannelAlignment;
+  uint64_t channel_register = in_channel_address / kDMAChannelRegisterSize;
+  uint64_t return_payload;
+
+  switch (channel_register) {
+    case kDMAChannelTransferBaseAddressIdx:
+      return_payload = channel->GetTransferBaseAddress();
+      break;
+    case kDMAChannelMaxTransferLengthIdx:
+      return_payload = channel->GetMaxTransferLength();
+      break;
+    case kDMAChannelTransferredLengthIdx:
+      return_payload = channel->GetTransferredLength();
+      break;
+    case kDMAChannelControlRegIdx:
+      return_payload = channel->GetControlRegister();
+      break;
+    case kDMAChannelIRQIdx:
+      return_payload = channel->GetIRQReg();
+      break;
+    default:
+      return_payload = 0;
+      XLS_LOG(WARNING) << "Offset:" + std::to_string(in_channel_address) +
+                              " doesn't map to any DMA register!";
+  }
+
+  uint64_t byte_shift = in_channel_address % kDMAChannelRegisterSize;
+  uint64_t mask = Mask(CHAR_BIT * bytes_count);
+
+  return (return_payload >> (CHAR_BIT * byte_shift)) & mask;
+}
+
+absl::StatusOr<uint64_t> DmaStreamManager::ReadInternal(
+    channel_addr_t address, uint64_t log_byte_count) {
+  uint64_t bytes_count = 1 << log_byte_count;
+  XLS_RETURN_IF_ERROR(CheckAddressAlignment(address, bytes_count));
+  uint64_t byte_offset = address - base_address_;
+
+  if (offset_to_first_dma_channel_ <= byte_offset)
+    return ReadDMAChannel(address, bytes_count);
+
+  uint64_t mask = Mask(CHAR_BIT * bytes_count);
+
+  if (byte_offset < kNumberOfDMAChannelsRegSize)
+    return ReadNumberOfDMAChannels(byte_offset, mask);
+  byte_offset -= kNumberOfDMAChannelsRegSize;
+
+  if (byte_offset < kOffsetToFirstDMAChannelRegSize)
+    return ReadOffsetToFirstDMAChannel(byte_offset, mask);
+  byte_offset -= kOffsetToFirstDMAChannelRegSize;
+
+  if (byte_offset < dma_channel_irq_mask_reg_size_)
+    return ReadDMAChannelIRQMask(bytes_count, byte_offset, mask);
+  byte_offset -= dma_channel_irq_mask_reg_size_;
+
+  if (byte_offset < dma_channel_irq_reg_size_)
+    return ReadDMAChannelIRQ(bytes_count, byte_offset, mask);
+
+  XLS_LOG(WARNING) << "Read access to not existing register";
+  return 0;
+}
+
+absl::Status DmaStreamManager::WriteNumberOfDMAChannels() {
+  XLS_LOG(WARNING) << "Write access to RO register: NumberOfDMAChannels!";
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::WriteOffsetToFirstDMAChannel() {
+  XLS_LOG(WARNING) << "Write access to RO register: OffsetToFirstDMAChannel!";
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::WriteDMAChannelIRQMask(uint64_t byte_offset,
+                                                      uint64_t bytes_count,
+                                                      uint64_t payload) {
+  uint64_t current_byte = byte_offset;
+  uint64_t current_first_bit = current_byte * CHAR_BIT;
+  for (int byte = 0;
+       (byte < bytes_count) && (current_first_bit < channel_irq_mask_.size());
+       ++byte) {
+    for (int bit = 0; (bit < CHAR_BIT) &&
+                      (current_first_bit + bit < channel_irq_mask_.size());
+         ++bit) {
+      channel_irq_mask_[current_first_bit + bit] = ((payload & 1) != 0u);
+      payload >>= 1;
+    }
+    current_byte++;
+    current_first_bit += CHAR_BIT;
+  }
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::WriteDMAChannelIRQ() {
+  XLS_LOG(WARNING) << "Write access to RO register: ActiveIRQs!";
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::WriteDMAChannel(channel_addr_t address,
+                                               uint64_t payload,
+                                               uint64_t bytes_count) {
+  uint64_t byte_offset = address - base_address_ - offset_to_first_dma_channel_;
+  uint64_t id = byte_offset / kChannelAlignment;
+  if (id_to_channel_.find(id) == id_to_channel_.end()) {
+    XLS_LOG(WARNING) << "DMA channel with id:" + std::to_string(id) +
+                            " does not exist.";
+    return absl::OkStatus();
+  }
+
+  uint64_t in_channel_address = byte_offset % kChannelAlignment;
+  uint64_t channel_register = in_channel_address / kDMAChannelRegisterSize;
+
+  auto HandleShiftedWrite = [=](uint64_t (StreamDmaChannel::*Getter)(),
+                                void (StreamDmaChannel::*Setter)(uint64_t)) {
+    const auto& channel = id_to_channel_[id];
+    uint64_t byte_shift = in_channel_address % kDMAChannelRegisterSize;
+    uint64_t mask = Mask(BytesToBits(bytes_count));
+
+    uint64_t updated_value = (channel.get()->*Getter)();
+    updated_value &= ~(mask << BytesToBits(byte_shift));
+    updated_value |= (payload & mask) << BytesToBits(byte_shift);
+    (channel.get()->*Setter)(updated_value);
+  };
+
+  switch (channel_register) {
+    case kDMAChannelTransferBaseAddressIdx:
+      HandleShiftedWrite(&StreamDmaChannel::GetTransferBaseAddress,
+                         &StreamDmaChannel::SetTransferBaseAddress);
+      break;
+    case kDMAChannelMaxTransferLengthIdx:
+      HandleShiftedWrite(&StreamDmaChannel::GetMaxTransferLength,
+                         &StreamDmaChannel::SetMaxTransferLength);
+      break;
+    case kDMAChannelTransferredLengthIdx:
+      XLS_LOG(WARNING)
+          << "Write access to DMA channel RO register: TransferredLength!";
+      break;
+    case kDMAChannelControlRegIdx:
+      HandleShiftedWrite(&StreamDmaChannel::GetControlRegister,
+                         &StreamDmaChannel::SetControlRegister);
+      break;
+    case kDMAChannelIRQIdx:
+      HandleShiftedWrite(&StreamDmaChannel::GetIRQReg,
+                         &StreamDmaChannel::ClearIRQReg);
+      break;
+    default:
+      XLS_LOG(WARNING) << "Offset:" + std::to_string(in_channel_address) +
+                              " doesn't map to any DMA register!";
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::WriteInternal(channel_addr_t address,
+                                             uint64_t payload,
+                                             uint64_t log_byte_count) {
+  uint64_t bytes_count = 1 << log_byte_count;
+  XLS_RETURN_IF_ERROR(CheckAddressAlignment(address, bytes_count));
+  uint64_t byte_offset = address - base_address_;
+
+  if (offset_to_first_dma_channel_ <= byte_offset)
+    return WriteDMAChannel(address, payload, bytes_count);
+
+  if (byte_offset < kNumberOfDMAChannelsRegSize)
+    return WriteNumberOfDMAChannels();
+  byte_offset -= kNumberOfDMAChannelsRegSize;
+
+  if (byte_offset < kOffsetToFirstDMAChannelRegSize)
+    return WriteOffsetToFirstDMAChannel();
+  byte_offset -= kOffsetToFirstDMAChannelRegSize;
+
+  if (byte_offset < dma_channel_irq_mask_reg_size_)
+    return WriteDMAChannelIRQMask(byte_offset, bytes_count, payload);
+  byte_offset -= dma_channel_irq_mask_reg_size_;
+
+  if (byte_offset < dma_channel_irq_reg_size_) return WriteDMAChannelIRQ();
+
+  XLS_LOG(WARNING) << "Write access to not existing register";
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::Update() {
+  for (const auto& it : id_to_channel_) {
+    XLS_RETURN_IF_ERROR(it.second->Update());
+  }
+  return absl::OkStatus();
+}
+
+absl::Status DmaStreamManager::UpdateIRQ() {
+  for (const auto& it : id_to_channel_) {
+    XLS_RETURN_IF_ERROR(it.second->UpdateIRQ());
+    active_irq_mask_[it.first] =
+        channel_irq_mask_[it.first] && it.second->GetIRQ();
+  }
+  return absl::OkStatus();
+}
+
+bool DmaStreamManager::GetIRQ() {
+  for (int i = 0; i < active_irq_mask_.size(); ++i) {
+    if (active_irq_mask_[i]) return true;
+  }
+
+  return false;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/dmastreammanager.h
+++ b/xls/simulation/generic/dmastreammanager.h
@@ -1,0 +1,145 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_DMASTREAMMANAGER_H_
+#define XLS_SIMULATION_GENERIC_DMASTREAMMANAGER_H_
+
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/iactive.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+#include "xls/simulation/generic/idmaendpoint.h"
+#include "xls/simulation/generic/iirq.h"
+#include "xls/simulation/generic/imasterport.h"
+#include "xls/simulation/generic/streamdmachannel.h"
+
+namespace xls::simulation::generic {
+
+class DmaStreamManager : public IActive, public IIRQ, public IChannelManager {
+ public:
+  using channel_addr_t = uint64_t;
+
+  explicit DmaStreamManager(uint64_t base_address);
+  DmaStreamManager(DmaStreamManager&& other) = default;
+  DmaStreamManager& operator=(DmaStreamManager&& other) = default;
+
+  ~DmaStreamManager() override = default;
+
+  absl::Status RegisterEndpoint(std::unique_ptr<IDmaEndpoint> endpoint,
+                                int64_t id, IMasterPort* bus_master_port);
+
+  // IChannelManager
+  absl::Status WriteU8AtAddress(channel_addr_t address,
+                                uint8_t value) override {
+    return WriteInternal(address, value, 0);
+  }
+  absl::Status WriteU16AtAddress(channel_addr_t address,
+                                 uint16_t value) override {
+    return WriteInternal(address, value, 1);
+  }
+  absl::Status WriteU32AtAddress(channel_addr_t address,
+                                 uint32_t value) override {
+    return WriteInternal(address, value, 2);
+  }
+  absl::Status WriteU64AtAddress(channel_addr_t address,
+                                 uint64_t value) override {
+    return WriteInternal(address, value, 3);
+  }
+  absl::StatusOr<uint8_t> ReadU8AtAddress(channel_addr_t address) override {
+    return ReadInternal(address, 0);
+  }
+  absl::StatusOr<uint16_t> ReadU16AtAddress(channel_addr_t address) override {
+    return ReadInternal(address, 1);
+  }
+  absl::StatusOr<uint32_t> ReadU32AtAddress(channel_addr_t address) override {
+    return ReadInternal(address, 2);
+  }
+  absl::StatusOr<uint64_t> ReadU64AtAddress(channel_addr_t address) override {
+    return ReadInternal(address, 3);
+  }
+
+  // IActive
+  absl::Status Update() override;
+
+  // IIRQ
+  bool GetIRQ() override;
+  absl::Status UpdateIRQ() override;
+
+ protected:
+  virtual absl::StatusOr<uint64_t> ReadDMAChannel(channel_addr_t address,
+                                                  uint64_t bytes_count);
+  virtual absl::Status WriteDMAChannel(channel_addr_t address, uint64_t payload,
+                                       uint64_t bytes_count);
+
+ private:
+  static const uint64_t kChannelAlignment = sizeof(uint64_t) * CHAR_BIT;
+  static const uint64_t kNumberOfDMAChannelsRegSize = sizeof(uint64_t);
+  static const uint64_t kOffsetToFirstDMAChannelRegSize = sizeof(uint64_t);
+  // DMA Channel mapping constants
+  // Reserve 64 bytes of space for each DMA Channel
+  static const uint64_t kDMAChannelAddressSpace = 64;
+  static const uint64_t kDMAChannelRegisterSize = sizeof(uint64_t);
+  static const uint64_t kDMAChannelTransferBaseAddressIdx = 0;  // 0x00 - 0x07
+  static const uint64_t kDMAChannelMaxTransferLengthIdx = 1;    // 0x08 - 0x0F
+  static const uint64_t kDMAChannelTransferredLengthIdx = 2;    // 0x10 - 0x17
+  static const uint64_t kDMAChannelControlRegIdx = 3;           // 0x18 - 0x1F
+  static const uint64_t kDMAChannelIRQIdx = 4;                  // 0x20 - 0x27
+  static const uint64_t kDMAChannelStartOfUnusedIdx = 5;        // 0x28 - 0x3F
+
+  DmaStreamManager();
+
+  absl::Status CheckAddressAlignment(channel_addr_t address,
+                                     uint64_t bytes_count);
+  uint64_t IRQBitAccess(const std::vector<bool>& bits, uint64_t bytes_count,
+                        uint64_t byte_offset, uint64_t mask) const;
+  uint64_t CalculateOffsetToFirstDMAChannel() const;
+
+  absl::StatusOr<uint64_t> ReadNumberOfDMAChannels(uint64_t byte_offset,
+                                                   uint64_t mask) const;
+  absl::StatusOr<uint64_t> ReadOffsetToFirstDMAChannel(uint64_t byte_offset,
+                                                       uint64_t mask) const;
+  absl::StatusOr<uint64_t> ReadDMAChannelIRQMask(uint64_t bytes_count,
+                                                 uint64_t byte_offset,
+                                                 uint64_t mask) const;
+  absl::StatusOr<uint64_t> ReadDMAChannelIRQ(uint64_t bytes_count,
+                                             uint64_t byte_offset,
+                                             uint64_t mask) const;
+  absl::StatusOr<uint64_t> ReadInternal(channel_addr_t address,
+                                        uint64_t log_byte_count);
+
+  absl::Status WriteNumberOfDMAChannels();
+  absl::Status WriteOffsetToFirstDMAChannel();
+  absl::Status WriteDMAChannelIRQMask(uint64_t byte_offset,
+                                      uint64_t bytes_count, uint64_t payload);
+  absl::Status WriteDMAChannelIRQ();
+  absl::Status WriteInternal(channel_addr_t address, uint64_t payload,
+                             uint64_t log_byte_count);
+
+  int64_t highest_channel_id_;
+  // size in bytes but aligned to quad words (8 bytes)
+  uint64_t offset_to_first_dma_channel_;
+  uint64_t dma_channel_irq_mask_reg_size_;
+  uint64_t dma_channel_irq_reg_size_;
+  std::map<uint64_t, std::unique_ptr<StreamDmaChannel>> id_to_channel_;
+  std::vector<bool> channel_irq_mask_;
+  std::vector<bool> active_irq_mask_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_DMASTREAMMANAGER_H_

--- a/xls/simulation/generic/dmastreammanager_test.cc
+++ b/xls/simulation/generic/dmastreammanager_test.cc
@@ -1,0 +1,321 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/dmastreammanager.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/imasterport.h"
+#include "xls/simulation/generic/istream_mock.h"
+#include "xls/simulation/generic/stream_dma_endpoint.h"
+#include "xls/simulation/generic/streamdmachannel.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using status_testing::IsOk;
+using status_testing::IsOkAndHolds;
+using status_testing::StatusIs;
+using ::testing::_;
+using ::testing::Eq;
+using ::testing::InSequence;
+using ::testing::Return;
+
+class DmaStreamManagerIMasterPortMock : public IMasterPort {
+ public:
+  MOCK_METHOD(absl::Status, RequestWrite,
+              (uint64_t address, uint64_t payload, AccessWidth width));
+  MOCK_METHOD(absl::StatusOr<uint64_t>, RequestRead,
+              (uint64_t address, AccessWidth width));
+};
+
+static std::unique_ptr<IDmaEndpoint> MakeIStreamMockEndpoint(
+    bool is_read_stream) {
+  if (is_read_stream) {
+    return std::make_unique<StreamDmaEndpoint>(
+        std::make_unique<IStreamMock<120, true>>());
+  }
+  return std::make_unique<StreamDmaEndpoint>(
+      std::make_unique<IStreamMock<120, false>>());
+}
+
+class DmaStreamManagerTest : public ::testing::Test {
+ protected:
+  DmaStreamManagerTest() : bus_master_port_(), manager_(0x10000) {}
+
+  DmaStreamManagerIMasterPortMock bus_master_port_;
+  DmaStreamManager manager_;
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(DmaStreamManagerTest, EmptyManager) {
+  EXPECT_FALSE(this->manager_.InRange(0x100));
+  EXPECT_FALSE(this->manager_.InRange(0xFFFF));
+  EXPECT_TRUE(this->manager_.InRange(0x10000));
+  EXPECT_TRUE(this->manager_.InRange(0x10001));
+  EXPECT_TRUE(this->manager_.InRange(0x1003F));
+  EXPECT_FALSE(this->manager_.InRange(0x10040));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10000), IsOkAndHolds(Eq(0ULL)));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(this->manager_.WriteU64AtAddress(0x10000, 0xDEADBEEFULL), IsOk());
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr(
+                  "Write access to RO register: NumberOfDMAChannels!"));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10008), IsOkAndHolds(Eq(64)));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10008, 0xDEADBEEFULL)),
+              IsOk());
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr(
+                  "Write access to RO register: OffsetToFirstDMAChannel!"));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10010), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10010, 0xDEADBEEFULL)),
+              IsOk());
+  // Empty Manager can't store any IRQ mask
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10010), IsOkAndHolds(Eq(0)));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10018), IsOkAndHolds(Eq(0)));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10018, 0xDEADBEEFULL)),
+              IsOk());
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("Write access to RO register: ActiveIRQs!"));
+
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10020), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("Read access to not existing register"));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10020, 0xDEADBEEFULL)),
+              IsOk());
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("Write access to not existing register"));
+
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10040), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("DMA channel with id:0 does not exist."));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10040, 0xDEADBEEFULL)),
+              IsOk());
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("DMA channel with id:0 does not exist."));
+}
+
+TEST_F(DmaStreamManagerTest, UnalignedAccess) {
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10004),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+  EXPECT_THAT(this->manager_.ReadU32AtAddress(0x10002),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+  EXPECT_THAT(this->manager_.ReadU16AtAddress(0x10001),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10004, 0xDEADBEEF)),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+  EXPECT_THAT((this->manager_.WriteU32AtAddress(0x10002, 0xDEADBEEF)),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+  EXPECT_THAT((this->manager_.WriteU16AtAddress(0x10001, 0xDEAD)),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Unaligned access, address:")));
+}
+
+TEST_F(DmaStreamManagerTest, RegisterEndpoint) {
+  EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(true), 0,
+                                              &this->bus_master_port_),
+              IsOk());
+  EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(true), 0,
+                                              &this->bus_master_port_),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       ::testing::HasSubstr("Id: 0 already in use")));
+}
+
+TEST_F(DmaStreamManagerTest, AccessDMAChannel) {
+  EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(true), 0,
+                                              &this->bus_master_port_),
+              IsOk());
+  // Common for Read and Write DMA channels
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10040), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT(
+      (this->manager_.WriteU64AtAddress(0x10040, 0xDEADBEEF8BADF00DULL)),
+      IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10040),
+              IsOkAndHolds(Eq(0xDEADBEEF8BADF00DULL)));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10048), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT(
+      (this->manager_.WriteU64AtAddress(0x10048, 0xDEADBEEF8BADF004ULL)),
+      IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10048),
+              IsOkAndHolds(Eq(0xDEADBEEF8BADF004ULL)));
+
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(
+      (this->manager_.WriteU64AtAddress(0x10050, 0xDEADBEEF8BADF004ULL)),
+      IsOk());
+  EXPECT_THAT(
+      ::testing::internal::GetCapturedStderr(),
+      ::testing::HasSubstr(
+          "Write access to DMA channel RO register: TransferredLength!"));
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10050), IsOkAndHolds(Eq(0)));
+
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10060), IsOkAndHolds(Eq(0)));
+  EXPECT_THAT(
+      (this->manager_.WriteU64AtAddress(0x10060, 0xDEADBEEF8BADF004ULL)),
+      IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10060), IsOkAndHolds(Eq(0)));
+
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10068), IsOk());
+  EXPECT_THAT(
+      ::testing::internal::GetCapturedStderr(),
+      ::testing::HasSubstr("Offset:40 doesn't map to any DMA register!"));
+  ::testing::internal::CaptureStderr();
+  EXPECT_THAT(
+      (this->manager_.WriteU64AtAddress(0x10068, 0xDEADBEEF8BADF004ULL)),
+      IsOk());
+  EXPECT_THAT(
+      ::testing::internal::GetCapturedStderr(),
+      ::testing::HasSubstr("Offset:40 doesn't map to any DMA register!"));
+
+  // Check Read DMA channel
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10058), IsOkAndHolds(Eq(0x10)));
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10058, 0x27ULL)), IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10058),
+              IsOkAndHolds(Eq(0x37LL)));
+
+  // Check Write DMA channel
+  EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(false), 1,
+                                              &this->bus_master_port_),
+              IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10098), IsOkAndHolds(Eq(0x40)));
+  EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10098, 0x27ULL)), IsOk());
+  EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10098),
+              IsOkAndHolds(Eq(0x67LL)));
+}
+
+TEST_F(DmaStreamManagerTest, TestUpdateAndIRQClearing) {
+  const int kChannelCount = 2;
+  for (int i = 0; i < kChannelCount; ++i) {
+    EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(false),
+                                                i, &this->bus_master_port_),
+                IsOk());
+    EXPECT_THAT(
+        (this->manager_.WriteU64AtAddress(0x10040 + 0x40 * i, 0x100 << i * 4)),
+        IsOk());
+    EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10048 + 0x40 * i, 0xF)),
+                IsOk());
+    EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10058 + 0x40 * i, 0x4)),
+                IsOk());
+  }
+  {
+    InSequence s;
+    for (int i = 0; i < kChannelCount; ++i) {
+      EXPECT_CALL(this->bus_master_port_,
+                  RequestRead(Eq(0x100 << 4 * i), Eq(AccessWidth::QWORD)))
+          .Times(1)
+          .WillOnce(Return(0));
+      for (int j = 8; j < 15; ++j) {
+        EXPECT_CALL(
+            this->bus_master_port_,
+            RequestRead(Eq((0x100 << 4 * i) + j), Eq(AccessWidth::BYTE)))
+            .Times(1)
+            .WillOnce(Return(0));
+      }
+    }
+  }
+  XLS_EXPECT_OK(this->manager_.Update());
+  for (int i = 0; i < kChannelCount; ++i) {
+    EXPECT_THAT(this->manager_.ReadU64AtAddress(0x10050 + 0x40 * i),
+                IsOkAndHolds(Eq(15)));
+    EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10058 + 0x40 * i)),
+                IsOkAndHolds(Eq(0x4C)));
+    EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10060 + 0x40 * i)),
+                IsOkAndHolds(Eq(0x1)));
+    EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10060 + 0x40 * i, 0x1)),
+                IsOk());
+    EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10060 + 0x40 * i)),
+                IsOkAndHolds(Eq(0)));
+  }
+}
+
+TEST_F(DmaStreamManagerTest, TestUpdateIRQAndGetIRQ) {
+  const int kChannelCount = 4;
+  for (int i = 0; i < kChannelCount; ++i) {
+    EXPECT_THAT(this->manager_.RegisterEndpoint(MakeIStreamMockEndpoint(false),
+                                                i, &this->bus_master_port_),
+                IsOk());
+    EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10058 + 0x40 * i, 0x4)),
+                IsOk());
+  }
+  XLS_EXPECT_OK(this->manager_.Update());
+  // All channels should have reached end and have IRQ ready, but masked
+  EXPECT_FALSE(this->manager_.GetIRQ());
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_FALSE(this->manager_.GetIRQ());
+  // Unmask IRQ in DMA manager, but not in DMA channels
+  XLS_EXPECT_OK((this->manager_.WriteU64AtAddress(0x10010, 0xf)));
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_FALSE(this->manager_.GetIRQ());
+  // Unmask IRQ in DMA channels
+  for (int i = 0; i < kChannelCount; ++i) {
+    EXPECT_THAT((this->manager_.WriteU64AtAddress(0x10058 + 0x40 * i, 0x5)),
+                IsOk());
+  }
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0xf)));
+  EXPECT_TRUE(this->manager_.GetIRQ());
+  XLS_EXPECT_OK((this->manager_.WriteU64AtAddress(0x10010, 0x5)));
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0xf)));
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0x5)));
+  // Mask IRQ in DMA manager
+  XLS_EXPECT_OK((this->manager_.WriteU64AtAddress(0x10010, 0x0)));
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_FALSE(this->manager_.GetIRQ());
+  // Unmask IRQ in DMA channels
+  XLS_EXPECT_OK((this->manager_.WriteU64AtAddress(0x10010, 0xf)));
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0xf)));
+  XLS_EXPECT_OK((this->manager_.WriteU64AtAddress(0x10060, 0x1)));
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0xf)));
+  XLS_EXPECT_OK(this->manager_.UpdateIRQ());
+  EXPECT_THAT((this->manager_.ReadU64AtAddress(0x10018)),
+              IsOkAndHolds(Eq(0xe)));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iactive.h
+++ b/xls/simulation/generic/iactive.h
@@ -1,0 +1,30 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IACTIVE_H_
+#define XLS_SIMULATION_GENERIC_IACTIVE_H_
+
+#include "absl/status/status.h"
+
+namespace xls::simulation::generic {
+
+class IActive {
+ public:
+  virtual ~IActive() = default;
+  virtual absl::Status Update() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IACTIVE_H_

--- a/xls/simulation/generic/iactive_stub.cc
+++ b/xls/simulation/generic/iactive_stub.cc
@@ -1,0 +1,35 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iactive_stub.h"
+
+#include "absl/status/status.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IActiveStub::IActiveStub() : cnt_(0) {}
+
+absl::Status IActiveStub::Update() {
+  XLS_LOG(INFO) << "IActiveStub tick: " << this->cnt_;
+
+  ++this->cnt_;
+  return absl::OkStatus();
+}
+
+int IActiveStub::getCnt() { return this->cnt_; }
+
+void IActiveStub::setCnt(int cnt) { this->cnt_ = cnt; }
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iactive_stub.h
+++ b/xls/simulation/generic/iactive_stub.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_
+#define XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iactive.h"
+
+namespace xls::simulation::generic {
+
+class IActiveStub : public IActive {
+ public:
+  IActiveStub();
+  virtual ~IActiveStub() = default;
+
+  int getCnt();
+  void setCnt(int cnt);
+
+  absl::Status Update() override;
+
+ private:
+  int cnt_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IACTIVE_STUB_H_

--- a/xls/simulation/generic/iactive_test.cc
+++ b/xls/simulation/generic/iactive_test.cc
@@ -1,0 +1,37 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iactive_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IActiveStubTest : public ::testing::Test {
+ protected:
+  IActiveStub stub;
+};
+
+TEST_F(IActiveStubTest, Init) { ASSERT_EQ(stub.getCnt(), 0); }
+
+TEST_F(IActiveStubTest, Update) {
+  for (auto i = 0; i < 100; ++i) {
+    ASSERT_EQ(stub.getCnt(), i);
+    XLS_EXPECT_OK(stub.Update());
+  }
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iaxistreamlike.h
+++ b/xls/simulation/generic/iaxistreamlike.h
@@ -1,0 +1,47 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_
+#define XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+// IAxiStreamLike - extension to IStream interface that provides methods
+// for managing AXI-Stream-like bits of data payload.
+class IAxiStreamLike : public IStream {
+ public:
+  virtual uint64_t GetNumSymbols() const = 0;
+  // Get the width of the underlying XLS channel symbol in bits.
+  // In the CPU-facing interface (IChannel), implementation must pad symbols
+  // with zero MSB bits to align them on 8/16/32..-bit boundaries.
+  virtual uint64_t GetSymbolWidth() const = 0;
+  // Get number of bytes occupied by a single symbol in the IChannel interface.
+  virtual uint64_t GetSymbolSize() const = 0;
+
+  // Number of data valid (TKEEP) flags must match the number of symbols.
+  virtual void SetDataValid(std::vector<bool> dataValid) = 0;
+  virtual std::vector<bool> GetDataValid() const = 0;
+
+  virtual void SetLast(bool last) = 0;
+  virtual bool GetLast() const = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_H_

--- a/xls/simulation/generic/iaxistreamlike_stub.cc
+++ b/xls/simulation/generic/iaxistreamlike_stub.cc
@@ -1,0 +1,127 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iaxistreamlike_stub.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+uint64_t IAxiStreamLikeStub::GetNumSymbols() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetNumSymbols()";
+  return 2;
+}
+
+uint64_t IAxiStreamLikeStub::GetSymbolWidth() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetSymbolWidth()";
+  return 14;
+}
+
+uint64_t IAxiStreamLikeStub::GetSymbolSize() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetSymbolSize()";
+  return 2;
+}
+
+uint64_t IAxiStreamLikeStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetChannelWidth()";
+  return 32;
+}
+
+void IAxiStreamLikeStub::SetDataValid(std::vector<bool> dataValid) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetDataValid()";
+}
+
+std::vector<bool> IAxiStreamLikeStub::GetDataValid() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetDataValid()";
+  return {true, true};
+}
+
+void IAxiStreamLikeStub::SetLast(bool last) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetLast()";
+}
+
+bool IAxiStreamLikeStub::GetLast() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetLast()";
+  return true;
+}
+
+bool IAxiStreamLikeStub::IsReadStream() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::IsReadStream()";
+  return true;
+}
+
+bool IAxiStreamLikeStub::IsReady() const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::IsReady()";
+  return true;
+}
+
+absl::Status IAxiStreamLikeStub::Transfer() {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::Transfer()";
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IAxiStreamLikeStub::GetPayloadData8(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IAxiStreamLikeStub::GetPayloadData16(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IAxiStreamLikeStub::GetPayloadData32(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IAxiStreamLikeStub::GetPayloadData64(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData8(uint64_t offset,
+                                                 uint8_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData16(uint64_t offset,
+                                                  uint16_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData32(uint64_t offset,
+                                                  uint32_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IAxiStreamLikeStub::SetPayloadData64(uint64_t offset,
+                                                  uint64_t data) {
+  XLS_LOG(INFO) << "IAxiStreamLikeStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iaxistreamlike_stub.h
+++ b/xls/simulation/generic/iaxistreamlike_stub.h
@@ -1,0 +1,56 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_
+#define XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/iaxistreamlike.h"
+
+namespace xls::simulation::generic {
+
+class IAxiStreamLikeStub : public IAxiStreamLike {
+ public:
+  // IAxiStreamLike
+
+  uint64_t GetNumSymbols() const override;
+  uint64_t GetSymbolWidth() const override;
+  uint64_t GetSymbolSize() const override;
+  void SetDataValid(std::vector<bool> dataValid) override;
+  std::vector<bool> GetDataValid() const override;
+  void SetLast(bool last) override;
+  bool GetLast() const override;
+  // IStream
+  bool IsReadStream() const override;
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+  // IChannel
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IAXISTREAMLIKE_STUB_H_

--- a/xls/simulation/generic/iaxistreamlike_stub_test.cc
+++ b/xls/simulation/generic/iaxistreamlike_stub_test.cc
@@ -1,0 +1,180 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iaxistreamlike_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IAxiStreamLikeStubTest : public ::testing::Test {
+ protected:
+  IAxiStreamLikeStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IAxiStreamLikeStubTest, GetSymbolWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetSymbolWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetSymbolWidth"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetDataValid) {
+  ::testing::internal::CaptureStderr();
+  stub.SetDataValid({true, false});
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::SetDataValid"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetDataValid) {
+  ::testing::internal::CaptureStderr();
+  stub.GetDataValid();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::GetDataValid"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetLast) {
+  ::testing::internal::CaptureStderr();
+  stub.SetLast(true);
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::SetLast"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetLast) {
+  ::testing::internal::CaptureStderr();
+  stub.GetLast();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::GetLast"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, IsReadStream) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReadStream();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::IsReadStream"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, IsReady) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReady();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::IsReady"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, Transfer) {
+  ::testing::internal::CaptureStderr();
+  auto result = stub.Transfer();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  XLS_EXPECT_OK(result);
+  EXPECT_THAT(output, ::testing::HasSubstr("IAxiStreamLikeStub::Transfer"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetChannelWidth"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData8"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData16"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData32"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::GetPayloadData64"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData8"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData16"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData32"));
+}
+
+TEST_F(IAxiStreamLikeStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output,
+              ::testing::HasSubstr("IAxiStreamLikeStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannel.h
+++ b/xls/simulation/generic/ichannel.h
@@ -1,0 +1,43 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNEL_H_
+#define XLS_SIMULATION_GENERIC_ICHANNEL_H_
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+class IChannel {
+ public:
+  virtual absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const = 0;
+  virtual absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const = 0;
+  virtual absl::Status SetPayloadData8(uint64_t offset, uint8_t data) = 0;
+  virtual absl::Status SetPayloadData16(uint64_t offset, uint16_t data) = 0;
+  virtual absl::Status SetPayloadData32(uint64_t offset, uint32_t data) = 0;
+  virtual absl::Status SetPayloadData64(uint64_t offset, uint64_t data) = 0;
+
+  virtual uint64_t GetChannelWidth() const = 0;
+
+  virtual ~IChannel() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNEL_H_

--- a/xls/simulation/generic/ichannel.h
+++ b/xls/simulation/generic/ichannel.h
@@ -19,6 +19,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
 
 namespace xls::simulation::generic {
 
@@ -36,6 +37,8 @@ class IChannel {
   virtual uint64_t GetChannelWidth() const = 0;
 
   virtual ~IChannel() = default;
+
+  uint64_t GetChannelWidthInBytes() { return BitsToBytes(GetChannelWidth()); }
 };
 
 }  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannelmanager.h
+++ b/xls/simulation/generic/ichannelmanager.h
@@ -1,0 +1,62 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_
+#define XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+class IChannelManager {
+ public:
+  using channel_addr_t = uint64_t;
+
+  virtual absl::Status WriteU8AtAddress(channel_addr_t, uint8_t) = 0;
+  virtual absl::Status WriteU16AtAddress(channel_addr_t, uint16_t) = 0;
+  virtual absl::Status WriteU32AtAddress(channel_addr_t, uint32_t) = 0;
+  virtual absl::Status WriteU64AtAddress(channel_addr_t, uint64_t) = 0;
+  virtual absl::StatusOr<uint8_t> ReadU8AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint16_t> ReadU16AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint32_t> ReadU32AtAddress(channel_addr_t) = 0;
+  virtual absl::StatusOr<uint64_t> ReadU64AtAddress(channel_addr_t) = 0;
+
+  // range: [base_address, base_address+address_range_end_)
+  explicit IChannelManager(uint64_t base_address)
+      : base_address_(base_address), address_range_end_(0) {}
+  IChannelManager(uint64_t base_address, uint64_t address_range_end)
+      : base_address_(base_address), address_range_end_(address_range_end) {}
+
+  uint64_t GetBaseAddress() const { return this->base_address_; }
+
+  bool InRange(uint64_t address) const {
+    return this->base_address_ <= address &&
+           address < (this->base_address_ + this->address_range_end_);
+  }
+
+  virtual ~IChannelManager() = default;
+
+ protected:
+  uint64_t base_address_;
+  uint64_t address_range_end_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNELMANAGER_H_

--- a/xls/simulation/generic/ichannelmanager_stub.cc
+++ b/xls/simulation/generic/ichannelmanager_stub.cc
@@ -1,0 +1,87 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ichannelmanager_stub.h"
+
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+IChannelManagerStub::IChannelManagerStub(uint64_t base_address,
+                                         uint64_t address_range_end)
+    : IChannelManager(base_address, address_range_end) {}
+
+IChannelManagerStub::~IChannelManagerStub() = default;
+
+absl::Status IChannelManagerStub::WriteU8AtAddress(uint64_t address,
+                                                   uint8_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU8AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU16AtAddress(uint64_t address,
+                                                    uint16_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU16AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU32AtAddress(uint64_t address,
+                                                    uint32_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU32AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::Status IChannelManagerStub::WriteU64AtAddress(uint64_t address,
+                                                    uint64_t value) {
+  XLS_LOG(INFO) << "IChannelManagerStub::WriteU64AtAddress()";
+
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IChannelManagerStub::ReadU8AtAddress(uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU8AtAddress()";
+
+  return 0xDE;
+}
+
+absl::StatusOr<uint16_t> IChannelManagerStub::ReadU16AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU16AtAddress()";
+
+  return 0xDEAD;
+}
+
+absl::StatusOr<uint32_t> IChannelManagerStub::ReadU32AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU32AtAddress()";
+
+  return 0xDEADBEEF;
+}
+
+absl::StatusOr<uint64_t> IChannelManagerStub::ReadU64AtAddress(
+    uint64_t address) {
+  XLS_LOG(INFO) << "IChannelManagerStub::ReadU64AtAddress()";
+
+  return 0xDEADBEEFFEEBDAED;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ichannelmanager_stub.h
+++ b/xls/simulation/generic/ichannelmanager_stub.h
@@ -1,0 +1,45 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_
+#define XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_
+
+#include <cstdint>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/ichannel.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+
+namespace xls::simulation::generic {
+
+class IChannelManagerStub : public IChannelManager {
+ public:
+  absl::Status WriteU8AtAddress(uint64_t address, uint8_t value) override;
+  absl::Status WriteU16AtAddress(uint64_t address, uint16_t value) override;
+  absl::Status WriteU32AtAddress(uint64_t address, uint32_t value) override;
+  absl::Status WriteU64AtAddress(uint64_t address, uint64_t value) override;
+  absl::StatusOr<uint8_t> ReadU8AtAddress(uint64_t address) override;
+  absl::StatusOr<uint16_t> ReadU16AtAddress(uint64_t address) override;
+  absl::StatusOr<uint32_t> ReadU32AtAddress(uint64_t address) override;
+  absl::StatusOr<uint64_t> ReadU64AtAddress(uint64_t address) override;
+
+  IChannelManagerStub(uint64_t base_address, uint64_t max_offset);
+  virtual ~IChannelManagerStub();
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICHANNELMANAGER_STUB_H_

--- a/xls/simulation/generic/ichannelmanager_stub_test.cc
+++ b/xls/simulation/generic/ichannelmanager_stub_test.cc
@@ -1,0 +1,112 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ichannelmanager_stub.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/istream_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IChannelManagerStubTest : public ::testing::Test {
+ protected:
+  IChannelManagerStub* stub;
+
+  IChannelManagerStubTest() { stub = new IChannelManagerStub(0x0, 0x200); }
+  ~IChannelManagerStubTest() { delete stub; }
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IChannelManagerStubTest, GetBaseAddress) {
+  EXPECT_EQ(stub->GetBaseAddress(), 0x0);
+}
+
+TEST_F(IChannelManagerStubTest, InRange) {
+  EXPECT_FALSE(stub->InRange(-1));
+  EXPECT_TRUE(stub->InRange(0x0));
+  EXPECT_TRUE(stub->InRange(0x1));
+  EXPECT_TRUE(stub->InRange(0x8));
+  EXPECT_FALSE(stub->InRange(0x200));
+  EXPECT_FALSE(stub->InRange(0x201));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU8AtAddress(0x0, 0xDE));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU8AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU16AtAddress(0x0, 0xDEAD));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU16AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU32AtAddress(0x0, 0xDEADBEEF));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU32AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, WriteU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->WriteU64AtAddress(0x0, 0xDEADBEEFFEEBDAED));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::WriteU64AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU8AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU8AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU16AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU16AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU32AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU32AtAddress()"));
+}
+
+TEST_F(IChannelManagerStubTest, ReadU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub->ReadU64AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IChannelManagerStub::ReadU64AtAddress()"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iconnection.h
+++ b/xls/simulation/generic/iconnection.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ICONNECTION_H_
+#define XLS_SIMULATION_GENERIC_ICONNECTION_H_
+
+#include <string_view>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IConnection is used in conjunction with IPeripheral and provides methods for
+// XLS-initiated communication with Renode:
+//  - SendResponse() is used to send a response for a request received via
+//  IPeripheral::HandleRequest().
+//  - SendRequest() is used to send peripheral-initiated requests (e.g. IRQ).
+//  - ReceiveResponse() is used to receive a response for a request transmitted
+//  via SendRequest.
+//  - Log() allows to push messages to the Renode's logging subsystem.
+class IConnection {
+ public:
+  virtual absl::Status Log(absl::LogSeverity level, std::string_view msg) = 0;
+  virtual ~IConnection() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ICONNECTION_H_

--- a/xls/simulation/generic/iconnection.h
+++ b/xls/simulation/generic/iconnection.h
@@ -20,6 +20,7 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/imasterport.h"
 
 namespace xls::simulation::generic {
 
@@ -33,6 +34,7 @@ namespace xls::simulation::generic {
 //  - Log() allows to push messages to the Renode's logging subsystem.
 class IConnection {
  public:
+  virtual IMasterPort* GetMasterPort() = 0;
   virtual absl::Status Log(absl::LogSeverity level, std::string_view msg) = 0;
   virtual ~IConnection() = default;
 };

--- a/xls/simulation/generic/idmaendpoint.h
+++ b/xls/simulation/generic/idmaendpoint.h
@@ -1,0 +1,55 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_
+#define XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_
+
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IDmaEndpoint represents a peripheral end of a 1D DMA channel.
+//
+// It allows to transfer a stream of fixed-size elements, and supports framing
+// those elements into packets by flagging the last element of the transfer.
+// User can query the size of a single element, as well as a maximum number of
+// elements that a single transfer can fit. In general, transferring any number
+// of elements between 0 and maximum should be supported by the implementation.
+//
+// Transfers with number of bytes not divisible by the element size, are deemed
+// as erroneous. Empty transfers (zero bytes) are supported by the interface,
+// however, an implemnentation is allowed to ignore them.
+class IDmaEndpoint {
+ public:
+  struct Payload {
+    std::vector<uint8_t> data;
+    bool last;
+  };
+
+  virtual ~IDmaEndpoint() = default;
+
+  virtual uint64_t GetElementSize() const = 0;
+  virtual uint64_t GetMaxElementsPerTransfer() const = 0;
+  virtual bool IsReadStream() const = 0;
+  virtual bool IsReady() const = 0;
+  virtual absl::Status Write(Payload payload) = 0;
+  virtual absl::StatusOr<Payload> Read() = 0;
+};
+
+};  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IDMAENDPOINT_H_

--- a/xls/simulation/generic/iirq.h
+++ b/xls/simulation/generic/iirq.h
@@ -1,0 +1,31 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IIRQ_H_
+#define XLS_SIMULATION_GENERIC_IIRQ_H_
+
+#include "absl/status/status.h"
+
+namespace xls::simulation::generic {
+
+class IIRQ {
+ public:
+  virtual ~IIRQ() = default;
+  virtual bool GetIRQ() = 0;
+  virtual absl::Status UpdateIRQ() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IIRQ_H_

--- a/xls/simulation/generic/iirq_stub.cc
+++ b/xls/simulation/generic/iirq_stub.cc
@@ -1,0 +1,41 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iirq_stub.h"
+
+#include <functional>
+
+#include "absl/status/status.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IIRQStub::IIRQStub() : status_(false), policy_([] { return true; }) {}
+
+bool IIRQStub::GetIRQ() {
+  XLS_LOG(INFO) << "IIRQStub::GetIRQ()";
+  return this->status_;
+}
+
+absl::Status IIRQStub::UpdateIRQ() {
+  XLS_LOG(INFO) << "IIRQStub::UpdateIRQ()";
+  this->status_ = this->policy_();
+  return absl::OkStatus();
+}
+
+void IIRQStub::SetPolicy(std::function<bool(void)> policy) {
+  this->policy_ = policy;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iirq_stub.h
+++ b/xls/simulation/generic/iirq_stub.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IIRQ_STUB_H_
+#define XLS_SIMULATION_GENERIC_IIRQ_STUB_H_
+
+#include <functional>
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iirq.h"
+
+namespace xls::simulation::generic {
+
+class IIRQStub : public IIRQ {
+ public:
+  IIRQStub();
+  virtual ~IIRQStub() = default;
+
+  bool GetIRQ() override;
+  absl::Status UpdateIRQ() override;
+
+  void SetPolicy(std::function<bool(void)> policy);
+
+ private:
+  bool status_;
+  std::function<bool(void)> policy_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IIRQ_STUB_H_

--- a/xls/simulation/generic/iirq_test.cc
+++ b/xls/simulation/generic/iirq_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iirq_stub.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IIRQStubTest : public ::testing::Test {
+ protected:
+  IIRQStub stub;
+};
+
+TEST_F(IIRQStubTest, Init) {
+  // stub should not request any interrupt after initialization
+  ASSERT_EQ(stub.GetIRQ(), false);
+}
+
+TEST_F(IIRQStubTest, UpdateIRQ) {
+  // with the default stub implementation,
+  // UpdateIRQ should change the internal interrupt state from false to true
+  ASSERT_EQ(stub.GetIRQ(), false);
+  XLS_EXPECT_OK(stub.UpdateIRQ());
+  EXPECT_EQ(stub.GetIRQ(), true);
+}
+
+TEST_F(IIRQStubTest, GetIRQ) {
+  // consecutive reads using GetIRQ should have the same value
+  ASSERT_EQ(stub.GetIRQ(), false);
+  EXPECT_EQ(stub.GetIRQ(), false);
+  EXPECT_EQ(stub.GetIRQ(), false);
+  XLS_EXPECT_OK(stub.UpdateIRQ());
+  EXPECT_EQ(stub.GetIRQ(), true);
+  EXPECT_EQ(stub.GetIRQ(), true);
+  EXPECT_EQ(stub.GetIRQ(), true);
+}
+
+TEST_F(IIRQStubTest, SetPolicy) {
+  // stub should be able to change the existing policy
+  bool prev = false;
+  std::function<bool(void)> alternate_policy = [&prev] {
+    prev = !prev;
+    return prev;
+  };
+
+  stub.SetPolicy(alternate_policy);
+  bool prev_policy = stub.GetIRQ();
+  for (int i = 0; i < 100; ++i) {
+    XLS_EXPECT_OK(stub.UpdateIRQ());
+    EXPECT_EQ(stub.GetIRQ(), !prev_policy);
+    prev_policy = stub.GetIRQ();
+  }
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/imasterport.h
+++ b/xls/simulation/generic/imasterport.h
@@ -1,0 +1,36 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IMASTERPORT_H_
+#define XLS_SIMULATION_GENERIC_IMASTERPORT_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
+
+namespace xls::simulation::generic {
+
+class IMasterPort {
+ public:
+  virtual absl::Status RequestWrite(uint64_t address, uint64_t value,
+                                    AccessWidth type) = 0;
+  virtual absl::StatusOr<uint64_t> RequestRead(uint64_t address,
+                                               AccessWidth type) = 0;
+
+  virtual ~IMasterPort() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IMASTERPORT_H_

--- a/xls/simulation/generic/iperipheral.h
+++ b/xls/simulation/generic/iperipheral.h
@@ -1,0 +1,52 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IPERIPHERAL_H_
+#define XLS_SIMULATION_GENERIC_IPERIPHERAL_H_
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+
+namespace xls::simulation::generic {
+
+// IPeripheral is used in conjunction with IConnection,
+// and implements callbacks for:
+// - read/write operations,
+// - reset,
+// - IRQ and
+// - simulation tick.
+// Calls:
+//  - CheckRequest() checks if address is mapped to channel manager
+//  - HandleRead() reads data from address `addr`
+//  - HandleWrite() writes data starting ad address `addr`
+//  - HandleIRQ() checks if any IRQ is ready
+//  - HandleTick() advances simulation
+//  - Reset() is used to reset a peripheral.
+class IPeripheral {
+ public:
+  virtual absl::Status CheckRequest(uint64_t addr, AccessWidth width) = 0;
+  virtual absl::StatusOr<uint64_t> HandleRead(uint64_t addr,
+                                              AccessWidth width) = 0;
+  virtual absl::Status HandleWrite(uint64_t addr, AccessWidth width,
+                                   uint64_t payload) = 0;
+  virtual absl::StatusOr<IRQEnum> HandleIRQ() = 0;
+  virtual absl::Status HandleTick() = 0;
+
+  virtual absl::Status Reset() = 0;
+  virtual ~IPeripheral() = default;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IPERIPHERAL_H_

--- a/xls/simulation/generic/iperipheral.h
+++ b/xls/simulation/generic/iperipheral.h
@@ -17,6 +17,7 @@
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "xls/simulation/generic/common.h"
 
 namespace xls::simulation::generic {
 

--- a/xls/simulation/generic/iperipheral_stub.cc
+++ b/xls/simulation/generic/iperipheral_stub.cc
@@ -1,0 +1,64 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iperipheral_stub.h"
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+IPeripheralStub::IPeripheralStub() {
+  XLS_LOG(INFO) << "IPeripheralStub::IPeripheralStub()";
+}
+
+absl::Status IPeripheralStub::CheckRequest(uint64_t addr, AccessWidth width) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::CheckRequest(addr=%lu, width=%d)", addr, width);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint64_t> IPeripheralStub::HandleRead(uint64_t addr,
+                                                     AccessWidth width) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::HandleRead(addr=%lu, width=%d), returns 0", addr,
+      width);
+  return 0;
+}
+
+absl::Status IPeripheralStub::HandleWrite(uint64_t addr, AccessWidth width,
+                                          uint64_t payload) {
+  XLS_LOG(INFO) << absl::StreamFormat(
+      "IPeripheralStub::HandleWrite(addr=%lu, width=%d, payload=%lu)", addr,
+      width, payload);
+  return absl::OkStatus();
+}
+
+absl::StatusOr<IRQEnum> IPeripheralStub::HandleIRQ() {
+  XLS_LOG(INFO) << absl::StreamFormat("IPeripheralStub::HandleIRQ()");
+  return IRQEnum::NoChange;
+}
+
+absl::Status IPeripheralStub::HandleTick() {
+  XLS_LOG(INFO) << absl::StreamFormat("IPeripheralStub::HandleTick()");
+  return absl::OkStatus();
+}
+
+absl::Status IPeripheralStub::Reset() {
+  XLS_LOG(INFO) << "IPeripheralStub::Reset()";
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iperipheral_stub.h
+++ b/xls/simulation/generic/iperipheral_stub.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_
+#define XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/iperipheral.h"
+
+namespace xls::simulation::generic {
+
+class IPeripheralStub : public IPeripheral {
+ public:
+  IPeripheralStub();
+  absl::Status CheckRequest(uint64_t addr, AccessWidth width) override;
+  absl::StatusOr<uint64_t> HandleRead(uint64_t addr,
+                                      AccessWidth width) override;
+  absl::Status HandleWrite(uint64_t addr, AccessWidth width,
+                           uint64_t payload) override;
+  absl::StatusOr<IRQEnum> HandleIRQ() override;
+  absl::Status HandleTick() override;
+
+  absl::Status Reset() override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IPERIPHERAL_STUB_H_

--- a/xls/simulation/generic/ir_axistreamlike.cc
+++ b/xls/simulation/generic/ir_axistreamlike.cc
@@ -1,0 +1,287 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_axistreamlike.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "absl/strings/str_format.h"
+#include "xls/ir/value.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/simulation/generic/ir_value_access_methods.h"
+
+namespace xls::simulation::generic {
+
+/* static */ absl::StatusOr<IrAxiStreamLike> IrAxiStreamLike::Make(
+    xls::ChannelQueue* queue, bool multisymbol, uint64_t data_value_index,
+    std::optional<uint64_t> tlast_value_index,
+    std::optional<uint64_t> tkeep_value_index) {
+  if (queue->channel()->kind() != xls::ChannelKind::kStreaming) {
+    return absl::InvalidArgumentError(
+        "Make expects queue from a Streaming channel.");
+  }
+  if (queue->channel()->supported_ops() == ChannelOps::kSendReceive) {
+    return absl::InvalidArgumentError(
+        "Given a bidirectional channel. These are not supported.");
+  }
+  // Check the type of the queue
+  const auto type = queue->channel()->type();
+  if (!type->IsTuple()) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Channel type must be a Tuple, not '%s'", type->ToString()));
+  }
+  auto tuple = type->AsTupleOrDie();
+  // Check index specifications
+  if (data_value_index >= tuple->size()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("DATA index %u is out of bounds of the "
+                        "specified channel type %s",
+                        data_value_index, type->ToString()));
+  }
+  if (multisymbol) {
+    // Type of the DATA element must be an array
+    auto eltype = tuple->element_type(data_value_index);
+    if (!eltype->IsArray()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "DATA value idx=%u should be of array type, but it is '%s'",
+          data_value_index, eltype->ToString()));
+    }
+  }
+  if (tlast_value_index) {
+    auto idx = *tlast_value_index;
+    if (idx >= tuple->size()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "TLAST index %u is out of bounds of the specified channel type %s",
+          idx, type->ToString()));
+    }
+    // TLAST must point to bits[1] type
+    auto eltype = tuple->element_type(idx);
+    if (!eltype->IsBits() || eltype->AsBitsOrDie()->bit_count() != 1) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "TLAST value idx=%u should be of type 'bits[1]', but it is '%s'", idx,
+          eltype->ToString()));
+    }
+  }
+  if (tkeep_value_index) {
+    auto idx = *tkeep_value_index;
+    if (idx >= tuple->size()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "TKEEP index %u is out of bounds of the specified channel type %s",
+          idx, type->ToString()));
+    }
+    // TKEEP must have correct size
+    uint64_t expected_size =
+        multisymbol
+            ? tuple->element_type(data_value_index)->AsArrayOrDie()->size()
+            : 1;
+    auto eltype = tuple->element_type(idx);
+    if (!eltype->IsBits() ||
+        eltype->AsBitsOrDie()->bit_count() != expected_size) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "TKEEP value idx=%u should be of type 'bits[%u]', but it is '%s'",
+          idx, expected_size, eltype->ToString()));
+    }
+  }
+  return IrAxiStreamLike(queue, multisymbol, data_value_index,
+                         tlast_value_index, tkeep_value_index);
+}
+
+IrAxiStreamLike::IrAxiStreamLike(xls::ChannelQueue* queue, bool multisymbol,
+                                 uint64_t data_index,
+                                 std::optional<uint64_t> tlast_index,
+                                 std::optional<uint64_t> tkeep_index)
+    : queue_(queue),
+      multisymbol_(multisymbol),
+      data_index_(data_index),
+      tlast_index_(tlast_index),
+      tkeep_index_(tkeep_index) {
+  auto chan_type = queue->channel()->type()->AsTupleOrDie();
+  auto data_type = chan_type->element_type(data_index);
+  auto sym_type =
+      multisymbol ? data_type->AsArrayOrDie()->element_type() : data_type;
+  num_symbols_ = multisymbol ? data_type->AsArrayOrDie()->size() : 1;
+  symbol_bits_ = sym_type->GetFlatBitCount();
+  symbol_bytes_padded_ = (symbol_bits_ + 7) / 8;
+  zero_padding_ = Value(Bits(symbol_bytes_padded_ * 8 - symbol_bits_));
+  zero_payload_ = ZeroOfType(chan_type);
+  read_channel_ = queue->channel()->CanSend();
+  // Initialize all CPU-accessible registers including data holding register
+  // which will include padding
+  UnpackChannelPayload(zero_payload_);
+}
+
+Value IrAxiStreamLike::PackChannelPayload() {
+  // Start with a zero-filled payload
+  std::vector<Value> payload{zero_payload_.elements().begin(),
+                             zero_payload_.elements().end()};
+  // Fill data item
+  if (multisymbol_) {
+    std::vector<Value> symbols;
+    for (size_t i = 0; i < num_symbols_; i++) {
+      // odd-indexed values are padding, skip them
+      symbols.push_back(data_reg_[2 * i]);
+    }
+    payload[data_index_] = Value::ArrayOrDie(symbols);
+  } else {
+    payload[data_index_] = data_reg_[0];
+  }
+  // Fill TLAST
+  if (tlast_index_) {
+    payload[*tlast_index_] =
+        Value(Bits(absl::InlinedVector<bool, 1>({tlast_reg_})));
+  }
+  // Fill TKEEP
+  if (tkeep_index_) {
+    payload[*tkeep_index_] = Value(Bits(tkeep_reg_));
+  }
+  return Value::Tuple(payload);
+}
+
+void IrAxiStreamLike::UnpackChannelPayload(const Value& value) {
+  XLS_CHECK(value.SameTypeAs(zero_payload_));
+  // unpack data payload + add padding for CPU
+  const auto& data_value = value.element(data_index_);
+  data_reg_.clear();
+  if (multisymbol_) {
+    // data_value is an array
+    for (size_t i = 0; i < data_value.size(); i++) {
+      data_reg_.push_back(data_value.element(i));
+      data_reg_.push_back(zero_padding_);
+    }
+  } else {
+    XLS_CHECK_EQ(data_value.GetFlatBitCount(), symbol_bits_);
+    data_reg_.push_back(data_value);
+  }
+  // unpack tlast & tkeep
+  if (tlast_index_) {
+    const auto& tlast_value = value.element(*tlast_index_);
+    tlast_reg_ = tlast_value.bits().Get(0);
+  } else {
+    tlast_reg_ = false;
+  }
+  if (tkeep_index_) {
+    const auto& tkeep_value = value.element(*tkeep_index_);
+    tkeep_reg_ = tkeep_value.bits().ToBitVector();
+  } else {
+    tkeep_reg_.clear();
+    tkeep_reg_.resize(num_symbols_, true);
+  }
+}
+
+absl::StatusOr<uint64_t> IrAxiStreamLike::DataRead(uint64_t offset,
+                                                   uint64_t byte_count) const {
+  // Note: data_reg_ already includes inter-symbol padding
+  XLS_ASSIGN_OR_RETURN(
+      uint64_t ans,
+      ValueArrayReadUInt64(data_reg_, this->queue_->channel()->name(), offset,
+                           byte_count));
+  return ans;
+}
+
+absl::Status IrAxiStreamLike::DataWrite(uint64_t offset, uint64_t data,
+                                        uint64_t byte_count) {
+  // Note: data_reg_ already includes inter-symbol padding
+  XLS_ASSIGN_OR_RETURN(
+      auto data_reg,
+      ValueArrayWriteUInt64(data_reg_, this->queue_->channel()->name(), offset,
+                            byte_count, data));
+  data_reg_ = data_reg;
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IrAxiStreamLike::GetPayloadData8(
+    uint64_t offset) const {
+  return DataRead(offset, 1);
+}
+
+absl::StatusOr<uint16_t> IrAxiStreamLike::GetPayloadData16(
+    uint64_t offset) const {
+  return DataRead(offset, 2);
+}
+
+absl::StatusOr<uint32_t> IrAxiStreamLike::GetPayloadData32(
+    uint64_t offset) const {
+  return DataRead(offset, 4);
+}
+
+absl::StatusOr<uint64_t> IrAxiStreamLike::GetPayloadData64(
+    uint64_t offset) const {
+  return DataRead(offset, 8);
+}
+
+absl::Status IrAxiStreamLike::SetPayloadData8(uint64_t offset, uint8_t data) {
+  return DataWrite(offset, data, 1);
+}
+
+absl::Status IrAxiStreamLike::SetPayloadData16(uint64_t offset, uint16_t data) {
+  return DataWrite(offset, data, 2);
+}
+
+absl::Status IrAxiStreamLike::SetPayloadData32(uint64_t offset, uint32_t data) {
+  return DataWrite(offset, data, 4);
+}
+
+absl::Status IrAxiStreamLike::SetPayloadData64(uint64_t offset, uint64_t data) {
+  return DataWrite(offset, data, 8);
+}
+
+bool IrAxiStreamLike::IsReady() const {
+  if (read_channel_) {
+    // Read FIFO
+    return !queue_->IsEmpty();
+  }
+  // Write FIFO
+  return queue_->GetSize() < kWriteFifoMaxDepth;
+}
+
+absl::Status IrAxiStreamLike::Transfer() {
+  if (read_channel_) {
+    std::optional<Value> read_value = queue_->Read();
+    if (!read_value) {
+      return absl::InternalError(absl::StrFormat(
+          "Streaming queue '%s' is empty", queue_->channel()->name()));
+    }
+    UnpackChannelPayload(*read_value);
+    return absl::OkStatus();
+  }
+
+  if (queue_->GetSize() >= kWriteFifoMaxDepth) {
+    return absl::InternalError(
+        absl::StrFormat("Streaming queue '%s' overflown, data is lost",
+                        queue_->channel()->name()));
+  }
+
+  XLS_RETURN_IF_ERROR(queue_->Write(PackChannelPayload()));
+  return absl::OkStatus();
+}
+
+void IrAxiStreamLike::SetDataValid(std::vector<bool> dataValid) {
+  XLS_CHECK_EQ(dataValid.size(), num_symbols_);
+  for (size_t i = 0; i < num_symbols_; i++) {
+    tkeep_reg_[i] = dataValid[i];
+  }
+}
+
+std::vector<bool> IrAxiStreamLike::GetDataValid() const {
+  std::vector<bool> ret(num_symbols_);
+  std::copy(tkeep_reg_.begin(), tkeep_reg_.end(), ret.begin());
+  return ret;
+}
+
+void IrAxiStreamLike::SetLast(bool last) { tlast_reg_ = last; }
+
+bool IrAxiStreamLike::GetLast() const { return tlast_reg_; }
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_axistreamlike.h
+++ b/xls/simulation/generic/ir_axistreamlike.h
@@ -1,0 +1,114 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IR_AXISTREAMLIKE_H_
+#define XLS_SIMULATION_GENERIC_IR_AXISTREAMLIKE_H_
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/value.h"
+#include "xls/simulation/generic/iaxistreamlike.h"
+
+namespace xls::simulation::generic {
+
+class IrAxiStreamLike : public IAxiStreamLike {
+ public:
+  // TODO(rdobrodii): 2023-09-13 Add field to configuration file that will
+  // set write FIFO limit. For now use 4 as limit.
+  static const int kWriteFifoMaxDepth = 4;
+
+  // - multisymbol controls how the data payload is treated:
+  //   - if it is 'true', data element should be an array of size N. In this
+  //   case AXI Stream-like protocol assumes that
+  // data contains N symbols which can be individually set to be present or
+  // absent with the help of TKEEP signal.
+  //   - if it is 'false', data element can be of any time. In this case AXI
+  //   Stream-like protocol assumes that the data
+  // contains a single symbol (N=1), and if TKEEP is present, its length will
+  // be 1.
+  // - data_value_index specifies the index of xls::Value element used to convey
+  // data.
+  // - tlast_value_index should specify a bits[1] tuple member that is used to
+  // convey TLAST AXI Stream value
+  // - tkeep_value_index should specify a bits[N] tuple member that is used to
+  // convey TKEEP AXI Stream value
+  static absl::StatusOr<IrAxiStreamLike> Make(
+      xls::ChannelQueue* queue, bool multisymbol, uint64_t data_value_index,
+      std::optional<uint64_t> tlast_value_index,
+      std::optional<uint64_t> tkeep_value_index);
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  uint64_t GetChannelWidth() const override {
+    return num_symbols_ * symbol_bytes_padded_ * 8;
+  }
+  uint64_t GetNumSymbols() const override { return num_symbols_; }
+  uint64_t GetSymbolWidth() const override { return symbol_bits_; }
+  uint64_t GetSymbolSize() const override { return symbol_bytes_padded_; }
+
+  bool IsReadStream() const override { return read_channel_; }
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+
+  void SetDataValid(std::vector<bool> dataValid) override;
+  std::vector<bool> GetDataValid() const override;
+
+  void SetLast(bool last) override;
+  bool GetLast() const override;
+
+ private:
+  explicit IrAxiStreamLike(xls::ChannelQueue* queue, bool multisymbol,
+                           uint64_t data_index,
+                           std::optional<uint64_t> tlast_index,
+                           std::optional<uint64_t> tkeep_index);
+
+  Value PackChannelPayload();
+  void UnpackChannelPayload(const Value& value);
+  absl::StatusOr<uint64_t> DataRead(uint64_t offset, uint64_t byte_count) const;
+  absl::Status DataWrite(uint64_t offset, uint64_t data, uint64_t byte_count);
+
+  xls::ChannelQueue* queue_{};
+  bool multisymbol_;
+  uint64_t data_index_;
+  std::optional<uint64_t> tlast_index_;
+  std::optional<uint64_t> tkeep_index_;
+  bool read_channel_;
+  uint64_t num_symbols_;
+  uint64_t symbol_bits_;
+  uint64_t symbol_bytes_padded_;
+  xls::Value zero_payload_;
+  xls::Value zero_padding_;
+  // data_reg_ this has length of 2N: even elements are data, odd are padding
+  std::vector<xls::Value> data_reg_;
+  bool tlast_reg_;
+  absl::InlinedVector<bool, 1> tkeep_reg_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IR_AXISTREAMLIKE_H_

--- a/xls/simulation/generic/ir_axistreamlike_test.cc
+++ b/xls/simulation/generic/ir_axistreamlike_test.cc
@@ -1,0 +1,578 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_axistreamlike.h"
+
+#include <exception>
+#include <memory>
+#include <new>
+#include <optional>
+#include <stdexcept>
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/channel.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/package.h"
+#include "xls/ir/value_helpers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using ::testing::Optional;
+
+class MakeTest : public IrTestBase {
+ protected:
+  MakeTest() : package_(TestName()) {}
+  void SetUp() final {
+    // Single-symbol channel type
+    std::vector<Type*> single_members = {
+        package_.GetBitsType(2),   // padding
+        package_.GetBitsType(11),  // data
+        package_.GetBitsType(1),   // tlast
+        package_.GetBitsType(1),   // tkeep
+        package_.GetBitsType(5),   // padding
+    };
+    singlesymbol_type_ = package_.GetTupleType(single_members);
+    // Multi-symbol channel type
+    std::vector<Type*> multi_members = {
+        package_.GetBitsType(2),                             // padding
+        package_.GetArrayType(3, package_.GetBitsType(11)),  // data
+        package_.GetBitsType(1),                             // tlast
+        package_.GetBitsType(3),                             // tkeep
+        package_.GetBitsType(5),                             // padding
+    };
+    multisymbol_type_ = package_.GetTupleType(multi_members);
+  }
+
+  Package package_;
+  TupleType* singlesymbol_type_;
+  TupleType* multisymbol_type_;
+};
+
+TEST_F(MakeTest, RecvSingle) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel(
+          "my_channel", ChannelOps::kReceiveOnly, singlesymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(IrAxiStreamLike::Make(&queue, false, 1, 2, 3),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeTest, RecvMulti) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel(
+          "my_channel", ChannelOps::kReceiveOnly, multisymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(IrAxiStreamLike::Make(&queue, true, 1, 2, 3),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeTest, SendSingle) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel("my_channel", ChannelOps::kSendOnly,
+                                            singlesymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(IrAxiStreamLike::Make(&queue, false, 1, 2, 3),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeTest, SendMulti) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel("my_channel", ChannelOps::kSendOnly,
+                                            multisymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(IrAxiStreamLike::Make(&queue, true, 1, 2, 3),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeTest, SingleForMulti) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel(
+          "my_channel", ChannelOps::kReceiveOnly, multisymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(IrAxiStreamLike::Make(&queue, false, 1, 2, 3),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr("TKEEP value idx=3 should be of type")));
+}
+
+TEST_F(MakeTest, MultiForSingle) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel(
+          "my_channel", ChannelOps::kReceiveOnly, singlesymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(
+      IrAxiStreamLike::Make(&queue, true, 1, 2, 3),
+      xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          testing::HasSubstr("DATA value idx=1 should be of array type")));
+}
+
+TEST_F(MakeTest, Bidirectional) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel(
+          "my_channel", ChannelOps::kSendReceive, singlesymbol_type_));
+  ChannelQueue queue = ChannelQueue(channel);
+  EXPECT_THAT(
+      IrAxiStreamLike::Make(&queue, false, 1, 2, 3),
+      xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          testing::HasSubstr(
+              "Given a bidirectional channel. These are not supported.")));
+}
+
+class SingleSymbolReadTest : public IrTestBase {
+ protected:
+  SingleSymbolReadTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),   // padding
+        package_.GetBitsType(11),  // data
+        package_.GetBitsType(1),   // tlast
+        package_.GetBitsType(5),   // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kSendOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    dut_ = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), false, 1, 2, std::nullopt).value());
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<IrAxiStreamLike> dut_;
+};
+
+TEST_F(SingleSymbolReadTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), true);
+}
+
+TEST_F(SingleSymbolReadTest, GetNumSymbols) {
+  EXPECT_EQ(dut_->GetNumSymbols(), 1);
+}
+
+TEST_F(SingleSymbolReadTest, GetSymbolWidth) {
+  // 11 bits symbol payload
+  EXPECT_EQ(dut_->GetSymbolWidth(), 11);
+}
+
+TEST_F(SingleSymbolReadTest, GetSymbolSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetSymbolSize(), 2);
+}
+
+TEST_F(SingleSymbolReadTest, GetChannelWidth) {
+  // Width of all padded symbols combined, in bits
+  EXPECT_EQ(dut_->GetChannelWidth(), 16);
+}
+
+TEST_F(SingleSymbolReadTest, Transfer) {
+  EXPECT_FALSE(dut_->IsReady());
+  // fill the queue
+  XLS_ASSERT_OK(queue_->Write(ZeroOfType(type_)));
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(queue_->Write(ZeroOfType(type_)));
+  EXPECT_TRUE(this->dut_->IsReady());
+  // read out
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_FALSE(this->dut_->IsReady());
+  // check handling of underflow
+  EXPECT_THAT(dut_->Transfer(),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal,
+                                            testing::HasSubstr("is empty")));
+  EXPECT_FALSE(this->dut_->IsReady());
+}
+
+TEST_F(SingleSymbolReadTest, ReadDefault) {
+  EXPECT_EQ(dut_->GetLast(), false);
+  EXPECT_EQ(dut_->GetDataValid(), std::vector<bool>{true});
+  EXPECT_THAT(dut_->GetPayloadData8(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData16(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData32(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData64(0), xls::status_testing::IsOkAndHolds(0));
+}
+
+TEST_F(SingleSymbolReadTest, ReadPayload) {
+  auto payload = Value::Tuple({
+      Value(UBits(0x3, 2)),     // pad
+      Value(UBits(0x7AB, 11)),  // data
+      Value(UBits(1, 1)),       // tlast
+      Value(UBits(0x11, 5)),    // pad
+  });
+  XLS_ASSERT_OK(queue_->Write(payload));
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_EQ(dut_->GetLast(), true);
+  EXPECT_EQ(dut_->GetDataValid(), std::vector<bool>{true});
+  EXPECT_THAT(dut_->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0xAB));
+  EXPECT_THAT(dut_->GetPayloadData8(1),
+              xls::status_testing::IsOkAndHolds(0x07));
+  EXPECT_THAT(dut_->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x7AB));
+  EXPECT_THAT(dut_->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x7AB));
+  EXPECT_THAT(dut_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0x7AB));
+  EXPECT_THAT(dut_->GetPayloadData8(2),
+              xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                            testing::HasSubstr("is outside")));
+}
+
+class SingleSymbolWriteTest : public IrTestBase {
+ protected:
+  SingleSymbolWriteTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),   // padding
+        package_.GetBitsType(11),  // data
+        package_.GetBitsType(1),   // tlast
+        package_.GetBitsType(5),   // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kReceiveOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    dut_ = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), false, 1, 2, std::nullopt).value());
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<IrAxiStreamLike> dut_;
+};
+
+TEST_F(SingleSymbolWriteTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), false);
+}
+
+TEST_F(SingleSymbolWriteTest, GetNumSymbols) {
+  EXPECT_EQ(dut_->GetNumSymbols(), 1);
+}
+
+TEST_F(SingleSymbolWriteTest, GetSymbolWidth) {
+  // 11 bits symbol payload
+  EXPECT_EQ(dut_->GetSymbolWidth(), 11);
+}
+
+TEST_F(SingleSymbolWriteTest, GetSymbolSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetSymbolSize(), 2);
+}
+
+TEST_F(SingleSymbolWriteTest, GetChannelWidth) {
+  // Width of all padded symbols combined, in bits
+  EXPECT_EQ(dut_->GetChannelWidth(), 16);
+}
+
+TEST_F(SingleSymbolWriteTest, Transfer) {
+  EXPECT_TRUE(dut_->IsReady());
+  for (uint32_t i = 0; i < IrAxiStreamLike::kWriteFifoMaxDepth; i++) {
+    XLS_ASSERT_OK(dut_->Transfer());
+  }
+  EXPECT_FALSE(dut_->IsReady());
+  // check handling of overflow
+  EXPECT_THAT(dut_->Transfer(),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInternal,
+                  testing::HasSubstr("overflown, data is lost")));
+  for (uint32_t i = 0; i < IrAxiStreamLike::kWriteFifoMaxDepth; i++) {
+    EXPECT_EQ(queue_->Read()->empty(), false);
+    EXPECT_TRUE(dut_->IsReady());
+  }
+  EXPECT_EQ(queue_->IsEmpty(), true);
+}
+
+TEST_F(SingleSymbolWriteTest, ReadDefault) {
+  EXPECT_EQ(dut_->GetLast(), false);
+  EXPECT_EQ(dut_->GetDataValid(), std::vector<bool>{{true}});
+  EXPECT_THAT(dut_->GetPayloadData8(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData16(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData32(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData64(0), xls::status_testing::IsOkAndHolds(0));
+}
+
+TEST_F(SingleSymbolWriteTest, WritePayload) {
+  dut_->SetLast(true);
+  XLS_ASSERT_OK(dut_->SetPayloadData64(0, 0x7AB));
+  EXPECT_THAT(dut_->SetPayloadData64(2, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                            testing::HasSubstr("is outside")));
+  XLS_ASSERT_OK(dut_->Transfer());
+  auto popt = queue_->Read();
+  EXPECT_EQ(popt->empty(), false);
+  auto payload = *popt;
+  auto payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),       // pad
+      Value(UBits(0x7AB, 11)),  // data
+      Value(UBits(1, 1)),       // tlast
+      Value(UBits(0, 5)),       // pad
+  });
+
+  EXPECT_EQ(payload, payload_ref);
+}
+
+class MultiSymbolReadTest : public IrTestBase {
+ protected:
+  MultiSymbolReadTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),                             // padding
+        package_.GetArrayType(3, package_.GetBitsType(11)),  // data
+        package_.GetBitsType(3),                             // tkeep
+        package_.GetBitsType(1),                             // tlast
+        package_.GetBitsType(5),                             // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kSendOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    dut_ = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), true, 1, 3, 2).value());
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<IrAxiStreamLike> dut_;
+};
+
+TEST_F(MultiSymbolReadTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), true);
+}
+
+TEST_F(MultiSymbolReadTest, GetNumSymbols) {
+  EXPECT_EQ(dut_->GetNumSymbols(), 3);
+}
+
+TEST_F(MultiSymbolReadTest, GetSymbolWidth) {
+  // 11 bits symbol payload
+  EXPECT_EQ(dut_->GetSymbolWidth(), 11);
+}
+
+TEST_F(MultiSymbolReadTest, GetSymbolSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetSymbolSize(), 2);
+}
+
+TEST_F(MultiSymbolReadTest, GetChannelWidth) {
+  // Width of all padded symbols combined, in bits
+  EXPECT_EQ(dut_->GetChannelWidth(), 48);
+}
+
+TEST_F(MultiSymbolReadTest, Transfer) {
+  EXPECT_FALSE(dut_->IsReady());
+  // fill the queue
+  XLS_ASSERT_OK(queue_->Write(ZeroOfType(type_)));
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(queue_->Write(ZeroOfType(type_)));
+  EXPECT_TRUE(this->dut_->IsReady());
+  // read out
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_TRUE(this->dut_->IsReady());
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_FALSE(this->dut_->IsReady());
+  // check handling of underflow
+  EXPECT_THAT(dut_->Transfer(),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal,
+                                            testing::HasSubstr("is empty")));
+  EXPECT_FALSE(this->dut_->IsReady());
+}
+
+TEST_F(MultiSymbolReadTest, ReadDefault) {
+  EXPECT_EQ(dut_->GetLast(), false);
+  auto valid_ref = std::vector<bool>{{false, false, false}};
+  EXPECT_EQ(dut_->GetDataValid(), valid_ref);
+  EXPECT_THAT(dut_->GetPayloadData8(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData16(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData32(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData64(0), xls::status_testing::IsOkAndHolds(0));
+}
+
+TEST_F(MultiSymbolReadTest, ReadPayload) {
+  auto payload = Value::Tuple({
+      Value(UBits(0x3, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x4CD, 11)),
+                       Value(UBits(0x7AB, 11)),
+                       Value(UBits(0x511, 11)),
+                   })
+          .value(),           // data
+      Value(UBits(0x6, 3)),   // tkeep
+      Value(UBits(1, 1)),     // tlast
+      Value(UBits(0x11, 5)),  // pad
+  });
+  XLS_ASSERT_OK(queue_->Write(payload));
+  XLS_ASSERT_OK(dut_->Transfer());
+  EXPECT_EQ(dut_->GetLast(), true);
+  auto valid_ref = std::vector<bool>{{false, true, true}};
+  EXPECT_EQ(dut_->GetDataValid(), valid_ref);
+  EXPECT_THAT(dut_->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0xCD));
+  EXPECT_THAT(dut_->GetPayloadData8(1),
+              xls::status_testing::IsOkAndHolds(0x04));
+  EXPECT_THAT(dut_->GetPayloadData8(2),
+              xls::status_testing::IsOkAndHolds(0xAB));
+  EXPECT_THAT(dut_->GetPayloadData8(3),
+              xls::status_testing::IsOkAndHolds(0x07));
+  EXPECT_THAT(dut_->GetPayloadData8(4),
+              xls::status_testing::IsOkAndHolds(0x11));
+  EXPECT_THAT(dut_->GetPayloadData8(5),
+              xls::status_testing::IsOkAndHolds(0x05));
+  EXPECT_THAT(dut_->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x4CD));
+  EXPECT_THAT(dut_->GetPayloadData16(1),
+              xls::status_testing::IsOkAndHolds(0xAB04));
+  EXPECT_THAT(dut_->GetPayloadData16(2),
+              xls::status_testing::IsOkAndHolds(0x07AB));
+  EXPECT_THAT(dut_->GetPayloadData16(4),
+              xls::status_testing::IsOkAndHolds(0x511));
+  EXPECT_THAT(dut_->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x07AB04CD));
+  EXPECT_THAT(dut_->GetPayloadData32(4),
+              xls::status_testing::IsOkAndHolds(0x511));
+  EXPECT_THAT(dut_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0x051107AB04CD));
+  EXPECT_THAT(dut_->GetPayloadData8(6),
+              xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                            testing::HasSubstr("is outside")));
+}
+
+class MultiSymbolWriteTest : public IrTestBase {
+ protected:
+  MultiSymbolWriteTest() : package_(TestName()) {}
+  void SetUp() override {
+    std::vector<Type*> members = {
+        package_.GetBitsType(2),                             // padding
+        package_.GetArrayType(3, package_.GetBitsType(11)),  // data
+        package_.GetBitsType(3),                             // tkeep
+        package_.GetBitsType(1),                             // tlast
+        package_.GetBitsType(5),                             // padding
+    };
+    type_ = package_.GetTupleType(members);
+    auto chn = this->package_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kReceiveOnly, type_);
+    XLS_ASSERT_OK(chn);
+    channel_ = chn.value();
+    queue_ = std::make_unique<ChannelQueue>(channel_);
+    dut_ = std::make_unique<IrAxiStreamLike>(
+        IrAxiStreamLike::Make(queue_.get(), true, 1, 3, 2).value());
+  }
+  Package package_;
+  TupleType* type_;
+  Channel* channel_;
+  std::unique_ptr<ChannelQueue> queue_;
+  std::unique_ptr<IrAxiStreamLike> dut_;
+};
+
+TEST_F(MultiSymbolWriteTest, IsReadStream) {
+  EXPECT_EQ(dut_->IsReadStream(), false);
+}
+
+TEST_F(MultiSymbolWriteTest, GetNumSymbols) {
+  EXPECT_EQ(dut_->GetNumSymbols(), 3);
+}
+
+TEST_F(MultiSymbolWriteTest, GetSymbolWidth) {
+  // 11 bits symbol payload
+  EXPECT_EQ(dut_->GetSymbolWidth(), 11);
+}
+
+TEST_F(MultiSymbolWriteTest, GetSymbolSize) {
+  // 11 bits padded to 16=2x8 bits, so 2 bytes
+  EXPECT_EQ(dut_->GetSymbolSize(), 2);
+}
+
+TEST_F(MultiSymbolWriteTest, GetChannelWidth) {
+  // Width of all padded symbols combined, in bits
+  EXPECT_EQ(dut_->GetChannelWidth(), 48);
+}
+
+TEST_F(MultiSymbolWriteTest, Transfer) {
+  EXPECT_TRUE(dut_->IsReady());
+  for (uint32_t i = 0; i < IrAxiStreamLike::kWriteFifoMaxDepth; i++) {
+    XLS_ASSERT_OK(dut_->Transfer());
+  }
+  EXPECT_FALSE(dut_->IsReady());
+  // check handling of overflow
+  EXPECT_THAT(dut_->Transfer(),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInternal,
+                  testing::HasSubstr("overflown, data is lost")));
+  for (uint32_t i = 0; i < IrAxiStreamLike::kWriteFifoMaxDepth; i++) {
+    EXPECT_EQ(queue_->Read()->empty(), false);
+    EXPECT_TRUE(dut_->IsReady());
+  }
+  EXPECT_EQ(queue_->IsEmpty(), true);
+}
+
+TEST_F(MultiSymbolWriteTest, ReadDefault) {
+  EXPECT_EQ(dut_->GetLast(), false);
+  auto valid_ref = std::vector<bool>{{false, false, false}};
+  EXPECT_EQ(dut_->GetDataValid(), valid_ref);
+  EXPECT_THAT(dut_->GetPayloadData8(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData16(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData32(0), xls::status_testing::IsOkAndHolds(0));
+  EXPECT_THAT(dut_->GetPayloadData64(0), xls::status_testing::IsOkAndHolds(0));
+}
+
+TEST_F(MultiSymbolWriteTest, WritePayload) {
+  dut_->SetLast(true);
+  dut_->SetDataValid(std::vector<bool>{{true, true, false}});
+  XLS_ASSERT_OK(dut_->SetPayloadData64(0, 0x01AC07BA02DD));
+  EXPECT_THAT(dut_->SetPayloadData64(6, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument,
+                                            testing::HasSubstr("is outside")));
+  XLS_ASSERT_OK(dut_->Transfer());
+  auto popt = queue_->Read();
+  EXPECT_EQ(popt->empty(), false);
+  auto payload = *popt;
+  auto payload_ref = Value::Tuple({
+      Value(UBits(0, 2)),  // pad
+      Value::Array({
+                       Value(UBits(0x2DD, 11)),
+                       Value(UBits(0x7BA, 11)),
+                       Value(UBits(0x1AC, 11)),
+                   })
+          .value(),          // data
+      Value(UBits(0x3, 3)),  // tkeep
+      Value(UBits(1, 1)),    // tlast
+      Value(UBits(0, 5)),    // pad
+  });
+
+  EXPECT_EQ(payload, payload_ref);
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_single_value.cc
+++ b/xls/simulation/generic/ir_single_value.cc
@@ -1,0 +1,108 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_single_value.h"
+
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/value.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/simulation/generic/ir_value_access_methods.h"
+
+namespace xls::simulation::generic {
+
+/* static */ absl::StatusOr<IRSingleValue> IRSingleValue::MakeIRSingleValue(
+    xls::ChannelQueue* queue) {
+  if (queue->channel()->kind() != xls::ChannelKind::kSingleValue)
+    return absl::InvalidArgumentError(
+        "MakeIRSingleValue expects queue with SingleValueChannel channel.");
+  return IRSingleValue(queue);
+}
+
+IRSingleValue::IRSingleValue(xls::ChannelQueue* queue)
+    : ir_single_value_queue_(queue) {}
+
+absl::StatusOr<uint64_t> IRSingleValue::InternalRead(uint64_t offset,
+                                                     int count) const {
+  Value value_ = ZeroOfType(this->ir_single_value_queue_->channel()->type());
+  std::optional<Value> read_value = this->ir_single_value_queue_->Read();
+  if (read_value.has_value()) value_ = read_value.value();
+  std::vector<Value> input;
+  input.push_back(value_);
+  XLS_ASSIGN_OR_RETURN(
+      uint64_t ans, ValueArrayReadUInt64(
+                        input, this->ir_single_value_queue_->channel()->name(),
+                        offset, count));
+  return ans;
+}
+
+absl::StatusOr<uint8_t> IRSingleValue::GetPayloadData8(uint64_t offset) const {
+  return InternalRead(offset, 1);
+}
+
+absl::StatusOr<uint16_t> IRSingleValue::GetPayloadData16(
+    uint64_t offset) const {
+  return InternalRead(offset, 2);
+}
+
+absl::StatusOr<uint32_t> IRSingleValue::GetPayloadData32(
+    uint64_t offset) const {
+  return InternalRead(offset, 4);
+}
+
+absl::StatusOr<uint64_t> IRSingleValue::GetPayloadData64(
+    uint64_t offset) const {
+  return InternalRead(offset, 8);
+}
+
+absl::Status IRSingleValue::InternalWrite(uint64_t offset, uint64_t data,
+                                          int count) {
+  Value value_ = ZeroOfType(this->ir_single_value_queue_->channel()->type());
+  std::optional<Value> read_value = this->ir_single_value_queue_->Read();
+  if (read_value.has_value()) value_ = read_value.value();
+  std::vector<Value> input;
+  input.push_back(value_);
+  XLS_ASSIGN_OR_RETURN(
+      std::vector<Value> output_,
+      ValueArrayWriteUInt64(input,
+                            this->ir_single_value_queue_->channel()->name(),
+                            offset, count, data));
+  XLS_CHECK_OK(this->ir_single_value_queue_->Write(output_[0]));
+  return absl::OkStatus();
+}
+
+absl::Status IRSingleValue::SetPayloadData8(uint64_t offset, uint8_t data) {
+  return InternalWrite(offset, data, 1);
+}
+
+absl::Status IRSingleValue::SetPayloadData16(uint64_t offset, uint16_t data) {
+  return InternalWrite(offset, data, 2);
+}
+
+absl::Status IRSingleValue::SetPayloadData32(uint64_t offset, uint32_t data) {
+  return InternalWrite(offset, data, 4);
+}
+
+absl::Status IRSingleValue::SetPayloadData64(uint64_t offset, uint64_t data) {
+  return InternalWrite(offset, data, 8);
+}
+
+uint64_t IRSingleValue::GetChannelWidth() const {
+  return this->ir_single_value_queue_->channel()->type()->GetFlatBitCount();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_single_value.h
+++ b/xls/simulation/generic/ir_single_value.h
@@ -1,0 +1,62 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IR_SINGLE_VALUE_H_
+#define XLS_SIMULATION_GENERIC_IR_SINGLE_VALUE_H_
+
+#include "absl/status/statusor.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+class IRSingleValue : public IRegister {
+ public:
+  static absl::StatusOr<IRSingleValue> MakeIRSingleValue(xls::ChannelQueue*);
+
+  IRSingleValue(IRSingleValue&& old)
+      : ir_single_value_queue_(old.ir_single_value_queue_) {}
+
+  IRSingleValue& operator=(IRSingleValue&& rvalue_) {
+    this->ir_single_value_queue_ = rvalue_.ir_single_value_queue_;
+    return *this;
+  }
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  uint64_t GetChannelWidth() const override;
+
+  ~IRSingleValue() = default;
+
+ private:
+  IRSingleValue();
+  explicit IRSingleValue(xls::ChannelQueue*);
+
+  absl::StatusOr<uint64_t> InternalRead(uint64_t, int) const;
+  absl::Status InternalWrite(uint64_t, uint64_t, int);
+
+  xls::ChannelQueue* ir_single_value_queue_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IR_SINGLE_VALUE_H_

--- a/xls/simulation/generic/ir_single_value_test.cc
+++ b/xls/simulation/generic/ir_single_value_test.cc
@@ -1,0 +1,324 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_single_value.h"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/channel.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/package.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using ::testing::Optional;
+
+class MakeIrSingleValueQueueTest : public IrTestBase {};
+
+TEST_F(MakeIrSingleValueQueueTest, MakeIRSingleValue) {
+  Package package(TestName());
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      package.CreateSingleValueChannel("my_channel", ChannelOps::kSendReceive,
+                                       package.GetBitsType(64)));
+  std::unique_ptr<ChannelQueue> single_value_queue =
+      std::make_unique<ChannelQueue>(channel);
+  EXPECT_THAT(IRSingleValue::MakeIRSingleValue(single_value_queue.get()),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeIrSingleValueQueueTest, MakeIRSinglValueNotSingleValueChannel) {
+  Package package(TestName());
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      package.CreateStreamingChannel("my_channel", ChannelOps::kSendReceive,
+                                     package.GetBitsType(64)));
+  std::unique_ptr<ChannelQueue> single_value_queue =
+      std::make_unique<ChannelQueue>(channel);
+  EXPECT_THAT(
+      IRSingleValue::MakeIRSingleValue(single_value_queue.get()),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+class IrSingleValueQueueTest : public IrTestBase {
+ protected:
+  void SetUp() {
+    this->pkg = std::make_unique<Package>(TestName());
+    auto new_channel_ = pkg->CreateSingleValueChannel(
+        "my_channel", ChannelOps::kSendReceive, this->pkg->GetBitsType(64));
+    XLS_ASSERT_OK(new_channel_);
+    Channel* channel_ = new_channel_.value();
+    this->single_value_queue = std::make_unique<ChannelQueue>(channel_);
+    this->test_obj = std::make_unique<IRSingleValue>(
+        IRSingleValue::MakeIRSingleValue(this->single_value_queue.get())
+            .value());
+  }
+
+  std::unique_ptr<Package> pkg;
+  std::unique_ptr<ChannelQueue> single_value_queue;
+  std::unique_ptr<IRSingleValue> test_obj;
+};
+
+TEST_F(IrSingleValueQueueTest, GetChannelWidth) {
+  EXPECT_EQ(this->test_obj->GetChannelWidth(), 64);
+}
+
+TEST_F(IrSingleValueQueueTest, ReadByte) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0x10));
+  EXPECT_THAT(this->test_obj->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0x10));
+  EXPECT_THAT(this->test_obj->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0x10));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x3210));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x3210));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x3210));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadDoubleWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x76543210));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x76543210));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x76543210));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadQuadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadIncorrectOffsetByte) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->GetPayloadData8(16),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, ReadIncorrectOffsetWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->GetPayloadData16(16),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, ReadIncorrectOffsetDoubleWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->GetPayloadData32(16),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, ReadIncorrectOffsetQuadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->GetPayloadData64(16),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, ReadPartialWord) {
+  EXPECT_THAT(this->test_obj->GetPayloadData16(7),
+              xls::status_testing::IsOkAndHolds(0));
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(7),
+              xls::status_testing::IsOkAndHolds(0xFE));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(7),
+              xls::status_testing::IsOkAndHolds(0xFE));
+  EXPECT_THAT(this->test_obj->GetPayloadData16(7),
+              xls::status_testing::IsOkAndHolds(0xFE));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadPartialDoubleWord) {
+  EXPECT_THAT(this->test_obj->GetPayloadData32(6),
+              xls::status_testing::IsOkAndHolds(0));
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(6),
+              xls::status_testing::IsOkAndHolds(0xFEDC));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(6),
+              xls::status_testing::IsOkAndHolds(0xFEDC));
+  EXPECT_THAT(this->test_obj->GetPayloadData32(6),
+              xls::status_testing::IsOkAndHolds(0xFEDC));
+}
+
+TEST_F(IrSingleValueQueueTest, ReadPartialQuadWord) {
+  EXPECT_THAT(this->test_obj->GetPayloadData64(5),
+              xls::status_testing::IsOkAndHolds(0));
+  XLS_ASSERT_OK(
+      this->single_value_queue->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(5),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(5),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA));
+  EXPECT_THAT(this->test_obj->GetPayloadData64(5),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA));
+}
+
+TEST_F(IrSingleValueQueueTest, WriteByte) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData8(0, 0x10),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x10, 64))));
+
+  EXPECT_THAT(this->test_obj->SetPayloadData8(1, 0x10),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x1010, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WriteWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData16(0, 0x3210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x3210, 64))));
+
+  EXPECT_THAT(this->test_obj->SetPayloadData16(1, 0x3210),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x321010, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WriteDoubleWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData32(0, 0x76543210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x76543210, 64))));
+
+  EXPECT_THAT(this->test_obj->SetPayloadData32(2, 0x76543210),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x765432103210, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WriteQuadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData64(0, 0xFEDCBA9876543210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0xFEDCBA9876543210, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WriteIncorrectOffsetByte) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->SetPayloadData8(16, 0),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, WriteIncorrectOffsetWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->SetPayloadData16(16, 0),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, WriteIncorrectOffsetDoubleWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->SetPayloadData32(16, 0),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, WriteIncorrectOffsetQuadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(
+      this->test_obj->SetPayloadData64(16, 0),
+      xls::status_testing::StatusIs(absl::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+}
+
+TEST_F(IrSingleValueQueueTest, WritePartialWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData16(7, 0x3210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x1000000000000000, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WritePartialDoubleWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData32(6, 0x76543210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x3210000000000000, 64))));
+}
+
+TEST_F(IrSingleValueQueueTest, WritePartialQuadWord) {
+  EXPECT_TRUE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->test_obj->SetPayloadData64(5, 0xFEDCBA9876543210),
+              xls::status_testing::IsOk());
+  EXPECT_FALSE(this->single_value_queue->IsEmpty());
+  EXPECT_THAT(this->single_value_queue->Read(),
+              Optional(Value(UBits(0x5432100000000000, 64))));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_stream.cc
+++ b/xls/simulation/generic/ir_stream.cc
@@ -1,0 +1,141 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_stream.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/value.h"
+#include "xls/ir/value_helpers.h"
+#include "xls/simulation/generic/ir_value_access_methods.h"
+
+namespace xls::simulation::generic {
+
+/* static */ absl::StatusOr<IRStream> IRStream::MakeIRStream(
+    xls::ChannelQueue* queue) {
+  if (queue->channel()->kind() != xls::ChannelKind::kStreaming)
+    return absl::InvalidArgumentError(
+        "MakeIRStream expects queue with Streaming channel.");
+  if (queue->channel()->CanSend() && queue->channel()->CanReceive())
+    return absl::InvalidArgumentError(
+        "MakeIRStream expects unidirectional Streaming channel.");
+  return IRStream(queue);
+}
+
+IRStream::IRStream(xls::ChannelQueue* queue)
+    : read_channel_(queue->channel()->CanSend()),
+      holding_reg_(ZeroOfType(queue->channel()->type())),
+      ir_stream_queue_(queue) {}
+
+absl::StatusOr<uint64_t> IRStream::InternalRead(uint64_t offset,
+                                                int count) const {
+  std::vector<Value> input;
+  input.push_back(this->holding_reg_);
+  XLS_ASSIGN_OR_RETURN(
+      uint64_t ans,
+      ValueArrayReadUInt64(input, this->ir_stream_queue_->channel()->name(),
+                           offset, count));
+  return ans;
+}
+
+absl::StatusOr<uint8_t> IRStream::GetPayloadData8(uint64_t offset) const {
+  return InternalRead(offset, 1);
+}
+
+absl::StatusOr<uint16_t> IRStream::GetPayloadData16(uint64_t offset) const {
+  return InternalRead(offset, 2);
+}
+
+absl::StatusOr<uint32_t> IRStream::GetPayloadData32(uint64_t offset) const {
+  return InternalRead(offset, 4);
+}
+
+absl::StatusOr<uint64_t> IRStream::GetPayloadData64(uint64_t offset) const {
+  return InternalRead(offset, 8);
+}
+
+absl::Status IRStream::InternalWrite(uint64_t offset, uint64_t data,
+                                     int count) {
+  std::vector<Value> input;
+  input.push_back(this->holding_reg_);
+  XLS_ASSIGN_OR_RETURN(
+      auto holding_reg_,
+      ValueArrayWriteUInt64(input, this->ir_stream_queue_->channel()->name(),
+                            offset, count, data));
+
+  // IRStream holding register consists of a single xls::Value
+  // Output vector from ValueArrayWriteUInt64 only has single element
+  // at index 0
+  this->holding_reg_ = holding_reg_[0];
+  return absl::OkStatus();
+}
+
+absl::Status IRStream::SetPayloadData8(uint64_t offset, uint8_t data) {
+  return InternalWrite(offset, data, 1);
+}
+
+absl::Status IRStream::SetPayloadData16(uint64_t offset, uint16_t data) {
+  return InternalWrite(offset, data, 2);
+}
+
+absl::Status IRStream::SetPayloadData32(uint64_t offset, uint32_t data) {
+  return InternalWrite(offset, data, 4);
+}
+
+absl::Status IRStream::SetPayloadData64(uint64_t offset, uint64_t data) {
+  return InternalWrite(offset, data, 8);
+}
+
+uint64_t IRStream::GetChannelWidth() const {
+  return this->holding_reg_.GetFlatBitCount();
+}
+
+bool IRStream::IsReadStream() const { return this->read_channel_; }
+
+bool IRStream::IsReady() const {
+  if (this->read_channel_) {
+    // Read FIFO
+    return !this->ir_stream_queue_->IsEmpty();
+  }
+  // Write FIFO
+  return this->ir_stream_queue_->GetSize() < this->kWriteFifoMaxDepth;
+}
+
+absl::Status IRStream::Transfer() {
+  if (this->read_channel_) {
+    std::optional<Value> read_value = this->ir_stream_queue_->Read();
+    if (!read_value.has_value())
+      return absl::InternalError(
+          "Streaming queue: " + this->ir_stream_queue_->channel()->name() +
+          " was empty during read");
+    this->holding_reg_ = read_value.value();
+    return absl::OkStatus();
+  }
+
+  if (this->ir_stream_queue_->GetSize() >= this->kWriteFifoMaxDepth)
+    return absl::InternalError(
+        "Streaming queue: " + this->ir_stream_queue_->channel()->name() +
+        " overfill");
+
+  XLS_CHECK_OK(this->ir_stream_queue_->Write(this->holding_reg_));
+  this->holding_reg_ = ZeroOfType(this->ir_stream_queue_->channel()->type());
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_stream.h
+++ b/xls/simulation/generic/ir_stream.h
@@ -1,0 +1,78 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IR_STREAM_H_
+#define XLS_SIMULATION_GENERIC_IR_STREAM_H_
+
+#include <stdint.h>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/value.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+class IRStream : public IStream {
+ public:
+  static absl::StatusOr<IRStream> MakeIRStream(xls::ChannelQueue*);
+  IRStream(IRStream&& old)
+      : read_channel_(old.read_channel_),
+        holding_reg_(old.holding_reg_),
+        ir_stream_queue_(old.ir_stream_queue_) {}
+
+  IRStream& operator=(IRStream&& rvalue_) {
+    this->read_channel_ = rvalue_.read_channel_;
+    this->holding_reg_ = rvalue_.holding_reg_;
+    this->ir_stream_queue_ = rvalue_.ir_stream_queue_;
+    return *this;
+  }
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  virtual ~IRStream() = default;
+
+  uint64_t GetChannelWidth() const override;
+
+  bool IsReadStream() const override;
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+
+ private:
+  // TODO(mtdudek): 2023-09-01 Add field to configuration file that will
+  // set write FIFO limit. For now use 4 as limit.
+  const int kWriteFifoMaxDepth = 4;
+
+  IRStream();
+  explicit IRStream(xls::ChannelQueue*);
+
+  absl::StatusOr<uint64_t> InternalRead(uint64_t, int) const;
+  absl::Status InternalWrite(uint64_t, uint64_t, int);
+
+  bool read_channel_;
+  xls::Value holding_reg_;
+  xls::ChannelQueue* ir_stream_queue_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IR_STREAM_H_

--- a/xls/simulation/generic/ir_stream_test.cc
+++ b/xls/simulation/generic/ir_stream_test.cc
@@ -1,0 +1,327 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_stream.h"
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/interpreter/channel_queue.h"
+#include "xls/ir/channel.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/ir/package.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using ::testing::Optional;
+
+class MakeIrStreamQueueTest : public IrTestBase {
+ protected:
+  MakeIrStreamQueueTest() : package_(TestName()) {}
+  Package package_;
+};
+
+TEST_F(MakeIrStreamQueueTest, MakeIRStreamRead) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Channel * channel,
+      this->package_.CreateStreamingChannel("my_channel", ChannelOps::kSendOnly,
+                                            this->package_.GetBitsType(64)));
+  ChannelQueue single_value_queue = ChannelQueue(channel);
+  EXPECT_THAT(IRStream::MakeIRStream(&single_value_queue),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeIrStreamQueueTest, MakeIRStreamWrite) {
+  XLS_ASSERT_OK_AND_ASSIGN(Channel * channel,
+                           this->package_.CreateStreamingChannel(
+                               "my_channel", ChannelOps::kReceiveOnly,
+                               this->package_.GetBitsType(64)));
+  ChannelQueue single_value_queue = ChannelQueue(channel);
+  EXPECT_THAT(IRStream::MakeIRStream(&single_value_queue),
+              xls::status_testing::IsOk());
+}
+
+TEST_F(MakeIrStreamQueueTest, MakeIRStreamReadWrite) {
+  XLS_ASSERT_OK_AND_ASSIGN(Channel * channel,
+                           this->package_.CreateStreamingChannel(
+                               "my_channel", ChannelOps::kSendReceive,
+                               this->package_.GetBitsType(64)));
+  std::unique_ptr<ChannelQueue> single_value_queue =
+      std::make_unique<ChannelQueue>(channel);
+  EXPECT_THAT(
+      IRStream::MakeIRStream(single_value_queue.get()),
+      xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          testing::HasSubstr(
+              "MakeIRStream expects unidirectional Streaming channel.")));
+}
+
+TEST_F(MakeIrStreamQueueTest, MakeIRStreamWithSingleValueChannel) {
+  XLS_ASSERT_OK_AND_ASSIGN(Channel * channel,
+                           this->package_.CreateSingleValueChannel(
+                               "my_channel", ChannelOps::kSendReceive,
+                               this->package_.GetBitsType(64)));
+  std::unique_ptr<ChannelQueue> single_value_queue =
+      std::make_unique<ChannelQueue>(channel);
+  EXPECT_THAT(IRStream::MakeIRStream(single_value_queue.get()),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr(
+                      "MakeIRStream expects queue with Streaming channel.")));
+}
+
+class IrStreamReadQueueTest : public IrTestBase {
+ protected:
+  IrStreamReadQueueTest() : pkg_(Package(TestName())) {}
+  void SetUp() {
+    auto new_channel_ = this->pkg_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kSendOnly, this->pkg_.GetBitsType(64));
+    XLS_ASSERT_OK(new_channel_);
+    Channel* channel_ = new_channel_.value();
+    this->stream_queue_ = std::make_unique<ChannelQueue>(channel_);
+    this->test_obj_ = std::make_unique<IRStream>(
+        IRStream::MakeIRStream(this->stream_queue_.get()).value());
+  }
+
+  Package pkg_;
+  std::unique_ptr<ChannelQueue> stream_queue_;
+  std::unique_ptr<IRStream> test_obj_;
+};
+
+TEST_F(IrStreamReadQueueTest, GetChannelWidth) {
+  EXPECT_EQ(this->test_obj_->GetChannelWidth(), 64);
+}
+
+TEST_F(IrStreamReadQueueTest, IsReadStream) {
+  EXPECT_EQ(this->test_obj_->IsReadStream(), true);
+}
+
+TEST_F(IrStreamReadQueueTest, IsReady) {
+  EXPECT_FALSE(this->test_obj_->IsReady());
+  XLS_ASSERT_OK(
+      this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_TRUE(this->test_obj_->IsReady());
+
+  this->stream_queue_->Read();
+  EXPECT_TRUE(this->stream_queue_->IsEmpty());
+  EXPECT_FALSE(this->test_obj_->IsReady());
+}
+
+TEST_F(IrStreamReadQueueTest, Transfer) {
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0x0));
+  EXPECT_FALSE(this->test_obj_->IsReady());
+  EXPECT_THAT(this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))),
+              xls::status_testing::IsOk());
+  EXPECT_EQ(this->test_obj_->IsReady(), !this->stream_queue_->IsEmpty());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+
+  EXPECT_EQ(this->stream_queue_->IsEmpty(), true);
+  EXPECT_EQ(this->test_obj_->IsReady(), false);
+
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+
+  EXPECT_THAT(this->test_obj_->Transfer(),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInternal,
+                  testing::HasSubstr("was empty during read")));
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+}
+
+class IrStreamWriteQueueTest : public IrTestBase {
+ protected:
+  IrStreamWriteQueueTest() : pkg_(Package(TestName())) {}
+
+  void SetUp() {
+    auto new_channel_ = this->pkg_.CreateStreamingChannel(
+        "my_channel", ChannelOps::kReceiveOnly, this->pkg_.GetBitsType(64));
+    XLS_ASSERT_OK(new_channel_);
+    Channel* channel_ = new_channel_.value();
+    this->stream_queue_ = std::make_unique<ChannelQueue>(channel_);
+    this->test_obj_ = std::make_unique<IRStream>(
+        IRStream::MakeIRStream(this->stream_queue_.get()).value());
+  }
+
+  Package pkg_;
+  std::unique_ptr<ChannelQueue> stream_queue_;
+  std::unique_ptr<IRStream> test_obj_;
+};
+
+TEST_F(IrStreamWriteQueueTest, GetChannelWidth) {
+  EXPECT_EQ(this->test_obj_->GetChannelWidth(), 64);
+}
+
+TEST_F(IrStreamWriteQueueTest, IsReadStream) {
+  EXPECT_EQ(this->test_obj_->IsReadStream(), false);
+}
+
+TEST_F(IrStreamWriteQueueTest, IsReady) {
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  XLS_ASSERT_OK(
+      this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  XLS_ASSERT_OK(
+      this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  XLS_ASSERT_OK(
+      this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  XLS_ASSERT_OK(
+      this->stream_queue_->Write(Value(UBits(0xFEDCBA9876543210, 64))));
+  EXPECT_FALSE(this->test_obj_->IsReady());
+}
+
+TEST_F(IrStreamWriteQueueTest, Transfer) {
+  EXPECT_THAT(this->test_obj_->SetPayloadData64(0, 0xFEDCBA9876543210),
+              xls::status_testing::IsOk());
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+  EXPECT_TRUE(this->test_obj_->IsReady());
+  EXPECT_THAT(this->stream_queue_->Read(),
+              Optional(Value(UBits(0xFEDCBA9876543210, 64))));
+
+  ASSERT_TRUE(this->stream_queue_->IsEmpty());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->Transfer(), xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->Transfer(),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal,
+                                            testing::HasSubstr("overfill")));
+}
+
+class IRStreamInternalBufferTestBase
+    : public IrTestBase,
+      public testing::WithParamInterface<xls::ChannelOps> {
+ protected:
+  IRStreamInternalBufferTestBase() : pkg_(Package(TestName())) {}
+
+  void SetUp() {
+    auto new_channel_ = this->pkg_.CreateStreamingChannel(
+        "my_channel", GetParam(), this->pkg_.GetBitsType(64));
+    XLS_ASSERT_OK(new_channel_);
+    Channel* channel_ = new_channel_.value();
+    this->stream_queue_ = std::make_unique<ChannelQueue>(channel_);
+    this->test_obj_ = std::make_unique<IRStream>(
+        IRStream::MakeIRStream(this->stream_queue_.get()).value());
+  }
+
+  Package pkg_;
+  std::unique_ptr<ChannelQueue> stream_queue_;
+  std::unique_ptr<IRStream> test_obj_;
+};
+
+// 2 following tests check that reads/writes to the IRStream only modify
+// internal register and keep queue state instact.
+TEST_P(IRStreamInternalBufferTestBase,
+       TestReadAccessMethodNoQueueModification) {
+  EXPECT_TRUE(this->stream_queue_->IsEmpty());
+
+  xls::Value queue_payload = Value(UBits(0xFEDCBA9876543210, 64));
+  auto queue_check = [&]() {
+    EXPECT_EQ(this->stream_queue_->GetSize(), 1);
+    EXPECT_THAT(this->stream_queue_->Read(), Optional(queue_payload));
+    XLS_ASSERT_OK(this->stream_queue_->Write(queue_payload));
+  };
+
+  XLS_ASSERT_OK(this->stream_queue_->Write(queue_payload));
+  EXPECT_EQ(this->stream_queue_->GetSize(), 1);
+
+  EXPECT_THAT(this->test_obj_->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0x0));
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x0));
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x0));
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0x0));
+  queue_check();
+}
+
+TEST_P(IRStreamInternalBufferTestBase,
+       TestWriteAccessMethodNoQueueModification) {
+  EXPECT_TRUE(this->stream_queue_->IsEmpty());
+
+  xls::Value queue_payload = Value(UBits(0xFEDCBA9876543210, 64));
+  auto queue_check = [&]() {
+    EXPECT_EQ(this->stream_queue_->GetSize(), 1);
+    EXPECT_THAT(this->stream_queue_->Read(), Optional(queue_payload));
+    XLS_ASSERT_OK(this->stream_queue_->Write(queue_payload));
+  };
+
+  XLS_ASSERT_OK(this->stream_queue_->Write(queue_payload));
+  EXPECT_EQ(this->stream_queue_->GetSize(), 1);
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData8(0, 0x0),
+              xls::status_testing::IsOk());
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData16(0, 0x0),
+              xls::status_testing::IsOk());
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData32(0, 0x0),
+              xls::status_testing::IsOk());
+  queue_check();
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData64(0, 0x0),
+              xls::status_testing::IsOk());
+  queue_check();
+}
+
+TEST_P(IRStreamInternalBufferTestBase, TestInternalBuffer) {
+  EXPECT_THAT(this->test_obj_->SetPayloadData64(0, 0xFEDCBA9876543210),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->GetPayloadData8(0),
+              xls::status_testing::IsOkAndHolds(0x10));
+  EXPECT_THAT(this->test_obj_->GetPayloadData16(0),
+              xls::status_testing::IsOkAndHolds(0x3210));
+  EXPECT_THAT(this->test_obj_->GetPayloadData32(0),
+              xls::status_testing::IsOkAndHolds(0x76543210));
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCBA9876543210));
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData8(5, 0x0),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDC009876543210));
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData16(4, 0xFF00),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCFF0076543210));
+
+  EXPECT_THAT(this->test_obj_->SetPayloadData32(0, 0xDEADBEEF),
+              xls::status_testing::IsOk());
+  EXPECT_THAT(this->test_obj_->GetPayloadData64(0),
+              xls::status_testing::IsOkAndHolds(0xFEDCFF00DEADBEEF));
+}
+
+INSTANTIATE_TEST_SUITE_P(IRStreamCommon, IRStreamInternalBufferTestBase,
+                         testing::Values(ChannelOps::kReceiveOnly,
+                                         ChannelOps::kSendOnly));
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_value_access_methods.cc
+++ b/xls/simulation/generic/ir_value_access_methods.cc
@@ -1,0 +1,169 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_value_access_methods.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/bits.h"
+#include "xls/ir/value.h"
+
+namespace xls::simulation::generic {
+
+static absl::Status ReadBits(const Value value_node,
+                             uint64_t& processed_value_bits,
+                             uint64_t const start_bit,
+                             uint64_t& used_payload_bits,
+                             uint64_t const bits_to_read, uint64_t& payload_) {
+  if (value_node.IsToken() || value_node.kind() == ValueKind::kInvalid)
+    return absl::InternalError("Got token or invalid XLS::Value");
+  if (used_payload_bits >= bits_to_read) {
+    return absl::OkStatus();
+  }
+
+  uint64_t bits_size = value_node.GetFlatBitCount();
+  if (processed_value_bits + bits_size < start_bit) {
+    processed_value_bits += bits_size;
+    return absl::OkStatus();
+  }
+
+  if (value_node.IsBits()) {
+    for (int i = 0; i < value_node.bits().bit_count();
+         ++i, ++processed_value_bits) {
+      if (used_payload_bits >= bits_to_read) {
+        return absl::OkStatus();
+      }
+      if (start_bit <= processed_value_bits) {
+        payload_ |= ((uint64_t)value_node.bits().bitmap().Get(i))
+                    << used_payload_bits;
+        used_payload_bits++;
+      }
+    }
+    return absl::OkStatus();
+  }
+
+  for (auto& node : value_node.elements()) {
+    XLS_RETURN_IF_ERROR(ReadBits(node, processed_value_bits, start_bit,
+                                 used_payload_bits, bits_to_read, payload_));
+    if (used_payload_bits >= bits_to_read) {
+      return absl::OkStatus();
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint64_t> ValueArrayReadUInt64(
+    absl::Span<const Value> data_array, std::string_view channel_name,
+    uint64_t byte_offset, uint64_t byte_count) {
+  uint64_t size_ = 0;
+  for (auto& it : data_array) {
+    size_ += it.GetFlatBitCount();
+  }
+  int byte_size_ = (size_ + 7) / 8;
+
+  // Outside of the address range
+  if (byte_offset >= byte_size_)
+    return absl::InvalidArgumentError("Offset: " + std::to_string(byte_offset) +
+                                      std::string(" is outside ") +
+                                      std::string(channel_name) + " range");
+
+  uint64_t ans = 0;
+  uint64_t processed_value_bits = 0;
+  uint64_t used_payload_bits = 0;
+  for (auto& it : data_array) {
+    XLS_RETURN_IF_ERROR(ReadBits(it, processed_value_bits, byte_offset * 8,
+                                 used_payload_bits, byte_count * 8, ans));
+  }
+  return ans;
+}
+
+static absl::StatusOr<Value> UpdateBits(const Value& value_node,
+                                        uint64_t& processed_value_bits,
+                                        uint64_t const start_bit,
+                                        uint64_t& used_payload_bits,
+                                        uint64_t const bits_to_update,
+                                        uint64_t const payload) {
+  if (value_node.IsToken() || value_node.kind() == ValueKind::kInvalid)
+    return absl::InternalError("Got Token or invalid XLS::Value");
+  if (used_payload_bits >= bits_to_update) {
+    return value_node;
+  }
+
+  uint64_t bits_size = value_node.GetFlatBitCount();
+  if (processed_value_bits + bits_size < start_bit) {
+    processed_value_bits += bits_size;
+    return value_node;
+  }
+
+  if (value_node.IsBits()) {
+    Bits bit_representation = value_node.bits();
+    for (int i = 0; i < bit_representation.bit_count();
+         ++i, ++processed_value_bits) {
+      if (used_payload_bits >= bits_to_update) {
+        return Value(bit_representation);
+      }
+      if (start_bit <= processed_value_bits) {
+        bit_representation = bit_representation.UpdateWithSet(
+            i, !!(payload & (1LL << used_payload_bits)));
+        used_payload_bits++;
+      }
+    }
+    return Value(bit_representation);
+  }
+
+  std::vector<Value> new_elements;
+  new_elements.reserve(value_node.size());
+  for (auto& node : value_node.elements()) {
+    XLS_ASSIGN_OR_RETURN(
+        Value new_node, UpdateBits(node, processed_value_bits, start_bit,
+                                   used_payload_bits, bits_to_update, payload));
+    new_elements.push_back(new_node);
+  }
+  if (value_node.IsTuple()) return Value::Tuple(new_elements);
+  return Value::Array(new_elements);
+}
+
+absl::StatusOr<std::vector<Value>> ValueArrayWriteUInt64(
+    absl::Span<const Value> data_array, std::string_view channel_name,
+    uint64_t byte_offset, uint64_t byte_count, uint64_t const payload_) {
+  uint64_t size_ = 0;
+  for (auto& it : data_array) {
+    size_ += it.GetFlatBitCount();
+  }
+  uint64_t byte_size_ = (size_ + 7) / 8;
+
+  // Outside of the address range
+  if (byte_offset >= byte_size_)
+    return absl::InvalidArgumentError("Offset: " + std::to_string(byte_offset) +
+                                      std::string(" is outside ") +
+                                      std::string(channel_name) + " range");
+  uint64_t processed_value_bits = 0;
+  uint64_t used_payload_bits = 0;
+  std::vector<Value> output;
+  output.reserve(data_array.size());
+  for (auto& it : data_array) {
+    XLS_ASSIGN_OR_RETURN(
+        Value updated_value,
+        UpdateBits(it, processed_value_bits, byte_offset * 8, used_payload_bits,
+                   byte_count * 8, payload_));
+    output.push_back(updated_value);
+  }
+  return output;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/ir_value_access_methods.h
+++ b/xls/simulation/generic/ir_value_access_methods.h
@@ -1,0 +1,55 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IR_VALUE_ACCESS_METHODS_H_
+#define XLS_SIMULATION_GENERIC_IR_VALUE_ACCESS_METHODS_H_
+
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "xls/ir/value.h"
+
+namespace xls::simulation::generic {
+
+// ValueArrayReadUInt64 adds a byte level interface to read up to 8 bytes from
+// an array of XLS::IR::Values using byte offsets and number of bytes to be
+// read. It returns a value read from the array. Each value in the array is
+// treated as a bit vector and the whole array is treated as a concatenation of
+// its values. This virtual bit vector is then sliced into virtual bytes that
+// can be addressed. Arguments:
+// 1. array of XLS::IR::Values
+// 2. name of the underlying XLS::IR:Channel
+// 3. byte offset in the array
+// 4. maximal number of bytes to read from the array
+absl::StatusOr<uint64_t> ValueArrayReadUInt64(
+    absl::Span<const Value> data_array, std::string_view channel_name,
+    uint64_t byte_offset, uint64_t byte_count);
+
+// ValueArrayWriteUInt64 adds a byte level interface to modify up to 8 bytes
+// from an array of XLS::IR::Values using byte offsets and number of bytes to be
+// modified and payload. It returns a new vector with modified values. Each
+// value in the array is treated as a bit vector and the whole array is treated
+// as a concatenation of its values. This virtual bit vector is then sliced into
+// virtual bytes that can be addressed and modified. Arguments:
+// 1. array of XLS::IR::Values
+// 2. name of the underlying XLS::IR:Channel
+// 3. byte offset in the array
+// 4. maximal number of bytes to modify in the array
+// 5. payload with new value
+absl::StatusOr<std::vector<Value>> ValueArrayWriteUInt64(
+    absl::Span<const Value> data_array, std::string_view channel_name,
+    uint64_t byte_offset, uint64_t byte_count, uint64_t const payload);
+
+}  // namespace xls::simulation::generic
+#endif  // XLS_SIMULATION_GENERIC_IR_VALUE_ACCESS_METHODS_H_

--- a/xls/simulation/generic/ir_value_access_methods_test.cc
+++ b/xls/simulation/generic/ir_value_access_methods_test.cc
@@ -1,0 +1,437 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/ir_value_access_methods.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/ir/bits.h"
+#include "xls/ir/type.h"
+#include "xls/ir/value.h"
+#include "xls/ir/value_helpers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class BitsVectorTest : public ::testing::Test {
+ protected:
+  BitsVectorTest()
+      : bits_types_{BitsType(1), BitsType(31), BitsType(64), BitsType(128)} {}
+  void SetUp() {
+    this->bits_ = std::vector<Value>{
+        ZeroOfType(&bits_types_[0]), ZeroOfType(&bits_types_[1]),
+        ZeroOfType(&bits_types_[2]), ZeroOfType(&bits_types_[3])};
+  }
+
+  BitsType bits_types_[4];
+  std::vector<Value> bits_;
+};
+
+TEST_F(BitsVectorTest, OutOfRangeRead) {
+  EXPECT_THAT(
+      ValueArrayReadUInt64(this->bits_, std::string("OutOfRangeRead"), 32, 1),
+      ::xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          "Offset: 32 is outside OutOfRangeRead range"));
+}
+
+TEST_F(BitsVectorTest, SingleBitsReadLateStart) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 23; i < 31; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  EXPECT_THAT(ValueArrayReadUInt64(
+                  this->bits_, std::string("SingleBitsReadLateStart"), 3, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(BitsVectorTest, SingleBitsReadEarlyEnd) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 7; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  EXPECT_THAT(ValueArrayReadUInt64(this->bits_,
+                                   std::string("SingleBitsReadEarlyEnd"), 1, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(BitsVectorTest, SingleBitsReadOverMultipleValues) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 0; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+
+  bit_representation = this->bits_[2].bits();
+  bit_representation = bit_representation.UpdateWithSet(31, 1);
+  this->bits_[2] = Value(bit_representation);
+
+  EXPECT_THAT(
+      ValueArrayReadUInt64(
+          this->bits_, std::string("SingleBitsReadOverMultipleValues"), 0, 8),
+      ::xls::status_testing::IsOkAndHolds((uint64_t)0x800000000000FFFE));
+}
+
+TEST_F(BitsVectorTest, SingleBitsReadPartial) {
+  Bits bit_representation = this->bits_[3].bits();
+  for (int i = 112; i < 128; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[3] = Value(bit_representation);
+
+  EXPECT_THAT(ValueArrayReadUInt64(this->bits_,
+                                   std::string("SingleBitsReadPartial"), 24, 8),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFFFF0000));
+}
+
+TEST_F(BitsVectorTest, OutOfRangeWrite) {
+  EXPECT_THAT(ValueArrayWriteUInt64(this->bits_, std::string("OutOfRangeWrite"),
+                                    32, 1, 0),
+              ::xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  "Offset: 32 is outside OutOfRangeWrite range"));
+}
+
+TEST_F(BitsVectorTest, SingleBitsWriteLateStart) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(23, 31, 1);
+  std::vector<Value> ans{Value(Bits(1)), Value(set_value), Value(Bits(64)),
+                         Value(Bits(128))};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(this->bits_,
+                                    std::string("SingleBitsWriteLateStart"), 3,
+                                    1, (uint64_t)0xFFFF),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(BitsVectorTest, SingleBitsWriteEarlyEnd) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(7, 15, 1);
+  std::vector<Value> ans{Value(Bits(1)), Value(set_value), Value(Bits(64)),
+                         Value(Bits(128))};
+
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->bits_, std::string("SingleBitsWriteEarlyEnd"),
+                            1, 1, (uint64_t)0xFFFF),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(BitsVectorTest, SingleBitsWriteOverMultipleValues) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(0, 15, 1);
+  Bits set_value2 = Bits(64);
+  set_value2.SetRange(31, 32, 1);
+  std::vector<Value> ans{Value(Bits(1)), Value(set_value), Value(set_value2),
+                         Value(Bits(128))};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(
+                  this->bits_, std::string("SingleBitsWriteOverMultipleValues"),
+                  0, 8, (uint64_t)0x800000000000FFFE),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(BitsVectorTest, SingleBitsWritePartial) {
+  Bits set_value = Bits(128);
+  set_value.SetRange(112, 128, 1);
+  std::vector<Value> ans{Value(Bits(1)), Value(Bits(31)), Value(Bits(64)),
+                         Value(set_value)};
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->bits_, std::string("SingleBitsWritePartial"),
+                            26, 8, (uint64_t)0xFFFFFFFFFFFFFFFF),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+class TupleTest : public BitsVectorTest {
+ protected:
+  TupleTest()
+      : tuple_type_({&bits_types_[0], &bits_types_[1], &bits_types_[2],
+                     &bits_types_[3]}) {}
+  void SetUp() {
+    this->bits_ = std::vector<Value>{
+        ZeroOfType(&bits_types_[0]), ZeroOfType(&bits_types_[1]),
+        ZeroOfType(&bits_types_[2]), ZeroOfType(&bits_types_[3])};
+    this->tuple_ = std::vector<Value>{ZeroOfType(&tuple_type_)};
+  }
+
+  TupleType tuple_type_;
+  std::vector<Value> tuple_;
+};
+
+TEST_F(TupleTest, OutOfRangeRead) {
+  EXPECT_THAT(
+      ValueArrayReadUInt64(this->tuple_, std::string("OutOfRangeRead"), 32, 1),
+      ::xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          "Offset: 32 is outside OutOfRangeRead range"));
+}
+
+TEST_F(TupleTest, SingleBitsReadLateStart) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 23; i < 31; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  this->tuple_[0] = Value::Tuple(this->bits_);
+  EXPECT_THAT(ValueArrayReadUInt64(
+                  this->tuple_, std::string("SingleBitsReadLateStart"), 3, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(TupleTest, SingleBitsReadEarlyEnd) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 7; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  this->tuple_[0] = Value::Tuple(this->bits_);
+  EXPECT_THAT(ValueArrayReadUInt64(this->tuple_,
+                                   std::string("SingleBitsReadEarlyEnd"), 1, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(TupleTest, SingleBitsReadOverMultipleValues) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 0; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+
+  bit_representation = this->bits_[2].bits();
+  bit_representation = bit_representation.UpdateWithSet(31, 1);
+  this->bits_[2] = Value(bit_representation);
+  this->tuple_[0] = Value::Tuple(this->bits_);
+
+  EXPECT_THAT(
+      ValueArrayReadUInt64(
+          this->tuple_, std::string("SingleBitsReadOverMultipleValues"), 0, 8),
+      ::xls::status_testing::IsOkAndHolds((uint64_t)0x800000000000FFFE));
+}
+
+TEST_F(TupleTest, SingleBitsReadPartial) {
+  Bits bit_representation = this->bits_[3].bits();
+  for (int i = 112; i < 128; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[3] = Value(bit_representation);
+  this->tuple_[0] = Value::Tuple(this->bits_);
+
+  EXPECT_THAT(ValueArrayReadUInt64(this->tuple_,
+                                   std::string("SingleBitsReadPartial"), 24, 8),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFFFF0000));
+}
+
+TEST_F(TupleTest, OutOfRangeWrite) {
+  EXPECT_THAT(ValueArrayWriteUInt64(this->tuple_,
+                                    std::string("OutOfRangeWrite"), 32, 1, 0),
+              ::xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  "Offset: 32 is outside OutOfRangeWrite range"));
+}
+
+TEST_F(TupleTest, SingleBitsWriteLateStart) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(23, 31, 1);
+  std::vector<Value> ans{Value::Tuple(
+      {Value(Bits(1)), Value(set_value), Value(Bits(64)), Value(Bits(128))})};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(this->tuple_,
+                                    std::string("SingleBitsWriteLateStart"), 3,
+                                    1, (uint64_t)0xFFFF),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(TupleTest, SingleBitsWriteEarlyEnd) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(7, 15, 1);
+  std::vector<Value> ans{Value::Tuple(
+      {Value(Bits(1)), Value(set_value), Value(Bits(64)), Value(Bits(128))})};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(this->tuple_,
+                                    std::string("SingleBitsWriteEarlyEnd"), 1,
+                                    1, (uint64_t)0xFFFF),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(TupleTest, SingleBitsWriteOverMultipleValues) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(0, 15, 1);
+  Bits set_value2 = Bits(64);
+  set_value2.SetRange(31, 32, 1);
+  std::vector<Value> ans{Value::Tuple(
+      {Value(Bits(1)), Value(set_value), Value(set_value2), Value(Bits(128))})};
+
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->tuple_,
+                            std::string("SingleBitsWriteOverMultipleValues"), 0,
+                            8, (uint64_t)0x800000000000FFFE),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(TupleTest, SingleBitsWritePartial) {
+  Bits set_value = Bits(128);
+  set_value.SetRange(112, 128, 1);
+  std::vector<Value> ans{Value::Tuple(
+      {Value(Bits(1)), Value(Bits(31)), Value(Bits(64)), Value(set_value)})};
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->tuple_, std::string("SingleBitsWritePartial"),
+                            26, 8, (uint64_t)0xFFFFFFFFFFFFFFFF),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+class ArrayTest : public TupleTest {
+ protected:
+  ArrayTest() : array_type_(1, &tuple_type_) {}
+
+  void SetUp() {
+    this->bits_ = std::vector<Value>{
+        ZeroOfType(&bits_types_[0]), ZeroOfType(&bits_types_[1]),
+        ZeroOfType(&bits_types_[2]), ZeroOfType(&bits_types_[3])};
+    this->array_ = std::vector<Value>{ZeroOfType(&array_type_)};
+  }
+
+  ArrayType array_type_;
+  std::vector<Value> array_;
+};
+
+TEST_F(ArrayTest, OutOfRangeRead) {
+  EXPECT_THAT(
+      ValueArrayReadUInt64(this->array_, std::string("OutOfRangeRead"), 32, 1),
+      ::xls::status_testing::StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          "Offset: 32 is outside OutOfRangeRead range"));
+}
+
+TEST_F(ArrayTest, SingleBitsReadLateStart) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 23; i < 31; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  this->array_[0] = Value::ArrayOrDie({Value::Tuple(this->bits_)});
+  EXPECT_THAT(ValueArrayReadUInt64(
+                  this->array_, std::string("SingleBitsReadLateStart"), 3, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(ArrayTest, SingleBitsReadEarlyEnd) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 7; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+  this->array_[0] = Value::ArrayOrDie({Value::Tuple(this->bits_)});
+  EXPECT_THAT(ValueArrayReadUInt64(this->array_,
+                                   std::string("SingleBitsReadEarlyEnd"), 1, 1),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFF));
+}
+
+TEST_F(ArrayTest, SingleBitsReadOverMultipleValues) {
+  Bits bit_representation = this->bits_[1].bits();
+  for (int i = 0; i < 15; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[1] = Value(bit_representation);
+
+  bit_representation = this->bits_[2].bits();
+  bit_representation = bit_representation.UpdateWithSet(31, 1);
+  this->bits_[2] = Value(bit_representation);
+  this->array_[0] = Value::ArrayOrDie({Value::Tuple(this->bits_)});
+
+  EXPECT_THAT(
+      ValueArrayReadUInt64(
+          this->array_, std::string("SingleBitsReadOverMultipleValues"), 0, 8),
+      ::xls::status_testing::IsOkAndHolds((uint64_t)0x800000000000FFFE));
+}
+
+TEST_F(ArrayTest, SingleBitsReadPartial) {
+  Bits bit_representation = this->bits_[3].bits();
+  for (int i = 112; i < 128; ++i) {
+    bit_representation = bit_representation.UpdateWithSet(i, 1);
+  }
+  this->bits_[3] = Value(bit_representation);
+  this->array_[0] = Value::ArrayOrDie({Value::Tuple(this->bits_)});
+
+  EXPECT_THAT(ValueArrayReadUInt64(this->array_,
+                                   std::string("SingleBitsReadPartial"), 24, 8),
+              ::xls::status_testing::IsOkAndHolds((uint64_t)0xFFFF0000));
+}
+
+TEST_F(ArrayTest, OutOfRangeWrite) {
+  EXPECT_THAT(ValueArrayWriteUInt64(this->array_,
+                                    std::string("OutOfRangeWrite"), 32, 1, 0),
+              ::xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  "Offset: 32 is outside OutOfRangeWrite range"));
+}
+
+TEST_F(ArrayTest, SingleBitsWriteLateStart) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(23, 31, 1);
+  std::vector<Value> ans{Value::ArrayOrDie({Value::Tuple(
+      {Value(Bits(1)), Value(set_value), Value(Bits(64)), Value(Bits(128))})})};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(this->array_,
+                                    std::string("SingleBitsWriteLateStart"), 3,
+                                    1, (uint64_t)0xFFFF),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(ArrayTest, SingleBitsWriteEarlyEnd) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(7, 15, 1);
+  std::vector<Value> ans{Value::ArrayOrDie({Value::Tuple(
+      {Value(Bits(1)), Value(set_value), Value(Bits(64)), Value(Bits(128))})})};
+
+  EXPECT_THAT(ValueArrayWriteUInt64(this->array_,
+                                    std::string("SingleBitsWriteEarlyEnd"), 1,
+                                    1, (uint64_t)0xFFFF),
+              ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(ArrayTest, SingleBitsWriteOverMultipleValues) {
+  Bits set_value = Bits(31);
+  set_value.SetRange(0, 15, 1);
+  Bits set_value2 = Bits(64);
+  set_value2.SetRange(31, 32, 1);
+  std::vector<Value> ans{
+      Value::ArrayOrDie({Value::Tuple({Value(Bits(1)), Value(set_value),
+                                       Value(set_value2), Value(Bits(128))})})};
+
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->array_,
+                            std::string("SingleBitsWriteOverMultipleValues"), 0,
+                            8, (uint64_t)0x800000000000FFFE),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+TEST_F(ArrayTest, SingleBitsWritePartial) {
+  Bits set_value = Bits(128);
+  set_value.SetRange(112, 128, 1);
+  std::vector<Value> ans{Value::ArrayOrDie({Value::Tuple(
+      {Value(Bits(1)), Value(Bits(31)), Value(Bits(64)), Value(set_value)})})};
+  EXPECT_THAT(
+      ValueArrayWriteUInt64(this->array_, std::string("SingleBitsWritePartial"),
+                            26, 8, (uint64_t)0xFFFFFFFFFFFFFFFF),
+      ::xls::status_testing::IsOkAndHolds(ans));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iregister.h
+++ b/xls/simulation/generic/iregister.h
@@ -1,0 +1,26 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_H_
+
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+class IRegister : public IChannel {};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_H_

--- a/xls/simulation/generic/iregister_mock.h
+++ b/xls/simulation/generic/iregister_mock.h
@@ -1,0 +1,103 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_
+
+#include <array>
+#include <cstdint>
+#include <initializer_list>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/simulation/generic/byteops.h"
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+// Mock implementation of IRegister interface for tests
+// Exposes normal IRegister interface, as well as test-only
+// methods to access underlying data bytes as std::vector
+template <uint64_t WidthBits>
+class IRegisterMock : public IRegister {
+ public:
+  constexpr static uint64_t WidthBytes = (WidthBits + 7) / 8;
+  constexpr static uint64_t LastByte = (WidthBits - 1) / 8;
+  constexpr static uint64_t LastByteBitmask =
+      (1 << (WidthBits - 8 * LastByte)) - 1;
+  using ByteArray = std::array<uint8_t, WidthBytes>;
+
+  IRegisterMock() = default;
+  explicit IRegisterMock(ByteArray init_bytes) : bytes_{init_bytes} {
+    bytes_[LastByte] &= LastByteBitmask;
+  };
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint8_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint16_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint32_t>(bytes_, offset);
+  }
+
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override {
+    return byteops::bytes_read_word<uint64_t>(bytes_, offset);
+  }
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override {
+    XLS_RETURN_IF_ERROR(
+        byteops::bytes_write_word(absl::MakeSpan(bytes_), offset, data));
+    bytes_[LastByte] &= LastByteBitmask;
+    return absl::OkStatus();
+  }
+
+  uint64_t GetChannelWidth() const override { return WidthBits; }
+
+  const ByteArray& bytes() const { return bytes_; }
+  ByteArray& bytes() { return bytes_; }
+
+ private:
+  ByteArray bytes_{};
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_MOCK_H_

--- a/xls/simulation/generic/iregister_mock_test.cc
+++ b/xls/simulation/generic/iregister_mock_test.cc
@@ -1,0 +1,141 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_mock.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using testing::ElementsAre;
+
+class IRegisterMockTest : public ::testing::Test {};
+
+TEST_F(IRegisterMockTest, Init1) {
+  IRegisterMock<17> mock;
+  ASSERT_THAT(mock.bytes(), ElementsAre(0, 0, 0));
+}
+
+TEST_F(IRegisterMockTest, Init2) {
+  IRegisterMock<31> mock{{1, 2, 3, 4}};
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 2, 3, 4));
+}
+
+TEST_F(IRegisterMockTest, SetBytes) {
+  IRegisterMock<31> mock{};
+  mock.bytes() = {3, 4, 5, 6};
+  ASSERT_THAT(mock.bytes(), ElementsAre(3, 4, 5, 6));
+}
+
+TEST_F(IRegisterMockTest, GetChannelWidth) {
+  IRegisterMock<31> mock{};
+  ASSERT_EQ(mock.GetChannelWidth(), 31);
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData8) {
+  IRegisterMock<17> mock{{1, 2, 3}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData8(1));
+  EXPECT_EQ(data, 0x02);
+  EXPECT_THAT(mock.GetPayloadData8(3),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData16) {
+  IRegisterMock<35> mock{{1, 2, 3, 4, 5}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData16(3));
+  EXPECT_EQ(data, 0x0504);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(4));
+  EXPECT_EQ(data, 0x05);
+  EXPECT_THAT(mock.GetPayloadData16(5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData32) {
+  IRegisterMock<35> mock{{1, 2, 3, 4, 5}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData32(1));
+  EXPECT_EQ(data, 0x05040302);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData32(2));
+  EXPECT_EQ(data, 0x050403);
+  EXPECT_THAT(mock.GetPayloadData32(5),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, GetPayloadData64) {
+  IRegisterMock<70> mock{{1, 2, 3, 4, 5, 6, 7, 8, 9}};
+  XLS_ASSERT_OK_AND_ASSIGN(auto data, mock.GetPayloadData64(1));
+  EXPECT_EQ(data, 0x0908070605040302LL);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData64(4));
+  EXPECT_EQ(data, 0x0908070605LL);
+  EXPECT_THAT(mock.GetPayloadData64(9),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, CheckBitmasking) {
+  IRegisterMock<3> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 1));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 7));
+  ASSERT_THAT(mock.bytes(), ElementsAre(7));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 8));
+  ASSERT_THAT(mock.bytes(), ElementsAre(0));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 9));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData8) {
+  IRegisterMock<17> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 2));
+  XLS_EXPECT_OK(mock.SetPayloadData8(2, 3));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 2, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 4));
+  ASSERT_THAT(mock.bytes(), ElementsAre(1, 4, 1));
+  EXPECT_THAT(mock.SetPayloadData8(3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData16) {
+  IRegisterMock<17> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData16(1, 0x0503));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0506));
+  ASSERT_THAT(mock.bytes(), ElementsAre(6, 5, 1));
+  XLS_EXPECT_OK(mock.SetPayloadData16(2, 0));
+  ASSERT_THAT(mock.bytes(), ElementsAre(6, 5, 0));
+  EXPECT_THAT(mock.SetPayloadData16(3, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData32) {
+  IRegisterMock<33> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData32(0, 0x03020100));
+  XLS_EXPECT_OK(mock.SetPayloadData32(1, 0x07060504));
+  ASSERT_THAT(mock.bytes(), ElementsAre(0, 4, 5, 6, 1));
+  EXPECT_THAT(mock.SetPayloadData32(5, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+TEST_F(IRegisterMockTest, SetPayloadData64) {
+  IRegisterMock<70> mock{};
+  XLS_EXPECT_OK(mock.SetPayloadData64(0, 0x0102030405060708LL));
+  XLS_EXPECT_OK(mock.SetPayloadData64(1, 0x0102030405060708LL));
+  ASSERT_THAT(mock.bytes(), ElementsAre(8, 8, 7, 6, 5, 4, 3, 2, 1));
+  EXPECT_THAT(mock.SetPayloadData64(9, 0),
+              xls::status_testing::StatusIs(absl::StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iregister_stub.cc
+++ b/xls/simulation/generic/iregister_stub.cc
@@ -1,0 +1,73 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_stub.h"
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+absl::StatusOr<uint8_t> IRegisterStub::GetPayloadData8(uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IRegisterStub::GetPayloadData16(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IRegisterStub::GetPayloadData32(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IRegisterStub::GetPayloadData64(
+    uint64_t offset) const {
+  XLS_LOG(INFO) << "IRegisterStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IRegisterStub::SetPayloadData8(uint64_t offset, uint8_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData16(uint64_t offset, uint16_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData32(uint64_t offset, uint32_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IRegisterStub::SetPayloadData64(uint64_t offset, uint64_t data) {
+  XLS_LOG(INFO) << "IRegisterStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+uint64_t IRegisterStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IRegisterStub::GetChannelWidth()";
+  return 17;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/iregister_stub.h
+++ b/xls/simulation/generic/iregister_stub.h
@@ -1,0 +1,40 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_
+#define XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_
+
+#include <cstdint>
+
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+class IRegisterStub : public IRegister {
+ public:
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_IREGISTER_STUB_H_

--- a/xls/simulation/generic/iregister_stub_test.cc
+++ b/xls/simulation/generic/iregister_stub_test.cc
@@ -1,0 +1,105 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/iregister_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IRegisterStubTest : public ::testing::Test {
+ protected:
+  IRegisterStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IRegisterStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetChannelWidth"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData8"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData16"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData32"));
+}
+
+TEST_F(IRegisterStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::GetPayloadData64"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData8"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData16"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData32"));
+}
+
+TEST_F(IRegisterStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IRegisterStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream.h
+++ b/xls/simulation/generic/istream.h
@@ -1,0 +1,53 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_H_
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/ichannel.h"
+
+namespace xls::simulation::generic {
+
+// IStream - interface to the FIFO-like XLS streams (see xls::StreamingChannel)
+//
+// Contains internal holding register which stores a single data item. Holding
+// register can be accessed via methods provided by IChannel.
+class IStream : public IChannel {
+ public:
+  // Returns 'true' if the device reads from this stream, 'false' if it writes
+  // to it.
+  virtual bool IsReadStream() const = 0;
+
+  // Returns 'true' if the stream is ready to perform a single transfer:
+  //  - For a read stream to be ready, the underlying stream implementation
+  //    must have at least one data item available for reading, and must be
+  //    ready to transfer it into the holding register when Transfer() is
+  //    called.
+  //  - For a write stream to be ready, the underlying stream implementation
+  //    must be ready to accept at least a single data item whenever
+  //    Transfer() is called.
+  virtual bool IsReady() const = 0;
+
+  // Performs a single transfer on the stream:
+  //  - For read streams, this extracts a single data item from the stream
+  //    and places it into a holding register.
+  //  - For write streams, this takes a data item from the holding
+  //    register and sends it to the stream.
+  virtual absl::Status Transfer() = 0;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_H_

--- a/xls/simulation/generic/istream_mock.h
+++ b/xls/simulation/generic/istream_mock.h
@@ -1,0 +1,106 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_
+
+#include <array>
+#include <cstdint>
+#include <queue>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+#include "xls/simulation/generic/iregister_mock.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+// Mock implementation of IStream interface backed by std::deque queue.
+// Provides usual IStream methods as well as access to the queues.
+template <uint64_t WidthBits, bool IsReadStream_>
+class IStreamMock : public IStream {
+ public:
+  using Register = IRegisterMock<WidthBits>;
+  constexpr static uint64_t WidthBytes = Register::WidthBytes;
+  using Bytes = std::array<uint8_t, WidthBytes>;
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData8(offset);
+  }
+
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData16(offset);
+  }
+
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData32(offset);
+  }
+
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override {
+    return holding_reg_.GetPayloadData64(offset);
+  }
+
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override {
+    return holding_reg_.SetPayloadData8(offset, data);
+  }
+
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override {
+    return holding_reg_.SetPayloadData16(offset, data);
+  }
+
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override {
+    return holding_reg_.SetPayloadData32(offset, data);
+  }
+
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override {
+    return holding_reg_.SetPayloadData64(offset, data);
+  }
+
+  uint64_t GetChannelWidth() const override { return WidthBits; }
+
+  bool IsReadStream() const override { return IsReadStream_; }
+
+  bool IsReady() const override {
+    if (IsReadStream_)
+      return !fifo_.empty();
+    else
+      return true;
+  }
+
+  absl::Status Transfer() override {
+    if (IsReadStream_) {
+      if (fifo_.empty()) return absl::InternalError("FIFO is empty");
+      holding_reg_ = IRegisterMock<WidthBits>{fifo_.front()};
+      fifo_.pop();
+    } else {
+      fifo_.push(holding_reg_.bytes());
+    }
+    return absl::OkStatus();
+  }
+
+  Register& holding_reg() { return holding_reg_; }
+  const Register& holding_reg() const { return holding_reg_; }
+
+  std::queue<Bytes>& fifo() { return fifo_; }
+  const std::queue<Bytes>& fifo() const { return fifo_; }
+
+ private:
+  Register holding_reg_;
+  std::queue<Bytes> fifo_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_MOCK_H_

--- a/xls/simulation/generic/istream_mock_test.cc
+++ b/xls/simulation/generic/istream_mock_test.cc
@@ -1,0 +1,123 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_mock.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+using absl::StatusCode;
+using ::testing::_;
+using testing::ElementsAre;
+using ::xls::status_testing::StatusIs;
+
+class IStreamMockTest : public ::testing::Test {};
+
+TEST_F(IStreamMockTest, InitRead) {
+  IStreamMock<17, true> mock;
+  ASSERT_EQ(mock.IsReadStream(), true);
+  ASSERT_EQ(mock.GetChannelWidth(), 17);
+  ASSERT_EQ(mock.IsReady(), false);
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  ASSERT_EQ(mock.fifo().empty(), true);
+}
+
+TEST_F(IStreamMockTest, InitWrite) {
+  IStreamMock<17, false> mock;
+  ASSERT_EQ(mock.IsReadStream(), false);
+  ASSERT_EQ(mock.GetChannelWidth(), 17);
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  ASSERT_EQ(mock.fifo().empty(), true);
+}
+
+TEST_F(IStreamMockTest, HoldingRegSet8) {
+  IStreamMock<17, true> mock;
+  XLS_EXPECT_OK(mock.SetPayloadData8(1, 5));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 5, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData8(0, 6));
+  XLS_EXPECT_OK(mock.SetPayloadData8(2, 7));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(6, 5, 1));
+}
+
+TEST_F(IStreamMockTest, HoldingRegGet8) {
+  IStreamMock<17, true> mock;
+  mock.holding_reg().bytes() = {1, 2, 3};
+  uint8_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(0));
+  EXPECT_EQ(data, 1);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(1));
+  EXPECT_EQ(data, 2);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData8(2));
+  EXPECT_EQ(data, 3);
+}
+
+TEST_F(IStreamMockTest, HoldingRegSet16) {
+  IStreamMock<17, true> mock;
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(0, 0, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0203));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(3, 2, 0));
+  XLS_EXPECT_OK(mock.SetPayloadData16(1, 0x0505));
+  ASSERT_THAT(mock.holding_reg().bytes(), ElementsAre(3, 5, 1));
+}
+
+TEST_F(IStreamMockTest, HoldingRegGet16) {
+  IStreamMock<17, true> mock;
+  mock.holding_reg().bytes() = {1, 2, 3};
+  uint16_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0201);
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(1));
+  EXPECT_EQ(data, 0x0302);
+}
+
+TEST_F(IStreamMockTest, Write) {
+  IStreamMock<16, false> mock;
+  ASSERT_EQ(mock.IsReady(), true);
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0302));
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  XLS_EXPECT_OK(mock.SetPayloadData16(0, 0x0504));
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  ASSERT_EQ(mock.fifo().size(), 2);
+  ASSERT_THAT(mock.fifo().front(), ElementsAre(2, 3));
+  mock.fifo().pop();
+  ASSERT_THAT(mock.fifo().front(), ElementsAre(4, 5));
+}
+
+TEST_F(IStreamMockTest, Read) {
+  IStreamMock<16, true> mock;
+  ASSERT_EQ(mock.IsReady(), false);
+  mock.fifo().push({{2, 3}});
+  mock.fifo().push({{4, 5}});
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  uint16_t data;
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0302);
+  ASSERT_EQ(mock.IsReady(), true);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kOk));
+  XLS_ASSERT_OK_AND_ASSIGN(data, mock.GetPayloadData16(0));
+  EXPECT_EQ(data, 0x0504);
+  ASSERT_EQ(mock.IsReady(), false);
+  ASSERT_THAT(mock.Transfer(), StatusIs(StatusCode::kInternal));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream_stub.cc
+++ b/xls/simulation/generic/istream_stub.cc
@@ -1,0 +1,85 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_stub.h"
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+
+// IStreamStub
+
+bool IStreamStub::IsReadStream() const {
+  XLS_LOG(INFO) << "IStreamStub::IsReadStream()";
+  return true;
+}
+
+bool IStreamStub::IsReady() const {
+  XLS_LOG(INFO) << "IStreamStub::IsReady()";
+  return true;
+}
+
+absl::Status IStreamStub::Transfer() {
+  XLS_LOG(INFO) << "IStreamStub::Transfer()";
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint8_t> IStreamStub::GetPayloadData8(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData8()";
+  return 0x12;
+}
+
+absl::StatusOr<uint16_t> IStreamStub::GetPayloadData16(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData16()";
+  return 0x1234;
+}
+
+absl::StatusOr<uint32_t> IStreamStub::GetPayloadData32(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData32()";
+  return 0x12345678;
+}
+
+absl::StatusOr<uint64_t> IStreamStub::GetPayloadData64(uint64_t offset) const {
+  XLS_LOG(INFO) << "IStreamStub::GetPayloadData64()";
+  return 0x1234567890ABCDEFll;
+}
+
+absl::Status IStreamStub::SetPayloadData8(uint64_t offset, uint8_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData8()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData16(uint64_t offset, uint16_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData16()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData32(uint64_t offset, uint32_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData32()";
+  return absl::OkStatus();
+}
+
+absl::Status IStreamStub::SetPayloadData64(uint64_t offset, uint64_t data) {
+  XLS_LOG(INFO) << "IStreamStub::SetPayloadData64()";
+  return absl::OkStatus();
+}
+
+uint64_t IStreamStub::GetChannelWidth() const {
+  XLS_LOG(INFO) << "IStreamStub::GetChannelWidth()";
+  return 17;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/istream_stub.h
+++ b/xls/simulation/generic/istream_stub.h
@@ -1,0 +1,46 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_
+#define XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+class IStreamStub : public IStream {
+ public:
+  // IStream
+  bool IsReadStream() const override;
+  bool IsReady() const override;
+  absl::Status Transfer() override;
+  // IChannel
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+  uint64_t GetChannelWidth() const override;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_ISTREAM_STUB_H_

--- a/xls/simulation/generic/istream_stub_test.cc
+++ b/xls/simulation/generic/istream_stub_test.cc
@@ -1,0 +1,130 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/istream_stub.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class IStreamStubTest : public ::testing::Test {
+ protected:
+  IStreamStub stub;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(IStreamStubTest, IsReadStream) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReadStream();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::IsReadStream"));
+}
+
+TEST_F(IStreamStubTest, IsReady) {
+  ::testing::internal::CaptureStderr();
+  stub.IsReady();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::IsReady"));
+}
+
+TEST_F(IStreamStubTest, Transfer) {
+  ::testing::internal::CaptureStderr();
+  auto result = stub.Transfer();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  XLS_EXPECT_OK(result);
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::Transfer"));
+}
+
+TEST_F(IStreamStubTest, GetChannelWidth) {
+  ::testing::internal::CaptureStderr();
+  stub.GetChannelWidth();
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetChannelWidth"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData8(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData8"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData16(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData16"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData32(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData32"));
+}
+
+TEST_F(IStreamStubTest, GetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.GetPayloadData64(42));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::GetPayloadData64"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData8) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData8(42, 0x12));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData8"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData16) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData16(42, 0x1234));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData16"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData32) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData32(42, 0x12345678));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData32"));
+}
+
+TEST_F(IStreamStubTest, SetPayloadData64) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(stub.SetPayloadData64(42, 0x1234567890ABCDEFll));
+  auto output = ::testing::internal::GetCapturedStderr();
+
+  EXPECT_THAT(output, ::testing::HasSubstr("IStreamStub::SetPayloadData64"));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/managed_serial_proc_runtime.h
+++ b/xls/simulation/generic/managed_serial_proc_runtime.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_MANAGED_SERIAL_PROC_RUNTIME_H_
+#define XLS_SIMULATION_GENERIC_MANAGED_SERIAL_PROC_RUNTIME_H_
+
+#include <cstdint>
+#include <optional>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/interpreter/serial_proc_runtime.h"
+
+namespace xls::simulation::generic {
+
+class ManagedSerialProcRuntime : public SerialProcRuntime {
+ private:
+  ManagedSerialProcRuntime() = default;
+
+  absl::Status Tick();
+  absl::StatusOr<int64_t> TickUntilOutput(
+      absl::flat_hash_map<Channel*, int64_t> output_counts,
+      std::optional<int64_t> max_ticks = std::nullopt);
+  absl::StatusOr<int64_t> TickUntilBlocked(
+      std::optional<int64_t> max_ticks = std::nullopt);
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_MANAGED_SERIAL_PROC_RUNTIME_H_

--- a/xls/simulation/generic/peripheral_factory.cc
+++ b/xls/simulation/generic/peripheral_factory.cc
@@ -1,0 +1,58 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/peripheral_factory.h"
+
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <utility>
+
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/iperipheral.h"
+#include "xls/simulation/generic/xlsperipheral.h"
+
+namespace xls::simulation::generic {
+
+PeripheralFactory& PeripheralFactory::Instance() {
+  static PeripheralFactory inst{};
+  return inst;
+}
+
+PeripheralFactory::PeripheralFactory() {
+  // Default behavior - create XlsPeripheral, can be modified by calling
+  // OverrideFactoryMethod.
+  make_ = [](IConnection& connection,
+             std::string_view context) -> std::unique_ptr<IPeripheral> {
+    auto peripheral = XlsPeripheral::Make(connection, context);
+    if (!peripheral.ok()) {
+      XLS_LOG(FATAL) << "Failed to build XLS peripheral. Reason: "
+                     << peripheral.status();
+      return std::unique_ptr<XlsPeripheral>(nullptr);
+    }
+    return std::make_unique<XlsPeripheral>(std::move(peripheral.value()));
+  };
+}
+
+std::unique_ptr<IPeripheral> PeripheralFactory::Make(IConnection& connection,
+                                                     std::string_view context) {
+  return make_(connection, context);
+}
+
+void PeripheralFactory::OverrideFactoryMethod(
+    std::function<PeripheralFactory::FactoryMethod> func) {
+  make_ = std::move(func);
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/peripheral_factory.h
+++ b/xls/simulation/generic/peripheral_factory.h
@@ -1,0 +1,56 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_PERIPHERAL_FACTORY_H_
+#define XLS_SIMULATION_GENERIC_PERIPHERAL_FACTORY_H_
+
+#include <functional>
+#include <memory>
+#include <string_view>
+
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/iperipheral.h"
+
+namespace xls::simulation::generic {
+
+// This factory exists solely to make it possible to test low-level connection
+// modules like 'SharedLibConnection', since those have static code (e.g.
+// 'extern "C"' callbacks) which normally instantiates XlsPeripheral, but
+// in the test we'd like to replace it with something like
+// PeripheralMock. That is most easily done by factoring out
+// XlsPeripheral instantiation into a separate factory method, which can
+// be replaced by the testing code before the test actually provokes
+// instantiation of the Peripheral.
+class PeripheralFactory {
+ public:
+  using FactoryMethod = std::unique_ptr<IPeripheral>(IConnection& connection,
+                                                     std::string_view context);
+
+  static PeripheralFactory& Instance();
+
+  // Creates a peripheral, by default XlsPeripheral
+  std::unique_ptr<IPeripheral> Make(IConnection& connection,
+                                    std::string_view context);
+
+  // Allows to override factory method (intended to be used by tests)
+  void OverrideFactoryMethod(std::function<FactoryMethod> func);
+
+ private:
+  PeripheralFactory();
+  std::function<FactoryMethod> make_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_PERIPHERAL_FACTORY_H_

--- a/xls/simulation/generic/runtime_manager.cc
+++ b/xls/simulation/generic/runtime_manager.cc
@@ -1,0 +1,68 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/runtime_manager.h"
+
+#include <memory>
+#include <utility>
+
+#include "absl/memory/memory.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/interpreter/interpreter_proc_runtime.h"
+#include "xls/interpreter/serial_proc_runtime.h"
+#include "xls/ir/package.h"
+#include "xls/jit/jit_proc_runtime.h"
+#include "xls/simulation/generic/managed_serial_proc_runtime.h"
+
+namespace xls::simulation::generic {
+
+absl::StatusOr<std::unique_ptr<RuntimeManager>> RuntimeManager::Create(
+    Package* package, bool use_jit) {
+  absl::StatusOr<std::unique_ptr<SerialProcRuntime>> result;
+  if (use_jit) {
+    XLS_ASSIGN_OR_RETURN(result, CreateJitSerialProcRuntime(package));
+  } else {
+    XLS_ASSIGN_OR_RETURN(result, CreateInterpreterSerialProcRuntime(package));
+  }
+  return absl::WrapUnique(new RuntimeManager(std::move(result).value()));
+}
+
+RuntimeManager::RuntimeManager(std::unique_ptr<SerialProcRuntime> runtime) {
+  auto base_ptr = runtime.release();
+  auto derived_ptr = static_cast<ManagedSerialProcRuntime*>(base_ptr);
+  this->runtime_ = std::unique_ptr<ManagedSerialProcRuntime>(derived_ptr);
+  this->status_for_singlevalue_manager_ = std::make_unique<RuntimeStatus>();
+  this->status_ = this->status_for_singlevalue_manager_.get();
+}
+
+bool RuntimeManager::HasDeadlock() const { return this->status_->deadlock_; }
+
+absl::Status RuntimeManager::Reset() {
+  this->runtime_->ResetState();
+  this->status_->deadlock_ = false;
+  return absl::OkStatus();
+}
+
+ManagedSerialProcRuntime& RuntimeManager::runtime() { return *this->runtime_; }
+
+RuntimeStatus& RuntimeManager::status() { return *this->status_; }
+
+absl::Status RuntimeManager::Update() {
+  auto status = runtime_->SerialProcRuntime::Tick();
+  this->status_->deadlock_ = !status.ok();
+  return status;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/runtime_manager.h
+++ b/xls/simulation/generic/runtime_manager.h
@@ -1,0 +1,61 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_RUNTIME_MANAGER_H_
+#define XLS_SIMULATION_GENERIC_RUNTIME_MANAGER_H_
+
+#include <memory>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/interpreter/serial_proc_runtime.h"
+#include "xls/ir/package.h"
+#include "xls/simulation/generic/iactive.h"
+#include "xls/simulation/generic/managed_serial_proc_runtime.h"
+#include "xls/simulation/generic/runtime_status.h"
+
+namespace xls::simulation::generic {
+
+class RuntimeManager : public IActive {
+ public:
+  // factory method
+  static absl::StatusOr<std::unique_ptr<RuntimeManager>> Create(
+      Package* package, bool use_jit);
+
+  virtual ~RuntimeManager() = default;
+
+  bool HasDeadlock() const;
+  absl::Status Reset();
+
+  // accessors to runtime and status
+  ManagedSerialProcRuntime& runtime();
+  RuntimeStatus& status();
+  std::unique_ptr<RuntimeStatus>& GetRuntimeStatusOwnership() {
+    return status_for_singlevalue_manager_;
+  }
+
+  // IActive
+  absl::Status Update() override;
+
+ private:
+  explicit RuntimeManager(std::unique_ptr<SerialProcRuntime> runtime);
+
+  std::unique_ptr<ManagedSerialProcRuntime> runtime_;
+  RuntimeStatus* status_;
+  std::unique_ptr<RuntimeStatus> status_for_singlevalue_manager_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_RUNTIME_MANAGER_H_

--- a/xls/simulation/generic/runtime_manager_test.cc
+++ b/xls/simulation/generic/runtime_manager_test.cc
@@ -1,0 +1,169 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/runtime_manager.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/status/matchers.h"
+#include "xls/ir/ir_parser.h"
+
+namespace xls::simulation::generic {
+namespace {
+
+class RuntimeManagerTest : public ::testing::Test,
+                           public ::testing::WithParamInterface<bool> {
+ private:
+  std::vector<Value> create_increasing_input_values(int amount, int bit_count,
+                                                    int start = 0,
+                                                    int increment = 1) {
+    std::vector<Value> data;
+    for (int i = start; i < start + amount; i = i + increment) {
+      data.push_back(Value(UBits(i, bit_count)));
+    }
+    return data;
+  }
+
+ public:
+  void SetUp() {
+    XLS_ASSERT_OK_AND_ASSIGN(std::filesystem::path ir_path,
+                             xls::GetXlsRunfilePath(ir_file));
+    XLS_ASSERT_OK_AND_ASSIGN(std::string ir_text,
+                             xls::GetFileContents(ir_path));
+    XLS_ASSERT_OK_AND_ASSIGN(this->package, xls::Parser::ParsePackage(ir_text));
+    this->data_vector = create_increasing_input_values(10, 32);
+  }
+
+  std::unique_ptr<Package> package;
+  std::unique_ptr<RuntimeManager> manager;
+  std::vector<Value> data_vector;
+  std::string recv_channel_name = "passthrough__data_s";
+  std::string send_channel_name = "passthrough__data_r";
+  std::uint8_t status_addr = 0x0;
+  std::string ir_file =
+      "xls/simulation/generic/testdata/pasthrough_opt_ir.opt.ir";
+};
+
+TEST_P(RuntimeManagerTest, Init) {
+  XLS_EXPECT_OK(RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+}
+
+TEST_P(RuntimeManagerTest, DeadlockStateAfterInit) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+
+  EXPECT_EQ(manager->HasDeadlock(), false);
+}
+
+TEST_P(RuntimeManagerTest, RuntimeSimulation) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+
+  auto& queue_manager = manager->runtime().queue_manager();
+  XLS_ASSERT_OK_AND_ASSIGN(auto recv_queue,
+                           queue_manager.GetQueueByName(recv_channel_name));
+  XLS_ASSERT_OK_AND_ASSIGN(auto send_queue,
+                           queue_manager.GetQueueByName(send_channel_name));
+  XLS_EXPECT_OK(manager->Reset());
+
+  for (const auto& x : data_vector) {
+    XLS_EXPECT_OK(send_queue->Write(x));
+  }
+
+  for (int i = 0; i < data_vector.size(); ++i) {
+    XLS_EXPECT_OK(manager->Update());
+    auto val = recv_queue->Read();
+    EXPECT_EQ(val.has_value(), true);
+    EXPECT_EQ(val.value(), data_vector[i]);
+  }
+}
+
+TEST_P(RuntimeManagerTest, HasDeadlock) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+
+  XLS_EXPECT_OK(manager->Reset());
+  XLS_EXPECT_OK(manager->Update());
+  EXPECT_EQ(manager->HasDeadlock(), false);
+  EXPECT_EQ(manager->Update().code(), absl::StatusCode::kInternal);
+  EXPECT_EQ(manager->HasDeadlock(), true);
+}
+
+TEST_P(RuntimeManagerTest, Reset) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+
+  XLS_EXPECT_OK(manager->Reset());
+  XLS_EXPECT_OK(manager->Update());
+  EXPECT_EQ(manager->Update().code(), absl::StatusCode::kInternal);
+  EXPECT_EQ(manager->HasDeadlock(), true);
+  XLS_EXPECT_OK(manager->Reset());
+  EXPECT_EQ(manager->HasDeadlock(), false);
+}
+
+TEST_P(RuntimeManagerTest, GetPayloadData) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+
+  XLS_ASSERT_OK(manager->Reset());
+  XLS_ASSERT_OK(manager->Update());
+
+  auto& status = manager->status();
+
+  XLS_ASSERT_OK_AND_ASSIGN(auto value8, status.GetPayloadData8(status_addr));
+  EXPECT_EQ(value8, static_cast<uint8_t>(0x0));
+  XLS_ASSERT_OK_AND_ASSIGN(auto value16, status.GetPayloadData16(status_addr));
+  EXPECT_EQ(value16, static_cast<uint16_t>(0x0));
+  XLS_ASSERT_OK_AND_ASSIGN(auto value32, status.GetPayloadData32(status_addr));
+  EXPECT_EQ(value32, static_cast<uint32_t>(0x0));
+  XLS_ASSERT_OK_AND_ASSIGN(auto value64, status.GetPayloadData64(status_addr));
+  EXPECT_EQ(value64, static_cast<uint64_t>(0x0));
+
+  EXPECT_EQ(manager->Update().code(), absl::StatusCode::kInternal);
+  EXPECT_EQ(manager->HasDeadlock(), true);
+
+  XLS_ASSERT_OK_AND_ASSIGN(value8, status.GetPayloadData8(status_addr));
+  EXPECT_EQ(value8, static_cast<uint8_t>(0x1));
+  XLS_ASSERT_OK_AND_ASSIGN(value16, status.GetPayloadData16(status_addr));
+  EXPECT_EQ(value16, static_cast<uint16_t>(0x1));
+  XLS_ASSERT_OK_AND_ASSIGN(value32, status.GetPayloadData32(status_addr));
+  EXPECT_EQ(value32, static_cast<uint32_t>(0x1));
+  XLS_ASSERT_OK_AND_ASSIGN(value64, status.GetPayloadData64(status_addr));
+  EXPECT_EQ(value64, static_cast<uint64_t>(0x1));
+}
+
+TEST_P(RuntimeManagerTest, GetChannelWidth) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      auto manager,
+      RuntimeManager::Create(package.get(), /*use_jit=*/GetParam()));
+  auto& status = manager->status();
+  EXPECT_EQ(status.GetChannelWidth(), 1);
+}
+
+INSTANTIATE_TEST_SUITE_P(RuntimeManagerTestInstantiation, RuntimeManagerTest,
+                         testing::Values(true, false));
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/runtime_status.cc
+++ b/xls/simulation/generic/runtime_status.cc
@@ -1,0 +1,66 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/runtime_status.h"
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/logging/logging.h"
+
+namespace xls::simulation::generic {
+absl::StatusOr<uint64_t> RuntimeStatus::GetPayloadData64(
+    uint64_t offset) const {
+  switch (offset) {
+    case 0x0:
+      return this->deadlock_;
+    default:
+      XLS_LOG(WARNING) << "RuntimeStatus::GetPayloadData64: "
+                          "Selected register does not exist";
+      return 0;
+  }
+}
+
+absl::Status RuntimeStatus::SetPayloadData64(uint64_t offset, uint64_t data) {
+  return absl::UnavailableError("All registers are read-only");
+}
+
+absl::StatusOr<uint8_t> RuntimeStatus::GetPayloadData8(uint64_t offset) const {
+  return GetPayloadData64(offset);
+}
+
+absl::StatusOr<uint16_t> RuntimeStatus::GetPayloadData16(
+    uint64_t offset) const {
+  return GetPayloadData64(offset);
+}
+
+absl::StatusOr<uint32_t> RuntimeStatus::GetPayloadData32(
+    uint64_t offset) const {
+  return GetPayloadData64(offset);
+}
+
+absl::Status RuntimeStatus::SetPayloadData8(uint64_t offset, uint8_t data) {
+  return this->SetPayloadData64(offset, data);
+}
+absl::Status RuntimeStatus::SetPayloadData16(uint64_t offset, uint16_t data) {
+  return this->SetPayloadData64(offset, data);
+}
+absl::Status RuntimeStatus::SetPayloadData32(uint64_t offset, uint32_t data) {
+  return this->SetPayloadData64(offset, data);
+}
+
+uint64_t RuntimeStatus::GetChannelWidth() const { return 1; }
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/runtime_status.h
+++ b/xls/simulation/generic/runtime_status.h
@@ -1,0 +1,52 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_RUNTIME_STATUS_H_
+#define XLS_SIMULATION_GENERIC_RUNTIME_STATUS_H_
+
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/iregister.h"
+
+class RuntimeManager;
+
+namespace xls::simulation::generic {
+
+class RuntimeStatus : public IRegister {
+  friend class RuntimeManager;
+
+ public:
+  RuntimeStatus() = default;
+  ~RuntimeStatus() override = default;
+
+  absl::StatusOr<uint8_t> GetPayloadData8(uint64_t offset) const override;
+  absl::StatusOr<uint16_t> GetPayloadData16(uint64_t offset) const override;
+  absl::StatusOr<uint32_t> GetPayloadData32(uint64_t offset) const override;
+  absl::StatusOr<uint64_t> GetPayloadData64(uint64_t offset) const override;
+  absl::Status SetPayloadData8(uint64_t offset, uint8_t data) override;
+  absl::Status SetPayloadData16(uint64_t offset, uint16_t data) override;
+  absl::Status SetPayloadData32(uint64_t offset, uint32_t data) override;
+  absl::Status SetPayloadData64(uint64_t offset, uint64_t data) override;
+
+  uint64_t GetChannelWidth() const override;
+
+ private:
+  bool deadlock_ = false;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_RUNTIME_STATUS_H_

--- a/xls/simulation/generic/singlevaluemanager.cc
+++ b/xls/simulation/generic/singlevaluemanager.cc
@@ -1,0 +1,269 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/singlevaluemanager.h"
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/simulation/generic/common.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+
+namespace xls::simulation::generic {
+
+SingleValueManager::SingleValueManager(uint64_t base_address)
+    : IChannelManager(base_address) {}
+
+absl::Status SingleValueManager::RegisterIRegister(
+    std::unique_ptr<IRegister> reg, uint64_t offset) {
+  if (reg == nullptr)
+    return absl::InvalidArgumentError("Invalid unique pointer!");
+  if (offset % kChannelAlignment != 0)
+    return absl::InvalidArgumentError("Unaligned channel offset: " +
+                                      std::to_string(offset));
+
+  if (!IsOffsetFree(offset, reg->GetChannelWidth()))
+    return absl::InvalidArgumentError("Channel to big or bad offset " +
+                                      std::to_string(offset));
+
+  // Check if registered channel moves address range upperbound
+  if (offset + ((reg->GetChannelWidth() + 63) / 64) * kChannelAlignment >
+      this->address_range_end_)
+    this->address_range_end_ =
+        offset + ((reg->GetChannelWidth() + 63) / 64) * kChannelAlignment;
+  this->channel_to_offset_.insert({reg.get(), offset});
+  this->offset_to_channel_.insert({offset, std::move(reg)});
+  return absl::OkStatus();
+}
+
+bool SingleValueManager::IsOffsetFree(uint64_t offset, uint64_t channel_width) {
+  if (this->offset_to_channel_.empty()) {
+    // No channels registered, any valid offset is good
+    return true;
+  }
+
+  auto upper = this->offset_to_channel_.upper_bound(offset);
+
+  // Insert before first mapping
+  if (upper == this->offset_to_channel_.begin()) {
+    auto before_first_element =
+        (offset + BitsToBytes(channel_width)) <= upper->first;
+    XLS_LOG_IF(WARNING, !before_first_element)
+        << "Offset: " + std::to_string(offset) +
+               " is already ocupied by channel at offset: " +
+               std::to_string(upper->first);
+    return before_first_element;
+  }
+
+  // Insert after last mapping
+  auto lower = std::prev(upper);
+  if (upper == this->offset_to_channel_.end()) {
+    auto after_last_element =
+        (lower->first + BitsToBytes(lower->second->GetChannelWidth())) <=
+        offset;
+    XLS_LOG_IF(WARNING, !after_last_element)
+        << "Offset: " + std::to_string(offset) +
+               " is already ocupied by channel at offset: " +
+               std::to_string(lower->first);
+    return after_last_element;
+  }
+
+  // Insert between existing mappings
+  auto before_upper_bound_element =
+      (offset + BitsToBytes(channel_width)) <= upper->first;
+  auto after_lower_bound_element =
+      (lower->first + BitsToBytes(lower->second->GetChannelWidth())) <= offset;
+  return before_upper_bound_element && after_lower_bound_element;
+}
+
+static std::string ErrorMessageWrite(uint64_t address, uint64_t value) {
+  return "Write to address: " + std::to_string(address) +
+         " data: " + std::to_string(value) +
+         " failed! Address doesn't match to channel.";
+}
+
+static std::string ErrorMessageRead(uint64_t address) {
+  return "Read from address: " + std::to_string(address) +
+         " failed! Address doesn't match to channel.";
+}
+
+absl::StatusOr<IRegister*> SingleValueManager::GetMappingOrStatus(
+    uint64_t address, std::string&& err_msg) {
+  uint64_t internal_address = address - this->base_address_;
+  auto upper = this->offset_to_channel_.upper_bound(internal_address);
+  if (upper == this->offset_to_channel_.begin())
+    return absl::InternalError(err_msg);
+
+  auto possible_mapping = std::prev(upper);
+  uint64_t in_channel_offset = internal_address - possible_mapping->first;
+  if (BitsToBytes(possible_mapping->second->GetChannelWidth()) <=
+      in_channel_offset)
+    return absl::InternalError(err_msg);
+  return possible_mapping->second.get();
+}
+
+static constexpr absl::Status (*SetPayloadWPow[4])(IRegister*, uint64_t,
+                                                   uint64_t) = {
+    [](IRegister* stream, uint64_t addr, uint64_t data) -> absl::Status {
+      return stream->SetPayloadData8(addr, data);
+    },
+    [](IRegister* stream, uint64_t addr, uint64_t data) -> absl::Status {
+      return stream->SetPayloadData16(addr, data);
+    },
+    [](IRegister* stream, uint64_t addr, uint64_t data) -> absl::Status {
+      return stream->SetPayloadData32(addr, data);
+    },
+    [](IRegister* stream, uint64_t addr, uint64_t data) -> absl::Status {
+      return stream->SetPayloadData64(addr, data);
+    },
+};
+
+absl::Status SingleValueManager::WriteInternal(channel_addr_t address,
+                                               uint64_t data,
+                                               uint64_t log_byte_count) {
+  XLS_ASSIGN_OR_RETURN(
+      IRegister * reg,
+      GetMappingOrStatus(address, ErrorMessageWrite(address, data)));
+  uint64_t internal_address = address - this->base_address_;
+  uint64_t in_channel_offset =
+      internal_address - this->channel_to_offset_.at(reg);
+
+  XLS_RETURN_IF_ERROR(
+      SetPayloadWPow[log_byte_count](reg, in_channel_offset, data));
+
+  uint64_t byte_count = 1 << log_byte_count;
+  if ((address + byte_count - 1) % kChannelAlignment >
+      address % kChannelAlignment)
+    return absl::OkStatus();
+
+  // Write may span multiple channels, check if true
+  uint64_t overlap = (address + byte_count) % kChannelAlignment;
+  uint64_t used_bytes = byte_count - overlap;
+  data >>= BytesToBits(used_bytes);
+
+  auto overlapping_channel =
+      GetMappingOrStatus(address + used_bytes, std::string());
+  if (!overlapping_channel.ok()) return absl::OkStatus();
+  int address_in_overlapping_channel = 0;
+  for (int i = 0; overlap > 0; ++i) {
+    if (overlap & 1) {
+      XLS_RETURN_IF_ERROR(SetPayloadWPow[i](
+          overlapping_channel.value(), address_in_overlapping_channel, data));
+      address_in_overlapping_channel += 1 << i;
+      data >>= (8 << i);
+    }
+    overlap >>= 1;
+  }
+  return absl::OkStatus();
+}
+
+absl::Status SingleValueManager::WriteU8AtAddress(channel_addr_t address,
+                                                  uint8_t value) {
+  return this->WriteInternal(address, value, 0);
+}
+
+absl::Status SingleValueManager::WriteU16AtAddress(channel_addr_t address,
+                                                   uint16_t value) {
+  return this->WriteInternal(address, value, 1);
+}
+
+absl::Status SingleValueManager::WriteU32AtAddress(channel_addr_t address,
+                                                   uint32_t value) {
+  return this->WriteInternal(address, value, 2);
+}
+
+absl::Status SingleValueManager::WriteU64AtAddress(channel_addr_t address,
+                                                   uint64_t value) {
+  return this->WriteInternal(address, value, 3);
+}
+
+static constexpr absl::StatusOr<uint64_t> (*GetPayloadWPow[4])(IRegister*,
+                                                               uint64_t) = {
+    [](IRegister* stream, uint64_t addr) -> absl::StatusOr<uint64_t> {
+      return stream->GetPayloadData8(addr);
+    },
+    [](IRegister* stream, uint64_t addr) -> absl::StatusOr<uint64_t> {
+      return stream->GetPayloadData16(addr);
+    },
+    [](IRegister* stream, uint64_t addr) -> absl::StatusOr<uint64_t> {
+      return stream->GetPayloadData32(addr);
+    },
+    [](IRegister* stream, uint64_t addr) -> absl::StatusOr<uint64_t> {
+      return stream->GetPayloadData64(addr);
+    },
+};
+
+absl::StatusOr<uint64_t> SingleValueManager::ReadInternal(
+    channel_addr_t address, uint64_t log_byte_count) {
+  XLS_ASSIGN_OR_RETURN(IRegister * reg,
+                       GetMappingOrStatus(address, ErrorMessageRead(address)));
+  uint64_t internal_address = address - this->base_address_;
+  uint64_t in_channel_offset =
+      internal_address - this->channel_to_offset_.at(reg);
+  XLS_ASSIGN_OR_RETURN(uint64_t data,
+                       GetPayloadWPow[log_byte_count](reg, in_channel_offset));
+
+  uint64_t byte_count = 1 << log_byte_count;
+  if ((address + byte_count - 1) % kChannelAlignment >=
+      address % kChannelAlignment) {
+    return data;
+  }
+
+  // Read may span multiple channels, check if true
+  uint64_t overlap = (address + byte_count) % kChannelAlignment;
+  uint64_t used_bytes = byte_count - overlap;
+
+  auto overlapping_channel =
+      GetMappingOrStatus(address + used_bytes, std::string());
+  if (!overlapping_channel.ok()) return data;
+  int address_in_overlapping_channel = 0;
+  for (int i = 0; overlap > 0; ++i, overlap >>= 1) {
+    if (overlap & 1) {
+      auto next_channel_bytes = GetPayloadWPow[i](
+          overlapping_channel.value(), address_in_overlapping_channel);
+      if (!next_channel_bytes.ok()) return data;
+      data |= next_channel_bytes.value()
+              << BytesToBits(used_bytes + address_in_overlapping_channel);
+      address_in_overlapping_channel |= 1 << i;
+    }
+  }
+  return data;
+}
+
+absl::StatusOr<uint8_t> SingleValueManager::ReadU8AtAddress(
+    channel_addr_t address) {
+  return this->ReadInternal(address, 0);
+}
+
+absl::StatusOr<uint16_t> SingleValueManager::ReadU16AtAddress(
+    channel_addr_t address) {
+  return this->ReadInternal(address, 1);
+}
+
+absl::StatusOr<uint32_t> SingleValueManager::ReadU32AtAddress(
+    channel_addr_t address) {
+  return this->ReadInternal(address, 2);
+}
+
+absl::StatusOr<uint64_t> SingleValueManager::ReadU64AtAddress(
+    channel_addr_t address) {
+  return this->ReadInternal(address, 3);
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/singlevaluemanager.h
+++ b/xls/simulation/generic/singlevaluemanager.h
@@ -1,0 +1,78 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_SINGLEVALUEMANAGER_H_
+#define XLS_SIMULATION_GENERIC_SINGLEVALUEMANAGER_H_
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/ichannel.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+#include "xls/simulation/generic/iregister.h"
+
+namespace xls::simulation::generic {
+
+class SingleValueManager : public IChannelManager {
+ public:
+  explicit SingleValueManager(uint64_t base_address);
+  SingleValueManager(SingleValueManager&& old) = default;
+  SingleValueManager& operator=(SingleValueManager&& old) = default;
+
+  absl::Status RegisterIRegister(std::unique_ptr<IRegister> reg,
+                                 uint64_t offset);
+  absl::Status WriteU8AtAddress(channel_addr_t address, uint8_t value) override;
+  absl::Status WriteU16AtAddress(channel_addr_t address,
+                                 uint16_t value) override;
+  absl::Status WriteU32AtAddress(channel_addr_t address,
+                                 uint32_t value) override;
+  absl::Status WriteU64AtAddress(channel_addr_t address,
+                                 uint64_t value) override;
+  absl::StatusOr<uint8_t> ReadU8AtAddress(channel_addr_t address) override;
+  absl::StatusOr<uint16_t> ReadU16AtAddress(channel_addr_t address) override;
+  absl::StatusOr<uint32_t> ReadU32AtAddress(channel_addr_t address) override;
+  absl::StatusOr<uint64_t> ReadU64AtAddress(channel_addr_t address) override;
+
+  virtual ~SingleValueManager() = default;
+
+ private:
+  friend class SingleValueManagerTest;
+  // 64-bit alignment
+  static const uint64_t kChannelAlignment = 8;
+
+  SingleValueManager();
+
+  absl::Status WriteInternal(channel_addr_t address, uint64_t data,
+                             uint64_t log_byte_count);
+  absl::StatusOr<uint64_t> ReadInternal(channel_addr_t address,
+                                        uint64_t log_byte_count);
+
+  bool IsOffsetFree(uint64_t offset, uint64_t channel_width);
+  absl::StatusOr<IRegister*> GetMappingOrStatus(uint64_t address,
+                                                std::string&& err_msg);
+  uint64_t GetMaxOffset() const { return this->address_range_end_; }
+
+  std::map<uint64_t, std::unique_ptr<IRegister>> offset_to_channel_;
+  std::unordered_map<IRegister*, uint64_t> channel_to_offset_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_SINGLEVALUEMANAGER_H_

--- a/xls/simulation/generic/singlevaluemanager_test.cc
+++ b/xls/simulation/generic/singlevaluemanager_test.cc
@@ -1,0 +1,373 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/singlevaluemanager.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iregister_mock.h"
+#include "xls/simulation/generic/iregister_stub.h"
+
+namespace xls::simulation::generic {
+
+// This class has to be in generic namespace as it's
+// a friend class with SingleValueManager
+class SingleValueManagerTest : public ::testing::Test {
+ protected:
+  static const uint64_t base_address = 0x10000;
+
+  std::unique_ptr<SingleValueManager> manager_;
+
+  uint64_t GetMaxOffset() { return manager_->GetMaxOffset(); }
+  SingleValueManagerTest() {
+    manager_ = std::unique_ptr<SingleValueManager>(
+        new SingleValueManager(base_address));
+  }
+  ~SingleValueManagerTest() {}
+};
+
+namespace {
+// Registering on valid offsets should succeed
+TEST_F(SingleValueManagerTest, RegisterIRegisterValidOffsets) {
+  std::unique_ptr<IRegister> channel_1bit =
+      std::make_unique<IRegisterMock<1>>();
+  std::unique_ptr<IRegister> channel_8bit =
+      std::make_unique<IRegisterMock<8>>();
+  std::unique_ptr<IRegister> channel_16bit =
+      std::make_unique<IRegisterMock<16>>();
+  std::unique_ptr<IRegister> channel_32bit =
+      std::make_unique<IRegisterMock<32>>();
+  std::unique_ptr<IRegister> channel_63bit =
+      std::make_unique<IRegisterMock<63>>();
+  std::unique_ptr<IRegister> channel_64bit =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_65bit =
+      std::make_unique<IRegisterMock<65>>();
+  std::unique_ptr<IRegister> channel_128bit =
+      std::make_unique<IRegisterMock<128>>();
+  std::unique_ptr<IRegister> channel_1024bit =
+      std::make_unique<IRegisterMock<1024>>();
+
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_1bit), 0x0));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_8bit), 0x40));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_16bit), 0x80));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_32bit), 0xC0));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_63bit), 0x100));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_64bit), 0x140));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_65bit), 0x180));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_128bit), 0x200));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_1024bit), 0x280));
+}
+
+// Registering on taken offsets should fail
+TEST_F(SingleValueManagerTest, RegisterIRegisterOnTakenOffset) {
+  std::unique_ptr<IRegister> channel_1bit =
+      std::make_unique<IRegisterMock<1>>();
+  std::unique_ptr<IRegister> channel_8bit =
+      std::make_unique<IRegisterMock<8>>();
+  std::unique_ptr<IRegister> channel_16bit =
+      std::make_unique<IRegisterMock<16>>();
+  std::unique_ptr<IRegister> channel_32bit =
+      std::make_unique<IRegisterMock<32>>();
+  std::unique_ptr<IRegister> channel_63bit =
+      std::make_unique<IRegisterMock<63>>();
+  std::unique_ptr<IRegister> channel_64bit =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_65bit =
+      std::make_unique<IRegisterMock<65>>();
+  std::unique_ptr<IRegister> channel_128bit =
+      std::make_unique<IRegisterMock<128>>();
+  std::unique_ptr<IRegister> channel_1024bit =
+      std::make_unique<IRegisterMock<1024>>();
+  std::unique_ptr<IRegister> channel_taken_offset =
+      std::make_unique<IRegisterMock<64>>();
+
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_1bit), 0x0));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_8bit), 0x8));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_16bit), 0x10));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_32bit), 0x18));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_63bit), 0x20));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_64bit), 0x28));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_65bit), 0x30));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_128bit), 0x40));
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_1024bit), 0x50));
+
+  for (uint64_t offset = 0x0; offset < 0x130; offset += 0x8) {
+    EXPECT_TRUE(absl::IsInvalidArgument(
+        manager_->RegisterIRegister(std::move(channel_taken_offset), offset)));
+  }
+}
+
+// Registering the same channel twice on different valid offsets should fail
+TEST_F(SingleValueManagerTest, RegisterIRegisterDouble) {
+  std::unique_ptr<IRegister> channel_1bit =
+      std::make_unique<IRegisterMock<1>>();
+
+  // Test valid channel registrations
+  XLS_EXPECT_OK(manager_->RegisterIRegister(std::move(channel_1bit), 0x0));
+  EXPECT_THAT(manager_->RegisterIRegister(std::move(channel_1bit), 0x8),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr("Invalid unique pointer!")));
+}
+
+// Registering unaligned offsets should fail
+TEST_F(SingleValueManagerTest, RegisterIRegisterUnaligned) {
+  std::unique_ptr<IRegister> channel_unaligned_offset =
+      std::make_unique<IRegisterMock<64>>();
+
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x1)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x3F)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x41)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x13F)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x181)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x1BF)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x1C1)));
+  EXPECT_TRUE(absl::IsInvalidArgument(
+      manager_->RegisterIRegister(std::move(channel_unaligned_offset), 0x1FF)));
+}
+
+// Channels smaller or equal than space available between already registered
+// channels should be registered
+TEST_F(SingleValueManagerTest, RegisterIRegisterBetweenWillFit) {
+  std::unique_ptr<IRegister> channel_64bit_first =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_64bit_second =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_64bit_between =
+      std::make_unique<IRegisterMock<64>>();
+
+  XLS_EXPECT_OK(
+      manager_->RegisterIRegister(std::move(channel_64bit_first), 0x0));
+  // Leave space for channel of width <= 64 at offset 0x40
+  XLS_EXPECT_OK(
+      manager_->RegisterIRegister(std::move(channel_64bit_second), 0x80));
+
+  XLS_EXPECT_OK(
+      manager_->RegisterIRegister(std::move(channel_64bit_between), 0x40));
+}
+
+// Channels wider than space available between already registered channels
+// should not be registered
+TEST_F(SingleValueManagerTest, RegisterIRegisterBetweenWontFit) {
+  std::unique_ptr<IRegister> channel_64bit_first =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_64bit_second =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_65bit =
+      std::make_unique<IRegisterMock<65>>();
+  std::unique_ptr<IRegister> channel_128bit =
+      std::make_unique<IRegisterMock<128>>();
+
+  XLS_EXPECT_OK(
+      manager_->RegisterIRegister(std::move(channel_64bit_first), 0x0));
+  // Leave space for channel of width <= 64 at offset 0x40
+  XLS_EXPECT_OK(
+      manager_->RegisterIRegister(std::move(channel_64bit_second), 0x10));
+
+  EXPECT_THAT(manager_->RegisterIRegister(std::move(channel_65bit), 0x8),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr("Channel to big or bad offset")));
+  EXPECT_THAT(manager_->RegisterIRegister(std::move(channel_128bit), 0x8),
+              xls::status_testing::StatusIs(
+                  absl::StatusCode::kInvalidArgument,
+                  testing::HasSubstr("Channel to big or bad offset")));
+}
+
+// Channels should move mapping upper limit
+TEST_F(SingleValueManagerTest, RegisterIRegisterPastAddressRange) {
+  std::unique_ptr<IRegister> channel_64bit =
+      std::make_unique<IRegisterMock<64>>();
+  std::unique_ptr<IRegister> channel_128bit =
+      std::make_unique<IRegisterMock<128>>();
+
+  EXPECT_THAT(manager_->RegisterIRegister(std::move(channel_64bit), 0x1000),
+              xls::status_testing::IsOk());
+  EXPECT_EQ(GetMaxOffset(), 0x1008);
+  EXPECT_THAT(
+      manager_->RegisterIRegister(std::move(channel_128bit), 0x1000 - 0x40),
+      xls::status_testing::IsOk());
+  EXPECT_EQ(GetMaxOffset(), 0x1008);
+}
+
+class SingleValueManagerTestWithStub : public ::testing::Test {
+ protected:
+  static const uint64_t base_address = 0x0;
+
+  std::unique_ptr<SingleValueManager> manager_;
+
+  SingleValueManagerTestWithStub() {
+    manager_ = std::unique_ptr<SingleValueManager>(
+        new SingleValueManager(base_address));
+  }
+  void SetUp() {
+    std::unique_ptr<IRegister> channel_64bit =
+        std::make_unique<IRegisterStub>();
+    XLS_ASSERT_OK(manager_->RegisterIRegister(std::move(channel_64bit), 0));
+  }
+  ~SingleValueManagerTestWithStub() {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(SingleValueManagerTestWithStub, WriteU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->WriteU8AtAddress(0x0, 0xDE));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::SetPayloadData8()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, WriteU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->WriteU16AtAddress(0x0, 0xDEAD));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::SetPayloadData16()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, WriteU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->WriteU32AtAddress(0x0, 0xDEADBEEF));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::SetPayloadData32()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, WriteU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->WriteU64AtAddress(0x0, 0xDEADBEEFFEEBDAED));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::SetPayloadData64()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, ReadU8AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->ReadU8AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::GetPayloadData8()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, ReadU16AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->ReadU16AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::GetPayloadData16()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, ReadU32AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->ReadU32AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::GetPayloadData32()"));
+}
+
+TEST_F(SingleValueManagerTestWithStub, ReadU64AtAddress) {
+  ::testing::internal::CaptureStderr();
+  XLS_EXPECT_OK(manager_->ReadU64AtAddress(0x0));
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("IRegisterStub::GetPayloadData64()"));
+}
+
+class SingleValueManagerTestWithMocks
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<uint64_t> {
+ protected:
+  static const uint64_t base_address = 0x0;
+
+  std::unique_ptr<SingleValueManager> manager_;
+  std::array<uint8_t, 8> first_mock_{0xDE, 0xAD, 0xBE, 0xEF,
+                                     0xDE, 0xAD, 0xBE, 0xEF};
+  std::array<uint8_t, 1> second_mock_{0xAA};
+
+  SingleValueManagerTestWithMocks() {
+    manager_ = std::unique_ptr<SingleValueManager>(
+        new SingleValueManager(base_address));
+  }
+  void SetUp() {
+    std::unique_ptr<IRegister> channel_64bit =
+        std::make_unique<IRegisterMock<64>>(first_mock_);
+    std::unique_ptr<IRegister> channel_7bit =
+        std::make_unique<IRegisterMock<7>>(second_mock_);
+    XLS_ASSERT_OK(manager_->RegisterIRegister(std::move(channel_64bit), 0));
+    XLS_ASSERT_OK(manager_->RegisterIRegister(std::move(channel_7bit), 0x8));
+  }
+  ~SingleValueManagerTestWithMocks() {}
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_P(SingleValueManagerTestWithMocks, ReadU8) {
+  EXPECT_THAT(this->manager_->ReadU8AtAddress(GetParam()),
+              xls::status_testing::IsOkAndHolds(first_mock_[GetParam()]));
+}
+
+TEST_P(SingleValueManagerTestWithMocks, ReadU16) {
+  std::array<uint8_t, 9> first_second_concatenation;
+  for (int i = 0; i < first_mock_.size(); ++i)
+    first_second_concatenation[i] = first_mock_[i];
+  first_second_concatenation[8] = second_mock_[0] & 0x7f;
+  uint16_t expected_output = first_second_concatenation[GetParam()] |
+                             (first_second_concatenation[GetParam() + 1] << 8);
+  EXPECT_THAT(this->manager_->ReadU16AtAddress(GetParam()),
+              xls::status_testing::IsOkAndHolds(expected_output));
+}
+
+TEST_P(SingleValueManagerTestWithMocks, ReadU32) {
+  std::array<uint8_t, 11> first_second_concatenation;
+  first_second_concatenation.fill(0);
+  for (int i = 0; i < first_mock_.size(); ++i)
+    first_second_concatenation[i] = first_mock_[i];
+  first_second_concatenation[8] = second_mock_[0] & 0x7f;
+  uint32_t expected_output = 0;
+  for (int i = 0; i < 4; ++i) {
+    expected_output |= first_second_concatenation[GetParam() + i] << (8 * i);
+  }
+  EXPECT_THAT(this->manager_->ReadU32AtAddress(GetParam()),
+              xls::status_testing::IsOkAndHolds(expected_output));
+}
+
+TEST_P(SingleValueManagerTestWithMocks, ReadU64) {
+  std::array<uint8_t, 15> first_second_concatenation;
+  first_second_concatenation.fill(0);
+  for (int i = 0; i < first_mock_.size(); ++i)
+    first_second_concatenation[i] = first_mock_[i];
+  first_second_concatenation[8] = second_mock_[0] & 0x7f;
+  uint64_t expected_output = 0;
+  for (int i = 0; i < 8; ++i) {
+    expected_output |= ((uint64_t)first_second_concatenation[GetParam() + i])
+                       << (8 * i);
+  }
+  EXPECT_THAT(this->manager_->ReadU64AtAddress(GetParam()),
+              xls::status_testing::IsOkAndHolds(expected_output));
+}
+
+INSTANTIATE_TEST_SUITE_P(RuntimeManagerTestInstantiation,
+                         SingleValueManagerTestWithMocks,
+                         testing::Values(0, 1, 2, 3, 4, 5, 6, 7));
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/stream_dma_endpoint.cc
+++ b/xls/simulation/generic/stream_dma_endpoint.cc
@@ -1,0 +1,52 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/stream_dma_endpoint.h"
+
+#include "absl/strings/str_format.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+
+namespace xls::simulation::generic {
+
+absl::Status StreamDmaEndpoint::Write(Payload payload) {
+  XLS_CHECK(!IsReadStream());
+  if (payload.data.empty()) {
+    // Empty writes are ignored
+    return absl::OkStatus();
+  }
+  if (payload.data.size() != transfer_size_) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Invalid transfer size: %u bytes, must be %u",
+                        payload.data.size(), transfer_size_));
+  }
+  for (uint64_t i = 0; i < transfer_size_; i++) {
+    XLS_RETURN_IF_ERROR(stream_->SetPayloadData8(i, payload.data[i]));
+  }
+  XLS_RETURN_IF_ERROR(stream_->Transfer());
+  return absl::OkStatus();
+}
+
+absl::StatusOr<StreamDmaEndpoint::Payload> StreamDmaEndpoint::Read() {
+  XLS_CHECK(IsReadStream());
+  XLS_RETURN_IF_ERROR(stream_->Transfer());
+  Payload payload{};
+  payload.data.resize(transfer_size_);
+  for (uint64_t i = 0; i < transfer_size_; i++) {
+    XLS_ASSIGN_OR_RETURN(payload.data[i], stream_->GetPayloadData8(i));
+  }
+  return payload;
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/stream_dma_endpoint.h
+++ b/xls/simulation/generic/stream_dma_endpoint.h
@@ -1,0 +1,49 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_STREAM_DMA_ENDPOINT_H_
+#define XLS_SIMULATION_GENERIC_STREAM_DMA_ENDPOINT_H_
+
+#include <memory>
+#include <utility>
+
+#include "xls/simulation/generic/idmaendpoint.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+class StreamDmaEndpoint : public IDmaEndpoint {
+ public:
+  explicit StreamDmaEndpoint(std::unique_ptr<IStream> stream)
+      : stream_(std::move(stream)) {
+    transfer_size_ = (stream_->GetChannelWidth() + 7) / 8;
+  }
+
+  uint64_t GetElementSize() const override { return transfer_size_; }
+  uint64_t GetMaxElementsPerTransfer() const override { return 1; }
+  bool IsReadStream() const override { return stream_->IsReadStream(); }
+  bool IsReady() const override { return stream_->IsReady(); }
+  absl::Status Write(Payload payload) override;
+  absl::StatusOr<Payload> Read() override;
+
+  IStream* GetStream() const { return stream_.get(); }
+
+ private:
+  std::unique_ptr<IStream> stream_;
+  uint64_t transfer_size_;
+};
+
+};  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_STREAM_DMA_ENDPOINT_H_

--- a/xls/simulation/generic/streamdmachannel.cc
+++ b/xls/simulation/generic/streamdmachannel.cc
@@ -1,0 +1,205 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/streamdmachannel.h"
+
+#include <algorithm>
+
+#include "absl/strings/str_format.h"
+#include "xls/common/bits_util.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/status_macros.h"
+
+namespace xls::simulation::generic {
+
+void StreamDmaChannel::SetTransferBaseAddress(channel_addr_t address) {
+  if (dma_run_) {
+    XLS_LOG(WARNING) << "Base address can't be modified while DMA is running";
+    return;
+  }
+  transfer_base_address_ = address;
+}
+
+void StreamDmaChannel::SetMaxTransferLength(uint64_t length) {
+  if (dma_run_) {
+    XLS_LOG(WARNING)
+        << "Max transfer length can't be modified while DMA is running";
+    return;
+  }
+  if (length % element_size_ != 0) {
+    XLS_LOG(WARNING) << "Max transfer length will be clipped to: "
+                     << length - (length % element_size_);
+  }
+  length -= length % element_size_;
+  max_transfer_length_ = length;
+}
+
+void StreamDmaChannel::SetControlRegister(uint64_t update_state) {
+  // First 2 bits are used for IRQ masking
+  irq_mask_ = update_state & kCsrIrqMaskMask;
+  // Third bit enables/resets DMA
+  bool new_dma_run =
+      static_cast<bool>((update_state >> kCsrDmaRunShift) & kCsrDmaRunMask);
+  if (!new_dma_run) {
+    transferred_length_ = 0;
+    dma_finished_ = false;
+  }
+  dma_run_ = new_dma_run;
+  // Sixth bit controls if DMA should discard read data
+  bool new_dma_discard_n = static_cast<bool>(
+      (update_state >> kCsrDmaDiscardNShift) & kCsrDmaDiscardNMask);
+  dma_discard_ = !new_dma_discard_n;
+}
+
+uint64_t StreamDmaChannel::GetControlRegister() {
+  uint64_t intermediate_cr_ = irq_mask_ & kCsrIrqMaskMask;
+  intermediate_cr_ |= static_cast<uint64_t>(dma_run_) << kCsrDmaRunShift;
+  intermediate_cr_ |= static_cast<uint64_t>(dma_finished_)
+                      << kCsrDmaFinishedShift;
+  intermediate_cr_ |= static_cast<uint64_t>(endpoint_->IsReadStream())
+                      << kCsrIsReadStreamShift;
+  intermediate_cr_ |= static_cast<uint64_t>(!dma_discard_)
+                      << kCsrDmaDiscardNShift;
+  intermediate_cr_ |= static_cast<uint64_t>(endpoint_->IsReady())
+                      << kCsrIsReadyShift;
+  return intermediate_cr_;
+}
+
+bool StreamDmaChannel::GetIRQ() { return (irq_mask_ & irq_) != 0u; }
+
+static AccessWidth AccessOfWidthPow(uint64_t pow2) {
+  switch (pow2) {
+    case 0:
+      return AccessWidth::BYTE;
+    case 1:
+      return AccessWidth::WORD;
+    case 2:
+      return AccessWidth::DWORD;
+    case 3:
+      return AccessWidth::QWORD;
+  }
+  ABSL_ASSERT(false);
+  // Unreachable
+  return AccessWidth::BYTE;
+}
+
+absl::Status StreamDmaChannel::UpdateWriteToEmulator() {
+  while (endpoint_->IsReady() && transferred_length_ < max_transfer_length_) {
+    XLS_ASSIGN_OR_RETURN(auto xfer, endpoint_->Read());
+    auto n_received = xfer.data.size();
+    XLS_CHECK_EQ(n_received % element_size_, 0);
+    uint64_t n_bytes_to_transfer =
+        std::min(n_received, max_transfer_length_ - transferred_length_);
+    if (dma_discard_) {
+      // Discard mode
+      transferred_length_ += n_bytes_to_transfer;
+    } else {
+      if (n_bytes_to_transfer != n_received) {
+        XLS_LOG(WARNING) << absl::StreamFormat(
+            "Endpoint returned %u bytes, but only %u will be transferred to "
+            "the memory to obey the max DMA transfer size set by the user. "
+            "Data will be lost.",
+            n_received, n_bytes_to_transfer);
+      }
+      // Where possible, use 64-bit DMA accesses
+      uint64_t quotient = n_bytes_to_transfer / sizeof(uint64_t);
+      for (uint64_t i = 0; i < quotient; ++i) {
+        // u8[8]<->u64 cast has to be done in native endianness
+        uint64_t payload;
+        memcpy(&payload, xfer.data.data() + i * sizeof(uint64_t),
+               sizeof(uint64_t));
+        bus_master_port_->RequestWrite(
+            transfer_base_address_ + transferred_length_, payload,
+            AccessWidth::QWORD);
+        transferred_length_ += sizeof(uint64_t);
+      }
+
+      // Handle remaining bytes using 8-bit accesses
+      for (uint64_t i = sizeof(uint64_t) * quotient; i < n_bytes_to_transfer;
+           ++i) {
+        bus_master_port_->RequestWrite(
+            transfer_base_address_ + transferred_length_, xfer.data[i],
+            AccessWidth::BYTE);
+        transferred_length_ += sizeof(uint8_t);
+      }
+    }
+    // If last element was signalled by the endpoint, signal the end of the DMA
+    // transfer
+    if (xfer.last) {
+      dma_finished_ = true;
+      irq_ |= kReceivedLastIrq;
+      break;
+    }
+  }
+  return absl::OkStatus();
+}
+
+absl::Status StreamDmaChannel::UpdateReadFromEmulator() {
+  while (endpoint_->IsReady() && transferred_length_ < max_transfer_length_) {
+    uint64_t max_bytes_per_transfer =
+        element_size_ * endpoint_->GetMaxElementsPerTransfer();
+    uint64_t n_bytes_to_transfer = std::min(
+        max_bytes_per_transfer, max_transfer_length_ - transferred_length_);
+
+    IDmaEndpoint::Payload xfer{};
+
+    // Where possible, use 64-bit DMA accesses
+    uint64_t quotient = n_bytes_to_transfer / sizeof(uint64_t);
+    for (uint64_t i = 0; i < quotient; ++i) {
+      auto resp = bus_master_port_->RequestRead(
+          transfer_base_address_ + transferred_length_, AccessWidth::QWORD);
+      uint64_t payload = resp.value();
+      // u8[8]<->u64 cast has to be done in native endianness
+      xfer.data.resize(xfer.data.size() + sizeof(uint64_t));
+      memcpy(xfer.data.data() + sizeof(uint64_t) * i, &payload,
+             sizeof(uint64_t));
+      transferred_length_ += sizeof(uint64_t);
+    }
+    // Handle remaining bytes using 8-bit accesses
+    for (uint64_t i = sizeof(uint64_t) * quotient; i < n_bytes_to_transfer;
+         ++i) {
+      auto resp = bus_master_port_->RequestRead(
+          transfer_base_address_ + transferred_length_, AccessWidth::BYTE);
+      uint8_t payload = resp.value();
+      xfer.data.push_back(payload);
+      transferred_length_ += sizeof(uint8_t);
+    }
+    // Set 'last' flag
+    if (transferred_length_ >= max_transfer_length_) {
+      xfer.last = true;
+    }
+    XLS_RETURN_IF_ERROR(endpoint_->Write(std::move(xfer)));
+  }
+  return absl::OkStatus();
+}
+
+absl::Status StreamDmaChannel::Update() {
+  if (dma_run_ && !dma_finished_) {
+    if (endpoint_->IsReadStream()) {
+      XLS_RETURN_IF_ERROR(UpdateWriteToEmulator());
+    } else {
+      XLS_RETURN_IF_ERROR(UpdateReadFromEmulator());
+    }
+    // If all the requested data has been transferred, or the transfer has been
+    // prematurely marked as complete by the Update function, signal the end of
+    // the transfer
+    if (transferred_length_ >= max_transfer_length_ || dma_finished_) {
+      dma_finished_ = true;
+      irq_ |= kTransferFinishedIrq;
+    }
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/streamdmachannel.h
+++ b/xls/simulation/generic/streamdmachannel.h
@@ -1,0 +1,127 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_STREAMDMACHANNEL_H_
+#define XLS_SIMULATION_GENERIC_STREAMDMACHANNEL_H_
+
+#include <memory>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "xls/simulation/generic/common.h"
+#include "xls/simulation/generic/iactive.h"
+#include "xls/simulation/generic/idmaendpoint.h"
+#include "xls/simulation/generic/iirq.h"
+#include "xls/simulation/generic/imasterport.h"
+
+namespace xls::simulation::generic {
+
+class StreamDmaChannel : public IActive, public IIRQ {
+ public:
+  using channel_addr_t = uint64_t;
+
+  // Control and status register
+  // 63       7       6             5            4            3       2        0
+  // ┌────────┬───────┬─────────────┬────────────┬────────────┬───────┬────────┐
+  // │(unused)│IsReady│DMA discard N│IsReadStream│DMA finished│DMA run│IRQ mask│
+  // └────────┴───────┴─────────────┴────────────┴────────────┴───────┴────────┘
+  //
+  // IRQ mask - (control) masks IRQ sources
+  // DMA run - (control) enables/resets DMA
+  // DMA finished - (status) set to 1 when transfered all data
+  // IsReadStream - (status) informs whether underlying stream can be read
+  // DMA discard - (control) when 0, performs the transfer through channel but
+  // doesn't read the transfered data
+  // IsReady - (status) set to 1 when the stream is ready to perform a single
+  // transfer
+  static const uint64_t kTransferFinishedIrq = 1;
+  static const uint64_t kReceivedLastIrq = 2;
+  static const uint64_t kCsrIrqMaskMask = 0b11;
+  static const uint64_t kCsrDmaRunShift = 2;
+  static const uint64_t kCsrDmaRunMask = 0b1;
+  static const uint64_t kCsrDmaFinishedShift = 3;
+  static const uint64_t kCsrIsReadStreamShift = 4;
+  static const uint64_t kCsrDmaDiscardNShift = 5;
+  static const uint64_t kCsrDmaDiscardNMask = 0b1;
+  static const uint64_t kCsrIsReadyShift = 6;
+
+  StreamDmaChannel(std::unique_ptr<IDmaEndpoint> endpoint,
+                   IMasterPort* bus_master_port)
+      : endpoint_(std::move(endpoint)),
+        transfer_base_address_(0),
+        max_transfer_length_(0),
+        transferred_length_(0),
+        irq_mask_(0),
+        dma_run_(false),
+        dma_finished_(false),
+        dma_discard_(true),
+        irq_(0),
+        bus_master_port_(bus_master_port) {
+    this->element_size_ = endpoint_->GetElementSize();
+  }
+
+  StreamDmaChannel(StreamDmaChannel&& other) = default;
+  StreamDmaChannel& operator=(StreamDmaChannel&& other_) = default;
+
+  ~StreamDmaChannel() override = default;
+
+  void SetTransferBaseAddress(channel_addr_t address);
+  channel_addr_t GetTransferBaseAddress() {
+    return this->transfer_base_address_;
+  }
+
+  void SetMaxTransferLength(uint64_t length);
+  uint64_t GetMaxTransferLength() { return this->max_transfer_length_; }
+
+  uint64_t GetTransferredLength() { return this->transferred_length_; }
+
+  void ClearIRQReg(uint64_t reset_vector) { this->irq_ &= ~reset_vector; }
+  uint64_t GetIRQReg() { return this->irq_; }
+
+  void SetControlRegister(uint64_t update_state);
+  uint64_t GetControlRegister();
+
+  // IActive
+  absl::Status Update() override;
+
+  // IIRQ
+  bool GetIRQ() override;
+  absl::Status UpdateIRQ() override { return absl::OkStatus(); }
+
+ protected:
+  std::unique_ptr<IDmaEndpoint> endpoint_;
+  virtual absl::Status UpdateReadFromEmulator();
+  virtual absl::Status UpdateWriteToEmulator();
+
+ private:
+  friend class StreamDmaChannelPrivateAccess;
+
+  channel_addr_t transfer_base_address_;
+  uint64_t max_transfer_length_;
+  uint64_t transferred_length_;
+
+  // Control and status register fields
+  uint64_t irq_mask_;
+  bool dma_run_;
+  bool dma_finished_;
+  bool dma_discard_;
+
+  uint64_t irq_;
+  uint64_t element_size_;
+  IMasterPort* bus_master_port_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_STREAMDMACHANNEL_H_

--- a/xls/simulation/generic/streamdmachannel_test.cc
+++ b/xls/simulation/generic/streamdmachannel_test.cc
@@ -1,0 +1,363 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/streamdmachannel.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "absl/flags/flag.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/imasterport.h"
+#include "xls/simulation/generic/istream_mock.h"
+#include "xls/simulation/generic/stream_dma_endpoint.h"
+
+namespace xls::simulation::generic {
+
+// This class has to be in generic namespace as it's
+// a friend class with StreamDmaChannel
+class StreamDmaChannelPrivateAccess {
+ public:
+  explicit StreamDmaChannelPrivateAccess(StreamDmaChannel& channel)
+      : dma_channel_(channel) {}
+  void SetIrq(uint64_t new_irq) { dma_channel_.irq_ = new_irq; }
+  void SetIrqMask(uint64_t new_irq_mask) {
+    dma_channel_.irq_mask_ = new_irq_mask;
+  }
+  void SetDmaRun(bool new_dma_run) { dma_channel_.dma_run_ = new_dma_run; }
+  void SetDmaDiscard(bool new_dma_discard) {
+    dma_channel_.dma_discard_ = new_dma_discard;
+  }
+
+  absl::Status InternalUpdate() {
+    if (dma_channel_.endpoint_->IsReadStream())
+      return dma_channel_.UpdateWriteToEmulator();
+    return dma_channel_.UpdateReadFromEmulator();
+  }
+
+  IStream* GetChannel() {
+    return dynamic_cast<StreamDmaEndpoint&>(*dma_channel_.endpoint_)
+        .GetStream();
+  }
+
+ private:
+  StreamDmaChannel& dma_channel_;
+};
+
+namespace {
+
+using ::testing::_;
+using ::testing::Eq;
+using ::testing::InSequence;
+using ::testing::Return;
+
+class StreamDmaChannelIMasterPortMock : public IMasterPort {
+ public:
+  MOCK_METHOD(absl::Status, RequestWrite,
+              (uint64_t address, uint64_t payload, AccessWidth width),
+              (override));
+  MOCK_METHOD(absl::StatusOr<uint64_t>, RequestRead,
+              (uint64_t address, AccessWidth width), (override));
+};
+
+static std::unique_ptr<IDmaEndpoint> MakeIStreamMockEndpoint(
+    bool is_read_stream) {
+  if (is_read_stream) {
+    return std::make_unique<StreamDmaEndpoint>(
+        std::make_unique<IStreamMock<120, true>>());
+  }
+  return std::make_unique<StreamDmaEndpoint>(
+      std::make_unique<IStreamMock<120, false>>());
+}
+
+static void MakeStreamReady(IStream* stream) {
+  if (stream->IsReadStream()) {
+    dynamic_cast<IStreamMock<120, true>*>(stream)->fifo().push(
+        std::array<uint8_t, 15>{0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xAD, 0x8B,
+                                0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xAD});
+  }
+}
+
+class StreamDmaChannelTest : public ::testing::Test,
+                             public ::testing::WithParamInterface<bool> {
+ protected:
+  StreamDmaChannelTest()
+      : bus_master_port_(),
+        dma_channel_(MakeIStreamMockEndpoint(GetParam()), &bus_master_port_),
+        proxy_(dma_channel_) {}
+  StreamDmaChannelIMasterPortMock bus_master_port_;
+  StreamDmaChannel dma_channel_;
+  StreamDmaChannelPrivateAccess proxy_;
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_P(StreamDmaChannelTest, GetIRQRegTest) {
+  this->proxy_.SetIrq(0xDEADBEEF);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0xDEADBEEF);
+}
+
+TEST_P(StreamDmaChannelTest, ClearIRQRegTest) {
+  this->proxy_.SetIrq(0x3);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x3);
+
+  this->dma_channel_.ClearIRQReg(0);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x3);
+
+  this->dma_channel_.ClearIRQReg(4);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x3);
+
+  this->dma_channel_.ClearIRQReg(1);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x2);
+
+  this->dma_channel_.ClearIRQReg(2);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x0);
+}
+
+TEST_P(StreamDmaChannelTest, BaseAddressTest) {
+  uint64_t base_address = 0x4000;
+  this->dma_channel_.SetTransferBaseAddress(base_address);
+  EXPECT_EQ(this->dma_channel_.GetTransferBaseAddress(), base_address);
+
+  this->proxy_.SetDmaRun(true);
+  ::testing::internal::CaptureStderr();
+  this->dma_channel_.SetTransferBaseAddress(base_address + 0x100);
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr(
+                  "Base address can't be modified while DMA is running"));
+  EXPECT_EQ(this->dma_channel_.GetTransferBaseAddress(), base_address);
+
+  this->proxy_.SetDmaRun(false);
+  this->dma_channel_.SetTransferBaseAddress(base_address + 0x100);
+  EXPECT_EQ(this->dma_channel_.GetTransferBaseAddress(), base_address + 0x100);
+}
+
+TEST_P(StreamDmaChannelTest, MaxTransferLength) {
+  uint64_t transfer_length = 0x3FFC;
+  this->dma_channel_.SetMaxTransferLength(transfer_length);
+  EXPECT_EQ(this->dma_channel_.GetMaxTransferLength(), transfer_length);
+
+  this->proxy_.SetDmaRun(true);
+  ::testing::internal::CaptureStderr();
+  this->dma_channel_.SetMaxTransferLength(transfer_length + 0x100);
+  EXPECT_THAT(
+      ::testing::internal::GetCapturedStderr(),
+      ::testing::HasSubstr(
+          "Max transfer length can't be modified while DMA is running"));
+  EXPECT_EQ(this->dma_channel_.GetMaxTransferLength(), transfer_length);
+
+  this->proxy_.SetDmaRun(false);
+  ::testing::internal::CaptureStderr();
+  this->dma_channel_.SetMaxTransferLength(transfer_length + 0x100);
+  EXPECT_THAT(::testing::internal::GetCapturedStderr(),
+              ::testing::HasSubstr("Max transfer length will be clipped to:"));
+  EXPECT_EQ(this->dma_channel_.GetMaxTransferLength(), 0x40FB);
+}
+
+TEST_P(StreamDmaChannelTest, IRQMaskAndGetIRQTest) {
+  this->proxy_.SetIrq(0x2);
+  EXPECT_EQ(this->dma_channel_.GetIRQ(), false);
+
+  this->proxy_.SetIrqMask(0x2);
+  EXPECT_EQ(this->dma_channel_.GetIRQ(), true);
+
+  this->proxy_.SetIrqMask(0x1);
+  EXPECT_EQ(this->dma_channel_.GetIRQ(), false);
+
+  this->proxy_.SetIrq(0x3);
+  this->proxy_.SetIrqMask(0x2);
+  EXPECT_EQ(this->dma_channel_.GetIRQ(), true);
+
+  this->proxy_.SetIrqMask(0x1);
+  EXPECT_EQ(this->dma_channel_.GetIRQ(), true);
+}
+
+TEST_P(StreamDmaChannelTest, GetTransferredLengthTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  uint64_t transfer_length = 0x3FFC;
+  this->dma_channel_.SetMaxTransferLength(transfer_length);
+  EXPECT_CALL(this->bus_master_port_, RequestRead(_, _))
+      .WillRepeatedly(Return(0));
+  XLS_EXPECT_OK(this->proxy_.InternalUpdate());
+  // Stream has channel width of 120bits which is exactly 15 bytes
+  // Transfer ends after whole channel is empty (when reading)
+  // and after all the bytes have been transferred (when writing)
+  EXPECT_EQ(this->dma_channel_.GetTransferredLength(),
+            proxy_.GetChannel()->IsReadStream() ? 15 : transfer_length);
+}
+
+TEST_P(StreamDmaChannelTest, UpdateTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  // DMA disabled
+  this->dma_channel_.SetMaxTransferLength(15);
+  EXPECT_EQ(this->dma_channel_.GetTransferredLength(), 0);
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+  EXPECT_EQ(this->dma_channel_.GetTransferredLength(), 0);
+
+  // Empty DMA transfer
+  this->dma_channel_.SetMaxTransferLength(0);
+  this->dma_channel_.SetControlRegister(0x4);
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(),
+            0xC | GetParam() << 4 | 1 << 6);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x1);
+
+  // Check that IRQ is not re triggered
+  this->dma_channel_.ClearIRQReg(0x1);
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x0);
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+  EXPECT_EQ(this->dma_channel_.GetIRQReg(), 0x0);
+}
+
+TEST_P(StreamDmaChannelTest, SetGetControlRegisterTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  // CR[4] = IsReadStream()
+  // CR[6] = Stream.Ready()
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(), GetParam() << 4 | 1 << 6);
+  this->dma_channel_.SetControlRegister(0xFF);
+  // CR[3] is set only by Update
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(),
+            0x7 | GetParam() << 4 | 1 << 5 | 1 << 6);
+  // Sets CR[3]
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(),
+            0xf | GetParam() << 4 | 1 << 5 | 1 << 6);
+
+  // CR[3] must not be changed by write
+  this->dma_channel_.SetControlRegister(0xF7);
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(),
+            0xf | GetParam() << 4 | 1 << 5 | 1 << 6);
+
+  // CR[3] must be cleared when CR[2] is cleared
+  this->dma_channel_.SetControlRegister(0xFB);
+  EXPECT_EQ(this->dma_channel_.GetControlRegister(),
+            0x3 | GetParam() << 4 | 1 << 5 | 1 << 6);
+}
+
+INSTANTIATE_TEST_SUITE_P(StreamDmaChannelTestInstantiation,
+                         StreamDmaChannelTest, testing::Values(true, false));
+
+class StreamDmaChannelReadTest : public ::testing::Test {
+ protected:
+  StreamDmaChannelReadTest()
+      : bus_master_port_(),
+        dma_channel_(MakeIStreamMockEndpoint(true), &bus_master_port_),
+        proxy_(dma_channel_) {}
+  StreamDmaChannelIMasterPortMock bus_master_port_;
+  StreamDmaChannel dma_channel_;
+  StreamDmaChannelPrivateAccess proxy_;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(StreamDmaChannelReadTest, PeripheralAccessTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  uint64_t transfer_length = 0x3FFC;
+  this->dma_channel_.SetMaxTransferLength(transfer_length);
+  this->proxy_.SetDmaDiscard(false);
+  this->proxy_.SetDmaRun(true);
+  {
+    InSequence s;
+    EXPECT_CALL(
+        this->bus_master_port_,
+        RequestWrite(Eq(0), Eq(0x8BADF00DDEADBEEFULL), Eq(AccessWidth::QWORD)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(8), Eq(0xEFULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(9), Eq(0xBEULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(10), Eq(0xADULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(11), Eq(0xDEULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(12), Eq(0x0DULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(13), Eq(0xF0ULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+    EXPECT_CALL(this->bus_master_port_,
+                RequestWrite(Eq(14), Eq(0xADULL), Eq(AccessWidth::BYTE)))
+        .Times(1);
+  }
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+}
+
+TEST_F(StreamDmaChannelReadTest, DiscardTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  uint64_t transfer_length = 0x3FFC;
+  this->dma_channel_.SetMaxTransferLength(transfer_length);
+  this->proxy_.SetDmaDiscard(true);
+  this->proxy_.SetDmaRun(true);
+  {
+    InSequence s;
+    EXPECT_CALL(this->bus_master_port_, RequestWrite(_, _, _)).Times(0);
+    EXPECT_CALL(this->bus_master_port_, RequestRead(_, _)).Times(0);
+  }
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+}
+
+class StreamDmaChannelWriteTest : public ::testing::Test {
+ protected:
+  StreamDmaChannelWriteTest()
+      : bus_master_port_(),
+        dma_channel_(MakeIStreamMockEndpoint(false), &bus_master_port_),
+        proxy_(dma_channel_) {}
+  StreamDmaChannelIMasterPortMock bus_master_port_;
+  StreamDmaChannel dma_channel_;
+  StreamDmaChannelPrivateAccess proxy_;
+
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(StreamDmaChannelWriteTest, PeripheralAccessTest) {
+  MakeStreamReady(this->proxy_.GetChannel());
+  uint64_t transfer_length = 15;
+  this->dma_channel_.SetMaxTransferLength(transfer_length);
+  this->proxy_.SetDmaRun(true);
+  {
+    InSequence s;
+    EXPECT_CALL(this->bus_master_port_,
+                RequestRead(Eq(0), Eq(AccessWidth::QWORD)))
+        .Times(1)
+        .WillOnce(Return(0x8BADF00DDEADBEEFULL));
+    for (int i = 8; i < 15; ++i) {
+      EXPECT_CALL(this->bus_master_port_,
+                  RequestRead(Eq(i), Eq(AccessWidth::BYTE)))
+          .Times(1)
+          .WillOnce(Return(0));
+    }
+  }
+  XLS_EXPECT_OK(this->dma_channel_.Update());
+  IStreamMock<120, false>* channel =
+      dynamic_cast<IStreamMock<120, false>*>(this->proxy_.GetChannel());
+  EXPECT_NE(channel, nullptr);
+  EXPECT_EQ(channel->fifo().size(), 1);
+  EXPECT_EQ(channel->fifo().front(),
+            (std::array<uint8_t, 15>{0xEF, 0xBE, 0xAD, 0xDE, 0x0D, 0xF0, 0xAD,
+                                     0x8B}));
+}
+
+}  // namespace
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/streammanager.cc
+++ b/xls/simulation/generic/streammanager.cc
@@ -1,0 +1,403 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/streammanager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "xls/common/bits_util.h"
+#include "xls/simulation/generic/common.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+using channel_addr_t = IChannelManager::channel_addr_t;
+
+std::string ToHex(uint64_t value) {
+  return "0x" + absl::StrCat(absl::Hex(value, absl::kZeroPad16));
+}
+
+absl::Status ChannelNotFound() {
+  return absl::InternalError("Channel not found");
+}
+
+channel_addr_t StreamManager::StreamEnd(channel_addr_t offset_bytes,
+                                        const IStream& stream) {
+  return offset_bytes + StreamManager::ctrl_reg_width_bytes_ +
+         BitsToBytes(stream.GetChannelWidth());
+}
+
+StreamManager::StreamManager(uint64_t base_address,
+                             std::vector<StreamRange>&& sorted_channels)
+    : IChannelManager(base_address), channels_(std::move(sorted_channels)) {
+  if (!channels_.empty()) {
+    StreamRange& stream_range = channels_[channels_.size() - 1];
+    address_range_end_ =
+        StreamManager::StreamEnd(stream_range.first, *stream_range.second);
+  } else {
+    address_range_end_ = 0x0;
+  }
+}
+
+absl::StatusOr<StreamManager> StreamManager::Build(
+    uint64_t base_address, const StreamCreator& BuildStreams) {
+  std::vector<StreamRange> channels;
+  StreamRegistrator RegisterStream = [&channels](channel_addr_t offset,
+                                                 IStream* stream) {
+    channels.push_back(StreamRange(offset, std::unique_ptr<IStream>(stream)));
+  };
+  absl::Status build_status = BuildStreams(RegisterStream);
+  if (!build_status.ok()) {
+    return build_status;
+  }
+  std::sort(channels.begin(), channels.end(),
+            [](const StreamRange& a, const StreamRange& b) {
+              return a.first < b.first;
+            });
+  for (int i = 1; i < channels.size(); ++i) {
+    channel_addr_t end_of_stream = StreamManager::StreamEnd(
+        channels[i - 1].first, *channels[i - 1].second);
+    if (channels[i].first < end_of_stream) {
+      return absl::InternalError(
+          "Overlapping streams. Channel to be added at " +
+          ToHex(channels[i].first) + " overlaps with a channel added at " +
+          ToHex(channels[i - 1].first) + " (width: " +
+          std::to_string(channels[i - 1].second->GetChannelWidth()) + ").");
+    }
+  }
+
+  return StreamManager(base_address, std::move(channels));
+}
+
+// Assumption regarding R/W ops: The emulated architecture is little-endian
+// Logic for truncatting values and splitting them between ctrl register area
+// stream payload would differ for big-endian architectures.
+//
+// Another assumption: The memory outside of the channel is unmapped. Write
+// should fail, even if it partially overlaps with the channel.
+
+template <>
+class StreamManager::TypedAccessToStream<uint8_t>
+    : public StreamManager::AccessToStream {
+ public:
+  absl::StatusOr<uint64_t> GetData() const {
+    return this->ShiftResult(
+        this->stream_->GetPayloadData8(this->OffsetRelativeToPayload()));
+  }
+  absl::Status SetData(uint64_t data) const {
+    return this->stream_->SetPayloadData8(this->OffsetRelativeToPayload(),
+                                          data);
+  }
+};
+
+template <>
+class StreamManager::TypedAccessToStream<uint16_t>
+    : public StreamManager::AccessToStream {
+ public:
+  absl::StatusOr<uint64_t> GetData() const {
+    return this->ShiftResult(
+        this->stream_->GetPayloadData16(this->OffsetRelativeToPayload()));
+  }
+  absl::Status SetData(uint64_t data) const {
+    return this->stream_->SetPayloadData16(this->OffsetRelativeToPayload(),
+                                           data);
+  }
+};
+
+template <>
+class StreamManager::TypedAccessToStream<uint32_t>
+    : public StreamManager::AccessToStream {
+ public:
+  absl::StatusOr<uint64_t> GetData() const {
+    return this->ShiftResult(
+        this->stream_->GetPayloadData32(this->OffsetRelativeToPayload()));
+  }
+  absl::Status SetData(uint64_t data) const {
+    return this->stream_->SetPayloadData32(this->OffsetRelativeToPayload(),
+                                           data);
+  }
+};
+
+template <>
+class StreamManager::TypedAccessToStream<uint64_t>
+    : public StreamManager::AccessToStream {
+ public:
+  absl::StatusOr<uint64_t> GetData() const {
+    return this->ShiftResult(
+        this->stream_->GetPayloadData64(this->OffsetRelativeToPayload()));
+  }
+  absl::Status SetData(uint64_t data) const {
+    return this->stream_->SetPayloadData64(this->OffsetRelativeToPayload(),
+                                           data);
+  }
+};
+
+template <typename AccessType>
+absl::StatusOr<AccessType> StreamManager::ReadAccess(
+    TypedAccessToStream<AccessType> access) {
+  // Ctrl register sits at the beginning of this stream (0x0)
+  if (access.offset_bytes_ == StreamManager::ctrl_reg_offset_bytes_) {
+    return this->ReadCtrl(access);
+  }
+
+  if (StreamManager::AccessExceedsCtrlArea(access)) {
+    return this->ReadTail(access);
+  }
+  if (access.OffsetRelativeToPayload() >= 0) {
+    return access.GetData();
+  }
+  return 0;
+}
+
+template <typename AccessType>
+absl::Status StreamManager::WriteAccess(TypedAccessToStream<AccessType> access,
+                                        AccessType value) {
+  // Ctrl register sits at the beginning of this stream (0x0)
+  if (access.offset_bytes_ == StreamManager::ctrl_reg_offset_bytes_) {
+    this->WriteCtrl(access, value);
+    return absl::OkStatus();
+  }
+
+  if (StreamManager::AccessExceedsCtrlArea(access)) {
+    return this->WriteTail(access, value);
+  }
+
+  if (access.OffsetRelativeToPayload() >= 0) {
+    return access.SetData(value);
+  }
+  return absl::OkStatus();
+}
+
+// Read from 0x0 address of a stream into a portion of returned value.
+template <typename AccessType>
+absl::StatusOr<uint64_t> StreamManager::ReadTail(
+    const TypedAccessToStream<AccessType>& access) const {
+  auto read = access.stream_->GetPayloadData64(0x0);
+  if (!read.ok()) {
+    return read.status();
+  }
+
+  uint64_t stream_head = read.value();
+  // Assumption: litle-endian arch
+  uint64_t tail_width_bytes =
+      sizeof(AccessType) + access.OffsetRelativeToPayload();
+  uint64_t keep_mask = xls::Mask(BytesToBits(tail_width_bytes));
+  return (stream_head & keep_mask)
+         << (access.shift_ - BytesToBits(access.OffsetRelativeToPayload()));
+}
+
+template <typename AccessType>
+absl::Status StreamManager::WriteTail(
+    const TypedAccessToStream<AccessType> access, AccessType value) const {
+  // Read 8 bytes, modify them and then write them back
+  auto read = access.stream_->GetPayloadData64(0x0);
+  if (!read.ok()) {
+    return read.status();
+  }
+  uint64_t stream_head = read.value();
+  // Assumption: litle-endian arch
+  uint64_t keep_mask = ~xls::Mask(
+      BytesToBits(sizeof(AccessType) + access.OffsetRelativeToPayload()));
+  stream_head =
+      (stream_head & keep_mask) | (value >> -access.OffsetRelativeToPayload());
+  // In case the stream is shorter, the value should be truncated
+  return access.stream_->SetPayloadData64(0x0, stream_head);
+}
+
+template <typename AccessType>
+bool StreamManager::AccessExceedsCtrlArea(
+    const TypedAccessToStream<AccessType>& access) {
+  return (access.offset_bytes_ < StreamManager::ctrl_reg_end_) &&
+         (access.offset_bytes_ + sizeof(AccessType) >
+          StreamManager::ctrl_reg_end_);
+}
+
+template <typename AccessType, typename F>
+absl::Status StreamManager::forEachStreamInRange(
+    channel_addr_t global_offset_bytes, F action) {
+  static_assert(std::is_invocable<F, TypedAccessToStream<AccessType>>::value,
+                "action is not callable");
+  static_assert(std::numeric_limits<AccessType>::is_integer,
+                "AccessType must be an integer");
+
+  absl::StatusOr<std::pair<channel_addr_t, IStream*>> get_res;
+  absl::Status action_status;
+
+  channel_addr_t local_offset_bytes =
+      global_offset_bytes - this->GetBaseAddress();
+
+  get_res = this->GetOffsetChannelPair(local_offset_bytes);
+  if (!get_res.ok()) {
+    return get_res.status();
+  }
+  channel_addr_t rel_addr = get_res->first;
+  IStream* ch1 = get_res->second;
+
+  // Assumption: litle-endian arch
+  action_status = action(TypedAccessToStream<AccessType>{ch1, rel_addr, 0});
+  if (!action_status.ok()) {
+    return action_status;
+  }
+
+  if (rel_addr == 0) {
+    // We can skip further checks if this was an access to Ctrl register as its
+    // 64-bit wide
+    return absl::OkStatus();
+  }
+
+  channel_addr_t new_beginning = local_offset_bytes - rel_addr +
+                                 BitsToBytes(ch1->GetChannelWidth()) +
+                                 StreamManager::ctrl_reg_width_bytes_;
+  if (local_offset_bytes + sizeof(AccessType) <= new_beginning) {
+    return absl::OkStatus();
+  }
+
+  get_res = this->GetOffsetChannelPair(local_offset_bytes + sizeof(AccessType));
+  if (!get_res.ok()) {
+    return absl::OkStatus();
+  }  // There was no second channel
+
+  // Assumption: litle-endian arch
+  // Read from a beginning of an adjacent stream. A shift paramenter is required
+  // to adjust the value.
+  uint8_t shift = BytesToBits(sizeof(AccessType) - get_res->first);
+  return action(TypedAccessToStream<AccessType>{get_res->second, 0x0, shift});
+}
+
+template <typename AccessType>
+absl::StatusOr<AccessType> StreamManager::ReadUAtAddress(channel_addr_t addr) {
+  static_assert(std::numeric_limits<AccessType>::is_integer,
+                "AccessType must be an integer");
+
+  if (addr < this->base_address_) {
+    return absl::InternalError("Address not in range");
+  }
+
+  uint64_t value = 0;
+  absl::Status stream_access_status = this->forEachStreamInRange<AccessType>(
+      addr, [&](const TypedAccessToStream<AccessType>& access) {
+        absl::StatusOr<AccessType> read = this->ReadAccess(access);
+        if (!read.ok()) {
+          return read.status();
+        }
+        value |= *read;
+        return absl::OkStatus();
+      });
+
+  if (stream_access_status.ok()) {
+    return value;
+  }
+  return stream_access_status;
+}
+
+template <typename AccessType>
+absl::Status StreamManager::WriteUAtAddress(channel_addr_t addr,
+                                            AccessType value) {
+  static_assert(std::numeric_limits<AccessType>::is_integer,
+                "T must be an integer");
+
+  if (addr < this->base_address_) {
+    return absl::InternalError("Address not in range");
+  }
+
+  return this->forEachStreamInRange<AccessType>(
+      addr, [&](const TypedAccessToStream<AccessType>& access) {
+        return this->WriteAccess(access, value);
+      });
+}
+
+absl::Status StreamManager::WriteU8AtAddress(channel_addr_t addr,
+                                             uint8_t value) {
+  return this->WriteUAtAddress(addr, value);
+}
+
+absl::Status StreamManager::WriteU16AtAddress(channel_addr_t addr,
+                                              uint16_t value) {
+  return this->WriteUAtAddress(addr, value);
+}
+
+absl::Status StreamManager::WriteU32AtAddress(channel_addr_t addr,
+                                              uint32_t value) {
+  return this->WriteUAtAddress(addr, value);
+}
+
+absl::Status StreamManager::WriteU64AtAddress(channel_addr_t addr,
+                                              uint64_t value) {
+  return this->WriteUAtAddress(addr, value);
+}
+
+absl::StatusOr<uint8_t> StreamManager::ReadU8AtAddress(channel_addr_t addr) {
+  return this->ReadUAtAddress<uint8_t>(addr);
+}
+
+absl::StatusOr<uint16_t> StreamManager::ReadU16AtAddress(channel_addr_t addr) {
+  return this->ReadUAtAddress<uint16_t>(addr);
+}
+
+absl::StatusOr<uint32_t> StreamManager::ReadU32AtAddress(channel_addr_t addr) {
+  return this->ReadUAtAddress<uint32_t>(addr);
+}
+
+absl::StatusOr<uint64_t> StreamManager::ReadU64AtAddress(channel_addr_t addr) {
+  return this->ReadUAtAddress<uint64_t>(addr);
+}
+
+void StreamManager::WriteCtrl(const AccessToStream& access, uint64_t value) {
+  value >>= access.shift_;
+  if (value & StreamManager::ctrl_reg_DOXFER_) {
+    this->tsfr_status_ = access.stream_->Transfer();
+  }
+  if (value & StreamManager::ctrl_reg_ERRXFER_) {
+    this->tsfr_status_ = absl::OkStatus();
+  }
+}
+
+uint64_t StreamManager::ReadCtrl(const AccessToStream& access) {
+  uint64_t value = 0x0;
+  value |= access.stream_->IsReady() ? StreamManager::ctrl_reg_READY_ : 0x0;
+  value |= access.stream_->IsReadStream() ? StreamManager::ctrl_reg_DIR_ : 0x0;
+  value |= this->tsfr_status_.ok() ? 0x0 : StreamManager::ctrl_reg_ERRXFER_;
+  return value << access.shift_;
+}
+
+absl::StatusOr<std::pair<channel_addr_t, IStream*>>
+StreamManager::GetOffsetChannelPair(channel_addr_t offset_bytes) {
+  // Binary-search for a channel.
+  auto it = std::upper_bound(
+      this->channels_.begin(), this->channels_.end(), offset_bytes,
+      [](uint64_t value, const StreamManager::StreamRange& range) -> bool {
+        return value < range.first;
+      });
+  if (it == this->channels_.begin()) {
+    return ChannelNotFound();
+  }
+  --it;
+  channel_addr_t end_of_strem =
+      StreamManager::StreamEnd(it->first, *it->second);
+  if ((offset_bytes >= it->first) && (offset_bytes < end_of_strem)) {
+    return std::make_pair(offset_bytes - it->first, it->second.get());
+  }
+  return ChannelNotFound();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/streammanager.h
+++ b/xls/simulation/generic/streammanager.h
@@ -1,0 +1,173 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_STREAMMANAGER_H_
+#define XLS_SIMULATION_GENERIC_STREAMMANAGER_H_
+
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/common/bits_util.h"
+#include "xls/simulation/generic/ichannel.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+#include "xls/simulation/generic/istream.h"
+
+namespace xls::simulation::generic {
+
+class StreamManager : public IChannelManager {
+ public:
+  // A stream along with its beginning address (relative to StreamManager's base
+  // address)
+  using StreamRange = std::pair<channel_addr_t, std::unique_ptr<IStream>>;
+  // Registers a stream when using StreamManager::Build
+  using StreamRegistrator =
+      std::function<void(channel_addr_t offset, IStream* stream)>;
+  using StreamCreator = std::function<absl::Status(const StreamRegistrator&)>;
+
+  // All registered streams begin with a control register that has the following
+  // format:
+  //
+  //     BIT:       ┌63──────4┬──────3┬──2┬─────1┬────0┐
+  //                ┌─┬─┬─┬─┬─┬───────┬───┬──────┬─────┐
+  //     CONTENT:   │(unused) │ERRXFER│DIR│DOXFER│READY│
+  //                └─┴─┴─┴─┴─┴───────┴───┴──────┴─────┘
+  //     ACCESS:    └────R────┴──R/W──┴─R─┴───W──┴──R──┘
+  //
+  // The address where the stream get registered will contain that register,
+  // followed by the stream's payload data register.
+
+  // Ctrl register offset relative to the registration offset
+  static const uint64_t ctrl_reg_offset_bytes_ = 0x0;
+  // Ctrl register width
+  static const uint64_t ctrl_reg_width_bytes_ = 8;
+  // Ctrl register bits
+  static const uint64_t ctrl_reg_READY_ = 0x01;
+  static const uint64_t ctrl_reg_DOXFER_ = 0x02;
+  static const uint64_t ctrl_reg_DIR_ = 0x04;
+  static const uint64_t ctrl_reg_ERRXFER_ = 0x08;
+
+  StreamManager(StreamManager&& other) = default;
+  StreamManager& operator=(StreamManager&& other) = default;
+  ~StreamManager() override = default;
+
+  // Use a stream-registering function to build StreamManager.
+  // The function takes one argument which is a callback for registering a
+  // stream.
+  static absl::StatusOr<StreamManager> Build(uint64_t base_address,
+                                             const StreamCreator& BuildStreams);
+
+  absl::Status LastTransferStatus() { return this->tsfr_status_; }
+
+  absl::Status WriteU8AtAddress(channel_addr_t addr, uint8_t value) override;
+  absl::Status WriteU16AtAddress(channel_addr_t addr, uint16_t value) override;
+  absl::Status WriteU32AtAddress(channel_addr_t addr, uint32_t value) override;
+  absl::Status WriteU64AtAddress(channel_addr_t addr, uint64_t value) override;
+  absl::StatusOr<uint8_t> ReadU8AtAddress(channel_addr_t addr) override;
+  absl::StatusOr<uint16_t> ReadU16AtAddress(channel_addr_t addr) override;
+  absl::StatusOr<uint32_t> ReadU32AtAddress(channel_addr_t addr) override;
+  absl::StatusOr<uint64_t> ReadU64AtAddress(channel_addr_t addr) override;
+
+  class AccessToStream {
+   public:
+    IStream* stream_;
+    channel_addr_t offset_bytes_;
+    uint8_t shift_;
+
+    int64_t OffsetRelativeToPayload() const {
+      return this->offset_bytes_ - StreamManager::ctrl_reg_width_bytes_;
+    }
+
+   protected:
+    template <typename StatusT>
+    absl::StatusOr<uint64_t> ShiftResult(StatusT s) const {
+      if (s.ok()) {
+        return *s << this->shift_;
+      }
+      return s;
+    }
+  };
+  template <typename AccessType>
+  class TypedAccessToStream : public AccessToStream {
+   public:
+    absl::StatusOr<uint64_t> GetData() const {
+      return absl::InternalError("Unsupported access type");
+    }
+    absl::Status SetData(uint64_t data) const {
+      return absl::InternalError("Unsupported access type");
+    }
+  };
+
+ private:
+  static constexpr uint64_t ctrl_reg_end_ =
+      StreamManager::ctrl_reg_offset_bytes_ +
+      StreamManager::ctrl_reg_width_bytes_;
+
+  StreamManager(uint64_t base_address,
+                std::vector<StreamRange>&& sorted_channels);
+
+  static constexpr unsigned int floorlog2(unsigned int x) {
+    return x == 1 ? 0 : 1 + floorlog2(x >> 1);
+  }
+
+  template <typename AccessType, typename F>
+  absl::Status forEachStreamInRange(channel_addr_t offset_bytes, F action);
+
+  template <typename AccessType>
+  absl::StatusOr<AccessType> ReadUAtAddress(channel_addr_t addr);
+
+  template <typename T>
+  absl::Status WriteUAtAddress(channel_addr_t addr, T value);
+
+  absl::StatusOr<std::pair<channel_addr_t, IStream*>> GetOffsetChannelPair(
+      channel_addr_t offset_bytes);
+
+  static channel_addr_t StreamEnd(channel_addr_t offset_bytes,
+                                  const IStream& stream);
+
+  template <typename AccessType>
+  absl::Status WriteTail(TypedAccessToStream<AccessType>,
+                         AccessType value) const;
+
+  template <typename AccessType>
+  absl::StatusOr<uint64_t> ReadTail(
+      const TypedAccessToStream<AccessType>& access) const;
+  void WriteCtrl(const AccessToStream& access, uint64_t value);
+  uint64_t ReadCtrl(const AccessToStream& access);
+
+  template <typename AccessType>
+  absl::StatusOr<AccessType> ReadAccess(TypedAccessToStream<AccessType> access);
+
+  template <typename AccessType>
+  absl::Status WriteAccess(TypedAccessToStream<AccessType> access,
+                           AccessType value);
+
+  template <typename AccessType>
+  static bool AccessExceedsCtrlArea(
+      const TypedAccessToStream<AccessType>& access);
+
+  std::vector<StreamRange> channels_;  // Streams sorted by their
+                                       //  beginning addresses
+  absl::Status tsfr_status_;           // Status of the last transfer
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_STREAMMANAGER_H_

--- a/xls/simulation/generic/streammanager_test.cc
+++ b/xls/simulation/generic/streammanager_test.cc
@@ -1,0 +1,605 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/streammanager.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/bits_util.h"
+#include "xls/common/logging/log_flags.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/matchers.h"
+#include "xls/simulation/generic/common.h"
+#include "xls/simulation/generic/istream.h"
+#include "xls/simulation/generic/istream_mock.h"
+
+namespace xls::simulation::generic {
+
+namespace {
+
+std::string ToHex(uint64_t value) {
+  return "0x" + absl::StrCat(absl::Hex(value, absl::kZeroPad16));
+}
+
+uint64_t BitsToBytesFloor(uint64_t bits) { return bits >> 3; }
+
+class StreamManagerTestParams {
+ public:
+  uint64_t base;
+  uint64_t offset1;
+  uint64_t offset2;
+  uint64_t payload64;
+};
+
+class StreamManagerTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<StreamManagerTestParams> {
+ protected:
+  static void SetUpTestSuite() { absl::SetFlag(&FLAGS_logtostderr, true); }
+};
+
+TEST_F(StreamManagerTest, AddStreams) {
+  // DESCRIPTION: Test registering streams. See if overlaps are reported
+  // correctly.
+
+  const uint64_t s1_width_bits = 128;  // 16 bytes
+  const uint64_t s1_offset = 0;
+  const uint64_t s2_width_bits = 128;  // 16 bytes
+  const uint64_t s2_offset = 24;
+  const uint64_t s3_width_bits = 128;  // 16 bytes
+  const uint64_t s3_offset = 32;
+
+  auto CheckRangeEnd = [](const StreamManager& sm, uint64_t last_offset,
+                          uint64_t last_width_bytes) {
+    uint64_t end =
+        last_offset + last_width_bytes + StreamManager::ctrl_reg_width_bytes_;
+    EXPECT_EQ(sm.InRange(end), false);
+    EXPECT_EQ(sm.InRange(end - 1), true);
+  };
+
+  auto sm1 = StreamManager::Build(0x0, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, new IStreamMock<s1_width_bits, true>());
+    RegisterStream(s2_offset, new IStreamMock<s2_width_bits, true>());
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm1);
+  CheckRangeEnd(*sm1, s2_offset, BitsToBytesFloor(s2_width_bits));
+
+  auto sm2 = StreamManager::Build(0x0, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, new IStreamMock<s1_width_bits, true>());
+    RegisterStream(s2_offset, new IStreamMock<s2_width_bits, true>());
+    RegisterStream(s3_offset, new IStreamMock<s3_width_bits, true>());
+    return absl::OkStatus();
+  });
+  EXPECT_THAT(
+      sm2,
+      xls::status_testing::StatusIs(
+          absl::StatusCode::kInternal,
+          testing::HasSubstr(
+              "Overlapping streams. Channel to be added at 0x0000000000000020 "
+              "overlaps with a channel added at 0x0000000000000018")));
+}
+
+TEST_F(StreamManagerTest, StreamAccess) {
+  const uint64_t s_width_bits = 32;
+  const uint8_t stream_count = 255;
+
+  // Register 256 4-byte streams (reverse order, just to make sure that
+  // insertion works fine)
+  auto sm_status = StreamManager::Build(0x0, [=](const auto& RegisterStream) {
+    for (int64_t i = stream_count; i != -1; --i) {
+      uint64_t offset = i * (StreamManager::ctrl_reg_width_bytes_ +
+                             BitsToBytesFloor(s_width_bits));
+      IStreamMock<s_width_bits, true>* stream =
+          new IStreamMock<s_width_bits, true>();
+      for (int j = 0; j < 4; ++j) {
+        // Make those streams identifiable
+        XLS_EXPECT_OK(stream->SetPayloadData8(j, static_cast<uint8_t>(i)));
+      }
+      RegisterStream(offset, stream);
+    }
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm_status);
+  StreamManager sm = std::move(sm_status.value());
+
+  absl::StatusOr<uint8_t> status;
+
+  uint64_t stream_bytes =
+      BitsToBytesFloor(s_width_bits) + StreamManager::ctrl_reg_width_bytes_;
+
+  for (uint64_t i = 0; i < stream_count * stream_bytes; ++i) {
+    XLS_LOG(INFO) << "Checking access to stream " << (i / stream_bytes)
+                  << ", byte " << (i % stream_bytes);
+    XLS_EXPECT_OK(status = sm.ReadU8AtAddress(i));
+    if (i % 5 < StreamManager::ctrl_reg_width_bytes_) {
+      continue;
+    }  // Skip the control register
+    EXPECT_EQ(status.value(), i / stream_bytes);
+  }
+}
+
+// 64 bits of test data for reads and writes
+constexpr uint64_t Payload64(const char* str) {
+  uint64_t payload = 0;
+  for (int i = 0; i < 8; ++i) {
+    payload |= static_cast<uint64_t>(str[i]) << BytesToBits(i);
+  }
+  return payload;
+}
+
+// Masks `msbs` most-significant-bytes
+uint64_t Payload64Mask(int msbs) {
+  if (msbs == 0) {
+    return 0x0;
+  }
+  if (msbs == 64) {
+    return -0x1;
+  }
+  return ~xls::Mask(BytesToBits(8 - msbs));
+}
+// Returns `msbs` most-significant-bytes
+uint64_t Payload64Tail(uint64_t payload64, int msbs) {
+  uint64_t pl = (payload64 & Payload64Mask(msbs)) >>
+                (BytesToBits(sizeof(uint64_t) - msbs));
+  return pl;
+}
+
+TEST_P(StreamManagerTest, ReadFromASingleStream) {
+  // DESCRIPTION: Test reading from a stream. Offset must be within the streams
+  // range.
+
+  const StreamManagerTestParams params = GetParam();
+
+  const uint64_t s1_width = 128;  // 16 bytes
+  const uint64_t s1_offset = params.offset1;
+  const uint64_t payload64 = params.payload64;
+  const uint64_t payload_offset = 8;
+
+  absl::StatusOr<uint64_t> status;
+
+  IStreamMock<s1_width, true>* stream1 = new IStreamMock<s1_width, true>();
+  auto sm = StreamManager::Build(params.base, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, stream1);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  // Setup stream content ({64'h0, Payload64})
+  XLS_EXPECT_OK(stream1->SetPayloadData64(0, 0));
+  XLS_EXPECT_OK(stream1->SetPayloadData64(payload_offset, payload64));
+
+  // Read at all possible different offsets
+  for (int i = 0; i < 8; ++i) {
+    uint64_t read_offset = params.base + s1_offset + payload_offset +
+                           StreamManager::ctrl_reg_width_bytes_ - i;
+    uint64_t shifted_payload = payload64 << BytesToBits(i);
+
+    XLS_EXPECT_OK(status = sm->ReadU8AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xff);
+
+    XLS_EXPECT_OK(status = sm->ReadU16AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xffff);
+
+    XLS_EXPECT_OK(status = sm->ReadU32AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xffffffff);
+
+    XLS_EXPECT_OK(status = sm->ReadU64AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload);
+  }
+  for (int i = 1; i < 8; ++i) {
+    uint64_t read_offset = params.base + s1_offset + payload_offset +
+                           StreamManager::ctrl_reg_width_bytes_ + i;
+    uint64_t shifted_payload = payload64 >> BytesToBits(i);
+
+    XLS_EXPECT_OK(status = sm->ReadU8AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xff);
+
+    XLS_EXPECT_OK(status = sm->ReadU16AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xffff);
+
+    XLS_EXPECT_OK(status = sm->ReadU32AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload & 0xffffffff);
+
+    XLS_EXPECT_OK(status = sm->ReadU64AtAddress(read_offset));
+    EXPECT_EQ(status.value(), shifted_payload);
+  }
+}
+
+TEST_F(StreamManagerTest, ReadCtrl) {
+  // DESCRIPTION: Test reading the control register.
+
+  const uint64_t r_width = 128;  // 16 bytes
+  const uint64_t r_offset = 0;
+  const uint64_t w_width = 128;  // 16 bytes
+  const uint64_t w_offset = 24;
+
+  auto sm = StreamManager::Build(0x0, [&](const auto& RegisterStream) {
+    RegisterStream(r_offset, new IStreamMock<r_width, true>);
+    RegisterStream(w_offset, new IStreamMock<w_width, false>);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  absl::StatusOr<uint8_t> res;
+
+  // Test direction
+  XLS_EXPECT_OK(res = sm->ReadU8AtAddress(r_offset));
+  uint8_t expect = StreamManager::ctrl_reg_DIR_;
+  EXPECT_EQ(res.value(), expect);
+
+  // Test ready
+  XLS_EXPECT_OK(res = sm->ReadU8AtAddress(w_offset));
+  expect = StreamManager::ctrl_reg_READY_;
+  EXPECT_EQ(res.value(), expect);
+}
+
+uint64_t AdjacentStreamOffset(uint64_t offset, uint64_t width_bits) {
+  return offset + StreamManager::ctrl_reg_width_bytes_ +
+         BitsToBytesFloor(width_bits);
+}
+
+TEST_P(StreamManagerTest, DoubleReadAdjacentStreams) {
+  // DESCRIPTION: Test an edge case: Read offset starts in one stream, but the
+  // range of the read includes another, adjacent stream.
+
+  const StreamManagerTestParams params = GetParam();
+
+  const uint64_t s1_width_bits = 128;  // 16 bytes
+  const uint64_t s1_offset = params.offset1;
+  const uint64_t s2_width_bits = 128;  // 16 bytes
+  const uint64_t s2_offset = AdjacentStreamOffset(s1_offset, s1_width_bits);
+  const uint64_t payload64 = params.payload64;
+  const uint64_t payload_offset = 8;
+
+  IStreamMock<s1_width_bits, true>* stream1 =
+      new IStreamMock<s1_width_bits, true>();
+  IStreamMock<s2_width_bits, true>* stream2 =
+      new IStreamMock<s2_width_bits, true>();
+
+  auto sm = StreamManager::Build(params.base, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, stream1);
+    RegisterStream(s2_offset, stream2);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  // Setup stream content ({64'h0, Payload64})
+  XLS_EXPECT_OK(stream1->SetPayloadData64(0, 0));
+  XLS_EXPECT_OK(stream1->SetPayloadData64(payload_offset, payload64));
+
+  absl::StatusOr<uint64_t> res;
+
+  for (int i = 1; i < 8; ++i) {
+    if (i < sizeof(uint16_t)) {
+      XLS_LOG(INFO) << "Reading 16 bits at offset -" << i;
+      XLS_EXPECT_OK(res = sm->ReadU16AtAddress(params.base + s2_offset - i));
+      uint16_t expected16 =
+          Payload64Tail(payload64, i) |
+          (StreamManager::ctrl_reg_DIR_ << BytesToBits(i));
+      XLS_LOG(INFO) << "  expected: " << ToHex(expected16);
+      EXPECT_EQ(res.value(), expected16);
+    }
+    if (i < sizeof(uint32_t)) {
+      XLS_LOG(INFO) << "Reading 32 bits at offset -" << i;
+      XLS_EXPECT_OK(res = sm->ReadU32AtAddress(params.base + s2_offset - i));
+      uint32_t expected32 =
+          Payload64Tail(payload64, i) |
+          (StreamManager::ctrl_reg_DIR_ << BytesToBits(i));
+      XLS_LOG(INFO) << "  expected: " << ToHex(expected32);
+      EXPECT_EQ(res.value(), expected32);
+    }
+    if (i < sizeof(uint64_t)) {
+      XLS_LOG(INFO) << "Reading 64 bits at offset -" << i;
+      XLS_EXPECT_OK(res = sm->ReadU64AtAddress(params.base + s2_offset - i));
+      uint64_t expected64 =
+          Payload64Tail(payload64, i) |
+          (StreamManager::ctrl_reg_DIR_ << BytesToBits(i));
+      XLS_LOG(INFO) << "  expected: " << ToHex(expected64);
+      EXPECT_EQ(res.value(), expected64);
+    }
+  }
+}
+
+TEST_P(StreamManagerTest, WriteToASingleStream) {
+  // DESCRIPTION: Test writing to a stream. Offset must be within the streams
+  // range.
+
+  const StreamManagerTestParams params = GetParam();
+
+  const uint64_t s1_width_bits = 128;  // 16 bytes
+  const uint64_t s1_offset = params.offset1;
+  const uint64_t payload64 = params.payload64;
+  const uint64_t payload_offset = 8;
+
+  absl::StatusOr<uint64_t> status;
+
+  IStreamMock<s1_width_bits, false>* stream1 =
+      new IStreamMock<s1_width_bits, false>();
+
+  auto sm = StreamManager::Build(params.base, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, stream1);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  uint64_t expected64;
+
+  for (int i = 0; i < 8; ++i) {
+    uint64_t write_offset = params.base + s1_offset +
+                            StreamManager::ctrl_reg_width_bytes_ +
+                            payload_offset + i;
+
+    auto Prepare = [&](uint8_t bytes) {
+      XLS_EXPECT_OK(stream1->SetPayloadData64(0, 0));
+      XLS_EXPECT_OK(stream1->SetPayloadData64(payload_offset, 0));
+      int64_t tail_len_bytes = payload_offset + i + sizeof(uint64_t) -
+                               BitsToBytesFloor(s1_width_bits);
+      expected64 = payload64 & ~Payload64Mask(tail_len_bytes) &
+                   xls::Mask(BytesToBits(bytes));
+    };
+
+    auto Check = [&]() {
+      XLS_EXPECT_OK(status = stream1->GetPayloadData64(payload_offset + i));
+      EXPECT_EQ(status.value(), expected64);
+    };
+
+    XLS_LOG(INFO) << "Writing 8 bits at offset " << i;
+    Prepare(1);
+    XLS_EXPECT_OK(sm->WriteU8AtAddress(write_offset, payload64));
+    Check();
+
+    XLS_LOG(INFO) << "Writing 16 bits at offset " << i;
+    Prepare(2);
+    XLS_EXPECT_OK(sm->WriteU16AtAddress(write_offset, payload64));
+    Check();
+
+    XLS_LOG(INFO) << "Writing 32 bits at offset " << i;
+    Prepare(4);
+    XLS_EXPECT_OK(sm->WriteU32AtAddress(write_offset, payload64));
+    Check();
+
+    XLS_LOG(INFO) << "Writing 64 bits at offset " << i;
+    Prepare(8);
+    XLS_EXPECT_OK(sm->WriteU64AtAddress(write_offset, payload64));
+    Check();
+  }
+}
+
+template <std::size_t WidthBytes>
+uint64_t ExtractU64FromArray(const std::array<uint8_t, WidthBytes>& bytes) {
+  EXPECT_GE(bytes.size(), 8);
+  uint64_t res = 0;
+  for (int i = 0; i < 8; ++i) {
+    res |= static_cast<uint64_t>(bytes[i]) << BytesToBits(i);
+  }
+  return res;
+}
+
+template <std::size_t WidthBytes>
+std::array<uint8_t, WidthBytes> MakeArrayFromU64(uint64_t data) {
+  static_assert(WidthBytes >= sizeof(uint64_t), "Too short array");
+  std::array<uint8_t, WidthBytes> res;
+  for (int i = 0; i < 8; ++i) {
+    res[i] = data & 0xff;
+    data >>= 8;
+  }
+  return res;
+}
+
+TEST_P(StreamManagerTest, WriteCtrl) {
+  // DESCRIPTION: Control register write test
+
+  const StreamManagerTestParams params = GetParam();
+
+  const uint64_t w_offset = params.offset1;
+  const uint64_t w_width_bits = 64;  // 8 bytes
+  const uint64_t r_offset = params.offset2;
+  const uint64_t r_width_bits = 64;  // 8 bytes
+  const uint64_t payload64 = params.payload64;
+
+  absl::StatusOr<uint64_t> status;
+
+  IStreamMock<w_width_bits, false>* wstream =
+      new IStreamMock<w_width_bits, false>();
+  IStreamMock<r_width_bits, true>* rstream =
+      new IStreamMock<r_width_bits, true>();
+
+  auto sm = StreamManager::Build(params.base, [&](const auto& RegisterStream) {
+    RegisterStream(w_offset, wstream);
+    RegisterStream(r_offset, rstream);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  // Test valid transfer for write stream
+  XLS_EXPECT_OK(wstream->SetPayloadData64(0, payload64));
+  EXPECT_EQ(wstream->fifo().size(), 0);
+  XLS_EXPECT_OK(sm->WriteU8AtAddress(params.base + w_offset,
+                                     StreamManager::ctrl_reg_DOXFER_));
+  XLS_EXPECT_OK(sm->LastTransferStatus());
+  EXPECT_EQ(wstream->fifo().size(), 1);
+  EXPECT_EQ(ExtractU64FromArray(wstream->fifo().front()), payload64);
+
+  // Test valid transfer for read stream
+  EXPECT_EQ(rstream->fifo().size(), 0);
+  rstream->fifo().push(MakeArrayFromU64<8>(payload64));
+  XLS_EXPECT_OK(sm->WriteU8AtAddress(params.base + r_offset,
+                                     StreamManager::ctrl_reg_DOXFER_));
+  XLS_EXPECT_OK(status = rstream->GetPayloadData64(0));
+  XLS_EXPECT_OK(sm->LastTransferStatus());
+  EXPECT_EQ(status.value(), payload64);
+
+  // Test invalid transfer for read stream
+  EXPECT_EQ(rstream->fifo().empty(), true);
+  XLS_EXPECT_OK(sm->WriteU8AtAddress(params.base + r_offset,
+                                     StreamManager::ctrl_reg_DOXFER_));
+  EXPECT_THAT(
+      sm->LastTransferStatus(),
+      xls::status_testing::StatusIs(absl::StatusCode::kInternal,
+                                    testing::HasSubstr("FIFO is empty")));
+
+  // Test status clearing
+  XLS_EXPECT_OK(sm->WriteU8AtAddress(params.base + r_offset,
+                                     StreamManager::ctrl_reg_ERRXFER_));
+  XLS_EXPECT_OK(sm->LastTransferStatus());
+}
+
+TEST_P(StreamManagerTest, DoubleWriteAdjacentStreams) {
+  // DESCRIPTION: Test an edge case: Write offset starts in one stream, but the
+  // range of the read includes another, adjacent stream.
+
+  const StreamManagerTestParams params = GetParam();
+
+  const uint64_t s1_width_bits = 128;  // 16 bytes
+  const uint64_t s1_offset = params.offset1;
+  const uint64_t s2_width_bits = 128;  // 16 bytes
+  const uint64_t s2_offset = AdjacentStreamOffset(s1_offset, s1_width_bits);
+  const uint64_t payload64 = params.payload64;
+  const uint64_t payload_offset = 8;
+
+  absl::StatusOr<uint64_t> status;
+
+  IStreamMock<s1_width_bits, false>* stream1 =
+      new IStreamMock<s1_width_bits, false>();
+  IStreamMock<s2_width_bits, false>* stream2 =
+      new IStreamMock<s2_width_bits, false>();
+
+  auto sm = StreamManager::Build(params.base, [&](const auto& RegisterStream) {
+    RegisterStream(s1_offset, stream1);
+    RegisterStream(s2_offset, stream2);
+    return absl::OkStatus();
+  });
+  XLS_EXPECT_OK(sm);
+
+  bool will_transfer;
+  uint64_t expected64, wr_offset;
+
+  auto ResetStreams = [&]() {
+    XLS_EXPECT_OK(stream1->SetPayloadData64(0, 0));
+    XLS_EXPECT_OK(stream1->SetPayloadData64(payload_offset, 0));
+    while (!stream2->fifo().empty()) {
+      stream2->fifo().pop();
+    }
+    // Clear error status. Requires WriteCtrl test to pass first
+    XLS_EXPECT_OK(sm->WriteU8AtAddress(params.base + s2_offset,
+                                       StreamManager::ctrl_reg_ERRXFER_));
+  };
+
+  auto Prepare = [&](uint8_t width_bytes, int i) {
+    ResetStreams();
+    will_transfer = static_cast<bool>(Payload64Tail(payload64, i) &
+                                      StreamManager::ctrl_reg_DOXFER_);
+    expected64 = payload64 >> BytesToBits(i);
+    wr_offset =
+        s1_offset + StreamManager::ctrl_reg_width_bytes_ + payload_offset + i;
+    if (will_transfer) {
+      XLS_EXPECT_OK(stream2->SetPayloadData64(0, payload64));
+    }
+  };
+
+  auto Check = [&]() {
+    if (will_transfer) {
+      XLS_LOG(INFO) << "    expecting transfer";
+      ASSERT_EQ(stream2->fifo().size(), 1);
+      ASSERT_EQ(ExtractU64FromArray(stream2->fifo().front()), payload64);
+    } else {
+      ASSERT_EQ(stream2->fifo().empty(), true);
+    }
+  };
+
+  for (int i = 1; i < 8; ++i) {
+    if (i > 6) {
+      XLS_LOG(INFO) << "Writing 16 bits at offset " << payload_offset + i;
+      Prepare(2, i);
+      XLS_EXPECT_OK(sm->WriteU16AtAddress(params.base + wr_offset,
+                                          static_cast<uint16_t>(payload64)));
+      Check();
+    }
+    if (i > 4) {
+      XLS_LOG(INFO) << "Writing 32 bits at offset " << payload_offset + i;
+      Prepare(4, i);
+      XLS_EXPECT_OK(sm->WriteU32AtAddress(params.base + wr_offset,
+                                          static_cast<uint32_t>(payload64)));
+      Check();
+    }
+    XLS_LOG(INFO) << "Writing 64 bits at offset " << payload_offset + i;
+    Prepare(8, i);
+    XLS_EXPECT_OK(sm->WriteU64AtAddress(params.base + wr_offset, payload64));
+    Check();
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    StreamManagerTestInstantiation, StreamManagerTest,
+    testing::Values(
+        StreamManagerTestParams{
+            .base = 0x0,
+            .offset1 = 0x0,
+            .offset2 = 0x18,
+            .payload64 = Payload64("01 Bipp"),
+        },
+        StreamManagerTestParams{
+            .base = 0x1,
+            .offset1 = 0x0,
+            .offset2 = 0x18,
+            .payload64 = Payload64("02 Elle"),
+        },
+        StreamManagerTestParams{
+            .base = 0x100,
+            .offset1 = 0x10,
+            .offset2 = 0x28,
+            .payload64 = Payload64("03 Lemonade"),
+        },
+        StreamManagerTestParams{
+            .base = 0x100,
+            .offset1 = 0x10,
+            .offset2 = 0x38,
+            .payload64 = Payload64("04 Hard"),
+        },
+        StreamManagerTestParams{
+            .base = 0x420,
+            .offset1 = 0x10,
+            .offset2 = 0x308,
+            .payload64 = Payload64("05 Msmsmsmsm"),
+        },
+        StreamManagerTestParams{
+            .base = 0x12,
+            .offset1 = 0x0a,
+            .offset2 = 0xa0,
+            .payload64 = Payload64("06 Vyzee"),
+        },
+        StreamManagerTestParams{
+            .base = 0x0,
+            .offset1 = 0x60,
+            .offset2 = 0x00,
+            .payload64 = Payload64("07 L.o.v.e."),
+        },
+        StreamManagerTestParams{
+            .base = 0xff,
+            .offset1 = 0x100a,
+            .offset2 = 0xa0,
+            .payload64 = Payload64("08 Just like we never said goodbye"),
+        }));
+
+}  // namespace
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/testdata/BUILD
+++ b/xls/simulation/generic/testdata/BUILD
@@ -1,0 +1,63 @@
+# Copyright 2020 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build rules for XLS examples.
+
+load(
+    "//xls/build_rules:xls_build_defs.bzl",
+    "xls_dslx_library",
+    "xls_dslx_opt_ir",
+    "xls_dslx_test",
+    "xls_dslx_verilog",
+)
+
+package(
+    default_visibility = ["//xls:xls_internal"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+xls_dslx_library(
+    name = "passthrough_dslx",
+    srcs = [
+        "passthrough.x",
+    ],
+)
+
+xls_dslx_opt_ir(
+    name = "pasthrough_opt_ir",
+    dslx_top = "Passthrough",
+    library = "passthrough_dslx",
+)
+
+xls_dslx_verilog(
+    name = "passthrough_verilog",
+    codegen_args = {
+        "module_name": "passthrough",
+        "delay_model": "unit",
+        "pipeline_stages": "1",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "Passthrough",
+    library = "passthrough_dslx",
+    verilog_file = "passthrough.v",
+)
+
+xls_dslx_test(
+    name = "passthrough_dslx_ir_test",
+    dslx_test_args = {
+        "compare": "interpreter",
+    },
+    library = "passthrough_dslx",
+)

--- a/xls/simulation/generic/testdata/passthrough.x
+++ b/xls/simulation/generic/testdata/passthrough.x
@@ -1,0 +1,64 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import std
+
+proc Passthrough {
+  data_r: chan<u32> in;
+  data_s: chan<u32> out;
+
+  init {()}
+
+  config(data_r: chan<u32> in, data_s: chan<u32> out) {
+    (data_r, data_s)
+  }
+
+  next(tok: token, state: ()) {
+    let (tok, data) = recv(tok, data_r);
+    let tok = send(tok, data_s, data);
+  }
+}
+
+#[test_proc]
+proc PassthroughTester {
+  terminator: chan<bool> out;
+  data_s: chan<u32> out;
+  data_r: chan<u32> in;
+
+  init { u32:0 }
+
+  config (terminator: chan<bool> out) {
+    let (data_s, data_r) = chan<u32>;
+
+    spawn Passthrough(data_r, data_s);
+    (terminator, data_s, data_r)
+  }
+
+  next(tok: token, recv_cnt: u32) {
+    let next_state = if (recv_cnt < u32:10) {
+      let data_send = recv_cnt;
+      let tok = send(tok, data_s, data_send);
+      let (tok, data_recv) = recv(tok, data_r);
+
+      assert_eq(data_send, data_recv);
+      trace_fmt!("Received {} cnt", recv_cnt);
+      recv_cnt + u32:1
+    } else {
+      send(tok, terminator, true);
+      u32:0
+    };
+
+    (next_state)
+  }
+}

--- a/xls/simulation/generic/xlsperipheral.cc
+++ b/xls/simulation/generic/xlsperipheral.cc
@@ -1,0 +1,505 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/simulation/generic/xlsperipheral.h"
+
+#include <cstdint>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/logging/logging.h"
+#include "xls/common/status/ret_check.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/package.h"
+#include "xls/simulation/generic/axi_stream_like_dma_endpoint.h"
+#include "xls/simulation/generic/config.h"
+#include "xls/simulation/generic/dmastreammanager.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/ir_axistreamlike.h"
+#include "xls/simulation/generic/ir_single_value.h"
+#include "xls/simulation/generic/ir_stream.h"
+#include "xls/simulation/generic/runtime_manager.h"
+#include "xls/simulation/generic/singlevaluemanager.h"
+#include "xls/simulation/generic/stream_dma_endpoint.h"
+#include "xls/simulation/generic/streammanager.h"
+
+namespace xls::simulation::generic {
+
+// Load config file
+// Assumptions: text proto, IR simulation
+// TODO(rdobrodii): 2023-09-05 extract this from the context string?
+absl::StatusOr<Config> LoadConfig(std::string_view context) {
+  ConfigType config_type = ConfigType::kTextproto;
+  SimulationType sim_type = SimulationType::kIR;
+
+  auto proto = MakeProtoForConfigFile(context, config_type);
+  if (!proto.ok()) {
+    return absl::InternalError(
+        absl::StrFormat("Error loading config file '%s': %s", context,
+                        proto.status().ToString()));
+  }
+  return Config(std::move(proto.value()), sim_type);
+}
+
+absl::StatusOr<std::optional<StreamManager>> SetUpStreamManager(
+    const Config& config, RuntimeManager* runtime) {
+  absl::StatusOr<std::optional<ConfigStreamManager>> sm_config =
+      config.GetStreamManagerConfig();
+  if (!sm_config.ok()) {
+    XLS_LOG(WARNING) << "Error loading Stream configuration: "
+                     << sm_config.status().ToString();
+    return std::nullopt;
+  }
+  if (!sm_config->has_value()) {
+    return std::nullopt;
+  }
+
+  absl::StatusOr<StreamManager> sm = StreamManager::Build(
+      sm_config->value().GetBaseAddress(),
+      [&](const auto& RegisterStream) -> absl::Status {
+        for (auto& ch_config : sm_config->value().GetChannels()) {
+          std::string_view ch_name = ch_config.GetName();
+
+          XLS_ASSIGN_OR_RETURN(
+              auto* queue,
+              runtime->runtime().queue_manager().GetQueueByName(ch_name));
+
+          if (queue->channel()->kind() != ChannelKind::kStreaming) {
+            return absl::InternalError(
+                absl::StrFormat("Channel \"%s\" is not a stream.", ch_name));
+          }
+
+          XLS_ASSIGN_OR_RETURN(IRStream stream, IRStream::MakeIRStream(queue));
+
+          XLS_ASSIGN_OR_RETURN(IChannelManager::channel_addr_t offset,
+                               ch_config.GetOffset());
+
+          XLS_LOG(INFO) << "Registering channel \"" << ch_name << "\"";
+          RegisterStream(offset, new IRStream(std::move(stream)));
+        }
+        return absl::OkStatus();
+      });
+  if (!sm.ok()) {
+    return sm.status();
+  }
+  return std::make_optional(std::move(sm.value()));
+}
+
+absl::StatusOr<std::unique_ptr<Package>> LoadPackage(const Config& config) {
+  // Describe the config
+  XLS_ASSIGN_OR_RETURN(std::filesystem::path design_path,
+                       config.GetDesignPath());
+  XLS_LOG(INFO) << "Setting up simulation of the following design: "
+                << design_path;
+
+  XLS_ASSIGN_OR_RETURN(std::string design_contents,
+                       xls::GetFileContents(design_path));
+
+  auto package = xls::Parser::ParsePackage(design_contents);
+  if (!package.ok()) {
+    XLS_LOG(FATAL) << "Failed to parse package " << design_path
+                   << "\n Reason: " << package.status();
+  }
+  return std::move(package.value());
+}
+
+static absl::StatusOr<std::optional<SingleValueManager>>
+SetUpSingleValueManager(const Config& config, RuntimeManager* runtime) {
+  absl::StatusOr<std::optional<ConfigSingleValueManager>> svm_config =
+      config.GetSingleValueManagerConfig();
+  if (!svm_config.ok()) {
+    XLS_LOG(WARNING) << "Error loading SingleValue configuration: "
+                     << svm_config.status().ToString();
+    return std::nullopt;
+  }
+  if (!svm_config->has_value()) {
+    return std::nullopt;
+  }
+  if (runtime == nullptr) {
+    return absl::InvalidArgumentError("Undefined runtime!");
+  }
+  SingleValueManager svm(svm_config->value().GetBaseAddress());
+  XLS_RETURN_IF_ERROR(
+      svm.RegisterIRegister(std::move(runtime->GetRuntimeStatusOwnership()),
+                            svm_config->value().GetRuntimeStatusOffset()));
+
+  for (auto& ch_config : svm_config->value().GetChannels()) {
+    std::string_view ch_name = ch_config.GetName();
+
+    XLS_ASSIGN_OR_RETURN(
+        auto* queue,
+        runtime->runtime().queue_manager().GetQueueByName(ch_name));
+
+    if (queue->channel()->kind() != ChannelKind::kSingleValue) {
+      return absl::InternalError(
+          absl::StrFormat("Channel \"%s\" is not a register.", ch_name));
+    }
+
+    XLS_ASSIGN_OR_RETURN(IRSingleValue singlevalue,
+                         IRSingleValue::MakeIRSingleValue(queue));
+
+    XLS_ASSIGN_OR_RETURN(uint64_t offset, ch_config.GetOffset());
+
+    XLS_LOG(INFO) << "Registering single value channel \"" << ch_name << "\"";
+    XLS_RETURN_IF_ERROR(svm.RegisterIRegister(
+        std::make_unique<IRSingleValue>(std::move(singlevalue)), offset));
+  }
+
+  return svm;
+}
+
+static absl::StatusOr<IRStream> CreateStreamFromConfig(
+    RuntimeManager* runtime, const ConfigChannel& config) {
+  std::string_view ch_name = config.GetName();
+  XLS_ASSIGN_OR_RETURN(
+      auto* queue, runtime->runtime().queue_manager().GetQueueByName(ch_name));
+
+  if (queue->channel()->kind() != ChannelKind::kStreaming) {
+    return absl::InternalError(
+        absl::StrFormat("Channel \"%s\" is not a stream.", ch_name));
+  }
+
+  XLS_ASSIGN_OR_RETURN(IRStream stream, IRStream::MakeIRStream(queue));
+  XLS_LOG(INFO) << "Created channel \"" << ch_name << "\"";
+
+  return std::move(stream);
+}
+
+static absl::StatusOr<std::optional<DmaStreamManager>> SetUpDmaStreamManager(
+    IMasterPort* bus_master_port, const Config& config,
+    RuntimeManager* runtime) {
+  // DMA Stream Manager not declared in config, skip it
+  absl::StatusOr<std::optional<ConfigStreamManager>> dma_config =
+      config.GetDmaStreamManagerConfig();
+  if (!dma_config.ok()) {
+    XLS_LOG(WARNING) << "Error loading DMA configuration: "
+                     << dma_config.status().ToString();
+    return std::nullopt;
+  }
+  if (!dma_config->has_value()) {
+    return std::nullopt;
+  }
+
+  DmaStreamManager dma = DmaStreamManager(dma_config->value().GetBaseAddress());
+  for (auto& ch_config : dma_config->value().GetChannels()) {
+    XLS_ASSIGN_OR_RETURN(auto stream,
+                         CreateStreamFromConfig(runtime, ch_config));
+    XLS_ASSIGN_OR_RETURN(uint64_t dma_id, ch_config.GetDMAID());
+    XLS_RETURN_IF_ERROR(dma.RegisterEndpoint(
+        std::unique_ptr<StreamDmaEndpoint>(new StreamDmaEndpoint(
+            std::unique_ptr<IStream>(new IRStream(std::move(stream))))),
+        dma_id, bus_master_port));
+  }
+
+  return dma;
+}
+
+static absl::StatusOr<IrAxiStreamLike> CreateAXIStreamFromConfig(
+    RuntimeManager* runtime, const ConfigAxiStreamLikeChannel& config) {
+  std::string_view ch_name = config.GetName();
+  XLS_ASSIGN_OR_RETURN(
+      auto* queue, runtime->runtime().queue_manager().GetQueueByName(ch_name));
+
+  if (queue->channel()->kind() != ChannelKind::kStreaming) {
+    return absl::InternalError(
+        absl::StrFormat("Channel \"%s\" is not a stream.", ch_name));
+  }
+
+  bool multisymbol;
+  std::optional<uint64_t> tkeep_index;
+  if (!config.GetKeepIdx().ok()) {
+    multisymbol = false;
+  } else {
+    multisymbol = true;
+    tkeep_index = config.GetKeepIdx().value();
+  }
+  std::optional<uint64_t> tlast_index;
+  if (config.GetLastIdx().ok()) {
+    tlast_index = config.GetLastIdx().value();
+  }
+
+  uint64_t data_index = config.GetDataIdxs()[0];
+  XLS_ASSIGN_OR_RETURN(IrAxiStreamLike stream,
+                       IrAxiStreamLike::Make(queue, multisymbol, data_index,
+                                             tlast_index, tkeep_index));
+  XLS_LOG(INFO) << "Created channel \"" << ch_name << "\"";
+
+  return std::move(stream);
+}
+
+static absl::StatusOr<std::optional<DmaStreamManager>> SetUpDmaAXIStreamManager(
+    IMasterPort* bus_master_port, const Config& config,
+    RuntimeManager* runtime) {
+  // AXI DMA Stream Manager not declared in config, skip it
+  absl::StatusOr<std::optional<ConfigDmaAxiStreamLikeManager>> dma_config =
+      config.GetDmaAxiStreamLikeManagerConfig();
+  if (!dma_config.ok()) {
+    XLS_LOG(WARNING) << "Error loading AXI DMA configuration: "
+                     << dma_config.status().ToString();
+    return std::nullopt;
+  }
+  if (!dma_config->has_value()) {
+    return std::nullopt;
+  }
+
+  DmaStreamManager dma = DmaStreamManager(dma_config->value().GetBaseAddress());
+  for (auto& ch_config : dma_config->value().GetChannels()) {
+    XLS_ASSIGN_OR_RETURN(auto stream,
+                         CreateAXIStreamFromConfig(runtime, ch_config));
+    XLS_ASSIGN_OR_RETURN(uint64_t dma_id, ch_config.GetDMAID());
+    XLS_RETURN_IF_ERROR(dma.RegisterEndpoint(
+        std::unique_ptr<AxiStreamLikeDmaEndpoint>(
+            new AxiStreamLikeDmaEndpoint(std::unique_ptr<IrAxiStreamLike>(
+                new IrAxiStreamLike(std::move(stream))))),
+        dma_id, bus_master_port));
+  }
+
+  return dma;
+}
+
+absl::StatusOr<XlsPeripheral> XlsPeripheral::Make(IConnection& connection,
+                                                  std::string_view context) {
+  XLS_LOG(INFO) << "Creating generic::XlsPeripheral. Config: " << context;
+
+  XLS_ASSIGN_OR_RETURN(Config config, LoadConfig(context));
+  XLS_ASSIGN_OR_RETURN(std::unique_ptr<Package> package, LoadPackage(config));
+
+  // Real init happens on `Reset` call.
+  return XlsPeripheral(std::move(config), connection, std::move(package),
+                       nullptr);
+}
+
+XlsPeripheral::XlsPeripheral(Config&& config, IConnection& connection,
+                             std::unique_ptr<Package> package,
+                             std::unique_ptr<RuntimeManager> runtime)
+    : config_(std::move(config)),
+      connection_(connection),
+      package_(std::move(package)),
+      runtime_(std::move(runtime)) {}
+
+uint64_t GetByteWidth(AccessWidth access) {
+  switch (access) {
+    case AccessWidth::BYTE:
+      return 1;
+    case AccessWidth::WORD:
+      return 2;
+    case AccessWidth::DWORD:
+      return 4;
+    case AccessWidth::QWORD:
+      return 8;
+    default:
+      XLS_LOG(ERROR) << "Unhandled AccessWidth!";
+      XLS_DCHECK(false);
+  }
+  return 0;
+}
+
+absl::Status XlsPeripheral::CheckRequest(uint64_t addr, AccessWidth width) {
+  if (runtime_ == nullptr) {
+    XLS_LOG(FATAL) << "Device has not been initialized";
+    return absl::FailedPreconditionError("Device has not been initialized");
+  }
+
+  uint64_t access_width = GetByteWidth(width);
+  bool in_range = false;
+  bool possible_unaligned = false;
+
+  for (auto& manager : managers_) {
+    if (manager->InRange(addr) && manager->InRange(addr + access_width - 1)) {
+      in_range = true;
+      break;
+    }
+    if (manager->InRange(addr)) {
+      in_range = true;
+    }
+    if (manager->InRange(addr + access_width - 1)) {
+      possible_unaligned = true;
+    }
+    if (in_range && possible_unaligned) {
+      return absl::InvalidArgumentError(
+          "Access to multiple managers at once is not supported");
+    }
+  }
+
+  if (!in_range) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Access at %016x - has no mapping", addr));
+  }
+  return absl::OkStatus();
+}
+
+absl::StatusOr<uint64_t> XlsPeripheral::HandleRead(uint64_t addr,
+                                                   AccessWidth width) {
+  absl::StatusOr<uint64_t> value;
+  for (auto& manager : managers_) {
+    if (manager->InRange(addr)) {
+      switch (width) {
+        case AccessWidth::BYTE:
+          value = manager->ReadU8AtAddress(addr);
+          break;
+        case AccessWidth::WORD:
+          value = manager->ReadU16AtAddress(addr);
+          break;
+        case AccessWidth::DWORD:
+          value = manager->ReadU32AtAddress(addr);
+          break;
+        case AccessWidth::QWORD:
+          value = manager->ReadU64AtAddress(addr);
+          break;
+      }
+    }
+  }
+  return value;
+}
+
+absl::Status XlsPeripheral::HandleWrite(uint64_t addr, AccessWidth width,
+                                        uint64_t payload) {
+  absl::Status status;
+  for (auto& manager : managers_) {
+    if (manager->InRange(addr)) {
+      switch (width) {
+        case AccessWidth::BYTE:
+          status = manager->WriteU8AtAddress(addr, payload);
+          break;
+        case AccessWidth::WORD:
+          status = manager->WriteU16AtAddress(addr, payload);
+          break;
+        case AccessWidth::DWORD:
+          status = manager->WriteU32AtAddress(addr, payload);
+          break;
+        case AccessWidth::QWORD:
+          status = manager->WriteU64AtAddress(addr, payload);
+          break;
+      }
+    }
+  }
+  return status;
+}
+
+absl::StatusOr<IRQEnum> XlsPeripheral::HandleIRQ() {
+  if (runtime_ == nullptr) {
+    XLS_LOG(FATAL) << "Device has not been initialized";
+    return absl::FailedPreconditionError("Device has not been initialized");
+  }
+  // Simulation only uses IRQ 0 if ever used
+  bool irq = false;
+  for (auto& manager : managers_) {
+    if (auto interrupt_manager = dynamic_cast<IIRQ*>(manager.get());
+        interrupt_manager != nullptr) {
+      if (auto s = interrupt_manager->UpdateIRQ(); !s.ok()) {
+        XLS_LOG(FATAL) << s.message();
+        return s;
+      }
+      irq |= interrupt_manager->GetIRQ();
+    }
+  }
+  if (last_irq_ != irq) {
+    last_irq_ = irq;
+    if (irq > 0)
+      return IRQEnum::SetIRQ;
+    else
+      return IRQEnum::UnsetIRQ;
+  }
+
+  return IRQEnum::NoChange;
+}
+
+absl::Status XlsPeripheral::HandleTick() {
+  if (runtime_ == nullptr) {
+    XLS_LOG(FATAL) << "Device has not been initialized";
+    return absl::FailedPreconditionError("Device has not been initialized");
+  }
+
+  absl::Status tick_status;
+  // Tick is special: response must be sent over a request channel
+  tick_status = runtime_->Update();
+  // This is horrible, but in order to avoid it we would have to change the
+  // way ProcRuntime::Tick() reports deadlocks. Those are almost never
+  // errors in case of co-simulation, instead they usually mean that the
+  // device is idle (not in use).
+  if (!tick_status.ok()) {
+    if (tick_status.message().find_first_of("Proc network is deadlocked.") !=
+        0) {
+      XLS_LOG(FATAL) << tick_status.message();
+      return tick_status;
+    }
+  }
+
+  for (auto& manager : managers_) {
+    if (auto active_manager = dynamic_cast<IActive*>(manager.get());
+        active_manager != nullptr) {
+      if (auto s = active_manager->Update(); !s.ok()) {
+        XLS_LOG(FATAL) << s.message();
+        return s;
+      }
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+absl::Status XlsPeripheral::Reset() {
+  this->managers_.clear();
+
+  auto runtime_man = RuntimeManager::Create(package_.get(), false);
+  if (!runtime_man.ok()) {
+    return absl::InternalError("Failed to initialize runtime: " +
+                               runtime_man.status().ToString());
+  }
+
+  XLS_ASSIGN_OR_RETURN(auto svm_option,
+                       SetUpSingleValueManager(config_, runtime_man->get()));
+  if (svm_option.has_value()) {
+    this->managers_.emplace_back(std::unique_ptr<IChannelManager>(
+        new SingleValueManager(std::move(svm_option.value()))));
+  }
+
+  XLS_ASSIGN_OR_RETURN(std::optional<StreamManager> sm_option,
+                       SetUpStreamManager(config_, runtime_man->get()));
+  if (sm_option.has_value()) {
+    this->managers_.emplace_back(std::unique_ptr<IChannelManager>(
+        new StreamManager(std::move(sm_option.value()))));
+  }
+
+  XLS_ASSIGN_OR_RETURN(std::optional<DmaStreamManager> dsm_option,
+                       SetUpDmaStreamManager(connection_.GetMasterPort(),
+                                             config_, runtime_man->get()));
+  if (dsm_option.has_value()) {
+    this->managers_.emplace_back(std::unique_ptr<IChannelManager>(
+        new DmaStreamManager(std::move(dsm_option.value()))));
+  }
+
+  XLS_ASSIGN_OR_RETURN(std::optional<DmaStreamManager> dasm_option,
+                       SetUpDmaAXIStreamManager(connection_.GetMasterPort(),
+                                                config_, runtime_man->get()));
+  if (dasm_option.has_value()) {
+    this->managers_.emplace_back(std::unique_ptr<IChannelManager>(
+        new DmaStreamManager(std::move(dasm_option.value()))));
+  }
+
+  this->runtime_ = std::move(runtime_man.value());
+
+  XLS_LOG(INFO) << "Peripheral has been reset";
+  return absl::OkStatus();
+}
+
+}  // namespace xls::simulation::generic

--- a/xls/simulation/generic/xlsperipheral.h
+++ b/xls/simulation/generic/xlsperipheral.h
@@ -1,0 +1,68 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_SIMULATION_GENERIC_XLSPERIPHERAL_H_
+#define XLS_SIMULATION_GENERIC_XLSPERIPHERAL_H_
+
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "xls/simulation/generic/config.h"
+#include "xls/simulation/generic/ichannelmanager.h"
+#include "xls/simulation/generic/iconnection.h"
+#include "xls/simulation/generic/iperipheral.h"
+#include "xls/simulation/generic/runtime_manager.h"
+#include "xls/simulation/generic/runtime_status.h"
+#include "xls/simulation/generic/singlevaluemanager.h"
+
+namespace xls::simulation::generic {
+
+class XlsPeripheral : public IPeripheral {
+ public:
+  XlsPeripheral() = delete;
+  XlsPeripheral(const XlsPeripheral&) = delete;
+  XlsPeripheral& operator=(const XlsPeripheral&) = delete;
+  XlsPeripheral(XlsPeripheral&&) = default;
+
+  static absl::StatusOr<XlsPeripheral> Make(IConnection& connection,
+                                            std::string_view context);
+
+  absl::Status CheckRequest(uint64_t addr, AccessWidth width) override;
+  absl::StatusOr<uint64_t> HandleRead(uint64_t addr,
+                                      AccessWidth width) override;
+  absl::Status HandleWrite(uint64_t addr, AccessWidth width,
+                           uint64_t payload) override;
+  absl::StatusOr<IRQEnum> HandleIRQ() override;
+  absl::Status HandleTick() override;
+  absl::Status Reset() override;
+
+ private:
+  XlsPeripheral(Config&& config, IConnection& connection,
+                std::unique_ptr<Package> package,
+                std::unique_ptr<RuntimeManager> runtime);
+
+  bool last_irq_;
+  Config config_;
+  IConnection& connection_;
+  std::unique_ptr<Package> package_;
+  std::unique_ptr<RuntimeManager> runtime_;
+  std::vector<std::unique_ptr<IChannelManager>> managers_;
+};
+
+}  // namespace xls::simulation::generic
+
+#endif  // XLS_SIMULATION_GENERIC_XLSPERIPHERAL_H_


### PR DESCRIPTION
Generic integration creates memory mapped device.

This is the third and last PR in the series of 3.
It requires #1177 

It adds concept of managers, they are responsible for translating
memory type accesses to stream operations. They are also
responsible for lifetime of the channel wrappers.
There are 3 types of manager:
* SingleValue,
* Stream,
*  DMA.

This PR also adds top level XlsPeripheral class.
It's responsible for:
* reading configuration file,
* initializing IR simulation, 
* configuring managers,
* redirecting memory operations to correct channel manager,
* advancing simulation. 