### PR TITLE
Emit actual value along with enum name

### DIFF
--- a/xls/dslx/cpp_transpiler/cpp_type_generator.cc
+++ b/xls/dslx/cpp_transpiler/cpp_type_generator.cc
@@ -161,9 +161,9 @@ class EnumCppTypeGenerator : public CppTypeGenerator {
                                        cpp_type(), ev.name, type_name, ev.name,
                                        ev.value_str));
     }
-    pieces.push_back(
-        absl::StrFormat("  default: return absl::StrFormat(%s, %s);",
-                        "\"<unknown> (%d)\"", CastToCppBaseType("value")));
+    pieces.push_back(absl::StrFormat(
+        "  default: return absl::StrFormat(\"<unknown> (%%d)\", %s);",
+        CastToCppBaseType("value")));
     pieces.push_back("}");
     return absl::StrJoin(pieces, "\n");
   }

--- a/xls/dslx/cpp_transpiler/cpp_type_generator.cc
+++ b/xls/dslx/cpp_transpiler/cpp_type_generator.cc
@@ -157,14 +157,13 @@ class EnumCppTypeGenerator : public CppTypeGenerator {
     std::vector<std::string> pieces;
     pieces.push_back("switch (value) {");
     for (const EnumValue& ev : enum_values_) {
-      // TODO(https://github.com/google/xls/issues/1127): Also emit the actual
-      // value along with the enum name. For example: `MyEnum::kFoo (42)`,
-      // `<unknown> (3)`.
-      pieces.push_back(absl::StrFormat("  case %s::%s: return \"%s::%s\";",
-                                       cpp_type(), ev.name, type_name,
-                                       ev.name));
+      pieces.push_back(absl::StrFormat("  case %s::%s: return \"%s::%s (%s)\";",
+                                       cpp_type(), ev.name, type_name, ev.name,
+                                       ev.value_str));
     }
-    pieces.push_back("  default: return \"<unknown>\";");
+    pieces.push_back(
+        absl::StrFormat("  default: return absl::StrFormat(%s, %s);",
+                        "\"<unknown> (%d)\"", CastToCppBaseType("value")));
     pieces.push_back("}");
     return absl::StrJoin(pieces, "\n");
   }

--- a/xls/dslx/cpp_transpiler/cpp_type_generator.cc
+++ b/xls/dslx/cpp_transpiler/cpp_type_generator.cc
@@ -161,9 +161,10 @@ class EnumCppTypeGenerator : public CppTypeGenerator {
                                        cpp_type(), ev.name, type_name, ev.name,
                                        ev.value_str));
     }
-    pieces.push_back(absl::StrFormat(
-        "  default: return absl::StrFormat(\"<unknown> (%%d)\", %s);",
-        CastToCppBaseType("value")));
+    pieces.push_back(
+        absl::StrFormat("  default: return absl::StrFormat(\"<unknown> "
+                        "(%%v)\", %s);",
+                        CastToCppBaseType("value")));
     pieces.push_back("}");
     return absl::StrJoin(pieces, "\n");
   }

--- a/xls/dslx/cpp_transpiler/testdata/BasicEnums.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/BasicEnums.cctxt
@@ -37,21 +37,21 @@ static std::string __indent(int64_t amount) {
 
 std::string MyEnumToString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    case MyEnum::kE: return "MyEnum::kE";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (1)";
+    case MyEnum::kC: return "MyEnum::kC (42)";
+    case MyEnum::kE: return "MyEnum::kE (4294967295)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
   }
 }
 
 std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    case MyEnum::kE: return "MyEnum::kE";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (1)";
+    case MyEnum::kC: return "MyEnum::kC (42)";
+    case MyEnum::kE: return "MyEnum::kE (4294967295)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/BasicEnums.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/BasicEnums.cctxt
@@ -41,7 +41,7 @@ std::string MyEnumToString(MyEnum value, int64_t indent) {
     case MyEnum::kB: return "MyEnum::kB (1)";
     case MyEnum::kC: return "MyEnum::kC (42)";
     case MyEnum::kE: return "MyEnum::kE (4294967295)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint32_t>(value));
   }
 }
 
@@ -51,7 +51,7 @@ std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
     case MyEnum::kB: return "MyEnum::kB (1)";
     case MyEnum::kC: return "MyEnum::kC (42)";
     case MyEnum::kE: return "MyEnum::kE (4294967295)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint32_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.cctxt
@@ -37,19 +37,19 @@ static std::string __indent(int64_t amount) {
 
 std::string MyEnumToString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (17)";
+    case MyEnum::kC: return "MyEnum::kC (289)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
   }
 }
 
 std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (17)";
+    case MyEnum::kC: return "MyEnum::kC (289)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.cctxt
@@ -40,7 +40,7 @@ std::string MyEnumToString(MyEnum value, int64_t indent) {
     case MyEnum::kA: return "MyEnum::kA (0)";
     case MyEnum::kB: return "MyEnum::kB (17)";
     case MyEnum::kC: return "MyEnum::kC (289)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint32_t>(value));
   }
 }
 
@@ -49,7 +49,7 @@ std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
     case MyEnum::kA: return "MyEnum::kA (0)";
     case MyEnum::kB: return "MyEnum::kB (17)";
     case MyEnum::kC: return "MyEnum::kC (289)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint32_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint32_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithS64.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithS64.cctxt
@@ -40,7 +40,7 @@ std::string MyEnumToString(MyEnum value, int64_t indent) {
     case MyEnum::kMIN: return "MyEnum::kMIN (-9223372036854775808)";
     case MyEnum::kMID: return "MyEnum::kMID (4611686018427387904)";
     case MyEnum::kMAX: return "MyEnum::kMAX (9223372036854775807)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<int64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<int64_t>(value));
   }
 }
 
@@ -49,7 +49,7 @@ std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
     case MyEnum::kMIN: return "MyEnum::kMIN (-9223372036854775808)";
     case MyEnum::kMID: return "MyEnum::kMID (4611686018427387904)";
     case MyEnum::kMAX: return "MyEnum::kMAX (9223372036854775807)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<int64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<int64_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithS64.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithS64.cctxt
@@ -37,19 +37,19 @@ static std::string __indent(int64_t amount) {
 
 std::string MyEnumToString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kMIN: return "MyEnum::kMIN";
-    case MyEnum::kMID: return "MyEnum::kMID";
-    case MyEnum::kMAX: return "MyEnum::kMAX";
-    default: return "<unknown>";
+    case MyEnum::kMIN: return "MyEnum::kMIN (-9223372036854775808)";
+    case MyEnum::kMID: return "MyEnum::kMID (4611686018427387904)";
+    case MyEnum::kMAX: return "MyEnum::kMAX (9223372036854775807)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<int64_t>(value));
   }
 }
 
 std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kMIN: return "MyEnum::kMIN";
-    case MyEnum::kMID: return "MyEnum::kMID";
-    case MyEnum::kMAX: return "MyEnum::kMAX";
-    default: return "<unknown>";
+    case MyEnum::kMIN: return "MyEnum::kMIN (-9223372036854775808)";
+    case MyEnum::kMID: return "MyEnum::kMID (4611686018427387904)";
+    case MyEnum::kMAX: return "MyEnum::kMAX (9223372036854775807)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<int64_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithU64.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithU64.cctxt
@@ -37,19 +37,19 @@ static std::string __indent(int64_t amount) {
 
 std::string MyEnumToString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kMIN: return "MyEnum::kMIN";
-    case MyEnum::kMID: return "MyEnum::kMID";
-    case MyEnum::kMAX: return "MyEnum::kMAX";
-    default: return "<unknown>";
+    case MyEnum::kMIN: return "MyEnum::kMIN (0)";
+    case MyEnum::kMID: return "MyEnum::kMID (9223372036854775808)";
+    case MyEnum::kMAX: return "MyEnum::kMAX (18446744073709551615)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
   }
 }
 
 std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kMIN: return "MyEnum::kMIN";
-    case MyEnum::kMID: return "MyEnum::kMID";
-    case MyEnum::kMAX: return "MyEnum::kMAX";
-    default: return "<unknown>";
+    case MyEnum::kMIN: return "MyEnum::kMIN (0)";
+    case MyEnum::kMID: return "MyEnum::kMID (9223372036854775808)";
+    case MyEnum::kMAX: return "MyEnum::kMAX (18446744073709551615)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithU64.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithU64.cctxt
@@ -40,7 +40,7 @@ std::string MyEnumToString(MyEnum value, int64_t indent) {
     case MyEnum::kMIN: return "MyEnum::kMIN (0)";
     case MyEnum::kMID: return "MyEnum::kMID (9223372036854775808)";
     case MyEnum::kMAX: return "MyEnum::kMAX (18446744073709551615)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint64_t>(value));
   }
 }
 
@@ -49,7 +49,7 @@ std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
     case MyEnum::kMIN: return "MyEnum::kMIN (0)";
     case MyEnum::kMID: return "MyEnum::kMID (9223372036854775808)";
     case MyEnum::kMAX: return "MyEnum::kMAX (18446744073709551615)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint64_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.cctxt
@@ -37,21 +37,21 @@ static std::string __indent(int64_t amount) {
 
 std::string MyEnumToString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    case MyEnum::kE: return "MyEnum::kE";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (1)";
+    case MyEnum::kC: return "MyEnum::kC (42)";
+    case MyEnum::kE: return "MyEnum::kE (4294967295)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
   }
 }
 
 std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
   switch (value) {
-    case MyEnum::kA: return "MyEnum::kA";
-    case MyEnum::kB: return "MyEnum::kB";
-    case MyEnum::kC: return "MyEnum::kC";
-    case MyEnum::kE: return "MyEnum::kE";
-    default: return "<unknown>";
+    case MyEnum::kA: return "MyEnum::kA (0)";
+    case MyEnum::kB: return "MyEnum::kB (1)";
+    case MyEnum::kC: return "MyEnum::kC (42)";
+    case MyEnum::kE: return "MyEnum::kE (4294967295)";
+    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
   }
 }
 

--- a/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.cctxt
+++ b/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.cctxt
@@ -41,7 +41,7 @@ std::string MyEnumToString(MyEnum value, int64_t indent) {
     case MyEnum::kB: return "MyEnum::kB (1)";
     case MyEnum::kC: return "MyEnum::kC (42)";
     case MyEnum::kE: return "MyEnum::kE (4294967295)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint64_t>(value));
   }
 }
 
@@ -51,7 +51,7 @@ std::string MyEnumToDslxString(MyEnum value, int64_t indent) {
     case MyEnum::kB: return "MyEnum::kB (1)";
     case MyEnum::kC: return "MyEnum::kC (42)";
     case MyEnum::kE: return "MyEnum::kE (4294967295)";
-    default: return absl::StrFormat("<unknown> (%d)", static_cast<uint64_t>(value));
+    default: return absl::StrFormat("<unknown> (%v)", static_cast<uint64_t>(value));
   }
 }
 


### PR DESCRIPTION
This pull request adds enum values adjacent to enum names in their string representations.

Fixes issue #1127.