### PR TITLE
dependency_support: bump bazel_rules_hdl

### DIFF
--- a/dependency_support/initialize_external.bzl
+++ b/dependency_support/initialize_external.bzl
@@ -24,7 +24,6 @@ load("@python39//:defs.bzl", python_interpreter_target = "interpreter")
 load("@rules_7zip//:setup.bzl", "setup_7zip")  # needed by rules_hdl
 load("@rules_hdl//:init.bzl", rules_hdl_init = "init")
 load("@rules_hdl//dependency_support:dependency_support.bzl", rules_hdl_dependency_support = "dependency_support")
-load("@rules_hdl//toolchains/cpython:cpython_toolchain.bzl", rules_hdl_register_cpython_repository = "register_cpython_repository")
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 load("@rules_python//python:pip.bzl", "pip_parse")
 load("@rules_python//python:repositories.bzl", "py_repositories")
@@ -33,7 +32,6 @@ def initialize_external_repositories():
     """Calls set-up methods for external repositories that require that."""
     bazel_skylib_workspace()
     protobuf_deps()
-    rules_hdl_register_cpython_repository()
     rules_hdl_init(python_interpreter_target = python_interpreter_target)
     rules_hdl_dependency_support()
     setup_7zip()

--- a/dependency_support/rules_hdl/workspace.bzl
+++ b/dependency_support/rules_hdl/workspace.bzl
@@ -37,9 +37,9 @@ def repo():
         sha256 = "fd9e99f6ccb9e946755f9bc444abefbdd1eedb32c372c56dcacc7eb486aed178",
     )
 
-    # Current as of 2023-12-05
-    git_hash = "37efe7ca7b8469454eacd3b70ef5fe5ddfea2cf4"
-    archive_sha256 = "d32c5d3a0864e351ca8e6e40d3cf1bb4b78cfc85ea81b5c52bd44b23d274d321"
+    # Current as of 2023-12-21
+    git_hash = "d40ce302bf3f766052ab88c0675cb0844e0b24c2"
+    archive_sha256 = "a5e61a2d7eeaee695a165addb2b9fa8d3a48240274012e98cf67e33272e079f5"
 
     maybe(
         http_archive,
@@ -49,7 +49,4 @@ def repo():
         urls = [
             "https://github.com/hdl/bazel_rules_hdl/archive/%s.tar.gz" % git_hash,
         ],
-        repo_mapping = {
-            "@rules_hdl_cpython": "@python39",
-        },
     )


### PR DESCRIPTION
This PR includes fixes for https://github.com/google/xls/pull/1031:

* improve hermetic python handling
* remove cpython and embedded_python_interpreter

Additionally, the bumped version of `bazel_rules_hdl` include work related to improving bazel place_and_route flow (https://github.com/hdl/bazel_rules_hdl/issues/239) and benchmarking experience (https://github.com/google/xls/issues/1226)

CC @proppy 