### PR TITLE
modules/zstd: Add Repacketizer

### DIFF
--- a/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
+++ b/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
@@ -49,3 +49,42 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+# NOTE: Required because of direct zstd_compress.c include in decodecorpus sources
+cc_library(
+    name = "decodecorpus_includes",
+    hdrs = [
+        "lib/compress/zstd_compress.c",
+    ],
+)
+
+cc_binary(
+    name = "decodecorpus",
+    srcs = [
+        "tests/decodecorpus.c",
+    ] + glob(
+        [
+            "programs/*.c",
+            "programs/*.h",
+        ],
+        exclude = [
+            "programs/zstdcli.c",
+        ],
+    ),
+    deps = [
+        ":zstd",
+        ":decodecorpus_includes",
+    ],
+    includes = [
+        "lib/",
+        "lib/common/",
+        "lib/compress/",
+        "lib/dictBuilder/",
+        "lib/deprecated/",
+        "programs/",
+    ],
+    local_defines = [
+        "XXH_NAMESPACE=ZSTD_",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
+++ b/dependency_support/com_github_facebook_zstd/bundled.BUILD.bazel
@@ -40,6 +40,7 @@ cc_library(
     ]),
     hdrs = [
         "lib/zstd.h",
+        "lib/common/zstd_errors.h",
     ],
     strip_include_prefix = "lib",
     local_defines = [

--- a/dependency_support/com_github_facebook_zstd/decodecorpus.patch
+++ b/dependency_support/com_github_facebook_zstd/decodecorpus.patch
@@ -1,0 +1,152 @@
+diff --git tests/decodecorpus.c tests/decodecorpus.c
+index 50935d31..522b3769 100644
+--- tests/decodecorpus.c
++++ tests/decodecorpus.c
+@@ -240,6 +240,12 @@ typedef enum {
+   gt_block,      /* generate compressed blocks without block/frame headers */
+ } genType_e;
+
++typedef enum {
++  lt_raw,
++  lt_rle,
++  lt_compressed,
++} literalType_e;
++
+ /*-*******************************************************
+ *  Global variables (set from command line)
+ *********************************************************/
+@@ -252,7 +258,11 @@ U32 g_maxBlockSize = ZSTD_BLOCKSIZE_MAX;                       /* <= 128 KB */
+
+ struct {
+     int contentSize; /* force the content size to be present */
+-} opts; /* advanced options on generation */
++    blockType_e *blockType; /* force specific block type */
++    literalType_e *literalType; /* force specific literals type */
++    int frame_header_only; /* generate only frame header */
++    int no_magic; /* do not generate magic number */
++} opts;
+
+ /* Generate and write a random frame header */
+ static void writeFrameHeader(U32* seed, frame_t* frame, dictInfo info)
+@@ -317,8 +327,10 @@ static void writeFrameHeader(U32* seed, frame_t* frame, dictInfo info)
+     }
+
+     /* write out the header */
+-    MEM_writeLE32(op + pos, ZSTD_MAGICNUMBER);
+-    pos += 4;
++    if (!opts.no_magic) {
++        MEM_writeLE32(op + pos, ZSTD_MAGICNUMBER);
++        pos += 4;
++    }
+
+     {
+         /*
+@@ -363,8 +375,10 @@ static void writeFrameHeader(U32* seed, frame_t* frame, dictInfo info)
+ /* Write a literal block in either raw or RLE form, return the literals size */
+ static size_t writeLiteralsBlockSimple(U32* seed, frame_t* frame, size_t contentSize)
+ {
++    int force_literal_type = opts.literalType != NULL;
++    int const type = (force_literal_type) ? *(opts.literalType) : RAND(seed) % 2;
++
+     BYTE* op = (BYTE*)frame->data;
+-    int const type = RAND(seed) % 2;
+     int const sizeFormatDesc = RAND(seed) % 8;
+     size_t litSize;
+     size_t maxLitSize = MIN(contentSize, g_maxBlockSize);
+@@ -612,8 +626,15 @@ static size_t writeLiteralsBlockCompressed(U32* seed, frame_t* frame, size_t con
+
+ static size_t writeLiteralsBlock(U32* seed, frame_t* frame, size_t contentSize)
+ {
+-    /* only do compressed for larger segments to avoid compressibility issues */
+-    if (RAND(seed) & 7 && contentSize >= 64) {
++    int select_compressed = 0;
++    if (opts.literalType) {
++        select_compressed = *(opts.literalType) == lt_compressed;
++    } else {
++        /* only do compressed for larger segments to avoid compressibility issues */
++        select_compressed = RAND(seed) & 7 && contentSize >= 64;
++    }
++
++    if (select_compressed) {
+         return writeLiteralsBlockCompressed(seed, frame, contentSize);
+     } else {
+         return writeLiteralsBlockSimple(seed, frame, contentSize);
+@@ -1030,7 +1051,8 @@ static size_t writeCompressedBlock(U32* seed, frame_t* frame, size_t contentSize
+ static void writeBlock(U32* seed, frame_t* frame, size_t contentSize,
+                        int lastBlock, dictInfo info)
+ {
+-    int const blockTypeDesc = RAND(seed) % 8;
++    int force_block_type = opts.blockType != NULL;
++    int const blockTypeDesc = (force_block_type) ? *(opts.blockType) : RAND(seed) % 8;
+     size_t blockSize;
+     int blockType;
+
+@@ -1069,7 +1091,7 @@ static void writeBlock(U32* seed, frame_t* frame, size_t contentSize,
+
+         frame->data = op;
+         compressedSize = writeCompressedBlock(seed, frame, contentSize, info);
+-        if (compressedSize >= contentSize) {   /* compressed block must be strictly smaller than uncompressed one */
++        if (compressedSize >= contentSize && !force_block_type) {   /* compressed block must be strictly smaller than uncompressed one */
+             blockType = 0;
+             memcpy(op, frame->src, contentSize);
+
+@@ -1240,7 +1262,11 @@ static U32 generateFrame(U32 seed, frame_t* fr, dictInfo info)
+     DISPLAYLEVEL(3, "frame seed: %u\n", (unsigned)seed);
+     initFrame(fr);
+
++
+     writeFrameHeader(&seed, fr, info);
++    if (opts.frame_header_only)
++        return seed;
++
+     writeBlocks(&seed, fr, info);
+     writeChecksum(fr);
+
+@@ -1768,6 +1794,9 @@ static void advancedUsage(const char* programName)
+     DISPLAY( " --max-block-size-log=#   : max block size log, must be in range [2, 17]\n");
+     DISPLAY( " --max-content-size-log=# : max content size log, must be <= 20\n");
+     DISPLAY( "                            (this is ignored with gen-blocks)\n");
++    DISPLAY( " --block-type=#           : force certain block type (raw=0, rle=1, compressed=2)\n");
++    DISPLAY( " --frame-header-only      : dump only frame header\n");
++    DISPLAY( " --no-magic               : do not add magic number\n");
+ }
+
+ /*! readU32FromChar() :
+@@ -1889,6 +1918,18 @@ int main(int argc, char** argv)
+                         U32 value = readU32FromChar(&argument);
+                         g_maxDecompressedSizeLog =
+                                 MIN(MAX_DECOMPRESSED_SIZE_LOG, value);
++                    } else if (longCommandWArg(&argument, "block-type=")) {
++                        U32 value = readU32FromChar(&argument);
++                        opts.blockType = malloc(sizeof(blockType_e));
++                        *(opts.blockType) = value;
++                    } else if (longCommandWArg(&argument, "literal-type=")) {
++                        U32 value = readU32FromChar(&argument);
++                        opts.literalType = malloc(sizeof(literalType_e));
++                        *(opts.literalType) = value;
++                    } else if (strcmp(argument, "frame-header-only") == 0) {
++                        opts.frame_header_only = 1;
++                    } else if (strcmp(argument, "no-magic") == 0) {
++                        opts.no_magic = 1;
+                     } else {
+                         advancedUsage(argv[0]);
+                         return 1;
+@@ -1900,6 +1941,18 @@ int main(int argc, char** argv)
+                     return 1;
+     }   }   }   }   /* for (argNb=1; argNb<argc; argNb++) */
+
++    if (opts.blockType) {
++        if ((opts.contentSize == 0) && (*(opts.blockType) == bt_rle)) {
++            DISPLAY("Error: content-size has to be used together with blockType=1 (rle block)\n");
++            return 1;
++        }
++
++        if (opts.literalType && (*(opts.blockType) != bt_compressed)) {
++            DISPLAY("Error: literal-type can be used only with blockType=2 (compressed block)\n");
++            return 1;
++        }
++    }
++
+     if (!seedset) {
+         seed = makeSeed();
+     }

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -296,4 +296,6 @@ def load_external_repositories():
         strip_prefix = "zstd-1.4.7",
         urls = ["https://github.com/facebook/zstd/releases/download/v1.4.7/zstd-1.4.7.tar.gz"],
         build_file = "@//dependency_support/com_github_facebook_zstd:bundled.BUILD.bazel",
+        # Modify decodecorpus to allow generation of zstd frame headers only
+        patches = ["@com_google_xls//dependency_support/com_github_facebook_zstd:decodecorpus.patch"],
     )

--- a/xls/examples/ram.x
+++ b/xls/examples/ram.x
@@ -55,7 +55,7 @@ pub fn ReadWordReq<NUM_PARTITIONS:u32, ADDR_WIDTH:u32>(addr:uN[ADDR_WIDTH]) ->
 }
 
 // Behavior of reads and writes to the same address in the same "tick".
-enum SimultaneousReadWriteBehavior : u2 {
+pub enum SimultaneousReadWriteBehavior : u2 {
   // The read shows the contents at the address before the write.
   READ_BEFORE_WRITE = 0,
   // The read shows the contents at the address after the write.
@@ -160,7 +160,7 @@ fn write_word_test() {
 
 // Function to compute num partitions (e.g. mask width) for a data_width-wide
 // word divided into word_partition_size-chunks.
-fn num_partitions(word_partition_size: u32, data_width: u32) -> u32 {
+pub fn num_partitions(word_partition_size: u32, data_width: u32) -> u32 {
   match word_partition_size {
     u32:0 => u32:0,
     _ => (word_partition_size + data_width - u32:1) / word_partition_size,

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -20,6 +20,7 @@ load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load(
     "//xls/build_rules:xls_build_defs.bzl",
     "xls_benchmark_ir",
+    "xls_benchmark_verilog",
     "xls_dslx_library",
     "xls_dslx_test",
     "xls_dslx_verilog",
@@ -617,4 +618,87 @@ xls_dslx_test(
         "compare": "none",
     },
     library = ":sequence_executor_dslx",
+)
+
+xls_dslx_verilog(
+    name = "sequence_executor_verilog",
+    codegen_args = {
+        "module_name": "sequence_executor",
+        "generator": "pipeline",
+        "delay_model": "asap7",
+        "ram_configurations": ",".join([
+            "{ram_name}:1R1W:{rd_req}:{rd_resp}:{wr_req}:{wr_resp}:{latency}".format(
+                latency = 5,
+                ram_name = "ram{}".format(num),
+                rd_req = "sequence_executor__rd_req_m{}_s".format(num),
+                rd_resp = "sequence_executor__rd_resp_m{}_r".format(num),
+                wr_req = "sequence_executor__wr_req_m{}_r".format(num),
+                wr_resp = "sequence_executor__wr_resp_m{}_r".format(num),
+            )
+            for num in range(7)
+        ]),
+        "pipeline_stages": "8",
+        "reset": "rst",
+        "reset_data_path": "true",
+        "reset_active_low": "false",
+        "reset_asynchronous": "true",
+        "flop_inputs": "false",
+        "flop_single_value_channels": "false",
+        "flop_outputs": "false",
+        "worst_case_throughput": "1",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "SequenceExecutorZstd",
+    library = ":sequence_executor_dslx",
+    opt_ir_args = {
+        "inline_procs": "true",
+        "top": "__sequence_executor__SequenceExecutorZstd__SequenceExecutor_0__64_0_0_0_13_8192_65536_next",
+    },
+    verilog_file = "sequence_executor.v",
+)
+
+xls_benchmark_ir(
+    name = "sequence_executor_ir_benchmark",
+    src = ":sequence_executor_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "8",
+        "delay_model": "asap7",
+    },
+)
+
+xls_benchmark_verilog(
+    name = "sequence_executor_verilog_benchmark",
+    verilog_target = "sequence_executor_verilog",
+)
+
+verilog_library(
+    name = "sequence_executor_lib",
+    srcs = [
+        ":sequence_executor.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "sequence_executor_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "sequence_executor",
+    deps = [
+        ":sequence_executor_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "sequence_executor_benchmark_synth",
+    synth_target = ":sequence_executor_asap7",
+)
+
+place_and_route(
+    name = "sequence_executor_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":sequence_executor_asap7",
+    target_die_utilization_percentage = "10",
 )

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -717,3 +717,58 @@ xls_dslx_test(
     name = "repacketizer_dslx_test",
     library = ":repacketizer_dslx",
 )
+
+xls_dslx_verilog(
+    name = "repacketizer_verilog",
+    codegen_args = {
+        "module_name": "Repacketizer",
+        "delay_model": "asap7",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "Repacketizer",
+    library = ":repacketizer_dslx",
+    verilog_file = "repacketizer.v",
+)
+
+xls_benchmark_ir(
+    name = "repacketizer_opt_ir_benchmark",
+    src = ":repacketizer_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "repacketizer_verilog_lib",
+    srcs = [
+        ":repacketizer.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "repacketizer_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "Repacketizer",
+    deps = [
+        ":repacketizer_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "repacketizer_benchmark_synth",
+    synth_target = ":repacketizer_synth_asap7",
+)
+
+place_and_route(
+    name = "repacketizer_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":repacketizer_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -1,0 +1,39 @@
+# Copyright 2023 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build rules for XLS ZSTD codec implementation.
+
+load(
+    "//xls/build_rules:xls_build_defs.bzl",
+    "xls_dslx_library",
+    "xls_dslx_test",
+)
+
+package(
+    default_applicable_licenses = ["//:license"],
+    default_visibility = ["//xls:xls_users"],
+    licenses = ["notice"],
+)
+
+xls_dslx_library(
+    name = "buffer_dslx",
+    srcs = [
+        "buffer.x",
+    ],
+)
+
+xls_dslx_test(
+    name = "buffer_dslx_test",
+    library = ":buffer_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -702,3 +702,18 @@ place_and_route(
     synthesized_rtl = ":sequence_executor_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "repacketizer_dslx",
+    srcs = [
+        "repacketizer.x",
+    ],
+    deps = [
+        ":common_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "repacketizer_dslx_test",
+    library = ":repacketizer_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -598,3 +598,23 @@ xls_dslx_test(
     name = "ram_printer_dslx_test",
     library = ":ram_printer_dslx",
 )
+
+xls_dslx_library(
+    name = "sequence_executor_dslx",
+    srcs = [
+        "sequence_executor.x",
+    ],
+    deps = [
+        ":common_dslx",
+        ":ram_printer_dslx",
+        "//xls/examples:ram_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "sequence_executor_dslx_test",
+    dslx_test_args = {
+        "compare": "none",
+    },
+    library = ":sequence_executor_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -88,6 +88,14 @@ xls_dslx_library(
     ],
 )
 
+xls_dslx_library(
+    name = "common_dslx",
+    srcs = [
+        "common.x",
+    ],
+    deps = [],
+)
+
 xls_dslx_test(
     name = "frame_header_dslx_test",
     library = ":frame_header_dslx",

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -214,3 +214,58 @@ xls_dslx_test(
     name = "raw_block_dec_dslx_test",
     library = ":raw_block_dec_dslx",
 )
+
+xls_dslx_verilog(
+    name = "raw_block_dec_verilog",
+    codegen_args = {
+        "module_name": "RawBlockDecoder",
+        "delay_model": "asap7",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "RawBlockDecoder",
+    library = ":raw_block_dec_dslx",
+    verilog_file = "raw_block_dec.v",
+)
+
+xls_benchmark_ir(
+    name = "raw_block_dec_opt_ir_benchmark",
+    src = ":raw_block_dec_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "raw_block_dec_verilog_lib",
+    srcs = [
+        ":raw_block_dec.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "raw_block_dec_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "RawBlockDecoder",
+    deps = [
+        ":raw_block_dec_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "raw_block_dec_benchmark_synth",
+    synth_target = ":raw_block_dec_synth_asap7",
+)
+
+place_and_route(
+    name = "raw_block_dec_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":raw_block_dec_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -269,3 +269,21 @@ place_and_route(
     synthesized_rtl = ":raw_block_dec_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "rle_block_dec_dslx",
+    srcs = [
+        "rle_block_dec.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+        ":common_dslx",
+        "//xls/modules/rle:rle_common_dslx",
+        "//xls/modules/rle:rle_dec_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "rle_block_dec_dslx_test",
+    library = ":rle_block_dec_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -434,3 +434,19 @@ place_and_route(
     synthesized_rtl = ":dec_mux_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "dec_demux_dslx",
+    srcs = [
+        "dec_demux.x",
+    ],
+    deps = [
+        ":block_header_dslx",
+        ":common_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "dec_demux_dslx_test",
+    library = ":dec_demux_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -198,3 +198,19 @@ place_and_route(
     synthesized_rtl = ":frame_header_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "raw_block_dec_dslx",
+    srcs = [
+        "raw_block_dec.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+        ":common_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "raw_block_dec_dslx_test",
+    library = ":raw_block_dec_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -585,3 +585,16 @@ place_and_route(
     synthesized_rtl = ":block_dec_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "ram_printer_dslx",
+    srcs = ["ram_printer.x"],
+    deps = [
+        "//xls/examples:ram_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "ram_printer_dslx_test",
+    library = ":ram_printer_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -37,3 +37,18 @@ xls_dslx_test(
     name = "buffer_dslx_test",
     library = ":buffer_dslx",
 )
+
+xls_dslx_library(
+    name = "magic_dslx",
+    srcs = [
+        "magic.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+    ]
+)
+
+xls_dslx_test(
+    name = "magic_dslx_test",
+    library = ":magic_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -14,10 +14,15 @@
 
 # Build rules for XLS ZSTD codec implementation.
 
+load("@rules_hdl//place_and_route:build_defs.bzl", "place_and_route")
+load("@rules_hdl//synthesis:build_defs.bzl", "benchmark_synth", "synthesize_rtl")
+load("@rules_hdl//verilog:providers.bzl", "verilog_library")
 load(
     "//xls/build_rules:xls_build_defs.bzl",
+    "xls_benchmark_ir",
     "xls_dslx_library",
     "xls_dslx_test",
+    "xls_dslx_verilog",
 )
 
 package(
@@ -66,4 +71,58 @@ xls_dslx_library(
 xls_dslx_test(
     name = "zstd_frame_header_dslx_test",
     library = ":zstd_frame_header_dslx",
+)
+
+xls_dslx_verilog(
+    name = "frame_header_verilog",
+    codegen_args = {
+        "module_name": "FrameHeaderDecoder",
+        "delay_model": "asap7",
+        "pipeline_stages": "9",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "parse_frame_header_128",
+    library = ":frame_header_test_dslx",
+    verilog_file = "frame_header.v",
+)
+
+xls_benchmark_ir(
+    name = "frame_header_opt_ir_benchmark",
+    src = ":frame_header_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "9",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "frame_header_verilog_lib",
+    srcs = [
+        ":frame_header.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "frame_header_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "FrameHeaderDecoder",
+    deps = [
+        ":frame_header_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "frame_header_benchmark_synth",
+    synth_target = ":frame_header_synth_asap7",
+)
+
+place_and_route(
+    name = "frame_header_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":frame_header_synth_asap7",
+    target_die_utilization_percentage = "10",
 )

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -348,3 +348,19 @@ place_and_route(
     synthesized_rtl = ":rle_block_dec_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "block_header_dslx",
+    srcs = [
+        "block_header.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+        ":common_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "block_header_dslx_test",
+    library = ":block_header_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -524,3 +524,64 @@ xls_dslx_test(
     name = "block_dec_dslx_test",
     library = ":block_dec_dslx",
 )
+
+xls_dslx_verilog(
+    name = "block_dec_verilog",
+    codegen_args = {
+        "module_name": "BlockDecoder",
+        "delay_model": "asap7",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "BlockDecoder",
+    library = ":block_dec_dslx",
+    # TODO: 2024-01-15: Workaround for https://github.com/google/xls/issues/869
+    # Force proc inlining and set last internal proc as top proc for IR optimization
+    opt_ir_args = {
+        "inline_procs": "true",
+        "top": "__xls_modules_zstd_dec_mux__BlockDecoder__DecoderMux_0_next",
+    },
+    verilog_file = "block_dec.v",
+)
+
+xls_benchmark_ir(
+    name = "block_dec_opt_ir_benchmark",
+    src = ":block_dec_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "block_dec_verilog_lib",
+    srcs = [
+        ":block_dec.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "block_dec_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "BlockDecoder",
+    deps = [
+        ":block_dec_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "block_dec_benchmark_synth",
+    synth_target = ":block_dec_synth_asap7",
+)
+
+place_and_route(
+    name = "block_dec_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":block_dec_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -379,3 +379,58 @@ xls_dslx_test(
     name = "dec_mux_dslx_test",
     library = ":dec_mux_dslx",
 )
+
+xls_dslx_verilog(
+    name = "dec_mux_verilog",
+    codegen_args = {
+        "module_name": "DecoderMux",
+        "delay_model": "asap7",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "DecoderMux",
+    library = ":dec_mux_dslx",
+    verilog_file = "dec_mux.v",
+)
+
+xls_benchmark_ir(
+    name = "dec_mux_opt_ir_benchmark",
+    src = ":dec_mux_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "dec_mux_verilog_lib",
+    srcs = [
+        ":dec_mux.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "dec_mux_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "DecoderMux",
+    deps = [
+        ":dec_mux_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "dec_mux_benchmark_synth",
+    synth_target = ":dec_mux_synth_asap7",
+)
+
+place_and_route(
+    name = "dec_mux_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":dec_mux_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -364,3 +364,18 @@ xls_dslx_test(
     name = "block_header_dslx_test",
     library = ":block_header_dslx",
 )
+
+xls_dslx_library(
+    name = "dec_mux_dslx",
+    srcs = [
+        "dec_mux.x",
+    ],
+    deps = [
+        ":common_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "dec_mux_dslx_test",
+    library = ":dec_mux_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -450,3 +450,58 @@ xls_dslx_test(
     name = "dec_demux_dslx_test",
     library = ":dec_demux_dslx",
 )
+
+xls_dslx_verilog(
+    name = "dec_demux_verilog",
+    codegen_args = {
+        "module_name": "DecoderDemux",
+        "delay_model": "asap7",
+        "pipeline_stages": "2",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "DecoderDemux",
+    library = ":dec_demux_dslx",
+    verilog_file = "dec_demux.v",
+)
+
+xls_benchmark_ir(
+    name = "dec_demux_opt_ir_benchmark",
+    src = ":dec_demux_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "2",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "dec_demux_verilog_lib",
+    srcs = [
+        ":dec_demux.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "dec_demux_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "DecoderDemux",
+    deps = [
+        ":dec_demux_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "dec_demux_benchmark_synth",
+    synth_target = ":dec_demux_synth_asap7",
+)
+
+place_and_route(
+    name = "dec_demux_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":dec_demux_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -52,3 +52,18 @@ xls_dslx_test(
     name = "magic_dslx_test",
     library = ":magic_dslx",
 )
+
+xls_dslx_library(
+    name = "frame_header_dslx",
+    srcs = [
+        "frame_header.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "zstd_frame_header_dslx_test",
+    library = ":zstd_frame_header_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -59,11 +59,22 @@ xls_dslx_test(
 )
 
 cc_library(
-    name = "zstd_test_data_generator",
-    srcs = ["zstd_test_data_generator.cc"],
-    hdrs = ["zstd_test_data_generator.h"],
+    name = "data_generator",
+    srcs = ["data_generator.cc"],
+    hdrs = ["data_generator.h"],
     data = [
         "@com_github_facebook_zstd//:decodecorpus",
+    ],
+    deps = [
+        "//xls/common:subprocess",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:status_macros",
+        "//xls/ir",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/time",
+        "@com_google_absl//absl/types:span",
     ],
 )
 

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -505,3 +505,22 @@ place_and_route(
     synthesized_rtl = ":dec_demux_synth_asap7",
     target_die_utilization_percentage = "10",
 )
+
+xls_dslx_library(
+    name = "block_dec_dslx",
+    srcs = [
+        "block_dec.x",
+    ],
+    deps = [
+        ":common_dslx",
+        ":dec_demux_dslx",
+        ":dec_mux_dslx",
+        ":raw_block_dec_dslx",
+        ":rle_block_dec_dslx",
+    ],
+)
+
+xls_dslx_test(
+    name = "block_dec_dslx_test",
+    library = ":block_dec_dslx",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -58,6 +58,15 @@ xls_dslx_test(
     library = ":magic_dslx",
 )
 
+cc_library(
+    name = "zstd_test_data_generator",
+    srcs = ["zstd_test_data_generator.cc"],
+    hdrs = ["zstd_test_data_generator.h"],
+    data = [
+        "@com_github_facebook_zstd//:decodecorpus",
+    ],
+)
+
 xls_dslx_library(
     name = "frame_header_dslx",
     srcs = [

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -287,3 +287,64 @@ xls_dslx_test(
     name = "rle_block_dec_dslx_test",
     library = ":rle_block_dec_dslx",
 )
+
+xls_dslx_verilog(
+    name = "rle_block_dec_verilog",
+    codegen_args = {
+        "module_name": "RleBlockDecoder",
+        "delay_model": "asap7",
+        "pipeline_stages": "3",
+        "reset": "rst",
+        "use_system_verilog": "false",
+    },
+    dslx_top = "RleBlockDecoder",
+    library = ":rle_block_dec_dslx",
+    # TODO: 2024-01-15: Workaround for https://github.com/google/xls/issues/869
+    # Force proc inlining and set last internal proc as top proc for IR optimization
+    opt_ir_args = {
+        "inline_procs": "true",
+        "top": "__rle_block_dec__RleBlockDecoder__BatchPacker_0_next",
+    },
+    verilog_file = "rle_block_dec.v",
+)
+
+xls_benchmark_ir(
+    name = "rle_block_dec_opt_ir_benchmark",
+    src = ":rle_block_dec_verilog.opt.ir",
+    benchmark_ir_args = {
+        "pipeline_stages": "3",
+        "delay_model": "asap7",
+    },
+)
+
+verilog_library(
+    name = "rle_block_dec_verilog_lib",
+    srcs = [
+        ":rle_block_dec.v",
+    ],
+)
+
+synthesize_rtl(
+    name = "rle_block_dec_synth_asap7",
+    standard_cells = "@org_theopenroadproject_asap7sc7p5t_28//:asap7-sc7p5t_rev28_rvt",
+    top_module = "RleBlockDecoder",
+    deps = [
+        ":rle_block_dec_verilog_lib",
+    ],
+)
+
+benchmark_synth(
+    name = "rle_block_dec_benchmark_synth",
+    synth_target = ":rle_block_dec_synth_asap7",
+)
+
+place_and_route(
+    name = "rle_block_dec_place_and_route",
+    clock_period = "750",
+    core_padding_microns = 2,
+    min_pin_distance = "0.5",
+    placement_density = "0.30",
+    skip_detailed_routing = True,
+    synthesized_rtl = ":rle_block_dec_synth_asap7",
+    target_die_utilization_percentage = "10",
+)

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -50,7 +50,7 @@ xls_dslx_library(
     ],
     deps = [
         ":buffer_dslx",
-    ]
+    ],
 )
 
 xls_dslx_test(
@@ -89,8 +89,52 @@ xls_dslx_library(
 )
 
 xls_dslx_test(
-    name = "zstd_frame_header_dslx_test",
-    library = ":zstd_frame_header_dslx",
+    name = "frame_header_dslx_test",
+    library = ":frame_header_dslx",
+)
+
+xls_dslx_library(
+    name = "frame_header_test_dslx",
+    srcs = [
+        "frame_header_test.x",
+    ],
+    deps = [
+        ":buffer_dslx",
+        ":frame_header_dslx",
+    ],
+)
+
+cc_test(
+    name = "frame_header_cc_test",
+    srcs = [
+        "frame_header_test.cc",
+    ],
+    data = [
+        ":frame_header_test_dslx",
+    ],
+    shard_count = 50,
+    deps = [
+        ":data_generator",
+        "//xls/common:xls_gunit",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:matchers",
+        "//xls/dslx:create_import_data",
+        "//xls/dslx:import_data",
+        "//xls/dslx:interp_value",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/dslx/ir_convert:ir_converter",
+        "//xls/dslx/type_system:parametric_env",
+        "//xls/ir",
+        "//xls/ir:ir_parser",
+        "//xls/ir:ir_test_base",
+        "@com_github_facebook_zstd//:zstd",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_fuzztest//fuzztest",
+        "@com_google_fuzztest//fuzztest:googletest_fixture_adapter",
+        "@com_google_googletest//:gtest",
+    ],
 )
 
 xls_dslx_verilog(

--- a/xls/modules/zstd/block_dec.x
+++ b/xls/modules/zstd/block_dec.x
@@ -1,0 +1,169 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import xls.modules.zstd.common;
+import xls.modules.zstd.dec_demux as demux;
+import xls.modules.zstd.raw_block_dec as raw;
+import xls.modules.zstd.rle_block_dec as rle;
+import xls.modules.zstd.dec_mux as mux;
+
+type BlockDataPacket = common::BlockDataPacket;
+type BlockData = common::BlockData;
+type BlockPacketLength = common::BlockPacketLength;
+type ExtendedBlockDataPacket = common::ExtendedBlockDataPacket;
+type CopyOrMatchContent = common::CopyOrMatchContent;
+type CopyOrMatchLength = common::CopyOrMatchLength;
+type SequenceExecutorPacket = common::SequenceExecutorPacket;
+type SequenceExecutorMessageType = common::SequenceExecutorMessageType;
+
+// Proc responsible for connecting internal procs used in Block data decoding.
+// It handles incoming block data packets by redirecting those to demuxer which passes those to
+// block decoder procs specific for given block type. Results are then gathered by mux which
+// transfers decoded data further. The connections are visualised on the following diagram:
+//
+//                  Block Decoder
+//   ┌───────────────────────────────────────┐
+//   │           Raw Block Decoder           │
+//   │         ┌───────────────────┐         │
+//   │       ┌─►                   ├┐        │
+//   │ Demux │ └───────────────────┘│   Mux  │
+//   │┌─────┐│   Rle Block Decoder  │ ┌─────┐│
+//   ││     ├┘ ┌───────────────────┐└─►     ││
+// ──┼►     ├──►                   ├──►     ├┼─►
+//   ││     ├┐ └───────────────────┘┌─►     ││
+//   │└─────┘│   Cmp Block Decoder  │ └─────┘│
+//   │       │ ┌───────────────────┐│        │
+//   │       └─►                   ├┘        │
+//   │         └───────────────────┘         │
+//   └───────────────────────────────────────┘
+
+proc BlockDecoder {
+    input_r: chan<BlockDataPacket> in;
+    output_s: chan<SequenceExecutorPacket> out;
+
+    config (input_r: chan<BlockDataPacket> in, output_s: chan<SequenceExecutorPacket> out) {
+        let (demux_raw_s, demux_raw_r) = chan<BlockDataPacket>;
+        let (demux_rle_s, demux_rle_r) = chan<BlockDataPacket>;
+        let (demux_cmp_s, demux_cmp_r) = chan<BlockDataPacket>;
+        let (mux_raw_s, mux_raw_r) = chan<ExtendedBlockDataPacket>;
+        let (mux_rle_s, mux_rle_r) = chan<ExtendedBlockDataPacket>;
+        let (mux_cmp_s, mux_cmp_r) = chan<ExtendedBlockDataPacket>;
+
+        spawn demux::DecoderDemux(input_r, demux_raw_s, demux_rle_s, demux_cmp_s);
+        spawn raw::RawBlockDecoder(demux_raw_r, mux_raw_s);
+        spawn rle::RleBlockDecoder(demux_rle_r, mux_rle_s);
+        // TODO(lpawelcz): 2023-11-28 change to compressed block decoder proc
+        spawn raw::RawBlockDecoder(demux_cmp_r, mux_cmp_s);
+        spawn mux::DecoderMux(mux_raw_r, mux_rle_r, mux_cmp_r, output_s);
+
+        (input_r, output_s)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {  }
+}
+
+#[test_proc]
+proc BlockDecoderTest {
+    terminator: chan<bool> out;
+    input_s: chan<BlockDataPacket> out;
+    output_r: chan<SequenceExecutorPacket> in;
+
+    init {}
+
+    config (terminator: chan<bool> out) {
+        let (input_s, input_r) = chan<BlockDataPacket>;
+        let (output_s, output_r) = chan<SequenceExecutorPacket>;
+
+        spawn BlockDecoder(input_r, output_s);
+
+        (terminator, input_s, output_r)
+    }
+
+    next(tok: token, state: ()) {
+        let EncodedDataBlocksPackets: BlockDataPacket[13] = [
+            // RAW Block 1 byte
+            BlockDataPacket { id: u32:0, last: true, last_block: false, data: BlockData:0xDE000008, length: BlockPacketLength:32 },
+            // RAW Block 2 bytes
+            BlockDataPacket { id: u32:1, last: true, last_block: false, data: BlockData:0xDEAD000010, length: BlockPacketLength:40 },
+            // RAW Block 4 bytes
+            BlockDataPacket { id: u32:2, last: true, last_block: false, data: BlockData:0xDEADBEEF000020, length: BlockPacketLength:56 },
+            // RAW Block 5 bytes (block header takes one full packet)
+            BlockDataPacket { id: u32:3, last: true, last_block: false, data: BlockData:0xDEADBEEFEF000028, length: BlockPacketLength:64 },
+            // RAW Block 24 bytes (multi-packet block header with unaligned data in the last packet)
+            BlockDataPacket { id: u32:4, last: false, last_block: false, data: BlockData:0x12345678900000C0, length: BlockPacketLength:64 },
+            BlockDataPacket { id: u32:4, last: false, last_block: false, data: BlockData:0x1234567890ABCDEF, length: BlockPacketLength:64 },
+            BlockDataPacket { id: u32:4, last: false, last_block: false, data: BlockData:0xFEDCBA0987654321, length: BlockPacketLength:64 },
+            BlockDataPacket { id: u32:4, last: true, last_block: false, data: BlockData:0xF0F0F0, length: BlockPacketLength:24 },
+
+            // RLE Block 1 byte
+            BlockDataPacket { id: u32:5, last: true, last_block: false, data: BlockData:0x6700000a, length: BlockPacketLength:32 },
+            // RLE Block 2 bytes
+            BlockDataPacket { id: u32:6, last: true, last_block: false, data: BlockData:0x45000012, length: BlockPacketLength:32 },
+            // RLE Block 4 bytes
+            BlockDataPacket { id: u32:7, last: true, last_block: false, data: BlockData:0x23000022, length: BlockPacketLength:32 },
+            // RLE Block 8 bytes (block takes one full packet)
+            BlockDataPacket { id: u32:8, last: true, last_block: false, data: BlockData:0x10000042, length: BlockPacketLength:32 },
+            // RLE Block 26 bytes (multi-packet block header with unaligned data in the last packet)
+            BlockDataPacket { id: u32:9, last: true, last_block: true, data: BlockData:0xDE0000d2, length: BlockPacketLength:32 },
+        ];
+
+        let tok = for ((counter, block_packet), tok): ((u32, BlockDataPacket), token) in enumerate(EncodedDataBlocksPackets) {
+            let tok = send(tok, input_s, block_packet);
+            trace_fmt!("Sent #{} encoded block packet, {:#x}", counter + u32:1, block_packet);
+            (tok)
+        }(tok);
+
+        let DecodedDataBlocksPackets: SequenceExecutorPacket[16] = [
+            // RAW Block 1 byte
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDE, length: CopyOrMatchLength:8 },
+            // RAW Block 2 bytes
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEAD, length: CopyOrMatchLength:16 },
+            // RAW Block 4 bytes
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEADBEEF, length: CopyOrMatchLength:32 },
+            // RAW Block 5 bytes (block header takes one full packet)
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEADBEEFEF, length: CopyOrMatchLength:40 },
+            // RAW Block 24 bytes (multi-packet block header with unaligned data in the last packet)
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x1234567890, length: CopyOrMatchLength:40 },
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x1234567890ABCDEF, length: CopyOrMatchLength:64 },
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xFEDCBA0987654321, length: CopyOrMatchLength:64 },
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xF0F0F0, length: CopyOrMatchLength:24 },
+
+            // RLE Block 1 byte
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x67, length: CopyOrMatchLength:8 },
+            // RLE Block 2 bytes
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x4545, length: CopyOrMatchLength:16 },
+            // RLE Block 4 bytes
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x23232323, length: CopyOrMatchLength:32 },
+            // RLE Block 8 bytes (block takes one full packet)
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x1010101010101010, length: CopyOrMatchLength:64 },
+            // RLE Block 26 bytes (multi-packet block header with unaligned data in the last packet)
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEDEDEDEDEDEDEDE, length: CopyOrMatchLength:64 },
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEDEDEDEDEDEDEDE, length: CopyOrMatchLength:64 },
+            SequenceExecutorPacket { last: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEDEDEDEDEDEDEDE, length: CopyOrMatchLength:64 },
+            SequenceExecutorPacket { last: true, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xDEDE, length: CopyOrMatchLength:16 },
+        ];
+
+        let tok = for ((counter, expected_block_packet), tok): ((u32, SequenceExecutorPacket), token) in enumerate(DecodedDataBlocksPackets) {
+            let (tok, decoded_block_packet) = recv(tok, output_r);
+            trace_fmt!("Received #{} decoded block packet, data: 0x{:x}", counter + u32:1, decoded_block_packet);
+            trace_fmt!("Expected #{} decoded block packet, data: 0x{:x}", counter + u32:1, expected_block_packet);
+            assert_eq(decoded_block_packet, expected_block_packet);
+            (tok)
+        }(tok);
+
+        send(tok, terminator, true);
+    }
+}

--- a/xls/modules/zstd/block_dec.x
+++ b/xls/modules/zstd/block_dec.x
@@ -53,12 +53,12 @@ proc BlockDecoder {
     output_s: chan<SequenceExecutorPacket> out;
 
     config (input_r: chan<BlockDataPacket> in, output_s: chan<SequenceExecutorPacket> out) {
-        let (demux_raw_s, demux_raw_r) = chan<BlockDataPacket>;
-        let (demux_rle_s, demux_rle_r) = chan<BlockDataPacket>;
-        let (demux_cmp_s, demux_cmp_r) = chan<BlockDataPacket>;
-        let (mux_raw_s, mux_raw_r) = chan<ExtendedBlockDataPacket>;
-        let (mux_rle_s, mux_rle_r) = chan<ExtendedBlockDataPacket>;
-        let (mux_cmp_s, mux_cmp_r) = chan<ExtendedBlockDataPacket>;
+        let (demux_raw_s, demux_raw_r) = chan<BlockDataPacket, u32:1>;
+        let (demux_rle_s, demux_rle_r) = chan<BlockDataPacket, u32:1>;
+        let (demux_cmp_s, demux_cmp_r) = chan<BlockDataPacket, u32:1>;
+        let (mux_raw_s, mux_raw_r) = chan<ExtendedBlockDataPacket, u32:1>;
+        let (mux_rle_s, mux_rle_r) = chan<ExtendedBlockDataPacket, u32:1>;
+        let (mux_cmp_s, mux_cmp_r) = chan<ExtendedBlockDataPacket, u32:1>;
 
         spawn demux::DecoderDemux(input_r, demux_raw_s, demux_rle_s, demux_cmp_s);
         spawn raw::RawBlockDecoder(demux_raw_r, mux_raw_s);

--- a/xls/modules/zstd/block_header.x
+++ b/xls/modules/zstd/block_header.x
@@ -1,0 +1,108 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains utilities related to ZSTD Block Header parsing.
+// More information about the ZSTD Block Header can be found in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1.2
+
+import std;
+import xls.modules.zstd.buffer as buff;
+import xls.modules.zstd.common as common;
+
+type Buffer = buff::Buffer;
+type BufferStatus = buff::BufferStatus;
+type BlockType = common::BlockType;
+
+// Status values reported by the block header parsing function
+pub enum BlockHeaderStatus: u2 {
+    OK = 0,
+    CORRUPTED = 1,
+    NO_ENOUGH_DATA = 2,
+}
+
+// Structure for data obtained from decoding Block_Header
+pub struct BlockHeader {
+    last: bool,
+    btype: BlockType,
+    size: u21,
+}
+
+// Structure for returning results of block header parsing
+pub struct BlockHeaderResult<CAPACITY: u32> {
+    buffer: Buffer<CAPACITY>,
+    status: BlockHeaderStatus,
+    header: BlockHeader,
+}
+
+// Auxiliary constant that can be used to initialize Proc's state
+// with empty FrameHeader, because `zero!` cannot be used in that context
+pub const ZERO_BLOCK_HEADER = zero!<BlockHeader>();
+
+// Extracts Block_Header fields from 24-bit chunk of data
+// that is assumed to be a valid Block_Header
+pub fn extract_block_header(data:u24) -> BlockHeader {
+    BlockHeader {
+        size: data[3:24],
+        btype: data[1:3] as BlockType,
+        last: data[0:1],
+    }
+}
+
+// Parses a Buffer and extracts information from a Block_Header. Returns BufferResult
+// with outcome of operations on buffer and information extracted from the Block_Header.
+pub fn parse_block_header<CAPACITY: u32>(buffer: Buffer<CAPACITY>) -> BlockHeaderResult<CAPACITY> {
+    let (result, data) = buff::buffer_fixed_pop_checked<CAPACITY, u32:24>(buffer);
+
+    match result.status {
+        BufferStatus::OK => {
+            let block_header = extract_block_header(data);
+            if (block_header.btype != BlockType::RESERVED) {
+                BlockHeaderResult {status: BlockHeaderStatus::OK, header: block_header, buffer: result.buffer}
+            } else {
+                BlockHeaderResult {status: BlockHeaderStatus::CORRUPTED, header: zero!<BlockHeader>(), buffer: buffer}
+            }
+        },
+        _ => {
+            trace_fmt!("parse_block_header: Not enough data to parse block header! {}", buffer.length);
+            BlockHeaderResult {status: BlockHeaderStatus::NO_ENOUGH_DATA, header: zero!<BlockHeader>(), buffer: buffer}
+        }
+    }
+}
+
+#[test]
+fn test_parse_block_header() {
+  let buffer = Buffer { content: u32:0x8001 , length: u32:24};
+  let result = parse_block_header(buffer);
+  assert_eq(result, BlockHeaderResult {
+      status: BlockHeaderStatus::OK,
+      header: BlockHeader { last: u1:1, btype: BlockType::RAW, size: u21:0x1000 },
+      buffer: Buffer { content: u32:0, length: u32:0 }
+  });
+
+  let buffer = Buffer { content: u32:0x91A2, length: u32:24};
+  let result = parse_block_header(buffer);
+  assert_eq(result, BlockHeaderResult {
+      status: BlockHeaderStatus::OK,
+      header: BlockHeader { last: u1:0, btype: BlockType::RLE, size: u21:0x1234 },
+      buffer: Buffer { content: u32:0, length: u32:0 }
+  });
+
+  let buffer = Buffer { content: u32:0x001, length: u32:16};
+  let result = parse_block_header(buffer);
+  assert_eq(result, BlockHeaderResult {
+      status: BlockHeaderStatus::NO_ENOUGH_DATA,
+      header: zero!<BlockHeader>(),
+      buffer: Buffer { content: u32:0x001, length: u32:16 }
+  });
+}

--- a/xls/modules/zstd/buffer.x
+++ b/xls/modules/zstd/buffer.x
@@ -1,0 +1,361 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains implementation of a Buffer structure that acts as
+// a simple FIFO. Additionally, the file provides various functions that
+// can simplify access to the stored.
+//
+// The utility functions containing the `_checked` suffix serve two purposes:
+// they perform the actual operation and return information on whether
+// the operation was successful. If you are sure that the precondition is
+// always true, you can use the function with the same name but without
+// the `_checked` suffix.
+
+import std;
+
+// Structure to hold the buffered data
+pub struct Buffer<CAPACITY: u32> {
+    content: bits[CAPACITY],
+    length: u32
+}
+
+// Status values reported by the functions operating on a Buffer
+pub enum BufferStatus : u2 {
+    OK = 0,
+    NO_ENOUGH_SPACE = 1,
+    NO_ENOUGH_DATA = 2,
+}
+
+// Structure for returning Buffer and BufferStatus together
+pub struct BufferResult<CAPACITY: u32> {
+    buffer: Buffer<CAPACITY>,
+    status: BufferStatus
+}
+
+// Checks whether a `buffer` can fit `data`
+pub fn buffer_can_fit<CAPACITY: u32, DSIZE: u32>(buffer: Buffer<CAPACITY>, data: bits[DSIZE]) -> bool {
+    buffer.length + DSIZE <= CAPACITY
+}
+
+#[test]
+fn test_buffer_can_fit() {
+    let buffer = Buffer<u32:32> { content: u32:0, length: u32:0 };
+    assert_eq(buffer_can_fit(buffer, bits[0]:0), true);
+    assert_eq(buffer_can_fit(buffer, u16:0), true);
+    assert_eq(buffer_can_fit(buffer, u32:0), true);
+    assert_eq(buffer_can_fit(buffer, u33:0), false);
+
+    let buffer = Buffer<u32:32> { content: u32:0, length: u32:16 };
+    assert_eq(buffer_can_fit(buffer, bits[0]:0), true);
+    assert_eq(buffer_can_fit(buffer, u16:0), true);
+    assert_eq(buffer_can_fit(buffer, u17:0), false);
+    assert_eq(buffer_can_fit(buffer, u32:0), false);
+
+    let buffer = Buffer<u32:32> { content: u32:0, length: u32:32 };
+    assert_eq(buffer_can_fit(buffer, bits[0]:0), true);
+    assert_eq(buffer_can_fit(buffer, u1:0), false);
+    assert_eq(buffer_can_fit(buffer, u16:0), false);
+    assert_eq(buffer_can_fit(buffer, u32:0), false);
+}
+
+// Checks whether a `buffer` has at least `length` amount of data
+pub fn buffer_has_at_least<CAPACITY: u32>(buffer: Buffer<CAPACITY>, length: u32) -> bool {
+    length <= buffer.length
+}
+
+#[test]
+fn test_buffer_has_at_least() {
+    let buffer = Buffer { content: u32:0, length: u32:0 };
+    assert_eq(buffer_has_at_least(buffer, u32:0), true);
+    assert_eq(buffer_has_at_least(buffer, u32:16), false);
+    assert_eq(buffer_has_at_least(buffer, u32:32), false);
+    assert_eq(buffer_has_at_least(buffer, u32:33), false);
+
+    let buffer = Buffer { content: u32:0, length: u32:16 };
+    assert_eq(buffer_has_at_least(buffer, u32:0), true);
+    assert_eq(buffer_has_at_least(buffer, u32:16), true);
+    assert_eq(buffer_has_at_least(buffer, u32:32), false);
+    assert_eq(buffer_has_at_least(buffer, u32:33), false);
+
+    let buffer = Buffer { content: u32:0, length: u32:32 };
+    assert_eq(buffer_has_at_least(buffer, u32:0), true);
+    assert_eq(buffer_has_at_least(buffer, u32:16), true);
+    assert_eq(buffer_has_at_least(buffer, u32:32), true);
+    assert_eq(buffer_has_at_least(buffer, u32:33), false);
+}
+
+// Returns a new buffer with `data` appended to the original `buffer`.
+// It will fail if the buffer cannot fit the data. For calls that need better
+// error handling, check `buffer_append_checked`
+pub fn buffer_append<CAPACITY: u32, DSIZE: u32> (buffer: Buffer<CAPACITY>, data: bits[DSIZE]) -> Buffer<CAPACITY> {
+    if buffer_can_fit(buffer, data) == false {
+        trace_fmt!("Not enough space in the buffer! {} + {} <= {}", buffer.length, DSIZE, CAPACITY);
+        fail!("not_enough_space", buffer)
+    } else {
+        Buffer {
+            content: (data as bits[CAPACITY] << buffer.length) | buffer.content,
+            length: DSIZE + buffer.length
+        }
+    }
+}
+
+#[test]
+fn test_buffer_append() {
+    let buffer = Buffer { content: u32:0, length: u32:0 };
+    let buffer = buffer_append(buffer, u16:0xBEEF);
+    assert_eq(buffer, Buffer { content: u32:0xBEEF, length: u32:16 });
+    let buffer = buffer_append(buffer, u16:0xDEAD);
+    assert_eq(buffer, Buffer { content: u32:0xDEADBEEF, length: u32:32 });
+}
+
+// Returns a new buffer with the `data` appended to the original `buffer` if
+// the buffer has enough space. Otherwise, it returns an unmodified buffer
+// along with an error. The results are stored in the BufferResult structure.
+pub fn buffer_append_checked<CAPACITY: u32, DSIZE: u32> (buffer: Buffer<CAPACITY>, data: bits[DSIZE]) -> BufferResult<CAPACITY> {
+    if buffer_can_fit(buffer, data) == false {
+        BufferResult { status: BufferStatus::NO_ENOUGH_SPACE, buffer }
+    } else {
+        BufferResult {
+            status: BufferStatus::OK,
+            buffer: Buffer {
+                content: (data as bits[CAPACITY] << buffer.length) | buffer.content,
+                length: DSIZE + buffer.length
+            }
+        }
+    }
+}
+
+#[test]
+fn test_buffer_append_checked() {
+    let buffer = Buffer { content: u32:0, length: u32:0 };
+
+    let result1 = buffer_append_checked(buffer, u16:0xBEEF);
+    assert_eq(result1, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0xBEEF, length: u32:16 }
+    });
+
+    let result2 = buffer_append_checked(result1.buffer, u16:0xDEAD);
+    assert_eq(result2, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0xDEADBEEF, length: u32:32 }
+    });
+
+    let result3 = buffer_append_checked(result2.buffer, u16:0xCAFE);
+    assert_eq(result3, BufferResult {
+        status: BufferStatus::NO_ENOUGH_SPACE,
+        buffer: result2.buffer
+    });
+}
+
+// Returns `length` amount of data from a `buffer` and a new buffer with
+// the data removed. Since the Buffer structure acts as a simple FIFO,
+// it pops the data in the same order as they were added to the buffer.
+// If the buffer does not have enough data to meet the specified length,
+// the function will fail. For calls that need better error handling,
+// check `buffer_pop_checked`.
+pub fn buffer_pop<CAPACITY: u32>(buffer: Buffer<CAPACITY>, length: u32) -> (Buffer<CAPACITY>, bits[CAPACITY]) {
+    if buffer_has_at_least(buffer, length) == false {
+        trace_fmt!("Not enough data in the buffer!");
+        fail!("not_enough_data", (buffer, bits[CAPACITY]:0))
+    } else {
+        let mask = (bits[CAPACITY]:1 << length) - bits[CAPACITY]:1;
+        (
+            Buffer {
+                content: buffer.content >> length,
+                length: buffer.length - length
+            },
+            buffer.content & mask
+        )
+    }
+}
+
+#[test]
+fn test_buffer_pop() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+    let (buffer, data) = buffer_pop(buffer, u32:16);
+    assert_eq(data, u32:0xBEEF);
+    assert_eq(buffer, Buffer { content: u32:0xDEAD, length: u32:16 });
+    let (buffer, data) = buffer_pop(buffer, u32:16);
+    assert_eq(data, u32:0xDEAD);
+    assert_eq(buffer, Buffer { content: u32:0, length: u32:0 });
+}
+
+// Returns `length` amount of data from a `buffer`, a new buffer with
+// the data removed and a positive status, if the buffer contains enough data.
+// Otherwise, it returns unmodified buffer, zeroed data field and error.
+// Since the Buffer structure acts as a simple FIFO, it pops the data in
+// the same order as they were added to the buffer.
+// The results are stored in the BufferResult structure.
+pub fn buffer_pop_checked<CAPACITY: u32> (buffer: Buffer<CAPACITY>, length: u32) -> (BufferResult<CAPACITY>, bits[CAPACITY]) {
+    if buffer_has_at_least(buffer, length) == false {
+        (
+            BufferResult { status: BufferStatus::NO_ENOUGH_DATA, buffer },
+            bits[CAPACITY]:0
+        )
+    } else {
+        let mask = (bits[CAPACITY]:1 << length) - bits[CAPACITY]:1;
+        (
+            BufferResult {
+                status: BufferStatus::OK,
+                buffer: Buffer {
+                    content: buffer.content >> length,
+                    length: buffer.length - length
+                }
+            },
+            buffer.content & mask
+        )
+    }
+}
+
+#[test]
+fn test_buffer_pop_checked() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+
+    let (result1, data1) = buffer_pop_checked(buffer, u32:16);
+    assert_eq(result1, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0xDEAD, length: u32:16 }
+    });
+    assert_eq(data1, u32:0xBEEF);
+
+    let (result2, data2) = buffer_pop_checked(result1.buffer, u32:16);
+    assert_eq(result2, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0, length: u32:0 }
+    });
+    assert_eq(data2, u32:0xDEAD);
+
+    let (result3, data3) = buffer_pop_checked(result2.buffer, u32:16);
+    assert_eq(result3, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: result2.buffer
+    });
+    assert_eq(data3, u32:0);
+}
+
+// Behaves like `buffer_pop` except that the length of the popped data can be
+// set using a DSIZE function parameter. For calls that need better error
+// handling, check `buffer_fixed_pop_checked`.
+pub fn buffer_fixed_pop<CAPACITY: u32, DSIZE: u32> (buffer: Buffer<CAPACITY>) -> (Buffer<CAPACITY>, bits[DSIZE]) {
+    let (buffer, value) = buffer_pop(buffer, DSIZE);
+    (buffer, value as bits[DSIZE])
+}
+
+#[test]
+fn test_buffer_fixed_pop() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+    let (buffer, data) = buffer_fixed_pop<u32:32, u32:16>(buffer);
+    assert_eq(data, u16:0xBEEF);
+    assert_eq(buffer, Buffer { content: u32:0xDEAD, length: u32:16 });
+    let (buffer, data) = buffer_fixed_pop<u32:32, u32:16>(buffer);
+    assert_eq(data, u16:0xDEAD);
+    assert_eq(buffer, Buffer { content: u32:0, length: u32:0 });
+}
+
+// Behaves like `buffer_pop_checked` except that the length of the popped data
+// can be set using a DSIZE function parameter.
+pub fn buffer_fixed_pop_checked<CAPACITY: u32, DSIZE: u32> (buffer: Buffer<CAPACITY>) -> (BufferResult<CAPACITY>, bits[DSIZE]) {
+    let (result, value) = buffer_pop_checked(buffer, DSIZE);
+    (result, value as bits[DSIZE])
+}
+
+#[test]
+fn test_buffer_fixed_pop_checked() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+    let (result1, data1) = buffer_fixed_pop_checked<u32:32, u32:16>(buffer);
+    assert_eq(result1, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0xDEAD, length: u32:16 }
+    });
+    assert_eq(data1, u16:0xBEEF);
+
+    let (result2, data2) = buffer_fixed_pop_checked<u32:32, u32:16>(result1.buffer);
+    assert_eq(result2, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0, length: u32:0 }
+    });
+    assert_eq(data2, u16:0xDEAD);
+
+    let (result3, data3) = buffer_fixed_pop_checked<u32:32, u32:16>(result2.buffer);
+    assert_eq(result3, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: result2.buffer
+    });
+    assert_eq(data3, u16:0);
+}
+
+// Returns `length` amount of data from a `buffer`.
+// It will fail if the buffer has no sufficient amount of data.
+// For calls that need better error handling, check `buffer_peek_checked`.
+pub fn buffer_peek<CAPACITY: u32>(buffer: Buffer<CAPACITY>, length: u32) -> bits[CAPACITY] {
+    if buffer_has_at_least(buffer, length) == false {
+        trace_fmt!("Not enough data in the buffer!");
+        fail!("not_enough_data", bits[CAPACITY]:0)
+    } else {
+        let mask = (bits[CAPACITY]:1 << length) - bits[CAPACITY]:1;
+        buffer.content & mask
+    }
+}
+
+#[test]
+fn test_buffer_peek() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+    assert_eq(buffer_peek(buffer, u32:0), u32:0);
+    assert_eq(buffer_peek(buffer, u32:16), u32:0xBEEF);
+    assert_eq(buffer_peek(buffer, u32:32), u32:0xDEADBEEF);
+}
+
+// Returns a new buffer with the `data` and a positive status if
+// the buffer has enough data. Otherwise, it returns a zeroed-data and error.
+// The results are stored in the BufferResult structure.
+pub fn buffer_peek_checked<CAPACITY: u32> (buffer: Buffer<CAPACITY>, length: u32) -> (BufferStatus, bits[CAPACITY]) {
+    if buffer_has_at_least(buffer, length) == false {
+        (BufferStatus::NO_ENOUGH_DATA, bits[CAPACITY]:0)
+    } else {
+        let mask = (bits[CAPACITY]:1 << length) - bits[CAPACITY]:1;
+        (BufferStatus::OK, buffer.content & mask)
+    }
+}
+
+#[test]
+fn test_buffer_peek_checked() {
+    let buffer = Buffer { content: u32:0xDEADBEEF, length: u32:32 };
+
+    let (status1, data1) = buffer_peek_checked(buffer, u32:0);
+    assert_eq(status1, BufferStatus::OK);
+    assert_eq(data1, u32:0);
+
+    let (status2, data2) = buffer_peek_checked(buffer, u32:16);
+    assert_eq(status2, BufferStatus::OK);
+    assert_eq(data2, u32:0xBEEF);
+
+    let (status3, data3) = buffer_peek_checked(buffer, u32:32);
+    assert_eq(status3, BufferStatus::OK);
+    assert_eq(data3, u32:0xDEADBEEF);
+
+    let (status4, data4) = buffer_peek_checked(buffer, u32:64);
+    assert_eq(status4, BufferStatus::NO_ENOUGH_DATA);
+    assert_eq(data4, u32:0);
+}
+
+// Creates a new buffer
+pub fn buffer_new<CAPACITY: u32>() -> Buffer<CAPACITY> {
+    Buffer { content: bits[CAPACITY]:0, length: u32:0 }
+}
+
+#[test]
+fn test_buffer_new() {
+    assert_eq(buffer_new<u32:32>(), Buffer { content: u32:0, length: u32:0 });
+}

--- a/xls/modules/zstd/common.x
+++ b/xls/modules/zstd/common.x
@@ -1,0 +1,49 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const DATA_WIDTH = u32:64;
+pub const MAX_ID = u32::MAX;
+pub const SYMBOL_WIDTH = u32:8;
+pub const BLOCK_SIZE_WIDTH = u32:21;
+
+pub type BlockData = bits[DATA_WIDTH];
+pub type BlockPacketLength = u32;
+pub type BlockSize = bits[BLOCK_SIZE_WIDTH];
+pub type CopyOrMatchContent = BlockData;
+pub type CopyOrMatchLength = u64;
+
+pub enum BlockType : u2 {
+    RAW = 0,
+    RLE = 1,
+    COMPRESSED = 2,
+    RESERVED = 3,
+}
+
+pub struct BlockDataPacket {
+    last: bool,
+    last_block: bool,
+    id: u32,
+    data: BlockData,
+    length: BlockPacketLength,
+}
+
+pub enum SequenceExecutorMessageType : u1 {
+  LITERAL = 0,
+  SEQUENCE = 1,
+}
+
+pub struct ExtendedBlockDataPacket {
+    msg_type: SequenceExecutorMessageType,
+    packet: BlockDataPacket,
+}

--- a/xls/modules/zstd/common.x
+++ b/xls/modules/zstd/common.x
@@ -16,12 +16,14 @@ pub const DATA_WIDTH = u32:64;
 pub const MAX_ID = u32::MAX;
 pub const SYMBOL_WIDTH = u32:8;
 pub const BLOCK_SIZE_WIDTH = u32:21;
+pub const OFFSET_WIDTH = u32:22;
 
 pub type BlockData = bits[DATA_WIDTH];
 pub type BlockPacketLength = u32;
 pub type BlockSize = bits[BLOCK_SIZE_WIDTH];
 pub type CopyOrMatchContent = BlockData;
 pub type CopyOrMatchLength = u64;
+pub type Offset = bits[OFFSET_WIDTH];
 
 pub enum BlockType : u2 {
     RAW = 0,

--- a/xls/modules/zstd/common.x
+++ b/xls/modules/zstd/common.x
@@ -54,3 +54,10 @@ pub struct SequenceExecutorPacket {
     content: CopyOrMatchContent, // Literal data or match offset
     last: bool, // Last packet in frame
 }
+
+// Defines output format of the ZSTD Decoder
+pub struct ZstdDecodedPacket {
+    data: BlockData,
+    length: BlockPacketLength, // valid bits in data
+    last: bool, // Last decoded packet in frame
+}

--- a/xls/modules/zstd/common.x
+++ b/xls/modules/zstd/common.x
@@ -47,3 +47,10 @@ pub struct ExtendedBlockDataPacket {
     msg_type: SequenceExecutorMessageType,
     packet: BlockDataPacket,
 }
+
+pub struct SequenceExecutorPacket {
+    msg_type: SequenceExecutorMessageType,
+    length: CopyOrMatchLength, // Literal length or match length
+    content: CopyOrMatchContent, // Literal data or match offset
+    last: bool, // Last packet in frame
+}

--- a/xls/modules/zstd/common.x
+++ b/xls/modules/zstd/common.x
@@ -17,6 +17,7 @@ pub const MAX_ID = u32::MAX;
 pub const SYMBOL_WIDTH = u32:8;
 pub const BLOCK_SIZE_WIDTH = u32:21;
 pub const OFFSET_WIDTH = u32:22;
+pub const HISTORY_BUFFER_SIZE_KB = u32:64;
 
 pub type BlockData = bits[DATA_WIDTH];
 pub type BlockPacketLength = u32;

--- a/xls/modules/zstd/data_generator.cc
+++ b/xls/modules/zstd/data_generator.cc
@@ -1,0 +1,110 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "xls/modules/zstd/data_generator.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/common/subprocess.h"
+#include "xls/ir/value.h"
+
+namespace xls::zstd {
+
+static void PrintRawDataVector(std::vector<uint8_t> vector) {
+  for (int i = 0; i < vector.size(); ++i) {
+    std::cout << std::setfill('0') << std::setw(8) << std::hex << i << ": "
+              << "0x" << std::setw(2) << std::hex << int(vector[i])
+              << std::endl;
+  }
+}
+
+static absl::StatusOr<std::vector<uint8_t>> ReadFileAsRawData(
+    const std::filesystem::path& path) {
+  std::ifstream file(path, std::ios::binary);
+  if (!file.is_open()) {
+    return absl::NotFoundError("Unable to open a test file");
+  }
+
+  std::vector<uint8_t> raw_data((std::istreambuf_iterator<char>(file)),
+                                (std::istreambuf_iterator<char>()));
+  return raw_data;
+}
+
+static std::string CreateNameForGeneratedFile(
+    absl::Span<std::string> args, std::string_view ext,
+    std::optional<std::string_view> prefix) {
+  std::string output;
+
+  if (prefix.has_value()) {
+    output += prefix.value();
+    output += "_";
+  }
+
+  for (auto const& x : args) {
+    output += x;
+  }
+  auto nospace_output = std::remove(output.begin(), output.end(), ' ');
+  output.erase(nospace_output, output.end());
+  std::replace(output.begin(), output.end(), '-', '_');
+
+  output += ext;
+
+  return output;
+}
+
+static absl::StatusOr<SubprocessResult> CallDecodecorpus(
+    absl::Span<const std::string> args,
+    std::optional<std::filesystem::path> cwd = std::nullopt,
+    std::optional<absl::Duration> timeout = std::nullopt) {
+  XLS_ASSIGN_OR_RETURN(
+      std::filesystem::path path,
+      xls::GetXlsRunfilePath("external/com_github_facebook_zstd/decodecorpus"));
+
+  std::vector<std::string> cmd = {path};
+  cmd.insert(cmd.end(), args.begin(), args.end());
+  return SubprocessErrorAsStatus(xls::InvokeSubprocess(cmd));
+}
+
+absl::StatusOr<std::vector<uint8_t>> GenerateFrameHeader(int seed, bool magic) {
+  std::array<std::string, 4> args;
+  args[0] = "-s" + std::to_string(seed);
+  args[1] = (magic) ? "" : "--no-magic";
+  args[2] = "--frame-header-only";
+  std::filesystem::path output_path =
+      std::filesystem::temp_directory_path() /
+      std::filesystem::path(
+          CreateNameForGeneratedFile(absl::MakeSpan(args), ".zstd", "fh"));
+  args[3] = "-p" + std::string(output_path);
+
+  XLS_ASSIGN_OR_RETURN(auto result, CallDecodecorpus(args));
+  auto raw_data = ReadFileAsRawData(output_path);
+  std::remove(output_path.c_str());
+  return raw_data;
+}
+
+}  // namespace xls::zstd

--- a/xls/modules/zstd/data_generator.h
+++ b/xls/modules/zstd/data_generator.h
@@ -1,0 +1,42 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef XLS_MODULES_ZSTD_DATA_GENERATOR_H_
+#define XLS_MODULES_ZSTD_DATA_GENERATOR_H_
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "absl/time/time.h"
+#include "absl/types/span.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/common/subprocess.h"
+#include "xls/ir/value.h"
+
+namespace xls::zstd {
+
+absl::StatusOr<std::vector<uint8_t>> GenerateFrameHeader(int seed, bool magic);
+
+}  // namespace xls::zstd
+
+#endif  // XLS_MODULES_ZSTD_DATA_GENERATOR_H_

--- a/xls/modules/zstd/dec_demux.x
+++ b/xls/modules/zstd/dec_demux.x
@@ -1,0 +1,251 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains DecoderDemux Proc, which is responsible for
+// parsing Block_Header and sending the obtained data to the Raw, RLE,
+// or Compressed Block decoders.
+
+import std;
+import xls.modules.zstd.common as common;
+import xls.modules.zstd.block_header as block_header;
+
+type BlockDataPacket = common::BlockDataPacket;
+
+const DATA_WIDTH = common::DATA_WIDTH;
+
+enum DecoderDemuxStatus : u2 {
+    IDLE = 0,
+    PASS_RAW = 1,
+    PASS_RLE = 2,
+    PASS_COMPRESSED = 3,
+}
+
+struct DecoderDemuxState {
+    status: DecoderDemuxStatus,
+    byte_to_pass: u21,
+    send_data: u21,
+    id: u32,
+    last_packet: BlockDataPacket,
+}
+
+// It's safe to assume that data contains full header and some extra data.
+// Previous stage aligns block header and data, it also guarantees
+// new block headers in new packets.
+fn handle_idle_state(data: BlockDataPacket, state: DecoderDemuxState)
+  -> DecoderDemuxState {
+    let header = block_header::extract_block_header(data.data[0:24] as u24);
+    let data = BlockDataPacket {
+        data: data.data[24:] as bits[DATA_WIDTH],
+        length: data.length - u32:24,
+        id: state.id,
+        ..data
+    };
+    match header.btype {
+        common::BlockType::RAW => {
+            DecoderDemuxState {
+                status: DecoderDemuxStatus::PASS_RAW,
+                byte_to_pass: header.size,
+                send_data: u21:0,
+                last_packet: data,
+                ..state
+            }
+        },
+        common::BlockType::RLE => {
+            DecoderDemuxState {
+                status: DecoderDemuxStatus::PASS_RLE,
+                byte_to_pass: header.size,
+                send_data: u21:0,
+                last_packet: data,
+                ..state
+            }
+        },
+        common::BlockType::COMPRESSED => {
+            DecoderDemuxState {
+                status: DecoderDemuxStatus::PASS_COMPRESSED,
+                byte_to_pass: header.size,
+                send_data: u21:0,
+                last_packet: data,
+                ..state
+            }
+        },
+        _ => {
+            fail!("Should_never_happen", state)
+        }
+    }
+}
+
+const ZERO_DECODER_DEMUX_STATE = zero!<DecoderDemuxState>();
+const ZERO_DATA = zero!<BlockDataPacket>();
+
+pub proc DecoderDemux {
+    input_r: chan<BlockDataPacket> in;
+    raw_s: chan<BlockDataPacket> out;
+    rle_s: chan<BlockDataPacket> out;
+    cmp_s: chan<BlockDataPacket> out;
+
+    init {(ZERO_DECODER_DEMUX_STATE)}
+
+    config (
+        input_r: chan<BlockDataPacket> in,
+        raw_s: chan<BlockDataPacket> out,
+        rle_s: chan<BlockDataPacket> out,
+        cmp_s: chan<BlockDataPacket> out,
+    ) {(
+        input_r,
+        raw_s,
+        rle_s,
+        cmp_s
+    )}
+
+    next (tok: token, state: DecoderDemuxState) {
+        let (tok, data) = recv_if(tok, input_r, !state.last_packet.last, ZERO_DATA);
+        let (send_raw, send_rle, send_cmp, new_state) = match state.status {
+            DecoderDemuxStatus::IDLE =>
+                (false, false, false, handle_idle_state(data, state)),
+            DecoderDemuxStatus::PASS_RAW => {
+                let new_state = DecoderDemuxState {
+                    send_data: state.send_data + (state.last_packet.length >> 3) as u21,
+                    last_packet: data,
+                    ..state
+                };
+                (true, false, false, new_state)
+            },
+            DecoderDemuxStatus::PASS_RLE => {
+                let new_state = DecoderDemuxState {
+                    send_data: state.send_data + state.byte_to_pass,
+                    last_packet: data,
+                    ..state
+                };
+                (false, true, false, new_state)
+            },
+            DecoderDemuxStatus::PASS_COMPRESSED => {
+                let new_state = DecoderDemuxState {
+                    send_data: state.send_data +(state.last_packet.length >> 3) as u21,
+                    last_packet: data,
+                    ..state
+                };
+                (false, false, true, new_state)
+            },
+            _ => fail!("IDLE_STATE_IMPOSSIBLE", (false, false, false, state))
+        };
+
+        let max_packet_width = DATA_WIDTH >> 3;
+        if (!send_rle) && ((state.byte_to_pass as u32 < max_packet_width) &&
+            ((state.byte_to_pass as u32 << 3) != state.last_packet.length)) {
+            // Demuxer expect that blocks would be received in a separate packets,
+            // even if 2 block would fit entirely or even partially in a single packet.
+            // It is the job of top-level ZSTD decoder to split each block into at least one
+            // BlockDataPacket.
+            // For Raw and Compressed blocks it is illegal to have block of size smaller than
+            // max size of packet and have packet length greater than this size.
+            fail!("Should_never_happen", state)
+        } else {
+            state
+        };
+        let data_to_send = BlockDataPacket {id: state.id, ..state.last_packet};
+        let tok = send_if(tok, raw_s, send_raw, data_to_send);
+        // RLE module expects single byte in data field
+        // and block length in length field. This is different from
+        // Raw and Compressed modules.
+        let rle_data = BlockDataPacket{
+            data: state.last_packet.data[0:8] as bits[DATA_WIDTH],
+            length: state.byte_to_pass as u32,
+            id: state.id,
+            ..state.last_packet
+        };
+        let tok = send_if(tok, rle_s, send_rle, rle_data);
+        let tok = send_if(tok, cmp_s, send_cmp, data_to_send);
+        if (new_state.send_data == new_state.byte_to_pass) {
+            let next_id = if (state.last_packet.last && state.last_packet.last_block) {
+                u32: 0
+            } else {
+                state.id + u32:1
+            };
+            DecoderDemuxState {
+                status: DecoderDemuxStatus::IDLE,
+                byte_to_pass: u21:0,
+                send_data: u21:0,
+                id: next_id,
+                last_packet: ZERO_DATA,
+            }
+        } else {
+            new_state
+        }
+    }
+}
+
+#[test_proc]
+proc DecoderDemuxTest {
+  terminator: chan<bool> out;
+  input_s: chan<BlockDataPacket> out;
+  raw_r: chan<BlockDataPacket> in;
+  rle_r: chan<BlockDataPacket> in;
+  cmp_r: chan<BlockDataPacket> in;
+
+  init {}
+
+  config (terminator: chan<bool> out) {
+    let (raw_s, raw_r) = chan<BlockDataPacket>;
+    let (rle_s, rle_r) = chan<BlockDataPacket>;
+    let (cmp_s, cmp_r) = chan<BlockDataPacket>;
+    let (input_s, input_r) = chan<BlockDataPacket>;
+
+    spawn DecoderDemux(input_r, raw_s, rle_s, cmp_s);
+    (terminator, input_s, raw_r, rle_r, cmp_r)
+  }
+
+  next(tok: token, state: ()) {
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x11111111110000c0, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x2222222222111111, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x3333333333222222, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: true,  last_block: bool: false, data: bits[DATA_WIDTH]:0x0000000000333333, length: u32:24 });
+
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0xAAAAAAAAAA000100, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0xBBBBBBBBBBAAAAAA, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0xCCCCCCCCCCBBBBBB, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x0000000000CCCCCC, length: u32:24 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: true,  last_block: bool: false, data: bits[DATA_WIDTH]:0xDDDDDDDDDDDDDDDD, length: u32:64 });
+
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: true, last_block: bool: false, data: bits[DATA_WIDTH]:0x0000000FF000102, length: u32:32 });
+
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x4444444444000145, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x5555555555444444, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x6666666666555555, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x7777777777666666, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x8888888888777777, length: u32:64 });
+    let tok = send(tok, input_s, BlockDataPacket { id: u32:0, last: bool: true,  last_block: bool: true, data: bits[DATA_WIDTH]:0x0000000000888888, length: u32:24 });
+
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x0000001111111111, length: u32:40 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x2222222222111111, length: u32:64 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:0, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x3333333333222222, length: u32:64 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:0, last: bool: true,  last_block: bool: false, data: bits[DATA_WIDTH]:0x0000000000333333, length: u32:24 });
+
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x000000AAAAAAAAAA, length: u32:40 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0xBBBBBBBBBBAAAAAA, length: u32:64 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0xCCCCCCCCCCBBBBBB, length: u32:64 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: bits[DATA_WIDTH]:0x0000000000CCCCCC, length: u32:24 });
+    let (tok, data) = recv(tok, raw_r); assert_eq(data, BlockDataPacket { id: u32:1, last: bool: true,  last_block: bool: false, data: bits[DATA_WIDTH]:0xDDDDDDDDDDDDDDDD, length: u32:64 });
+
+    let (tok, data) = recv(tok, rle_r); assert_eq(data, BlockDataPacket { id: u32:2, last: bool: true,  last_block: bool: false, data: bits[DATA_WIDTH]:0xFF, length: u32:32 });
+
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x0000004444444444, length: u32:40 });
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x5555555555444444, length: u32:64 });
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x6666666666555555, length: u32:64 });
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x7777777777666666, length: u32:64 });
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: false, last_block: bool: true, data: bits[DATA_WIDTH]:0x8888888888777777, length: u32:64 });
+    let (tok, data) = recv(tok, cmp_r); assert_eq(data, BlockDataPacket { id: u32:3, last: bool: true,  last_block: bool: true, data: bits[DATA_WIDTH]:0x0000000000888888, length: u32:24 });
+
+    send(tok, terminator, true);
+  }
+}

--- a/xls/modules/zstd/dec_demux.x
+++ b/xls/modules/zstd/dec_demux.x
@@ -196,7 +196,7 @@ proc DecoderDemuxTest {
   init {}
 
   config (terminator: chan<bool> out) {
-    let (raw_s, raw_r) = chan<BlockDataPacket>;
+    let (raw_s, raw_r) = chan<BlockDataPacket, u32:1>;
     let (rle_s, rle_r) = chan<BlockDataPacket>;
     let (cmp_s, cmp_r) = chan<BlockDataPacket>;
     let (input_s, input_r) = chan<BlockDataPacket>;

--- a/xls/modules/zstd/dec_mux.x
+++ b/xls/modules/zstd/dec_mux.x
@@ -1,0 +1,197 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the DecoderMux Proc, which collects data from
+// specialized Raw, RLE, and Compressed Block decoders and re-sends them in
+// the correct order.
+
+import std;
+import xls.modules.zstd.common as common;
+
+type BlockDataPacket = common::BlockDataPacket;
+type ExtendedBlockDataPacket = common::ExtendedBlockDataPacket;
+type BlockData = common::BlockData;
+type BlockPacketLength = common::BlockPacketLength;
+type CopyOrMatchContent = common::CopyOrMatchContent;
+type CopyOrMatchLength = common::CopyOrMatchLength;
+type SequenceExecutorMessageType = common::SequenceExecutorMessageType;
+type SequenceExecutorPacket = common::SequenceExecutorPacket;
+
+const MAX_ID = common::DATA_WIDTH;
+const DATA_WIDTH = common::DATA_WIDTH;
+
+struct DecoderMuxState {
+    prev_id: u32,
+    prev_last: bool,
+    prev_last_block: bool,
+    prev_valid: bool,
+    raw_data: ExtendedBlockDataPacket,
+    raw_data_valid: bool,
+    rle_data: ExtendedBlockDataPacket,
+    rle_data_valid: bool,
+    compressed_data: ExtendedBlockDataPacket,
+    compressed_data_valid: bool,
+}
+
+const ZERO_DECODER_MUX_STATE = zero!<DecoderMuxState>();
+
+pub proc DecoderMux {
+    raw_r: chan<ExtendedBlockDataPacket> in;
+    rle_r: chan<ExtendedBlockDataPacket> in;
+    cmp_r: chan<ExtendedBlockDataPacket> in;
+    output_s: chan<SequenceExecutorPacket> out;
+
+    init {(ZERO_DECODER_MUX_STATE)}
+
+    config (
+        raw_r: chan<ExtendedBlockDataPacket> in,
+        rle_r: chan<ExtendedBlockDataPacket> in,
+        cmp_r: chan<ExtendedBlockDataPacket> in,
+        output_s: chan<SequenceExecutorPacket> out,
+    ) {(raw_r, rle_r, cmp_r, output_s)}
+
+    next (tok: token, state: DecoderMuxState) {
+        let (tok, raw_data, raw_data_valid) = recv_if_non_blocking(
+            tok, raw_r, !state.raw_data_valid, zero!<ExtendedBlockDataPacket>());
+        let state = if (raw_data_valid) {
+            DecoderMuxState {raw_data, raw_data_valid, ..state}
+        } else { state };
+
+        let (tok, rle_data, rle_data_valid) = recv_if_non_blocking(
+            tok, rle_r, !state.rle_data_valid, zero!<ExtendedBlockDataPacket>());
+        let state = if (rle_data_valid) {
+            DecoderMuxState { rle_data, rle_data_valid, ..state}
+        } else { state };
+
+        let (tok, compressed_data, compressed_data_valid) = recv_if_non_blocking(
+            tok, cmp_r, !state.compressed_data_valid, zero!<ExtendedBlockDataPacket>());
+        let state = if (compressed_data_valid) {
+            DecoderMuxState { compressed_data, compressed_data_valid, ..state}
+        } else { state };
+
+        let raw_id = if state.raw_data_valid { state.raw_data.packet.id } else { MAX_ID };
+        let rle_id = if state.rle_data_valid { state.rle_data.packet.id } else { MAX_ID };
+        let compressed_id = if state.compressed_data_valid { state.compressed_data.packet.id } else { MAX_ID };
+
+        if state.prev_last_block && state.prev_last {
+            if (std::umin(std::umin(rle_id, raw_id), compressed_id) != u32:0) {
+                fail!("wrong_id_expected_0", ())
+            } else {()};
+        } else {
+            if (state.prev_id > (std::umin(std::umin(rle_id, raw_id), compressed_id))) && (state.prev_valid) {
+                fail!("wrong_id", ())
+            } else {()};
+        };
+
+        let (do_send, data_to_send, state) = if (state.raw_data_valid &&
+          ((state.raw_data.packet.id < std::umin(rle_id, compressed_id)) ||
+           (state.raw_data.packet.id == state.prev_id))) {
+            (true,
+             SequenceExecutorPacket {
+                 msg_type: state.raw_data.msg_type,
+                 length: state.raw_data.packet.length as CopyOrMatchLength,
+                 content: state.raw_data.packet.data as CopyOrMatchContent,
+                 last: state.raw_data.packet.last && state.raw_data.packet.last_block,
+             },
+             DecoderMuxState {
+                 raw_data_valid: false,
+                 prev_valid : true,
+                 prev_id: state.raw_data.packet.id,
+                 prev_last: state.raw_data.packet.last,
+                 prev_last_block: state.raw_data.packet.last_block,
+                 ..state})
+        } else if (state.rle_data_valid &&
+                 ((state.rle_data.packet.id < std::umin(raw_id, compressed_id)) ||
+                  (state.rle_data.packet.id == state.prev_id))) {
+            (true,
+             SequenceExecutorPacket {
+                 msg_type: state.rle_data.msg_type,
+                 length: state.rle_data.packet.length as CopyOrMatchLength,
+                 content: state.rle_data.packet.data as CopyOrMatchContent,
+                 last: state.rle_data.packet.last && state.rle_data.packet.last_block,
+             },
+             DecoderMuxState {
+                 rle_data_valid: false,
+                 prev_valid : true,
+                 prev_id: state.rle_data.packet.id,
+                 prev_last: state.rle_data.packet.last,
+                 prev_last_block: state.rle_data.packet.last_block,
+                 ..state})
+        } else if (state.compressed_data_valid &&
+                 ((state.compressed_data.packet.id < std::umin(raw_id, rle_id)) ||
+                  (state.compressed_data.packet.id == state.prev_id))) {
+            (true,
+             SequenceExecutorPacket {
+                 msg_type: state.compressed_data.msg_type,
+                 length: state.compressed_data.packet.length as CopyOrMatchLength,
+                 content: state.compressed_data.packet.data as CopyOrMatchContent,
+                 last: state.compressed_data.packet.last && state.compressed_data.packet.last_block,
+             },
+             DecoderMuxState {
+                 compressed_data_valid: false,
+                 prev_valid : true,
+                 prev_id: state.compressed_data.packet.id,
+                 prev_last: state.compressed_data.packet.last,
+                 prev_last_block: state.compressed_data.packet.last_block,
+                 ..state})
+        } else {
+            (false, zero!<SequenceExecutorPacket>(), state)
+        };
+
+        let tok = send_if(tok, output_s, do_send, data_to_send);
+        if (do_send) {
+            trace_fmt!("sent {:#x}", data_to_send);
+        } else {()};
+        state
+    }
+}
+
+#[test_proc]
+proc DecoderMuxTest {
+  terminator: chan<bool> out;
+  raw_s: chan<ExtendedBlockDataPacket> out;
+  rle_s: chan<ExtendedBlockDataPacket> out;
+  cmp_s: chan<ExtendedBlockDataPacket> out;
+  output_r: chan<SequenceExecutorPacket> in;
+
+  init {}
+
+  config (terminator: chan<bool> out) {
+    let (raw_s, raw_r) = chan<ExtendedBlockDataPacket>;
+    let (rle_s, rle_r) = chan<ExtendedBlockDataPacket>;
+    let (cmp_s, cmp_r) = chan<ExtendedBlockDataPacket>;
+    let (output_s, output_r) = chan<SequenceExecutorPacket>;
+
+    spawn DecoderMux(raw_r, rle_r, cmp_r, output_s);
+    (terminator, raw_s, rle_s, cmp_s, output_r)
+  }
+
+  next(tok: token, state: ()) {
+    let tok = send(tok, raw_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: BlockData:0x11111111, length: BlockPacketLength:32 }});
+    let tok = send(tok, raw_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:1, last: bool: false, last_block: bool: false, data: BlockData:0x22222222, length: BlockPacketLength:32 }});
+    let tok = send(tok, rle_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:2, last: bool: false, last_block: bool: false, data: BlockData:0xAAAAAAAA, length: BlockPacketLength:32 }});
+    let tok = send(tok, raw_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:1, last: bool: true,  last_block: bool: false, data: BlockData:0x33333333, length: BlockPacketLength:32 }});
+    let tok = send(tok, cmp_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:3, last: bool: true,  last_block: bool: true,  data: BlockData:0x00000000, length: BlockPacketLength:32 }});
+    let tok = send(tok, rle_s, ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { id: u32:2, last: bool: true,  last_block: bool: false, data: BlockData:0xBBBBBBBB, length: BlockPacketLength:32 }});
+
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x11111111, length: CopyOrMatchLength:32 });
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x22222222, length: CopyOrMatchLength:32 });
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x33333333, length: CopyOrMatchLength:32 });
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xAAAAAAAA, length: CopyOrMatchLength:32 });
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: false, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0xBBBBBBBB, length: CopyOrMatchLength:32 });
+    let (tok, data) = recv(tok, output_r); assert_eq(data, SequenceExecutorPacket {last: bool: true, msg_type: SequenceExecutorMessageType::LITERAL, content: CopyOrMatchContent:0x00000000, length: CopyOrMatchLength:32 });
+
+    send(tok, terminator, true);
+  }
+}

--- a/xls/modules/zstd/frame_header.x
+++ b/xls/modules/zstd/frame_header.x
@@ -1,0 +1,666 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains utilities related to ZSTD Frame Header parsing.
+// More information about the ZSTD Frame Header can be found in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1.1
+
+import std;
+import xls.modules.zstd.buffer as buff;
+
+type Buffer = buff::Buffer;
+type BufferStatus = buff::BufferStatus;
+type BufferResult = buff::BufferResult;
+
+pub type WindowSize = u64;
+type FrameContentSize = u64;
+type DictionaryId = u32;
+
+// Maximal mantissa value for calculating maximal accepted window_size
+// as per https://datatracker.ietf.org/doc/html/rfc8878#name-window-descriptor
+const MAX_MANTISSA = WindowSize:0b111;
+
+// Structure for holding ZSTD Frame_Header_Descriptor data, as in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1.1.1
+pub struct FrameHeaderDescriptor {
+    frame_content_size_flag: u2,
+    single_segment_flag: u1,
+    unused: u1,
+    reserved: u1,
+    content_checksum_flag: u1,
+    dictionary_id_flag: u2,
+}
+
+// Structure for data obtained from decoding the Frame_Header_Descriptor
+pub struct FrameHeader {
+    window_size: WindowSize,
+    frame_content_size: FrameContentSize,
+    dictionary_id: DictionaryId,
+    content_checksum_flag: u1,
+}
+
+// Status values reported by the frame header parsing function
+pub enum FrameHeaderStatus: u2 {
+    OK = 0,
+    CORRUPTED = 1,
+    NO_ENOUGH_DATA = 2,
+    UNSUPPORTED_WINDOW_SIZE = 3,
+}
+
+// structure for returning results of parsing a frame header
+pub struct FrameHeaderResult<CAPACITY: u32> {
+    status: FrameHeaderStatus,
+    header: FrameHeader,
+    buffer: Buffer<CAPACITY>,
+}
+
+// Auxiliary constant that can be used to initialize Proc's state
+// with empty FrameHeader, because `zero!` cannot be used in that context
+pub const ZERO_FRAME_HEADER = zero!<FrameHeader>();
+pub const FRAME_CONTENT_SIZE_NOT_PROVIDED_VALUE = FrameContentSize::MAX;
+
+// Extracts Frame_Header_Descriptor fields from 8-bit chunk of data
+// that is assumed to be a valid Frame_Header_Descriptor
+fn extract_frame_header_descriptor(data:u8) -> FrameHeaderDescriptor {
+    FrameHeaderDescriptor {
+        frame_content_size_flag: data[6:8],
+        single_segment_flag: data[5:6],
+        unused: data[4:5],
+        reserved: data[3:4],
+        content_checksum_flag: data[2:3],
+        dictionary_id_flag: data[0:2],
+    }
+}
+
+#[test]
+fn test_extract_frame_header_descriptor() {
+    assert_eq(
+        extract_frame_header_descriptor(u8:0xA4),
+        FrameHeaderDescriptor {
+            frame_content_size_flag: u2:0x2,
+            single_segment_flag: u1:0x1,
+            unused: u1:0x0,
+            reserved: u1:0x0,
+            content_checksum_flag: u1:0x1,
+            dictionary_id_flag: u2:0x0
+        }
+    );
+
+    assert_eq(
+        extract_frame_header_descriptor(u8:0x0),
+        FrameHeaderDescriptor {
+            frame_content_size_flag: u2:0x0,
+            single_segment_flag: u1:0x0,
+            unused: u1:0x0,
+            reserved: u1:0x0,
+            content_checksum_flag: u1:0x0,
+            dictionary_id_flag: u2:0x0
+        }
+    );
+}
+
+// Parses a Buffer and extracts information from the Frame_Header_Descriptor.
+// The Buffer is assumed to contain a valid Frame_Header_Descriptor. The function
+// returns BufferResult with the outcome of the operations on the buffer and
+// information extracted from the Frame_Header_Descriptor
+fn parse_frame_header_descriptor<CAPACITY: u32>(buffer: Buffer<CAPACITY>) -> (BufferResult<CAPACITY>, FrameHeaderDescriptor) {
+    let (result, data) = buff::buffer_fixed_pop_checked<CAPACITY, u32:8>(buffer);
+    match result.status {
+        BufferStatus::OK => {
+            let frame_header_desc = extract_frame_header_descriptor(data);
+            (result, frame_header_desc)
+        },
+        _ => (result, zero!<FrameHeaderDescriptor>())
+    }
+}
+
+#[test]
+fn test_parse_frame_header_descriptor() {
+    let buffer = Buffer { content: u32:0xA4, length: u32:8 };
+    let (result, header) = parse_frame_header_descriptor(buffer);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0, length: u32:0 },
+    });
+    assert_eq(header, FrameHeaderDescriptor {
+        frame_content_size_flag: u2:0x2,
+        single_segment_flag: u1:0x1,
+        unused: u1:0x0,
+        reserved: u1:0x0,
+        content_checksum_flag: u1:0x1,
+        dictionary_id_flag: u2:0x0
+    });
+
+    let buffer = Buffer { content: u32:0x0, length: u32:8 };
+    let (result, header) = parse_frame_header_descriptor(buffer);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0, length: u32:0 },
+    });
+    assert_eq(header, FrameHeaderDescriptor {
+        frame_content_size_flag: u2:0x0,
+        single_segment_flag: u1:0x0,
+        unused: u1:0x0,
+        reserved: u1:0x0,
+        content_checksum_flag: u1:0x0,
+        dictionary_id_flag: u2:0x0
+    });
+
+    let buffer = Buffer { content: u32:0x0, length: u32:0 };
+    let (result, header) = parse_frame_header_descriptor(buffer);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: Buffer { content: u32:0, length: u32:0 },
+    });
+    assert_eq(header, zero!<FrameHeaderDescriptor>());
+}
+
+// Returns a boolean showing if the Window_Descriptor section exists
+// for the frame with the given FrameHeaderDescriptor
+fn window_descriptor_exists(desc: FrameHeaderDescriptor) -> bool {
+    desc.single_segment_flag == u1:0
+}
+
+#[test]
+fn test_window_descriptor_exists() {
+    let zero_desc = zero!<FrameHeaderDescriptor>();
+
+    let desc_with_ss = FrameHeaderDescriptor {single_segment_flag: u1:1, ..zero_desc};
+    assert_eq(window_descriptor_exists(desc_with_ss), false);
+
+    let desc_without_ss = FrameHeaderDescriptor {single_segment_flag: u1:0, ..zero_desc};
+    assert_eq(window_descriptor_exists(desc_without_ss), true);
+}
+
+// Extracts window size from 8-bit chunk of data
+// that is assumed to be a valid Window_Descriptor
+fn extract_window_size_from_window_descriptor(data: u8) -> u64 {
+    let exponent = data >> u8:3;
+    let mantissa = data & u8:7;
+
+    let window_base = u64:1 << (u64:10 + exponent as u64);
+    let window_add = (window_base >> u64:3) * (mantissa as u64);
+
+    window_base + window_add
+}
+
+#[test]
+fn test_extract_window_size_from_window_descriptor() {
+    assert_eq(extract_window_size_from_window_descriptor(u8:0x0), u64:0x400);
+    assert_eq(extract_window_size_from_window_descriptor(u8:0x9), u64:0x900);
+    assert_eq(extract_window_size_from_window_descriptor(u8:0xFF), u64:0x3c000000000);
+}
+
+// Parses a Buffer with data and extracts information from the Window_Descriptor
+// The buffer is assumed to contain a valid Window_Descriptor that is related to
+// the same frame as the provided FrameHeaderDescriptor. The function returns
+// BufferResult with the outcome of the operations on the buffer and window size.
+fn parse_window_descriptor<CAPACITY: u32>(buffer: Buffer<CAPACITY>, desc: FrameHeaderDescriptor) -> (BufferResult<CAPACITY>, WindowSize) {
+    if !window_descriptor_exists(desc) {
+        fail!("window_descriptor_does_not_exist", ());
+    } else {()};
+
+    let (result, data) = buff::buffer_fixed_pop_checked<CAPACITY, u32:8>(buffer);
+    match result.status {
+        BufferStatus::OK => {
+            let window_size = extract_window_size_from_window_descriptor(data);
+            (result, window_size)
+        },
+        _ => (result, u64:0)
+    }
+}
+
+#[test]
+fn test_parse_window_descriptor() {
+    let zero_desc = zero!<FrameHeaderDescriptor>();
+    let desc_without_ss = FrameHeaderDescriptor {single_segment_flag: u1:0, ..zero_desc};
+
+    let buffer = Buffer { content: u32:0xF, length: u32:0x4 };
+    let (result, window_size) = parse_window_descriptor(buffer, desc_without_ss);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: Buffer { content: u32:0xF, length: u32:0x4 },
+    });
+    assert_eq(window_size, u64:0);
+
+    let buffer = Buffer { content: u32:0x0, length: u32:0x8 };
+    let (result, window_size) = parse_window_descriptor(buffer, desc_without_ss);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(window_size, u64:0x400);
+
+    let buffer = Buffer { content: u32:0x9, length: u32:0x8 };
+    let (result, window_size) = parse_window_descriptor(buffer, desc_without_ss);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(window_size, u64:0x900);
+
+    let buffer = Buffer { content: u32:0xFF, length: u32:0x8 };
+    let (result, window_size) = parse_window_descriptor(buffer, desc_without_ss);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(window_size, u64:0x3c000000000);
+}
+
+// Parses a Buffer with data and extracts information from the Dictionary_ID
+// The buffer is assumed to contain a valid Dictionary_ID that is related to
+// the same frame as the provided FrameHeaderDescriptor. The function returns
+// BufferResult with the outcome of the operations on the buffer and dictionary ID
+fn parse_dictionary_id<CAPACITY: u32>(buffer: Buffer<CAPACITY>, desc: FrameHeaderDescriptor) -> (BufferResult<CAPACITY>, DictionaryId) {
+    let bytes = match desc.dictionary_id_flag {
+      u2:0 => u32:0,
+      u2:1 => u32:1,
+      u2:2 => u32:2,
+      u2:3 => u32:4,
+      _    => fail!("not_possible", u32:0)
+    };
+
+    let (result, data) = buff::buffer_pop_checked(buffer, bytes * u32:8);
+    match result.status {
+        BufferStatus::OK => (result, data as u32),
+        _ => (result, u32:0)
+    }
+}
+
+#[test]
+fn test_parse_dictionary_id() {
+    let zero_desc = zero!<FrameHeaderDescriptor>();
+
+    let buffer = Buffer { content: u32:0x0, length: u32:0x0 };
+    let frame_header_desc = FrameHeaderDescriptor { dictionary_id_flag: u2:0, ..zero_desc};
+    let (result, dictionary_id) = parse_dictionary_id(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0x0 },
+    });
+    assert_eq(dictionary_id, u32:0);
+
+    let buffer = Buffer { content: u32:0x12, length: u32:0x8 };
+    let frame_header_desc = FrameHeaderDescriptor { dictionary_id_flag: u2:0x1, ..zero_desc};
+    let (result, dictionary_id) = parse_dictionary_id(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(dictionary_id, u32:0x12);
+
+    let buffer = Buffer { content: u32:0x1234, length: u32:0x10 };
+    let frame_header_desc = FrameHeaderDescriptor { dictionary_id_flag: u2:0x2, ..zero_desc};
+    let (result, dictionary_id) = parse_dictionary_id(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(dictionary_id, u32:0x1234);
+
+    let buffer = Buffer { content: u32:0x12345678, length: u32:0x20 };
+    let frame_header_desc = FrameHeaderDescriptor { dictionary_id_flag: u2:0x3, ..zero_desc};
+    let (result, dictionary_id) = parse_dictionary_id(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u32:0x0, length: u32:0 },
+    });
+    assert_eq(dictionary_id, u32:0x12345678);
+
+    let buffer = Buffer { content: u32:0x1234, length: u32:0x10 };
+    let frame_header_desc = FrameHeaderDescriptor { dictionary_id_flag: u2:0x3, ..zero_desc};
+    let (result, dictionary_id) = parse_dictionary_id(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: Buffer { content: u32:0x1234, length: u32:0x10 },
+    });
+    assert_eq(dictionary_id, u32:0x0);
+}
+
+// Returns boolean showing if the Frame_Content_Size section exists for
+// the frame with the given FrameHeaderDescriptor.
+fn frame_content_size_exists(desc: FrameHeaderDescriptor) -> bool {
+    desc.single_segment_flag != u1:0 || desc.frame_content_size_flag != u2:0
+}
+
+#[test]
+fn test_frame_content_size_exists() {
+    let zero_desc = zero!<FrameHeaderDescriptor>();
+
+    let desc = FrameHeaderDescriptor {single_segment_flag: u1:0, frame_content_size_flag: u2:0, ..zero_desc};
+    assert_eq(frame_content_size_exists(desc), false);
+
+    let desc = FrameHeaderDescriptor {single_segment_flag: u1:0, frame_content_size_flag: u2:2, ..zero_desc};
+    assert_eq(frame_content_size_exists(desc), true);
+
+    let desc = FrameHeaderDescriptor {single_segment_flag: u1:1, frame_content_size_flag: u2:0, ..zero_desc};
+    assert_eq(frame_content_size_exists(desc), true);
+
+    let desc = FrameHeaderDescriptor {single_segment_flag: u1:1, frame_content_size_flag: u2:3, ..zero_desc};
+    assert_eq(frame_content_size_exists(desc), true);
+}
+
+// Parses a Buffer with data and extracts information from the Frame_Content_Size
+// The buffer is assumed to contain a valid Frame_Content_Size that is related to
+// the same frame as the provided FrameHeaderDescriptor. The function returns
+// BufferResult with the outcome of the operations on the buffer and frame content size.
+fn parse_frame_content_size<CAPACITY: u32>(buffer: Buffer<CAPACITY>, desc: FrameHeaderDescriptor) -> (BufferResult<CAPACITY>, FrameContentSize) {
+    if !frame_content_size_exists(desc) {
+        fail!("frame_content_size_does_not_exist", ());
+    } else {()};
+
+    let bytes = match desc.frame_content_size_flag {
+      u2:0 => u32:1,
+      u2:1 => u32:2,
+      u2:2 => u32:4,
+      u2:3 => u32:8,
+      _    => fail!("not_possible", u32:0)
+    };
+
+    let (result, data) = buff::buffer_pop_checked(buffer, bytes * u32:8);
+    match (result.status, bytes) {
+        (BufferStatus::OK, u32:2) => (result, data as u64 + u64:256),
+        (BufferStatus::OK, _) => (result, data as u64),
+        (_, _) => (result, u64:0)
+    }
+}
+
+#[test]
+fn test_parse_frame_content_size() {
+    let zero_desc = zero!<FrameHeaderDescriptor>();
+
+    let buffer = Buffer { content: u64:0x12, length: u32:8 };
+    let frame_header_desc = FrameHeaderDescriptor {
+            frame_content_size_flag: u2:0,
+            single_segment_flag: u1:1,
+            ..zero_desc
+        };
+    let (result, frame_content_size) = parse_frame_content_size(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u64:0x0, length: u32:0x0 },
+    });
+    assert_eq(frame_content_size, u64:0x12);
+
+    let buffer = Buffer { content: u64:0x1234, length: u32:0x10 };
+    let frame_header_desc = FrameHeaderDescriptor { frame_content_size_flag: u2:1, ..zero_desc};
+    let (result, frame_content_size) = parse_frame_content_size(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u64:0x0, length: u32:0x0 },
+    });
+    assert_eq(frame_content_size, u64:0x1234 + u64:256);
+
+    let buffer = Buffer { content: u64:0x12345678, length: u32:0x20 };
+    let frame_header_desc = FrameHeaderDescriptor { frame_content_size_flag: u2:2, ..zero_desc};
+    let (result, frame_content_size) = parse_frame_content_size(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u64:0x0, length: u32:0x0 },
+    });
+    assert_eq(frame_content_size, u64:0x12345678);
+
+    let buffer = Buffer { content: u64:0x1234567890ABCDEF, length: u32:0x40 };
+    let frame_header_desc = FrameHeaderDescriptor { frame_content_size_flag: u2:3, ..zero_desc};
+    let (result, frame_content_size) = parse_frame_content_size(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::OK,
+        buffer: Buffer { content: u64:0x0, length: u32:0x0 },
+    });
+    assert_eq(frame_content_size, u64:0x1234567890ABCDEF);
+
+    let buffer = Buffer { content: u32:0x12345678, length: u32:0x20 };
+    let frame_header_desc = FrameHeaderDescriptor { frame_content_size_flag: u2:0x3, ..zero_desc};
+    let (result, frame_content_size) = parse_frame_content_size(buffer, frame_header_desc);
+    assert_eq(result, BufferResult {
+        status: BufferStatus::NO_ENOUGH_DATA,
+        buffer: Buffer { content: u32:0x12345678, length: u32:0x20 },
+    });
+    assert_eq(frame_content_size, u64:0x0);
+}
+
+// Calculate maximal accepted window_size for given WINDOW_LOG_MAX and return whether given
+// window_size should be accepted or discarded.
+// Based on window_size calculation from: RFC 8878
+// https://datatracker.ietf.org/doc/html/rfc8878#name-window-descriptor
+fn window_size_valid<WINDOW_LOG_MAX: WindowSize>(window_size: WindowSize) -> bool {
+    let max_window_size = (WindowSize:1 << WINDOW_LOG_MAX) + (((WindowSize:1 << WINDOW_LOG_MAX) >> WindowSize:3) * MAX_MANTISSA);
+
+    window_size <= max_window_size
+}
+
+// Parses a Buffer with data and extracts Frame_Header information. The buffer
+// is assumed to contain a valid Frame_Header The function returns FrameHeaderResult
+// with BufferResult that contains outcome of the operations on the Buffer,
+// FrameHeader with the extracted frame header if the parsing was successful,
+// and the status of the operation in FrameHeaderStatus. On failure, the returned
+// buffer is the same as the input buffer.
+// WINDOW_LOG_MAX is the base 2 logarithm used for calculating the maximal allowed
+//                window_size. Frame header parsing function must discard all frames that
+//                have window_size above the maximal allowed window_size.
+// CAPACITY is the buffer capacity
+pub fn parse_frame_header<WINDOW_LOG_MAX: WindowSize, CAPACITY: u32>(buffer: Buffer<CAPACITY>) -> FrameHeaderResult {
+    trace_fmt!("parse_frame_header: ==== Parsing ==== \n");
+    trace_fmt!("parse_frame_header: initial buffer: {:#x}", buffer);
+
+    let (result, desc) = parse_frame_header_descriptor(buffer);
+    trace_fmt!("parse_frame_header: buffer after parsing header descriptor: {:#x}", result.buffer);
+
+    let (result, header) = match result.status {
+        BufferStatus::OK => {
+            let (result, window_size) = if window_descriptor_exists(desc) {
+                trace_fmt!("parse_frame_header: window_descriptor exists, parse it");
+                parse_window_descriptor(result.buffer, desc)
+            } else {
+                trace_fmt!("parse_frame_header: window_descriptor does not exist, skip parsing it");
+                (result, u64:0)
+            };
+            trace_fmt!("parse_frame_header: buffer after parsing window_descriptor: {:#x}", result.buffer);
+
+            match result.status {
+                BufferStatus::OK => {
+                    trace_fmt!("parse_frame_header: parse dictionary_id");
+                    let (result, dictionary_id) = parse_dictionary_id(result.buffer, desc);
+                    trace_fmt!("parse_frame_header: buffer after parsing dictionary_id: {:#x}", result.buffer);
+
+                    match result.status {
+                        BufferStatus::OK => {
+                            let (result, frame_content_size) = if frame_content_size_exists(desc) {
+                                trace_fmt!("parse_frame_header: frame_content_size exists, parse it");
+                                parse_frame_content_size(result.buffer, desc)
+                            } else {
+                                trace_fmt!("parse_frame_header: frame_content_size does not exist, skip parsing it");
+                                (result, FRAME_CONTENT_SIZE_NOT_PROVIDED_VALUE)
+                            };
+                            trace_fmt!("parse_frame_header: buffer after parsing frame_content_size: {:#x}", result.buffer);
+
+                            match result.status {
+                                BufferStatus::OK => {
+                                    trace_fmt!("parse_frame_header: calculate frame header!");
+                                    let window_size = match window_descriptor_exists(desc) {
+                                        true => window_size,
+                                        _ => frame_content_size,
+                                    };
+
+                                    (
+                                        result,
+                                        FrameHeader {
+                                            window_size: window_size,
+                                            frame_content_size: frame_content_size,
+                                            dictionary_id: dictionary_id,
+                                            content_checksum_flag: desc.content_checksum_flag,
+                                        }
+                                    )
+                                },
+                                _ => {
+                                    trace_fmt!("parse_frame_header: Not enough data to parse frame_content_size!");
+                                    (result, zero!<FrameHeader>())
+                                }
+                             }
+                         },
+                         _ => {
+                            trace_fmt!("parse_frame_header: Not enough data to parse dictionary_id!");
+                            (result, zero!<FrameHeader>())
+                         }
+                     }
+                 },
+                 _ => {
+                    trace_fmt!("parse_frame_header: Not enough data to parse window_descriptor!");
+                    (result, zero!<FrameHeader>())
+                 }
+            }
+        },
+        _ => {
+            trace_fmt!("parse_frame_header: Not enough data to parse frame_header_descriptor!");
+            (result, zero!<FrameHeader>())
+        }
+    };
+
+    let (status, buffer) = match result.status {
+        BufferStatus::OK => (FrameHeaderStatus::OK, result.buffer),
+        _ => (FrameHeaderStatus::NO_ENOUGH_DATA, buffer)
+    };
+
+    let frame_header_result = FrameHeaderResult { status: status, header: header, buffer: buffer };
+
+    // libzstd always reports NO_ENOUGH_DATA errors before CORRUPTED caused by
+    // reserved bit being set
+    if (desc.reserved == u1:1 && frame_header_result.status != FrameHeaderStatus::NO_ENOUGH_DATA) {
+        trace_fmt!("parse_frame_header: frame descriptor corrupted!");
+        // Critical failure - requires resetting the whole decoder
+        FrameHeaderResult {
+            status: FrameHeaderStatus::CORRUPTED,
+            buffer: zero!<Buffer>(),
+            header: zero!<FrameHeader>(),
+        }
+    } else if (!window_size_valid<WINDOW_LOG_MAX>(header.window_size)) {
+        trace_fmt!("parse_frame_header: frame discarded: window_size to big: {}", header.window_size);
+        FrameHeaderResult {
+            status: FrameHeaderStatus::UNSUPPORTED_WINDOW_SIZE,
+            buffer: zero!<Buffer>(),
+            header: zero!<FrameHeader>(),
+        }
+    } else {
+        frame_header_result
+    }
+}
+
+// The largest allowed WindowLog for DSLX tests
+pub const TEST_WINDOW_LOG_MAX = WindowSize:22;
+
+#[test]
+fn test_parse_frame_header() {
+    // normal cases
+    let buffer = Buffer { content: bits[128]:0x1234567890ABCDEF_CAFE_09_C2, length: u32:96 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::OK,
+        buffer: Buffer {
+            content: bits[128]:0x0,
+            length: u32:0,
+        },
+        header: FrameHeader {
+            window_size: u64:0x900,
+            frame_content_size: u64:0x1234567890ABCDEF,
+            dictionary_id: u32:0xCAFE,
+            content_checksum_flag: u1:0,
+        }
+    });
+
+    // SingleSegmentFlag is set and FrameContentSize is bigger than accepted window_size
+    let buffer = Buffer { content: bits[128]:0x1234567890ABCDEF_CAFE_E2, length: u32:88 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::UNSUPPORTED_WINDOW_SIZE,
+        buffer: Buffer { content: bits[128]:0x0, length: u32:0 },
+        header: zero!<FrameHeader>()
+    });
+
+    let buffer = Buffer { content: bits[128]:0xaa20, length: u32:16 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::OK,
+        buffer: Buffer {
+            content: bits[128]:0x0,
+            length: u32:0,
+        },
+        header: FrameHeader {
+            window_size: u64:0xaa,
+            frame_content_size: u64:0xaa,
+            dictionary_id: u32:0x0,
+            content_checksum_flag: u1:0,
+        },
+    });
+
+    // when buffer is too short
+    let buffer = Buffer { content: bits[128]:0x0, length: u32:0 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+        header: zero!<FrameHeader>()
+    });
+
+    let buffer = Buffer { content: bits[128]:0xC2, length: u32:8 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+        header: zero!<FrameHeader>()
+    });
+
+    let buffer = Buffer { content: bits[128]:0x09_C2, length: u32:16 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+        header: zero!<FrameHeader>()
+    });
+
+    let buffer = Buffer { content: bits[128]:0x1234_09_C2, length: u32:32 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+        header: zero!<FrameHeader>()
+    });
+
+    let buffer = Buffer { content: bits[128]:0x1234_09_C2, length: u32:32 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+        header: zero!<FrameHeader>()
+    });
+
+    // when frame header descriptor is corrupted
+    let buffer = Buffer { content: bits[128]:0x1234567890ABCDEF_1234_09_CA, length: u32:96 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::CORRUPTED,
+        buffer: Buffer { content: bits[128]:0x0, length: u32:0 },
+        header: zero!<FrameHeader>()
+    });
+
+    // Frame Header is discarded because Window size required by frame is too big for given decoder
+    // configuration
+    let buffer = Buffer { content: bits[128]:0xd310, length: u32:16 };
+    let frame_header_result = parse_frame_header<TEST_WINDOW_LOG_MAX>(buffer);
+    assert_eq(frame_header_result, FrameHeaderResult {
+        status: FrameHeaderStatus::UNSUPPORTED_WINDOW_SIZE,
+        buffer: Buffer { content: bits[128]:0x0, length: u32:0 },
+        header: zero!<FrameHeader>()
+    });
+}

--- a/xls/modules/zstd/frame_header_test.cc
+++ b/xls/modules/zstd/frame_header_test.cc
@@ -1,0 +1,315 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define ZSTD_STATIC_LINKING_ONLY 1
+#include <zstd.h>
+
+#include <bitset>
+#include <climits>
+#include <cstdio>
+#include <fstream>
+#include <memory>
+#include <random>
+#include <sstream>
+
+#include "absl/container/flat_hash_map.h"
+#include "fuzztest/fuzztest.h"
+#include "fuzztest/googletest_fixture_adapter.h"
+#include "gtest/gtest.h"
+#include "lib/common/zstd_errors.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/get_runfile_path.h"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/import_data.h"
+#include "xls/dslx/interp_value.h"
+#include "xls/dslx/ir_convert/ir_converter.h"
+#include "xls/dslx/parse_and_typecheck.h"
+#include "xls/dslx/type_system/parametric_env.h"
+#include "xls/ir/events.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/ir_test_base.h"
+#include "xls/modules/zstd/data_generator.h"
+
+namespace xls {
+namespace {
+
+// Must be in sync with FrameHeaderStatus from
+// xls/modules/zstd/frame_header.x
+enum FrameHeaderStatus {
+  OK,
+  CORRUPTED,
+  NO_ENOUGH_DATA,
+  UNSUPPORTED_WINDOW_SIZE
+};
+
+class FrameHeaderTest : public xls::IrTestBase {
+ public:
+  // Prepare simulation environment
+  void SetUp() {
+    XLS_ASSERT_OK_AND_ASSIGN(std::filesystem::path path,
+                             xls::GetXlsRunfilePath(this->file));
+    XLS_ASSERT_OK_AND_ASSIGN(std::string module_text,
+                             xls::GetFileContents(path));
+
+    auto import_data = xls::dslx::CreateImportDataForTest();
+    XLS_ASSERT_OK_AND_ASSIGN(
+        xls::dslx::TypecheckedModule checked_module,
+        xls::dslx::ParseAndTypecheck(module_text, this->file_name,
+                                     this->module_name, &import_data));
+
+    auto options = xls::dslx::ConvertOptions{};
+    /* FIXME: The following code should work with a parametrized version of
+     * the `parse_frame_header` function. However, it seems that
+     * the symbolic_bindings are not correctly propagated inside
+     * ConvertOneFunction. To leverage the problem, a simple specialization
+     * of the function is used (`parse_frame_header_128`).
+     * Once the problem is solved, we can restore the code below.
+     */
+    // auto symbolic_bindings = xls::dslx::ParametricEnv(
+    //     absl::flat_hash_map<std::string, xls::dslx::InterpValue>{
+    //         {"CAPACITY", xls::dslx::InterpValue::MakeUBits(/*bit_count=*/32,
+    //                                                     /*value=*/32)}});
+    dslx::ParametricEnv* symbolic_bindings = nullptr;
+    XLS_ASSERT_OK_AND_ASSIGN(
+        this->converted, xls::dslx::ConvertOneFunction(
+                             checked_module.module, function_name, &import_data,
+                             symbolic_bindings, options));
+  }
+
+  // Parse Buffer contents with ZSTD library, prepare inputs for DSLX simulation
+  // based on the buffer contents, form the expected output from the simulation,
+  // run the simulation of frame header parser and compare the results against
+  // expected values.
+  void ParseAndCompareWithZstd(absl::Span<const uint8_t> buffer) {
+    absl::Span<const uint8_t> input_buffer;
+    ZSTD_frameHeader zstd_fh;
+    size_t result;
+    std::vector<uint8_t> buffer_extended(dslx_buffer_size_bytes, 0);
+
+    // Extend buffer contents to 128 bits if necessary
+    if (buffer.size() < dslx_buffer_size_bytes) {
+      std::copy(buffer.begin(), buffer.end(), buffer_extended.begin());
+      input_buffer = absl::MakeSpan(buffer_extended);
+    } else {
+      input_buffer = buffer;
+    }
+
+    // Parse input buffer with libzstd and write it as ZSTD_frameHeader
+    ASSERT_TRUE(!buffer.empty() && buffer.data() != nullptr);
+    result = ZSTD_getFrameHeader_advanced(
+        &zstd_fh, buffer.data(), buffer.size(), ZSTD_f_zstd1_magicless);
+
+    // Decide on the expected status
+    FrameHeaderStatus expected_status = FrameHeaderStatus::OK;
+    if (result != 0) {
+      if (ZSTD_isError(result)) {
+        switch (ZSTD_getErrorCode(result)) {
+          case ZSTD_error_frameParameter_windowTooLarge:
+            expected_status = FrameHeaderStatus::UNSUPPORTED_WINDOW_SIZE;
+            break;
+          case ZSTD_error_frameParameter_unsupported:
+            // Occurs when reserved_bit == 1, should result in CORRUPTED state
+          default:
+            // Provided data is corrupted. Unable to correctly parse ZSTD frame.
+            expected_status = FrameHeaderStatus::CORRUPTED;
+            break;
+        }
+      } else {
+        // Provided data is to small to correctly parse ZSTD frame, should
+        // have `result` bytes, got `buffer.size()` bytes.
+        expected_status = FrameHeaderStatus::NO_ENOUGH_DATA;
+      }
+    }
+
+    auto input = CreateDSLXSimulationInput(buffer.size(), input_buffer);
+    absl::flat_hash_map<std::string, Value> hashed_input = {{"buffer", input}};
+
+    auto expected_frame_header_result = CreateExpectedFrameHeaderResult(
+        &zstd_fh, input, buffer, expected_status);
+
+    RunAndExpectEq(hashed_input, expected_frame_header_result, this->converted,
+                   true, true);
+  }
+
+  const char* file = "xls/modules/zstd/frame_header_test.x";
+  const char* module_name = "frame_header_test";
+  const char* file_name = "frame_header_test.x";
+  const char* function_name = "parse_frame_header_128";
+  std::string converted;
+
+ private:
+  const uint32_t dslx_buffer_size = 128;
+  const uint32_t dslx_buffer_size_bytes =
+      (dslx_buffer_size + CHAR_BIT - 1) / CHAR_BIT;
+
+  void PrintZSTDFrameHeader(ZSTD_frameHeader* fh) {
+    std::cout << std::hex;
+    std::cout << "zstd_fh->frameContentSize: 0x" << fh->frameContentSize
+              << std::endl;
+    std::cout << "zstd_fh->windowSize: 0x" << fh->windowSize << std::endl;
+    std::cout << "zstd_fh->blockSizeMax: 0x" << fh->blockSizeMax << std::endl;
+    std::cout << "zstd_fh->frameType: 0x" << fh->frameType << std::endl;
+    std::cout << "zstd_fh->headerSize: 0x" << fh->headerSize << std::endl;
+    std::cout << "zstd_fh->dictID: 0x" << fh->dictID << std::endl;
+    std::cout << "zstd_fh->checksumFlag: 0x" << fh->checksumFlag << std::endl;
+  }
+
+  // Form DSLX Value representing ZSTD Frame header based on data parsed with
+  // ZSTD library. Represents DSLX struct `FrameHeader`.
+  Value CreateExpectedFrameHeader(ZSTD_frameHeader* fh) {
+    return Value::Tuple({
+        /*window_size:*/ Value(UBits(fh->windowSize, 64)),
+        /*frame_content_size:*/ Value(UBits(fh->frameContentSize, 64)),
+        /*dictionary_id:*/ Value(UBits(fh->dictID, 32)),
+        /*content_checksum_flag: */ Value(UBits(fh->checksumFlag, 1)),
+    });
+  }
+
+  // Create DSLX Value representing Buffer contents after parsing frame header
+  // in simulation. Represents DSLX struct `Buffer`.
+  Value CreateExpectedBuffer(Value dslx_simulation_input,
+                             absl::Span<const uint8_t> input_buffer,
+                             uint32_t consumed_bytes_count,
+                             FrameHeaderStatus expected_status) {
+    // Return original buffer contents
+    if (expected_status == FrameHeaderStatus::NO_ENOUGH_DATA)
+      return dslx_simulation_input;
+    // Critical failure - return empty buffer
+    if (expected_status == FrameHeaderStatus::CORRUPTED)
+      return Value::Tuple({/*contents:*/ Value(UBits(0, dslx_buffer_size)),
+                           /*length:*/ Value(UBits(0, 32))});
+
+    // Frame Header parsing succeeded. Expect output buffer contents with
+    // removed first `consumed_bytes_count` bytes and extended to
+    // dslx_buffer_size if necessary
+    int bytes_to_extend =
+        dslx_buffer_size_bytes - (input_buffer.size() - consumed_bytes_count);
+    std::vector output_buffer(input_buffer.begin() + consumed_bytes_count,
+                              input_buffer.end());
+    for (int i = 0; i < bytes_to_extend; i++) {
+      output_buffer.push_back(0);
+    }
+
+    auto expected_buffer_contents =
+        Value(Bits::FromBytes(output_buffer, dslx_buffer_size));
+    auto output_buffer_size_bits =
+        (input_buffer.size() - consumed_bytes_count) * CHAR_BIT;
+    uint32_t expected_buffer_size = output_buffer_size_bits > dslx_buffer_size
+                                        ? dslx_buffer_size
+                                        : output_buffer_size_bits;
+
+    return Value::Tuple({/*contents:*/ expected_buffer_contents,
+                         /*length:*/ Value(UBits(expected_buffer_size, 32))});
+  }
+
+  // Prepare DSLX Value representing Full Result of frame header parsing
+  // simulation. It consists of expected status, parsing result and buffer
+  // contents after parsing. Represents DSLX struct `FrameHeaderResult`.
+  Value CreateExpectedFrameHeaderResult(ZSTD_frameHeader* fh,
+                                        Value dslx_simulation_input,
+                                        absl::Span<const uint8_t> input_buffer,
+                                        FrameHeaderStatus expected_status) {
+    auto expected_buffer = CreateExpectedBuffer(
+        dslx_simulation_input, input_buffer, fh->headerSize, expected_status);
+    auto expected_frame_header = CreateExpectedFrameHeader(fh);
+    return Value::Tuple({/*status:*/ Value(UBits(expected_status, 2)),
+                         /*header:*/ expected_frame_header,
+                         /*buffer:*/ expected_buffer});
+  }
+
+  // Return DSLX Value used as input argument for running frame header parsing
+  // simulation. Represents DSLX struct `Buffer`.
+  Value CreateDSLXSimulationInput(size_t buffer_size,
+                                  absl::Span<const uint8_t> input_buffer) {
+    size_t size = buffer_size;
+
+    // ignore buffer contents that won't fit into specialized buffer
+    if (buffer_size > dslx_buffer_size_bytes) size = dslx_buffer_size_bytes;
+
+    return Value::Tuple(
+        {/*contents:*/ Value(Bits::FromBytes(input_buffer, dslx_buffer_size)),
+         /*length:*/ Value(UBits(size * CHAR_BIT, 32))});
+  }
+};
+
+/* TESTS */
+
+TEST(ZstdLib, Version) { ASSERT_EQ(ZSTD_VERSION_STRING, "1.4.7"); }
+
+TEST_F(FrameHeaderTest, ParseFrameHeaderSuccess) {
+  std::vector<uint8_t> buffer{0xC2, 0x09, 0xFE, 0xCA, 0xEF, 0xCD,
+                              0xAB, 0x90, 0x78, 0x56, 0x34, 0x12};
+  this->ParseAndCompareWithZstd(buffer);
+}
+
+TEST_F(FrameHeaderTest, ParseFrameHeaderFailCorruptedReservedBit) {
+  std::vector<uint8_t> buffer{0xEA, 0xFE, 0xCA, 0xEF, 0xCD, 0xAB,
+                              0x90, 0x78, 0x56, 0x34, 0x12};
+  this->ParseAndCompareWithZstd(buffer);
+}
+
+TEST_F(FrameHeaderTest, ParseFrameHeaderFailUnsupportedWindowSizeTooBig) {
+  std::vector<uint8_t> buffer{0x10, 0xD3};
+  this->ParseAndCompareWithZstd(buffer);
+}
+
+TEST_F(FrameHeaderTest, ParseFrameHeaderFailNoEnoughData) {
+  std::vector<uint8_t> buffer{0xD3, 0xED};
+  this->ParseAndCompareWithZstd(buffer);
+}
+
+// NO_ENOUGH_DATA has priority over CORRUPTED from reserved bit
+TEST_F(FrameHeaderTest, ParseFrameHeaderFailNoEnoughDataReservedBit) {
+  std::vector<uint8_t> buffer{0xED, 0xD3};
+  this->ParseAndCompareWithZstd(buffer);
+}
+
+class FrameHeaderSeededTest : public FrameHeaderTest,
+                              public ::testing::WithParamInterface<uint32_t> {
+ public:
+  static const uint32_t random_headers_count = 50;
+};
+
+// Test `random_headers_count` instances of randomly generated valid
+// frame headers, generated with `decodecorpus` tool.
+TEST_P(FrameHeaderSeededTest, ParseMultipleFrameHeaders) {
+  auto seed = GetParam();
+  auto frame_header = zstd::GenerateFrameHeader(seed, false);
+  ASSERT_TRUE(frame_header.ok());
+  this->ParseAndCompareWithZstd(frame_header.value());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FrameHeaderSeededTest, FrameHeaderSeededTest,
+    ::testing::Range<uint32_t>(0, FrameHeaderSeededTest::random_headers_count));
+
+class FrameHeaderFuzzTest
+    : public fuzztest::PerFuzzTestFixtureAdapter<FrameHeaderTest> {
+ public:
+  void ParseMultipleRandomFrameHeaders(std::vector<uint8_t> frame_header) {
+    this->ParseAndCompareWithZstd(frame_header);
+  }
+};
+
+// Perform UNDETERMINISTIC FuzzTests with input vectors of variable length and
+// contents. Frame Headers generated by FuzzTests can be invalid.
+// This test checks if negative cases are handled correctly.
+FUZZ_TEST_F(FrameHeaderFuzzTest, ParseMultipleRandomFrameHeaders)
+    .WithDomains(fuzztest::Arbitrary<std::vector<uint8_t>>()
+                     .WithMinSize(1)
+                     .WithMaxSize(32));
+
+}  // namespace
+}  // namespace xls

--- a/xls/modules/zstd/frame_header_test.x
+++ b/xls/modules/zstd/frame_header_test.x
@@ -1,0 +1,30 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import std;
+import xls.modules.zstd.buffer as buff;
+import xls.modules.zstd.frame_header as frame_header;
+
+type Buffer = buff::Buffer;
+type FrameHeaderResult = frame_header::FrameHeaderResult;
+type WindowSize = frame_header::WindowSize;
+
+// Largest allowed WindowLog accepted by libzstd decompression function
+// https://github.com/facebook/zstd/blob/v1.4.7/lib/decompress/zstd_decompress.c#L296
+// Use only in C++ tests when comparing DSLX ZSTD Decoder with libzstd
+pub const TEST_WINDOW_LOG_MAX_LIBZSTD = WindowSize:30;
+
+pub fn parse_frame_header_128(buffer: Buffer<128>) -> FrameHeaderResult<128> {
+    frame_header::parse_frame_header<TEST_WINDOW_LOG_MAX_LIBZSTD>(buffer)
+}

--- a/xls/modules/zstd/magic.x
+++ b/xls/modules/zstd/magic.x
@@ -1,0 +1,89 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains utilities related to ZSTD magic number parsing
+// More information about the ZSTD Magic Number can be found in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
+
+import std;
+import xls.modules.zstd.buffer as buff;
+
+type Buffer = buff::Buffer;
+type BufferStatus = buff::BufferStatus;
+
+// Magic number value, as in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
+const MAGIC_NUMBER = u32:0xFD2FB528;
+
+// Status values reported by the magic number parsing function
+pub enum MagicStatus: u2 {
+    OK = 0,
+    CORRUPTED = 1,
+    NO_ENOUGH_DATA = 2,
+}
+
+// structure for returning results of magic number parsing
+pub struct MagicResult<CAPACITY: u32> {
+    buffer: Buffer<CAPACITY>,
+    status: MagicStatus,
+}
+
+// Parses a Buffer and checks if it contains the magic number.
+// The buffer is assumed to contain a valid beginning of the ZSTD file.
+// The function returns MagicResult structure with the buffer after parsing
+// the magic number and the status of the operation. On failure, the returned
+// buffer is the same as the input buffer.
+pub fn parse_magic_number<CAPACITY: u32>(buffer: Buffer<CAPACITY>) -> MagicResult<CAPACITY> {
+    let (result, data) = buff::buffer_fixed_pop_checked<CAPACITY, u32:32>(buffer);
+
+    match result.status {
+        BufferStatus::OK => {
+            if data == MAGIC_NUMBER {
+                trace_fmt!("parse_magic_number: Magic number found!");
+                MagicResult {status: MagicStatus::OK, buffer: result.buffer}
+            } else {
+                trace_fmt!("parse_magic_number: Magic number not found!");
+                MagicResult {status: MagicStatus::CORRUPTED, buffer: buffer}
+            }
+        },
+        _ => {
+            trace_fmt!("parse_frame_header: Not enough data to parse magic number!");
+            MagicResult {status: MagicStatus::NO_ENOUGH_DATA, buffer: buffer}
+        }
+    }
+}
+
+#[test]
+fn test_parse_magic_number() {
+    let buffer = Buffer { content: MAGIC_NUMBER, length: u32:32};
+    let result = parse_magic_number(buffer);
+    assert_eq(result, MagicResult {
+        status: MagicStatus::OK,
+        buffer: Buffer {content: u32:0, length: u32:0},
+    });
+
+    let buffer = Buffer { content: u32:0x12345678, length: u32:32};
+    let result = parse_magic_number(buffer);
+    assert_eq(result, MagicResult {
+        status: MagicStatus::CORRUPTED,
+        buffer: buffer
+    });
+
+    let buffer = Buffer { content: u32:0x1234, length: u32:16};
+    let result = parse_magic_number(buffer);
+    assert_eq(result, MagicResult {
+        status: MagicStatus::NO_ENOUGH_DATA,
+        buffer: buffer,
+    });
+}

--- a/xls/modules/zstd/ram_printer.x
+++ b/xls/modules/zstd/ram_printer.x
@@ -1,0 +1,144 @@
+import std;
+import xls.examples.ram;
+
+enum RamPrinterStatus : u2 {
+    IDLE = 0,
+    BUSY = 1,
+}
+
+struct RamPrinterState<ADDR_WIDTH: u32> { status: RamPrinterStatus, addr: bits[ADDR_WIDTH] }
+
+proc RamPrinter<DATA_WIDTH: u32, SIZE: u32, NUM_PARTITIONS: u32, ADDR_WIDTH: u32, NUM_MEMORIES: u32>
+{
+    print_r: chan<()> in;
+    finish_s: chan<()> out;
+    rd_req_s: chan<ram::ReadReq<ADDR_WIDTH, NUM_PARTITIONS>>[NUM_MEMORIES] out;
+    rd_resp_r: chan<ram::ReadResp<DATA_WIDTH>>[NUM_MEMORIES] in;
+
+    config(print_r: chan<()> in, finish_s: chan<()> out,
+           rd_req_s: chan<ram::ReadReq<ADDR_WIDTH, NUM_PARTITIONS>>[NUM_MEMORIES] out,
+           rd_resp_r: chan<ram::ReadResp<DATA_WIDTH>>[NUM_MEMORIES] in) {
+        (print_r, finish_s, rd_req_s, rd_resp_r)
+    }
+
+    init { RamPrinterState { status: RamPrinterStatus::IDLE, addr: bits[ADDR_WIDTH]:0 } }
+
+    next(tok: token, state: RamPrinterState) {
+        let is_idle = state.status == RamPrinterStatus::IDLE;
+        let (tok, _) = recv_if(tok, print_r, is_idle, ());
+
+        let (tok, row) = for (i, (tok, row)): (u32, (token, bits[DATA_WIDTH][NUM_MEMORIES])) in
+            range(u32:0, NUM_MEMORIES) {
+            let tok = send(tok, rd_req_s[i], ram::ReadWordReq<NUM_PARTITIONS>(state.addr));
+            let (tok, resp) = recv(tok, rd_resp_r[i]);
+            let row = update(row, i, resp.data);
+            (tok, row)
+        }((tok, bits[DATA_WIDTH][NUM_MEMORIES]:[bits[DATA_WIDTH]:0, ...]));
+
+        let is_start = state.addr == bits[ADDR_WIDTH]:0;
+        let is_last = state.addr == (SIZE - u32:1) as bits[ADDR_WIDTH];
+
+        if is_start { trace_fmt!(" ========= RAM content ========= "); } else {  };
+        trace_fmt!(" {}:	{:x} ", state.addr, array_rev(row));
+
+        let tok = send_if(tok, finish_s, is_last, ());
+
+        if is_last {
+            RamPrinterState { addr: bits[ADDR_WIDTH]:0, status: RamPrinterStatus::IDLE }
+        } else {
+            RamPrinterState {
+                addr: state.addr + bits[ADDR_WIDTH]:1, status: RamPrinterStatus::BUSY
+            }
+        }
+    }
+}
+
+const TEST_NUM_MEMORIES = u32:8;
+const TEST_SIZE = u32:10;
+const TEST_DATA_WIDTH = u32:8;
+const TEST_WORD_PARTITION_SIZE = u32:1;
+const TEST_NUM_PARTITIONS = ram::num_partitions(TEST_WORD_PARTITION_SIZE, TEST_DATA_WIDTH);
+const TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR = ram::SimultaneousReadWriteBehavior::READ_BEFORE_WRITE;
+const TEST_ADDR_WIDTH = std::clog2(TEST_SIZE);
+const TEST_INITIALIZED = true;
+
+type TestAddr = uN[TEST_ADDR_WIDTH];
+type TestData = uN[TEST_DATA_WIDTH];
+
+fn TestWriteWordReq
+    (addr: TestAddr, data: TestData)
+    -> ram::WriteReq<TEST_ADDR_WIDTH, TEST_DATA_WIDTH, TEST_NUM_PARTITIONS> {
+    ram::WriteWordReq<TEST_NUM_PARTITIONS>(addr, data)
+}
+
+fn TestReadWordReq(addr: TestAddr) -> ram::ReadReq<TEST_ADDR_WIDTH, TEST_NUM_PARTITIONS> {
+    ram::ReadWordReq<TEST_NUM_PARTITIONS>(addr)
+}
+
+#[test_proc]
+proc RamPrinterTest {
+    terminator: chan<bool> out;
+    rd_req_s: chan<ram::ReadReq<TEST_ADDR_WIDTH, TEST_NUM_PARTITIONS>>[TEST_NUM_MEMORIES] out;
+    rd_resp_r: chan<ram::ReadResp<TEST_DATA_WIDTH>>[TEST_NUM_MEMORIES] in;
+    wr_req_s: chan<ram::WriteReq<TEST_ADDR_WIDTH, TEST_DATA_WIDTH, TEST_NUM_PARTITIONS>>[TEST_NUM_MEMORIES] out;
+    wr_resp_r: chan<ram::WriteResp>[TEST_NUM_MEMORIES] in;
+    print_s: chan<()> out;
+    finish_r: chan<()> in;
+
+    config(terminator: chan<bool> out) {
+        let (rd_req_s, rd_req_r) =
+            chan<ram::ReadReq<TEST_ADDR_WIDTH, TEST_NUM_PARTITIONS>>[TEST_NUM_MEMORIES];
+        let (rd_resp_s, rd_resp_r) = chan<ram::ReadResp<TEST_DATA_WIDTH>>[TEST_NUM_MEMORIES];
+        let (wr_req_s, wr_req_r) = chan<ram::WriteReq<TEST_ADDR_WIDTH, TEST_DATA_WIDTH, TEST_NUM_PARTITIONS>>[TEST_NUM_MEMORIES];
+        let (wr_resp_s, wr_resp_r) = chan<ram::WriteResp>[TEST_NUM_MEMORIES];
+        let (print_s, print_r) = chan<()>;
+        let (finish_s, finish_r) = chan<()>;
+
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[0], rd_resp_s[0], wr_req_r[0], wr_resp_s[0]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[1], rd_resp_s[1], wr_req_r[1], wr_resp_s[1]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[2], rd_resp_s[2], wr_req_r[2], wr_resp_s[2]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[3], rd_resp_s[3], wr_req_r[3], wr_resp_s[3]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[4], rd_resp_s[4], wr_req_r[4], wr_resp_s[4]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[5], rd_resp_s[5], wr_req_r[5], wr_resp_s[5]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[6], rd_resp_s[6], wr_req_r[6], wr_resp_s[6]);
+        spawn ram::RamModel<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_WORD_PARTITION_SIZE, TEST_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_INITIALIZED>(
+            rd_req_r[7], rd_resp_s[7], wr_req_r[7], wr_resp_s[7]);
+
+        spawn RamPrinter<
+            TEST_DATA_WIDTH, TEST_SIZE, TEST_NUM_PARTITIONS, TEST_ADDR_WIDTH, TEST_NUM_MEMORIES>(
+            print_r, finish_s, rd_req_s, rd_resp_r);
+
+        (terminator, rd_req_s, rd_resp_r, wr_req_s, wr_resp_r, print_s, finish_r)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let tok = send(tok, wr_req_s[0], TestWriteWordReq(TestAddr:2, TestData:0x10));
+        let tok = send(tok, wr_req_s[1], TestWriteWordReq(TestAddr:2, TestData:0x20));
+        let tok = send(tok, wr_req_s[2], TestWriteWordReq(TestAddr:2, TestData:0x30));
+        let tok = send(tok, wr_req_s[3], TestWriteWordReq(TestAddr:2, TestData:0x40));
+        let tok = send(tok, wr_req_s[4], TestWriteWordReq(TestAddr:2, TestData:0x50));
+        let tok = send(tok, wr_req_s[5], TestWriteWordReq(TestAddr:2, TestData:0x60));
+        let tok = send(tok, wr_req_s[6], TestWriteWordReq(TestAddr:2, TestData:0x70));
+        let tok = send(tok, wr_req_s[7], TestWriteWordReq(TestAddr:2, TestData:0x80));
+        let tok = send(tok, print_s, ());
+        let (tok, _) = recv(tok, finish_r);
+        let tok = send(tok, terminator, true);
+    }
+}

--- a/xls/modules/zstd/raw_block_dec.x
+++ b/xls/modules/zstd/raw_block_dec.x
@@ -1,0 +1,116 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the implementation of RawBlockDecoder responsible for decoding
+// ZSTD Raw Blocks. More information about Raw Block's format can be found in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1.2.2
+
+import xls.modules.zstd.common as common;
+
+type BlockDataPacket = common::BlockDataPacket;
+type BlockPacketLength = common::BlockPacketLength;
+type BlockData = common::BlockData;
+type ExtendedBlockDataPacket = common::ExtendedBlockDataPacket;
+type CopyOrMatchContent = common::CopyOrMatchContent;
+type CopyOrMatchLength = common::CopyOrMatchLength;
+type SequenceExecutorMessageType = common::SequenceExecutorMessageType;
+
+struct RawBlockDecoderState {
+    prev_id: u32, // ID of the previous block
+    prev_last: bool, // if the previous packet was the last one that makes up the whole block
+    prev_valid: bool, // if prev_id and prev_last contain valid data
+}
+
+const ZERO_RAW_BLOCK_DECODER_STATE = zero!<RawBlockDecoderState>();
+
+// RawBlockDecoder is responsible for decoding Raw Blocks,
+// it should be a part of the ZSTD Decoder pipeline.
+pub proc RawBlockDecoder {
+    input_r: chan<BlockDataPacket> in;
+    output_s: chan<ExtendedBlockDataPacket> out;
+
+    init { (ZERO_RAW_BLOCK_DECODER_STATE) }
+
+    config(
+        input_r: chan<BlockDataPacket> in,
+        output_s: chan<ExtendedBlockDataPacket> out
+    ) {(input_r, output_s)}
+
+    next(tok: token, state: RawBlockDecoderState) {
+        let (tok, data) = recv(tok, input_r);
+        if state.prev_valid && (data.id != state.prev_id) && (state.prev_last == false) {
+            trace_fmt!("ID changed but previous packet have no last!");
+            fail!("no_last", ());
+        } else {};
+
+        let output_data = ExtendedBlockDataPacket {
+            // Decoded RAW block is always a literal
+            msg_type: SequenceExecutorMessageType::LITERAL,
+            packet: BlockDataPacket {
+                last: data.last,
+                last_block: data.last_block,
+                id: data.id,
+                data: data.data as BlockData,
+                length: data.length as BlockPacketLength,
+            },
+        };
+
+        let tok = send(tok, output_s, output_data);
+
+        RawBlockDecoderState {
+            prev_valid: true,
+            prev_id: output_data.packet.id,
+            prev_last: output_data.packet.last
+        }
+    }
+}
+
+#[test_proc]
+proc RawBlockDecoderTest {
+    terminator: chan<bool> out;
+    dec_input_s: chan<BlockDataPacket> out;
+    dec_output_r: chan<ExtendedBlockDataPacket> in;
+
+    config(terminator: chan<bool> out) {
+        let (dec_input_s, dec_input_r) = chan<BlockDataPacket>;
+        let (dec_output_s, dec_output_r) = chan<ExtendedBlockDataPacket>;
+        spawn RawBlockDecoder(dec_input_r, dec_output_s);
+        (terminator, dec_input_s, dec_output_r)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let data_to_send: BlockDataPacket[5] = [
+            BlockDataPacket { id: u32:1, last: u1:false, last_block: u1:false, data: BlockData:1, length: BlockPacketLength:32 },
+            BlockDataPacket { id: u32:1, last: u1:false, last_block: u1:false, data: BlockData:2, length: BlockPacketLength:32 },
+            BlockDataPacket { id: u32:1, last: u1:true, last_block: u1:false, data: BlockData:3, length: BlockPacketLength:32 },
+            BlockDataPacket { id: u32:2, last: u1:false, last_block: u1:false, data: BlockData:4, length: BlockPacketLength:32 },
+            BlockDataPacket { id: u32:2, last: u1:true, last_block: u1:true, data: BlockData:5, length: BlockPacketLength:32 },
+        ];
+
+        let tok = for ((_, data), tok): ((u32, BlockDataPacket), token) in enumerate(data_to_send) {
+            let tok = send(tok, dec_input_s, data);
+            let (tok, received_data) = recv(tok, dec_output_r);
+            let expected_data = ExtendedBlockDataPacket {
+                msg_type: SequenceExecutorMessageType::LITERAL,
+                packet: data,
+            };
+            assert_eq(expected_data, received_data);
+            (tok)
+        }(tok);
+
+        send(tok, terminator, true);
+    }
+}

--- a/xls/modules/zstd/repacketizer.x
+++ b/xls/modules/zstd/repacketizer.x
@@ -1,0 +1,213 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Repacketizer
+//
+// Remove invalid bytes from input packets,
+// form new packets with all bits valid if possible.
+
+import std;
+import xls.modules.zstd.common as common;
+
+type ZstdDecodedPacket = common::ZstdDecodedPacket;
+type BlockData = common::BlockData;
+type BlockPacketLength = common::BlockPacketLength;
+
+const DATA_WIDTH = common::DATA_WIDTH;
+
+struct RepacketizerState {
+    repacked_data: BlockData,
+    valid_length: BlockPacketLength,
+    to_fill: BlockPacketLength,
+    send_last_leftover: bool
+}
+
+const ZERO_ZSTD_DECODED_PACKET = zero!<ZstdDecodedPacket>();
+const ZERO_REPACKETIZER_STATE = zero!<RepacketizerState>();
+const INIT_REPACKETIZER_STATE = RepacketizerState {to_fill: DATA_WIDTH, ..ZERO_REPACKETIZER_STATE};
+
+proc Repacketizer {
+    input_r: chan<ZstdDecodedPacket> in;
+    output_s: chan<ZstdDecodedPacket> out;
+
+    init {(INIT_REPACKETIZER_STATE)}
+
+    config (
+        input_r: chan<ZstdDecodedPacket> in,
+        output_s: chan<ZstdDecodedPacket> out,
+    ) {
+        (input_r, output_s)
+    }
+
+    next (tok: token, state: RepacketizerState) {
+        // Don't receive if we process leftovers
+        let (tok, decoded_packet) = recv_if(tok, input_r, !state.send_last_leftover, ZERO_ZSTD_DECODED_PACKET);
+
+        // Will be able to send repacketized packet in current next() evaluation
+        let send_now = state.to_fill <= decoded_packet.length || decoded_packet.last || state.send_last_leftover;
+        // Received last packet in frame which won't fit into currently processed repacketized packet.
+        // Set flag indicating that Repacketizer will send another packet to finish the frame in
+        // next evaluation.
+        let next_send_last_leftover = decoded_packet.last && state.to_fill < decoded_packet.length;
+
+        let combined_length = state.valid_length + decoded_packet.length;
+        let leftover_length = (combined_length - DATA_WIDTH) as s32;
+        let next_valid_length = if leftover_length >= s32:0 {leftover_length as BlockPacketLength} else {combined_length};
+        let next_to_fill = DATA_WIDTH - next_valid_length;
+
+        let current_valid_length = if leftover_length >= s32:0 {DATA_WIDTH} else {combined_length};
+        let bits_to_take_length = if leftover_length >= s32:0 {state.to_fill} else {decoded_packet.length};
+
+        // Append lest signifiant bits of received packet to most significant positions of repacked data buffer
+        let masked_data = ((BlockData:1 << bits_to_take_length) - BlockData:1) & decoded_packet.data;
+        let repacked_data = state.repacked_data | (masked_data << state.valid_length);
+
+        // Prepare buffer state for the next evaluation - take leftover most significant bits of
+        // received packet
+        let leftover_mask = (BlockData:1 << (decoded_packet.length - bits_to_take_length)) - BlockData:1;
+        let leftover_masked_data = (decoded_packet.data >> bits_to_take_length) & leftover_mask;
+        let next_repacked_data = if (send_now) {leftover_masked_data} else {repacked_data};
+
+        let packet_to_send = ZstdDecodedPacket {
+            data: repacked_data,
+            length: current_valid_length,
+            last: state.send_last_leftover || (decoded_packet.last && !next_send_last_leftover),
+        };
+        let tok = send_if(tok, output_s, send_now, packet_to_send);
+
+        let next_state = if (state.send_last_leftover || (decoded_packet.last && !next_send_last_leftover)) {
+            INIT_REPACKETIZER_STATE
+        } else {
+            RepacketizerState {
+                repacked_data: next_repacked_data,
+                valid_length: next_valid_length,
+                to_fill: next_to_fill,
+                send_last_leftover: next_send_last_leftover,
+            }
+        };
+
+        trace_fmt!("state: {:#x}", state);
+        if (!state.send_last_leftover) {
+            trace_fmt!("Received packet: {:#x}", decoded_packet);
+        } else {};
+        trace_fmt!("send_now: {}", send_now);
+        trace_fmt!("next_send_last_leftover: {}", next_send_last_leftover);
+        trace_fmt!("combined_length: {}", combined_length);
+        trace_fmt!("leftover_length: {}", leftover_length);
+        trace_fmt!("next_valid_length: {}", next_valid_length);
+        trace_fmt!("next_to_fill: {}", next_to_fill);
+        trace_fmt!("current_valid_length: {}", current_valid_length);
+        trace_fmt!("bits_to_take_length: {}", bits_to_take_length);
+        trace_fmt!("masked_data: {:#x}", masked_data);
+        trace_fmt!("repacked_data: {:#x}", repacked_data);
+        trace_fmt!("leftover_mask: {:#x}", leftover_mask);
+        trace_fmt!("leftover_masked_data: {:#x}", leftover_masked_data);
+        trace_fmt!("next_repacked_data: {:#x}", next_repacked_data);
+        if (send_now) {
+            trace_fmt!("Sent repacketized packet: {:#x}", packet_to_send);
+        } else {};
+        trace_fmt!("next_state: {:#x}", next_state);
+
+        next_state
+    }
+}
+
+#[test_proc]
+proc RepacketizerTest {
+    terminator: chan<bool> out;
+    input_s: chan<ZstdDecodedPacket> out;
+    output_r: chan<ZstdDecodedPacket> in;
+
+    init {}
+
+    config (terminator: chan<bool> out) {
+        let (input_s, input_r) = chan<ZstdDecodedPacket>;
+        let (output_s, output_r) = chan<ZstdDecodedPacket>;
+
+        spawn Repacketizer(input_r, output_s);
+        (terminator, input_s, output_r)
+    }
+
+    next(tok: token, state: ()) {
+        let DecodedInputs: ZstdDecodedPacket[24] = [
+            // Full packet - no need for removing alignment zeros
+            ZstdDecodedPacket {data: BlockData:0xDEADBEEF12345678, length: BlockPacketLength:64, last:false},
+            // Data in 4 packets - should be batched together into one full output packet
+            ZstdDecodedPacket {data: BlockData:0x78, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x56, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x1234, length: BlockPacketLength:16, last:false},
+            ZstdDecodedPacket {data: BlockData:0xDEADBEEF, length: BlockPacketLength:32, last:false},
+            // Small last packet - should be send out separatelly
+            ZstdDecodedPacket {data: BlockData:0x9A, length: BlockPacketLength:8, last:true},
+            // One not-full packet and consecutive last packet packet in frame which completes previous packet and
+            // starts new one which should be marked as last
+            ZstdDecodedPacket {data: BlockData:0xADBEEF12345678, length: BlockPacketLength:56, last:false},
+            ZstdDecodedPacket {data: BlockData:0x9ADE, length: BlockPacketLength:16, last:true},
+            // 8 1-byte packets forming single output packet
+            ZstdDecodedPacket {data: BlockData:0xEF, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0xCD, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0xAB, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x89, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x67, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x45, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x23, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x01, length: BlockPacketLength:8, last:false},
+            // 7 1-byte packets and 1 8-byte packet forming 1 full and 1 7-byte output packet
+            // marked as last
+            ZstdDecodedPacket {data: BlockData:0xEF, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0xCD, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0xAB, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x89, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x67, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x45, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0x23, length: BlockPacketLength:8, last:false},
+            ZstdDecodedPacket {data: BlockData:0xFEDCBA9876543201, length: BlockPacketLength:64, last:true},
+        ];
+
+        let DecodedOutputs: ZstdDecodedPacket[8] = [
+            // Full packet - no need for removing alignment zeros
+            ZstdDecodedPacket {data: BlockData:0xDEADBEEF12345678, length: BlockPacketLength:64, last:false},
+            // Data in 4 packets - should be batched together into one full output packet
+            ZstdDecodedPacket {data: BlockData:0xDEADBEEF12345678, length: BlockPacketLength:64, last:false},
+            // Small last packet - should be send out separatelly
+            ZstdDecodedPacket {data: BlockData:0x9A, length: BlockPacketLength:8, last:true},
+            // One not-full packet and consecutive last packet packet in frame which completes previous packet and
+            // starts new one which should be marked as last
+            ZstdDecodedPacket {data: BlockData:0xDEADBEEF12345678, length: BlockPacketLength:64, last:false},
+            ZstdDecodedPacket {data: BlockData:0x9A, length: BlockPacketLength:8, last:true},
+            // 8 1-byte packets forming single output packet
+            ZstdDecodedPacket {data: BlockData:0x0123456789ABCDEF, length: BlockPacketLength:64, last:false},
+            // 7 1-byte packets and 1 8-byte packet forming 1 full and 1 7-byte output packet
+            // marked as last
+            ZstdDecodedPacket {data: BlockData:0x0123456789ABCDEF, length: BlockPacketLength:64, last:false},
+            ZstdDecodedPacket {data: BlockData:0xFEDCBA98765432, length: BlockPacketLength:56, last:true},
+        ];
+
+        let tok = for ((counter, decoded_input), tok): ((u32, ZstdDecodedPacket), token) in enumerate(DecodedInputs) {
+            let tok = send(tok, input_s, decoded_input);
+            trace_fmt!("Sent #{} decoded zero-filled packet, {:#x}", counter + u32:1, decoded_input);
+            (tok)
+        } (tok);
+
+        let tok = for ((counter, expected_output), tok): ((u32, ZstdDecodedPacket), token) in enumerate(DecodedOutputs) {
+            let (tok, decoded_output) = recv(tok, output_r);
+            trace_fmt!("Received #{} decoded non-zero-filled packet, {:#x}", counter + u32:1, decoded_output);
+            trace_fmt!("Expected #{} decoded non-zero-filled packet, {:#x}", counter + u32:1, expected_output);
+            assert_eq(decoded_output, expected_output);
+            (tok)
+        } (tok);
+
+        send(tok, terminator, true);
+    }
+}

--- a/xls/modules/zstd/rle_block_dec.x
+++ b/xls/modules/zstd/rle_block_dec.x
@@ -333,9 +333,9 @@ pub proc RleBlockDecoder {
     output_s: chan<ExtendedBlockDataPacket> out;
 
     config(input_r: chan<BlockDataPacket> in, output_s: chan<ExtendedBlockDataPacket> out) {
-        let (in_s, in_r) = chan<RleInput>;
-        let (out_s, out_r) = chan<RleOutput>;
-        let (sync_s, sync_r) = chan<BlockSyncData>;
+        let (in_s, in_r) = chan<RleInput, u32:1>;
+        let (out_s, out_r) = chan<RleOutput, u32:1>;
+        let (sync_s, sync_r) = chan<BlockSyncData, u32:1>;
 
         spawn RleDataPacker(input_r, in_s, sync_s);
         spawn rle_dec::RunLengthDecoder<SYMBOL_WIDTH, BLOCK_SIZE_WIDTH>(

--- a/xls/modules/zstd/rle_block_dec.x
+++ b/xls/modules/zstd/rle_block_dec.x
@@ -1,0 +1,414 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains the implementation of RleBlockDecoder responsible for decoding
+// ZSTD RLE Blocks. More Information about Rle Block's format can be found in:
+// https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1.2.2
+//
+// The implementation consist of 3 procs:
+// * RleDataPacker
+// * RunLengthDecoder
+// * BatchPacker
+// Connections between those is represented on the diagram below:
+//
+//                                RleBlockDecoder
+//    ┌─────────────────────────────────────────────────────────────┐
+//    │    RleDataPacker       RunLengthDecoder       BatchPacker   │
+//    │  ┌───────────────┐   ┌──────────────────┐   ┌─────────────┐ │
+// ───┼─►│               ├──►│                  ├──►│             ├─┼──►
+//    │  └───────┬───────┘   └──────────────────┘   └─────────────┘ │
+//    │          │                                         ▲        │
+//    │          │            SynchronizationData          │        │
+//    │          └─────────────────────────────────────────┘        │
+//    └─────────────────────────────────────────────────────────────┘
+//
+// RleDataPacker is responsible for receiving the incoming packets of block data, converting
+// those to format accepted by RunLengthDecoder and passing the data to the actual decoder block.
+// It also extracts from the input packets the synchronization data like block_id and last_block
+// and then passes those to BatchPacker proc.
+// RunLengthDecoder decodes RLE blocks and outputs one symbol for each transaction on output
+// channel.
+// BatchPacker then gathers those symbols into packets, appends synchronization data received from
+// RleDataPacker and passes such packets to the output of the RleBlockDecoder.
+
+import xls.modules.zstd.common;
+import xls.modules.rle.rle_dec;
+import xls.modules.rle.rle_common;
+
+const SYMBOL_WIDTH = common::SYMBOL_WIDTH;
+const BLOCK_SIZE_WIDTH = common::BLOCK_SIZE_WIDTH;
+const DATA_WIDTH = common::DATA_WIDTH;
+const BATCH_SIZE = DATA_WIDTH / SYMBOL_WIDTH;
+
+type BlockDataPacket = common::BlockDataPacket;
+type BlockPacketLength = common::BlockPacketLength;
+type BlockData = common::BlockData;
+type BlockSize = common::BlockSize;
+
+type ExtendedBlockDataPacket = common::ExtendedBlockDataPacket;
+type CopyOrMatchContent = common::CopyOrMatchContent;
+type CopyOrMatchLength = common::CopyOrMatchLength;
+type SequenceExecutorMessageType = common::SequenceExecutorMessageType;
+
+type RleInput = rle_common::CompressedData<SYMBOL_WIDTH, BLOCK_SIZE_WIDTH>;
+type RleOutput = rle_common::PlainData<SYMBOL_WIDTH>;
+type Symbol = bits[SYMBOL_WIDTH];
+type SymbolCount = BlockSize;
+
+struct BlockSyncData {
+    last_block: bool,
+    id: u32
+}
+
+proc RleDataPacker {
+    block_data_r: chan<BlockDataPacket> in;
+    rle_data_s: chan<RleInput> out;
+    sync_s: chan<BlockSyncData> out;
+
+    config(
+        block_data_r: chan<BlockDataPacket> in,
+        rle_data_s: chan<RleInput> out,
+        sync_s: chan<BlockSyncData> out
+    ) {
+        (block_data_r, rle_data_s, sync_s)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let (tok, input) = recv(tok, block_data_r);
+        let rle_dec_data = RleInput {
+            symbol: input.data as Symbol, count: input.length as SymbolCount, last: true
+        };
+        let data_tok = send(tok, rle_data_s, rle_dec_data);
+        let sync_data = BlockSyncData { last_block: input.last_block, id: input.id };
+        let sync_tok = send(data_tok, sync_s, sync_data);
+    }
+}
+
+type RleTestVector = (Symbol, SymbolCount);
+
+#[test_proc]
+proc RleDataPacker_test {
+    terminator: chan<bool> out;
+    in_s: chan<BlockDataPacket> out;
+    out_r: chan<RleInput> in;
+    sync_r: chan<BlockSyncData> in;
+
+    config(terminator: chan<bool> out) {
+        let (in_s, in_r) = chan<BlockDataPacket>;
+        let (out_s, out_r) = chan<RleInput>;
+        let (sync_s, sync_r) = chan<BlockSyncData>;
+
+        spawn RleDataPacker(in_r, out_s, sync_s);
+
+        (terminator, in_s, out_r, sync_r)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let EncodedRleBlocks: RleTestVector[6] = [
+            (Symbol:0x1, SymbolCount:0x1),
+            (Symbol:0x2, SymbolCount:0x2),
+            (Symbol:0x3, SymbolCount:0x4),
+            (Symbol:0x4, SymbolCount:0x8),
+            (Symbol:0x5, SymbolCount:0x10),
+            (Symbol:0x6, SymbolCount:0x1F),
+        ];
+        let tok = for ((counter, block), tok): ((u32, RleTestVector), token) in enumerate(EncodedRleBlocks) {
+            let last_block = (counter == (array_size(EncodedRleBlocks) - u32:1));
+            let data_in = BlockDataPacket {
+                last: true,
+                last_block,
+                id: counter,
+                data: block.0 as BlockData,
+                length: block.1 as BlockPacketLength
+            };
+            let tok = send(tok, in_s, data_in);
+            trace_fmt!("Sent #{} raw encoded block, {:#x}", counter + u32:1, data_in);
+
+            let data_out = RleInput {
+                last: true, symbol: block.0 as Symbol, count: block.1 as BlockSize
+            };
+            let (tok, dec_output) = recv(tok, out_r);
+            trace_fmt!("Received #{} packed rle encoded block, {:#x}", counter + u32:1, dec_output);
+            assert_eq(dec_output, data_out);
+
+            let sync_out = BlockSyncData {
+                id: counter,
+                last_block: counter == (array_size(EncodedRleBlocks) - u32:1),
+            };
+            let (tok, sync_output) = recv(tok, sync_r);
+            trace_fmt!("Received #{} synchronization data, {:#x}", counter + u32:1, sync_output);
+            assert_eq(sync_output, sync_out);
+            (tok)
+        }(tok);
+        send(tok, terminator, true);
+    }
+}
+
+struct BatchState {
+    batch: BlockData,
+    symbols_in_batch: BlockPacketLength,
+    prev_id: u32,
+    prev_last: bool,
+    prev_last_block: bool,
+}
+
+const ZERO_BATCH_STATE = zero!<BatchState>();
+
+proc BatchPacker {
+    rle_data_r: chan<RleOutput> in;
+    sync_r: chan<BlockSyncData> in;
+    block_data_s: chan<ExtendedBlockDataPacket> out;
+
+    config(
+        rle_data_r: chan<RleOutput> in,
+        sync_r: chan<BlockSyncData> in,
+        block_data_s: chan<ExtendedBlockDataPacket> out
+    ) {
+        (rle_data_r, sync_r, block_data_s)
+    }
+
+    // Init the state to signal new batch to process
+    init { (BatchState { prev_last: true, ..ZERO_BATCH_STATE }) }
+
+    next(tok: token, state: BatchState) {
+        let (tok, decoded_data) = recv(tok, rle_data_r);
+
+        let symbols_in_batch = state.symbols_in_batch;
+        let shift = symbols_in_batch << u32:3;  // multiply by 8 bits
+        let batch = state.batch | ((decoded_data.symbol as BlockData) << shift);
+        let symbols_in_batch = symbols_in_batch + BlockPacketLength:1;
+        let do_send_batch = (decoded_data.last | (symbols_in_batch >= BATCH_SIZE));
+
+        let block_in_progress_sync =
+            BlockSyncData { id: state.prev_id, last_block: state.prev_last_block };
+        let (tok, sync_data) =
+            recv_if(tok, sync_r, state.prev_last, block_in_progress_sync);
+
+        let decoded_batch_data = ExtendedBlockDataPacket {
+            // Decoded RLE block is always a literal
+            msg_type: SequenceExecutorMessageType::LITERAL,
+            packet: BlockDataPacket {
+                last: decoded_data.last,
+                last_block: sync_data.last_block,
+                id: sync_data.id,
+                data: batch as BlockData,
+                // length in bits
+                length: (symbols_in_batch << 3) as BlockPacketLength,
+            }
+        };
+
+        let data_tok =
+            send_if(tok, block_data_s, do_send_batch, decoded_batch_data);
+
+        let new_symbols_in_batch =
+            if do_send_batch { BlockPacketLength:0 } else { symbols_in_batch };
+        let new_batch = if do_send_batch { BlockData:0 } else { batch };
+        BatchState {
+            batch: new_batch,
+            symbols_in_batch: new_symbols_in_batch,
+            prev_last: decoded_data.last,
+            prev_last_block: sync_data.last_block,
+            prev_id: sync_data.id
+        }
+    }
+}
+
+type BatchTestVector = (Symbol, bool);
+
+#[test_proc]
+proc BatchPacker_test {
+    terminator: chan<bool> out;
+    in_s: chan<RleOutput> out;
+    sync_s: chan<BlockSyncData> out;
+    out_r: chan<ExtendedBlockDataPacket> in;
+
+    config(terminator: chan<bool> out) {
+        let (in_s, in_r) = chan<RleOutput>;
+        let (sync_s, sync_r) = chan<BlockSyncData>;
+        let (out_s, out_r) = chan<ExtendedBlockDataPacket>;
+
+        spawn BatchPacker(in_r, sync_r, out_s);
+
+        (terminator, in_s, sync_s, out_r)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let SyncData: BlockSyncData[6] = [
+            BlockSyncData { last_block: false, id: u32:0 },
+            BlockSyncData { last_block: false, id: u32:1 },
+            BlockSyncData { last_block: false, id: u32:2 },
+            BlockSyncData { last_block: false, id: u32:3 },
+            BlockSyncData { last_block: false, id: u32:4 },
+            BlockSyncData { last_block: true, id: u32:5 },
+        ];
+        let tok = for ((counter, sync_data), tok): ((u32, BlockSyncData), token) in enumerate(SyncData) {
+            let tok = send(tok, sync_s, sync_data);
+            trace_fmt!("Sent #{} synchronization data, {:#x}", counter + u32:1, sync_data);
+            (tok)
+        }(tok);
+
+        let DecodedRleBlocks: BatchTestVector[62] = [
+            // 1st block
+            (Symbol:0x01, bool:true),
+            // 2nd block
+            (Symbol:0x02, bool:false), (Symbol:0x02, bool:true),
+            // 3rd block
+            (Symbol:0x03, bool:false), (Symbol:0x03, bool:false), (Symbol:0x03, bool:false),
+            (Symbol:0x03, bool:true),
+            // 4th block
+            (Symbol:0x04, bool:false), (Symbol:0x04, bool:false), (Symbol:0x04, bool:false),
+            (Symbol:0x04, bool:false), (Symbol:0x04, bool:false), (Symbol:0x04, bool:false),
+            (Symbol:0x04, bool:false), (Symbol:0x04, bool:true),
+            // 5th block
+            (Symbol:0x05, bool:false), (Symbol:0x05, bool:false), (Symbol:0x05, bool:false),
+            (Symbol:0x05, bool:false), (Symbol:0x05, bool:false), (Symbol:0x05, bool:false),
+            (Symbol:0x05, bool:false), (Symbol:0x05, bool:false), (Symbol:0x05, bool:false),
+            (Symbol:0x05, bool:false), (Symbol:0x05, bool:false), (Symbol:0x05, bool:false),
+            (Symbol:0x05, bool:false), (Symbol:0x05, bool:false), (Symbol:0x05, bool:false),
+            (Symbol:0x05, bool:true),
+            // 5th block
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:false), (Symbol:0x06, bool:false), (Symbol:0x06, bool:false),
+            (Symbol:0x06, bool:true),
+        ];
+        let tok = for ((counter, test_data), tok): ((u32, BatchTestVector), token) in enumerate(DecodedRleBlocks) {
+            let symbol = test_data.0 as Symbol;
+            let last = test_data.1;
+            let data_in = RleOutput { symbol, last };
+            let tok = send(tok, in_s, data_in);
+            trace_fmt!("Sent #{} decoded rle symbol, {:#x}", counter + u32:1, data_in);
+            (tok)
+        }(tok);
+
+        let BatchedDecodedRleSymbols: ExtendedBlockDataPacket[10] = [
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:false, id: u32:0, data: BlockData:0x01, length: BlockPacketLength:8}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:false, id: u32:1, data: BlockData:0x0202, length: BlockPacketLength:16}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:false, id: u32:2, data: BlockData:0x03030303, length: BlockPacketLength:32}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:false, id: u32:3, data: BlockData:0x0404040404040404, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket { msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:false, last_block: bool:false, id: u32:4, data: BlockData:0x0505050505050505, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:false, id: u32:4, data: BlockData:0x0505050505050505, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:false, last_block: bool:true, id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:false, last_block: bool:true, id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:false, last_block: bool:true, id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket {last: bool:true, last_block: bool:true, id: u32:5, data: BlockData:0x06060606060606, length: BlockPacketLength:56}},
+        ];
+
+        let tok = for ((counter, expected), tok): ((u32, ExtendedBlockDataPacket), token) in enumerate(BatchedDecodedRleSymbols) {
+            let (tok, dec_output) = recv(tok, out_r);
+            trace_fmt!("Received #{} batched decoded rle symbols, {:#x}", counter + u32:1, dec_output);
+            assert_eq(dec_output, expected);
+            (tok)
+        }(tok);
+        send(tok, terminator, true);
+    }
+}
+
+pub proc RleBlockDecoder {
+    input_r: chan<BlockDataPacket> in;
+    output_s: chan<ExtendedBlockDataPacket> out;
+
+    config(input_r: chan<BlockDataPacket> in, output_s: chan<ExtendedBlockDataPacket> out) {
+        let (in_s, in_r) = chan<RleInput>;
+        let (out_s, out_r) = chan<RleOutput>;
+        let (sync_s, sync_r) = chan<BlockSyncData>;
+
+        spawn RleDataPacker(input_r, in_s, sync_s);
+        spawn rle_dec::RunLengthDecoder<SYMBOL_WIDTH, BLOCK_SIZE_WIDTH>(
+            in_r, out_s);
+        spawn BatchPacker(out_r, sync_r, output_s);
+
+        (input_r, output_s)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {  }
+}
+
+#[test_proc]
+proc RleBlockDecoder_test {
+    terminator: chan<bool> out;
+    in_s: chan<BlockDataPacket> out;
+    out_r: chan<ExtendedBlockDataPacket> in;
+
+    config(terminator: chan<bool> out) {
+        let (in_s, in_r) = chan<BlockDataPacket>;
+        let (out_s, out_r) = chan<ExtendedBlockDataPacket>;
+
+        spawn RleBlockDecoder(in_r, out_s);
+
+        (terminator, in_s, out_r)
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        let EncodedRleBlocks: RleTestVector[6] = [
+            (Symbol:0x1, SymbolCount:0x1),
+            (Symbol:0x2, SymbolCount:0x2),
+            (Symbol:0x3, SymbolCount:0x4),
+            (Symbol:0x4, SymbolCount:0x8),
+            (Symbol:0x5, SymbolCount:0x10),
+            (Symbol:0x6, SymbolCount:0x1F),
+        ];
+        let tok = for ((counter, block), tok): ((u32, RleTestVector), token) in enumerate(EncodedRleBlocks) {
+            let last_block = (counter == (array_size(EncodedRleBlocks) - u32:1));
+            let data_in = BlockDataPacket {
+                last: true, // RLE block fits into single packet, each will be last for given block
+                last_block,
+                id: counter,
+                data: block.0 as BlockData,
+                length: block.1 as BlockPacketLength
+            };
+            let tok = send(tok, in_s, data_in);
+            trace_fmt!("Sent #{} raw encoded block, {:#x}", counter + u32:1, data_in);
+            (tok)
+        }(tok);
+
+        let BatchedDecodedRleSymbols: ExtendedBlockDataPacket[10] = [
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:false, id: u32:0, data: BlockData:0x01, length: BlockPacketLength:8}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:false, id: u32:1, data: BlockData:0x0202, length: BlockPacketLength:16}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:false, id: u32:2, data: BlockData:0x03030303, length: BlockPacketLength:32}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:false, id: u32:3, data: BlockData:0x0404040404040404, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:false, last_block: bool:false, id: u32:4, data: BlockData:0x0505050505050505, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:false, id: u32:4, data: BlockData:0x0505050505050505, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:false, last_block: bool:true,  id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:false, last_block: bool:true,  id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:false, last_block: bool:true,  id: u32:5, data: BlockData:0x0606060606060606, length: BlockPacketLength:64}},
+            ExtendedBlockDataPacket {msg_type: SequenceExecutorMessageType::LITERAL, packet: BlockDataPacket { last: bool:true,  last_block: bool:true,  id: u32:5, data: BlockData:0x06060606060606, length: BlockPacketLength:56}},
+        ];
+
+        let tok = for ((counter, expected), tok): ((u32, ExtendedBlockDataPacket), token) in enumerate(BatchedDecodedRleSymbols) {
+            let (tok, dec_output) = recv(tok, out_r);
+            trace_fmt!("Received #{} batched decoded rle symbols, {:#x}", counter + u32:1, dec_output);
+            assert_eq(dec_output, expected);
+            (tok)
+        }(tok);
+        send(tok, terminator, true);
+    }
+}

--- a/xls/modules/zstd/sequence_executor.x
+++ b/xls/modules/zstd/sequence_executor.x
@@ -1133,6 +1133,66 @@ proc SequenceExecutor<HISTORY_BUFFER_SIZE_KB: u32,
     }
 }
 
+const ZSTD_HISTORY_BUFFER_SIZE_KB: u32 = u32:64;
+const ZSTD_RAM_SIZE = ram_size(ZSTD_HISTORY_BUFFER_SIZE_KB);
+const ZSTD_RAM_ADDR_WIDTH = ram_addr_width(ZSTD_HISTORY_BUFFER_SIZE_KB);
+
+pub proc SequenceExecutorZstd {
+
+    init {  }
+
+    config(
+        input_r: chan<SequenceExecutorPacket> in,
+        output_s: chan<ZstdDecodedPacket> out,
+        rd_req_m0_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m1_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m2_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m3_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m4_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m5_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m6_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_req_m7_s: chan<ram::ReadReq<ZSTD_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+        rd_resp_m0_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m1_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m2_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m3_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m4_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m5_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m6_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        rd_resp_m7_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+        wr_req_m0_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m1_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m2_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m3_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m4_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m5_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m6_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_req_m7_s: chan<ram::WriteReq<ZSTD_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+        wr_resp_m0_r: chan<ram::WriteResp> in,
+        wr_resp_m1_r: chan<ram::WriteResp> in,
+        wr_resp_m2_r: chan<ram::WriteResp> in,
+        wr_resp_m3_r: chan<ram::WriteResp> in,
+        wr_resp_m4_r: chan<ram::WriteResp> in,
+        wr_resp_m5_r: chan<ram::WriteResp> in,
+        wr_resp_m6_r: chan<ram::WriteResp> in,
+        wr_resp_m7_r: chan<ram::WriteResp> in
+    ) {
+        spawn SequenceExecutor<ZSTD_HISTORY_BUFFER_SIZE_KB> (
+            input_r, output_s,
+            rd_req_m0_s, rd_req_m1_s, rd_req_m2_s, rd_req_m3_s,
+            rd_req_m4_s, rd_req_m5_s, rd_req_m6_s, rd_req_m7_s,
+            rd_resp_m0_r, rd_resp_m1_r, rd_resp_m2_r, rd_resp_m3_r,
+            rd_resp_m4_r, rd_resp_m5_r, rd_resp_m6_r, rd_resp_m7_r,
+            wr_req_m0_s, wr_req_m1_s, wr_req_m2_s, wr_req_m3_s,
+            wr_req_m4_s, wr_req_m5_s, wr_req_m6_s, wr_req_m7_s,
+            wr_resp_m0_r, wr_resp_m1_r, wr_resp_m2_r, wr_resp_m3_r,
+            wr_resp_m4_r, wr_resp_m5_r, wr_resp_m6_r, wr_resp_m7_r
+        );
+    }
+
+    next (tok: token, state: ()) { }
+}
+
 const LITERAL_TEST_INPUT_DATA = SequenceExecutorPacket[6]:[
      SequenceExecutorPacket {
         msg_type: SequenceExecutorMessageType::LITERAL,

--- a/xls/modules/zstd/sequence_executor.x
+++ b/xls/modules/zstd/sequence_executor.x
@@ -1,0 +1,1617 @@
+// Copyright 2023 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import std;
+import xls.modules.zstd.common as common;
+import xls.modules.zstd.ram_printer as ram_printer;
+import xls.examples.ram;
+
+type BlockData = common::BlockData;
+type SequenceExecutorMessageType = common::SequenceExecutorMessageType;
+type SequenceExecutorPacket = common::SequenceExecutorPacket;
+type CopyOrMatchContent = common::CopyOrMatchContent;
+type CopyOrMatchLength = common::CopyOrMatchLength;
+type ZstdDecodedPacket = common::ZstdDecodedPacket;
+type BlockPacketLength = common::BlockPacketLength;
+type Offset = common::Offset;
+
+fn calculate_ram_addr_width(hb_size_kb: u32, ram_data_width: u32, ram_num: u32) -> u32 {
+    ((hb_size_kb * u32:1024 * u32:8) / ram_data_width) / ram_num
+}
+
+// Configurable RAM parameters
+const RAM_DATA_WIDTH = common::SYMBOL_WIDTH;
+const RAM_NUM = u32:8;
+
+type RamData = bits[RAM_DATA_WIDTH];
+
+// Constants calculated from RAM parameters
+const RAM_NUM_WIDTH = std::clog2(RAM_NUM);
+const RAM_WORD_PARTITION_SIZE = RAM_DATA_WIDTH;
+const RAM_ORDER_WIDTH = std::clog2(RAM_DATA_WIDTH);
+const RAM_NUM_PARTITIONS = ram::num_partitions(RAM_WORD_PARTITION_SIZE, RAM_DATA_WIDTH);
+const RAM_REQ_MASK_ALL = std::unsigned_max_value<RAM_NUM_PARTITIONS>();
+const RAM_REQ_MASK_NONE = bits[RAM_NUM_PARTITIONS]:0;
+
+type RamNumber = bits[RAM_NUM_WIDTH];
+type RamOrder = bits[RAM_ORDER_WIDTH];
+
+fn ram_size(hb_size_kb: u32) -> u32 { (hb_size_kb * u32:1024 * u32:8) / RAM_DATA_WIDTH / RAM_NUM }
+
+fn ram_addr_width(hb_size_kb: u32) -> u32 { std::clog2(ram_size(hb_size_kb)) }
+
+// RAM related constants common for tests
+const TEST_HISTORY_BUFFER_SIZE_KB = u32:1;
+const TEST_RAM_SIZE = ram_size(TEST_HISTORY_BUFFER_SIZE_KB);
+const TEST_RAM_ADDR_WIDTH = ram_addr_width(TEST_HISTORY_BUFFER_SIZE_KB);
+const TEST_RAM_INITIALIZED = true;
+const TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR = ram::SimultaneousReadWriteBehavior::READ_BEFORE_WRITE;
+
+type TestRamAddr = bits[TEST_RAM_ADDR_WIDTH];
+type TestWriteReq = ram::WriteReq<TEST_RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>;
+type TestWriteResp = ram::WriteResp<TEST_RAM_ADDR_WIDTH>;
+type TestReadReq = ram::ReadReq<TEST_RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>;
+type TestReadResp = ram::ReadResp<RAM_DATA_WIDTH>;
+
+struct HistoryBufferPtr<RAM_ADDR_WIDTH: u32> { number: RamNumber, addr: bits[RAM_ADDR_WIDTH] }
+
+type HistoryBufferLength = u32;
+
+enum SequenceExecutorStatus : u2 {
+    IDLE = 0,
+    LITERAL_WRITE = 1,
+    SEQUENCE_READ = 2,
+    SEQUENCE_WRITE = 3,
+}
+
+struct SequenceExecutorState<RAM_ADDR_WIDTH: u32> {
+    status: SequenceExecutorStatus,
+    // Packet handling
+    packet: SequenceExecutorPacket,
+    packet_valid: bool,
+    // History Buffer handling
+    hyp_ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>,
+    real_ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>,
+    hb_len: HistoryBufferLength,
+    // Repeat Offset handling
+    repeat_offsets: Offset[3],
+    repeat_req: bool,
+    seq_cnt: bool,
+}
+
+fn decode_literal_packet(packet: SequenceExecutorPacket) -> ZstdDecodedPacket {
+    ZstdDecodedPacket {
+        data: packet.content, length: packet.length as BlockPacketLength, last: packet.last
+    }
+}
+
+#[test]
+fn test_decode_literal_packet() {
+    let content = CopyOrMatchContent:0xAA00BB11CC22DD33;
+    let length = CopyOrMatchLength:64;
+    let last = false;
+
+    assert_eq(
+        decode_literal_packet(
+            SequenceExecutorPacket {
+                msg_type: SequenceExecutorMessageType::LITERAL,
+                length, content, last
+            }),
+        ZstdDecodedPacket {
+            length: length as BlockPacketLength,
+            data: content, last
+        })
+}
+
+fn round_up_to_pow2<Y: u32, N: u32, Y_CLOG2: u32 = {std::clog2(Y)}>(x: uN[N]) -> uN[N] {
+    let base = x[Y_CLOG2 as s32:];
+    let reminder = x[0:Y_CLOG2 as s32] != bits[Y_CLOG2]:0;
+    (base as uN[N] + reminder as uN[N]) << Y_CLOG2
+}
+
+#[test]
+fn test_round_up_to_pow2() {
+    assert_eq(round_up_to_pow2<u32:8>(u16:0), u16:0);
+    assert_eq(round_up_to_pow2<u32:8>(u16:1), u16:8);
+    assert_eq(round_up_to_pow2<u32:8>(u16:7), u16:8);
+    assert_eq(round_up_to_pow2<u32:8>(u16:8), u16:8);
+    assert_eq(round_up_to_pow2<u32:8>(u16:9), u16:16);
+    assert_eq(round_up_to_pow2<u32:16>(u16:9), u16:16);
+}
+
+fn hb_ptr_from_offset_back
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_SIZE: u32 = {ram_size(HISTORY_BUFFER_SIZE_KB)},
+     RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, offset: Offset) -> HistoryBufferPtr<RAM_ADDR_WIDTH> {
+
+    const_assert!(common::OFFSET_WIDTH < u32:32);
+    type RamAddr = bits[RAM_ADDR_WIDTH];
+
+    let buff_change = std::mod_pow2(offset as u32, RAM_NUM) as RamNumber;
+    let rounded_offset = round_up_to_pow2<RAM_NUM>(offset as u32 + u32:1);
+    let max_row_span = std::div_pow2(rounded_offset, RAM_NUM) as RamAddr;
+    let (number, addr_change) = if ptr.number >= buff_change {
+        (ptr.number - buff_change, max_row_span - RamAddr:1)
+    } else {
+        ((RAM_NUM + ptr.number as u32 - buff_change as u32) as RamNumber, max_row_span)
+    };
+    let addr = if ptr.addr > addr_change {
+        ptr.addr - addr_change
+    } else {
+        (RAM_SIZE + ptr.addr as u32 - addr_change as u32) as RamAddr
+    };
+    HistoryBufferPtr { number, addr }
+}
+
+#[test]
+fn test_hb_ptr_from_offset_back() {
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:0),
+        HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:1),
+        HistoryBufferPtr { number: RamNumber:3, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:2),
+        HistoryBufferPtr { number: RamNumber:2, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:3),
+        HistoryBufferPtr { number: RamNumber:1, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:4),
+        HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:5),
+        HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:1 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:6),
+        HistoryBufferPtr { number: RamNumber:6, addr: TestRamAddr:1 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:7),
+        HistoryBufferPtr { number: RamNumber:5, addr: TestRamAddr:1 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:8),
+        HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:1 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:15),
+        HistoryBufferPtr { number: RamNumber:5, addr: TestRamAddr:0 });
+    assert_eq(
+        hb_ptr_from_offset_back<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:0 }, Offset:1),
+        HistoryBufferPtr { number: RamNumber:7, addr: (TEST_RAM_SIZE - u32:1) as TestRamAddr });
+}
+
+fn hb_ptr_from_offset_forw
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_SIZE: u32 = {ram_size(HISTORY_BUFFER_SIZE_KB)},
+     RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, offset: Offset) -> HistoryBufferPtr<RAM_ADDR_WIDTH> {
+
+    type RamAddr = bits[RAM_ADDR_WIDTH];
+    const MAX_ADDR = (RAM_SIZE - u32:1) as RamAddr;
+
+    let buff_change = std::mod_pow2(offset as u32, RAM_NUM) as RamNumber;
+    let rounded_offset = round_up_to_pow2<RAM_NUM>(offset as u32 + u32:1);
+    let max_row_span = std::div_pow2(rounded_offset, RAM_NUM) as RamAddr;
+    let (number, addr_change) = if ptr.number as u32 + buff_change as u32 < RAM_NUM {
+        (ptr.number + buff_change, max_row_span - RamAddr:1)
+    } else {
+        ((buff_change as u32 - (RAM_NUM - ptr.number as u32)) as RamNumber, max_row_span)
+    };
+
+    let addr = if ptr.addr + addr_change <= MAX_ADDR {
+        ptr.addr + addr_change
+    } else {
+        (addr_change - (MAX_ADDR - ptr.addr))
+    };
+
+    HistoryBufferPtr { number, addr }
+}
+
+#[test]
+fn test_hb_ptr_from_offset_forw() {
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:0),
+        HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:1),
+        HistoryBufferPtr { number: RamNumber:5, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:2),
+        HistoryBufferPtr { number: RamNumber:6, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:3),
+        HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:2 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:4),
+        HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:3 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:5),
+        HistoryBufferPtr { number: RamNumber:1, addr: TestRamAddr:3 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:6),
+        HistoryBufferPtr { number: RamNumber:2, addr: TestRamAddr:3 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:7),
+        HistoryBufferPtr { number: RamNumber:3, addr: TestRamAddr:3 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:8),
+        HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:3 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:4, addr: TestRamAddr:2 }, Offset:15),
+        HistoryBufferPtr { number: RamNumber:3, addr: TestRamAddr:4 });
+    assert_eq(
+        hb_ptr_from_offset_forw<TEST_HISTORY_BUFFER_SIZE_KB>(
+            HistoryBufferPtr { number: RamNumber:7, addr: (TEST_RAM_SIZE - u32:1) as TestRamAddr },
+            Offset:1), HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:0 });
+}
+
+fn literal_packet_to_single_write_req
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, literal: SequenceExecutorPacket, number: RamNumber)
+    -> ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS> {
+
+    let offset = std::mod_pow2(RAM_NUM - ptr.number as u32 + number as u32, RAM_NUM) as Offset;
+    let we = literal.length >= (offset as CopyOrMatchLength + CopyOrMatchLength:1) << CopyOrMatchLength:3;
+    let hb = hb_ptr_from_offset_forw<HISTORY_BUFFER_SIZE_KB>(ptr, offset);
+
+    if we {
+        ram::WriteReq {
+            data: literal.content[offset as u32 << u32:3+:RamData] as RamData,
+            addr: hb.addr,
+            mask: std::unsigned_max_value<RAM_NUM_PARTITIONS>()
+        }
+    } else {
+        ram::WriteReq {
+            addr: bits[RAM_ADDR_WIDTH]:0,
+            data: bits[RAM_DATA_WIDTH]:0,
+            mask: bits[RAM_NUM_PARTITIONS]:0
+        }
+    }
+}
+
+#[test]
+fn test_literal_packet_to_single_write_req() {
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 |  |  |  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 | o|  |  |  |  |  |  |  |     2 |11|  |  |  |  |  |  |  |
+    // 3 |  |  |  |  |  |  |  |  |     3 |  | o|77|66|55|44|33|22|
+    // 4 |  |  |  |  |  |  |  |  |     4 |  |  |  |  |  |  |  |  |
+
+    let ptr = HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:2 };
+    let literals = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        content: CopyOrMatchContent:0x77_6655_4433_2211,
+        length: CopyOrMatchLength:56,
+        last: false
+    };
+    assert_eq(
+        literal_packet_to_single_write_req<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, literals, RamNumber:0),
+        TestWriteReq { data: RamData:0x22, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL });
+    assert_eq(
+        literal_packet_to_single_write_req<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, literals, RamNumber:3),
+        TestWriteReq { data: RamData:0x55, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL });
+    assert_eq(
+        literal_packet_to_single_write_req<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, literals, RamNumber:6),
+        zero!<TestWriteReq>());
+}
+
+fn literal_packet_to_write_reqs
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, literal: SequenceExecutorPacket)
+    -> (ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>[RAM_NUM], HistoryBufferPtr) {
+    type WriteReq = ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>;
+    let result = WriteReq[RAM_NUM]:[
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:0),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:1),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:2),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:3),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:4),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:5),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:6),
+        literal_packet_to_single_write_req<HISTORY_BUFFER_SIZE_KB>(ptr, literal, RamNumber:7),
+    ];
+
+    let ptr_offset = literal.length >> CopyOrMatchLength:3;
+    (result, hb_ptr_from_offset_forw<HISTORY_BUFFER_SIZE_KB>(ptr, ptr_offset as Offset))
+}
+
+#[test]
+fn test_literal_packet_to_write_reqs() {
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 |  |  |  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 | o|  |  |  |  |  |  |  |     2 |11|  |  |  |  |  |  |  |
+    // 3 |  |  |  |  |  |  |  |  |     3 |  |  |  |  |  |  |  | o|
+    // 4 |  |  |  |  |  |  |  |  |     4 |  |  |  |  |  |  |  |  |
+
+    let ptr = HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:0x2 };
+    let literals = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        content: CopyOrMatchContent:0x11,
+        length: CopyOrMatchLength:8,
+        last: false
+    };
+    assert_eq(
+        literal_packet_to_write_reqs<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, literals),
+        (
+            TestWriteReq[RAM_NUM]:[
+                zero!<TestWriteReq>(), zero!<TestWriteReq>(), zero!<TestWriteReq>(),
+                zero!<TestWriteReq>(), zero!<TestWriteReq>(), zero!<TestWriteReq>(),
+                zero!<TestWriteReq>(),
+                TestWriteReq { data: RamData:0x11, addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL },
+            ], HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:0x3 },
+        ));
+
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 |  |  |  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 | o|  |  |  |  |  |  |  |     2 |11|  |  |  |  |  |  |  |
+    // 3 |  |  |  |  |  |  |  |  |     3 | o|88|77|66|55|44|33|22|
+    // 4 |  |  |  |  |  |  |  |  |     4 |  |  |  |  |  |  |  |  |
+
+    let ptr = HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:2 };
+    let literals = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        content: CopyOrMatchContent:0x8877_6655_4433_2211,
+        length: CopyOrMatchLength:64,
+        last: false
+    };
+    assert_eq(
+        literal_packet_to_write_reqs<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, literals),
+        (
+            TestWriteReq[RAM_NUM]:[
+                TestWriteReq { data: RamData:0x22, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x33, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x44, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x55, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x66, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x77, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x88, addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+                TestWriteReq { data: RamData:0x11, addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL },
+            ], HistoryBufferPtr { number: RamNumber:7, addr: TestRamAddr:3 },
+        ));
+}
+
+fn max_hb_ptr_for_sequence_packet
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, seq: SequenceExecutorPacket)
+    -> HistoryBufferPtr<RAM_ADDR_WIDTH> {
+    hb_ptr_from_offset_back<HISTORY_BUFFER_SIZE_KB>(ptr, seq.content as Offset)
+}
+
+fn sequence_packet_to_single_read_req
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, max_ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>,
+     seq: SequenceExecutorPacket, number: RamNumber)
+    -> (ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>, RamOrder) {
+    type ReadReq = ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>;
+    let offset_change = if max_ptr.number > number {
+        RAM_NUM - max_ptr.number as u32 + number as u32
+    } else {
+        number as u32 - max_ptr.number as u32
+    };
+    let offset = (seq.content as u32 - offset_change) as Offset;
+    let re = (offset_change as CopyOrMatchLength) < seq.length;
+    let hb = hb_ptr_from_offset_back<HISTORY_BUFFER_SIZE_KB>(ptr, offset);
+
+    if re {
+        (ReadReq { addr: hb.addr, mask: RAM_REQ_MASK_ALL }, offset_change as RamOrder)
+    } else {
+        (zero!<ReadReq>(), RamOrder:0)
+    }
+}
+
+#[test]
+fn test_sequence_packet_to_single_read_req() {
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 | x| x|  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 |  |  |  |  |  |  | x| x|     2 |  |  |  |  |  |  |  |  |
+    // 3 |  |  |  |  |  |  | o|  |     3 |  |  | o| y| y| y| y|  |
+    // 4 |  |  |  |  |  |  |  |  |     4 |  |  |  |  |  |  |  |  |
+
+    let ptr = HistoryBufferPtr { number: RamNumber:1, addr: TestRamAddr:0x3 };
+    let sequence = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        content: CopyOrMatchContent:11,
+        length: CopyOrMatchLength:4,
+        last: false
+    };
+    let max_ptr = max_hb_ptr_for_sequence_packet<TEST_HISTORY_BUFFER_SIZE_KB>(ptr, sequence);
+
+    assert_eq(
+        sequence_packet_to_single_read_req<TEST_HISTORY_BUFFER_SIZE_KB>(
+            ptr, max_ptr, sequence, RamNumber:0),
+        (TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL }, RamOrder:2));
+
+    assert_eq(
+        sequence_packet_to_single_read_req<TEST_HISTORY_BUFFER_SIZE_KB>(
+            ptr, max_ptr, sequence, RamNumber:1),
+        (TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL }, RamOrder:3));
+
+    assert_eq(
+        sequence_packet_to_single_read_req<TEST_HISTORY_BUFFER_SIZE_KB>(
+            ptr, max_ptr, sequence, RamNumber:2), (zero!<TestReadReq>(), RamOrder:0));
+
+    assert_eq(
+        sequence_packet_to_single_read_req<TEST_HISTORY_BUFFER_SIZE_KB>(
+            ptr, max_ptr, sequence, RamNumber:7),
+        (TestReadReq { addr: TestRamAddr:0x1, mask: RAM_REQ_MASK_ALL }, RamOrder:1));
+
+    assert_eq(
+        sequence_packet_to_single_read_req<TEST_HISTORY_BUFFER_SIZE_KB>(
+            ptr, max_ptr, sequence, RamNumber:6),
+        (TestReadReq { addr: TestRamAddr:0x1, mask: RAM_REQ_MASK_ALL }, RamOrder:0));
+}
+
+fn sequence_packet_to_read_reqs
+    <HISTORY_BUFFER_SIZE_KB: u32, RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)}>
+    (ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>, seq: SequenceExecutorPacket, hb_len: HistoryBufferLength)
+    -> (ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>[RAM_NUM], RamOrder[RAM_NUM], SequenceExecutorPacket, bool) {
+    type ReadReq = ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>;
+
+    let max_len = std::umin(seq.length as u32, std::umin(RAM_NUM, hb_len));
+
+    let (next_seq, next_seq_valid) = if seq.length > max_len as CopyOrMatchLength {
+        (
+            SequenceExecutorPacket {
+                msg_type: SequenceExecutorMessageType::SEQUENCE,
+                length: seq.length - max_len as CopyOrMatchLength,
+                content: seq.content,
+                last: seq.last
+            }, true,
+        )
+    } else {
+        (zero!<SequenceExecutorPacket>(), false)
+    };
+
+    let max_ptr = max_hb_ptr_for_sequence_packet<HISTORY_BUFFER_SIZE_KB>(ptr, seq);
+    let (req0, order0) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:0);
+    let (req1, order1) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:1);
+    let (req2, order2) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:2);
+    let (req3, order3) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:3);
+    let (req4, order4) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:4);
+    let (req5, order5) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:5);
+    let (req6, order6) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:6);
+    let (req7, order7) =
+        sequence_packet_to_single_read_req<HISTORY_BUFFER_SIZE_KB>(ptr, max_ptr, seq, RamNumber:7);
+
+    let reqs = ReadReq[RAM_NUM]:[req0, req1, req2, req3, req4, req5, req6, req7];
+    let orders = RamOrder[RAM_NUM]:[order0, order1, order2, order3, order4, order5, order6, order7];
+    (reqs, orders, next_seq, next_seq_valid)
+}
+
+#[test]
+fn test_sequence_packet_to_read_reqs() {
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 | x| x|  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 |  |  |  |  |  |  | x| x|     2 |  |  |  |  |  |  |  |  |
+    // 3 |  |  |  |  |  |  | o|  |     3 |  |  |  |  |  |  | o|  |
+    // 4 |  |  |  |  |  |  |  |  |     4 |  |  |  |  |  |  |  |  |
+
+    let ptr = HistoryBufferPtr { number: RamNumber:1, addr: TestRamAddr:0x3 };
+    let sequence = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        content: CopyOrMatchContent:11,
+        length: CopyOrMatchLength:4,
+        last: false
+    };
+    let result = sequence_packet_to_read_reqs<TEST_HISTORY_BUFFER_SIZE_KB>(
+        ptr, sequence, HistoryBufferLength:20);
+    let expected = (
+        TestReadReq[RAM_NUM]:[
+            TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL }, zero!<TestReadReq>(),
+            zero!<TestReadReq>(), zero!<TestReadReq>(), zero!<TestReadReq>(),
+            TestReadReq { addr: TestRamAddr:0x1, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x1, mask: RAM_REQ_MASK_ALL },
+        ],
+        RamOrder[RAM_NUM]:[
+            RamOrder:2, RamOrder:3, zero!<RamOrder>(), zero!<RamOrder>(), zero!<RamOrder>(),
+            zero!<RamOrder>(), RamOrder:0, RamOrder:1,
+        ], zero!<SequenceExecutorPacket>(), false,
+    );
+    assert_eq(result, expected);
+
+    // BEFORE:                         AFTER:
+    //     7  6  5  4  3  2  1  0          7  6  5  4  3  2  1  0
+    // 1 |  |  |  |  |  |  |  |  |     1 |  |  |  |  |  |  |  |  |
+    // 2 | x| x|  |  |  |  |  |  |     2 |  |  |  |  |  |  |  |  |
+    // 3 |  |  | x| x| x| x| x| x|     3 |  | x|  |  |  |  |  |  |
+    // 4 |  |  |  |  |  |  |  | o|     4 |  |  |  |  |  |  |  | o|
+
+    let ptr = HistoryBufferPtr { number: RamNumber:0, addr: TestRamAddr:0x4 };
+    let sequence = SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        content: CopyOrMatchContent:10,
+        length: CopyOrMatchLength:9,
+        last: false
+    };
+    let result = sequence_packet_to_read_reqs<TEST_HISTORY_BUFFER_SIZE_KB>(
+        ptr, sequence, HistoryBufferLength:20);
+    let expected = (
+        TestReadReq[RAM_NUM]:[
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x3, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL },
+            TestReadReq { addr: TestRamAddr:0x2, mask: RAM_REQ_MASK_ALL },
+        ],
+        RamOrder[RAM_NUM]:[
+            RamOrder:2, RamOrder:3, RamOrder:4, RamOrder:5, RamOrder:6, RamOrder:7, RamOrder:0,
+            RamOrder:1,
+        ],
+        SequenceExecutorPacket {
+            msg_type: SequenceExecutorMessageType::SEQUENCE,
+            content: CopyOrMatchContent:10,
+            length: CopyOrMatchLength:1,
+            last: false
+        }, true,
+    );
+    assert_eq(result, expected);
+}
+
+struct RamWrRespHandlerData<RAM_ADDR_WIDTH: u32> {
+    resp: bool[RAM_NUM],
+    ptr: HistoryBufferPtr<RAM_ADDR_WIDTH>,
+}
+
+fn create_ram_wr_data<RAM_ADDR_WIDTH: u32, RAM_DATA_WIDTH: u32, RAM_NUM_PARTITIONS: u32>
+    (reqs: ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>[RAM_NUM], ptr: HistoryBufferPtr) -> (bool, RamWrRespHandlerData) {
+    let do_write = for (i, do_write): (u32, bool) in range(u32:0, RAM_NUM) {
+        do_write || reqs[i].mask
+    }(false);
+
+    let resp = bool[RAM_NUM]:[
+            ((reqs[0]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[1]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[2]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[3]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[4]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[5]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[6]).mask != RAM_REQ_MASK_NONE),
+            ((reqs[7]).mask != RAM_REQ_MASK_NONE),
+    ];
+
+    (do_write, RamWrRespHandlerData { resp, ptr })
+}
+
+proc RamWrRespHandler<RAM_ADDR_WIDTH: u32> {
+    input_r: chan<RamWrRespHandlerData> in;
+    output_s: chan<HistoryBufferPtr> out;
+    wr_resp_m0_r: chan<ram::WriteResp> in;
+    wr_resp_m1_r: chan<ram::WriteResp> in;
+    wr_resp_m2_r: chan<ram::WriteResp> in;
+    wr_resp_m3_r: chan<ram::WriteResp> in;
+    wr_resp_m4_r: chan<ram::WriteResp> in;
+    wr_resp_m5_r: chan<ram::WriteResp> in;
+    wr_resp_m6_r: chan<ram::WriteResp> in;
+    wr_resp_m7_r: chan<ram::WriteResp> in;
+
+    config(input_r: chan<RamWrRespHandlerData<RAM_ADDR_WIDTH>> in,
+           output_s: chan<HistoryBufferPtr<RAM_ADDR_WIDTH>> out,
+           wr_resp_m0_r: chan<ram::WriteResp> in, wr_resp_m1_r: chan<ram::WriteResp> in,
+           wr_resp_m2_r: chan<ram::WriteResp> in, wr_resp_m3_r: chan<ram::WriteResp> in,
+           wr_resp_m4_r: chan<ram::WriteResp> in, wr_resp_m5_r: chan<ram::WriteResp> in,
+           wr_resp_m6_r: chan<ram::WriteResp> in, wr_resp_m7_r: chan<ram::WriteResp> in) {
+        (
+            input_r, output_s, wr_resp_m0_r, wr_resp_m1_r, wr_resp_m2_r, wr_resp_m3_r, wr_resp_m4_r,
+            wr_resp_m5_r, wr_resp_m6_r, wr_resp_m7_r,
+        )
+    }
+
+    init {  }
+
+    next(tok0: token, state: ()) {
+        let (tok1, input) = recv(tok0, input_r);
+
+        let (tok2_0, _) = recv_if(tok1, wr_resp_m0_r, input.resp[0], zero!<ram::WriteResp>());
+        let (tok2_1, _) = recv_if(tok1, wr_resp_m1_r, input.resp[1], zero!<ram::WriteResp>());
+        let (tok2_2, _) = recv_if(tok1, wr_resp_m2_r, input.resp[2], zero!<ram::WriteResp>());
+        let (tok2_3, _) = recv_if(tok1, wr_resp_m3_r, input.resp[3], zero!<ram::WriteResp>());
+        let (tok2_4, _) = recv_if(tok1, wr_resp_m4_r, input.resp[4], zero!<ram::WriteResp>());
+        let (tok2_5, _) = recv_if(tok1, wr_resp_m5_r, input.resp[5], zero!<ram::WriteResp>());
+        let (tok2_6, _) = recv_if(tok1, wr_resp_m6_r, input.resp[6], zero!<ram::WriteResp>());
+        let (tok2_7, _) = recv_if(tok1, wr_resp_m7_r, input.resp[7], zero!<ram::WriteResp>());
+        let tok2 = join(tok2_0, tok2_1, tok2_2, tok2_3, tok2_4, tok2_5, tok2_6, tok2_7);
+
+        let tok3 = send(tok2, output_s, input.ptr);
+    }
+}
+
+struct RamRdRespHandlerData {
+    resp: bool[RAM_NUM],
+    order: RamOrder[RAM_NUM],
+    last: bool
+}
+
+fn create_ram_rd_data<RAM_ADDR_WIDTH: u32, RAM_DATA_WIDTH: u32, RAM_NUM_PARTITIONS: u32>
+    (reqs: ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>[RAM_NUM], order: RamOrder[RAM_NUM], last: bool, next_packet_valid: bool) -> (bool, RamRdRespHandlerData) {
+    let do_read = for (i, do_read): (u32, bool) in range(u32:0, RAM_NUM) {
+        do_read || reqs[i].mask
+    }(false);
+
+    let resp = bool[RAM_NUM]:[
+        ((reqs[0]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[1]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[2]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[3]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[4]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[5]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[6]).mask != RAM_REQ_MASK_NONE),
+        ((reqs[7]).mask != RAM_REQ_MASK_NONE),
+    ];
+
+    let last = if next_packet_valid { false } else { last };
+    (do_read, RamRdRespHandlerData { resp, order, last })
+}
+
+proc RamRdRespHandler {
+    input_r: chan<RamRdRespHandlerData> in;
+    output_s: chan<SequenceExecutorPacket> out;
+    rd_resp_m0_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m1_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m2_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m3_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m4_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m5_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m6_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+    rd_resp_m7_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in;
+
+    config(input_r: chan<RamRdRespHandlerData> in, output_s: chan<SequenceExecutorPacket> out,
+           rd_resp_m0_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m1_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m2_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m3_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m4_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m5_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m6_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m7_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in) {
+        (
+            input_r, output_s, rd_resp_m0_r, rd_resp_m1_r, rd_resp_m2_r, rd_resp_m3_r, rd_resp_m4_r,
+            rd_resp_m5_r, rd_resp_m6_r, rd_resp_m7_r,
+        )
+    }
+
+    init {  }
+
+    next(tok0: token, state: ()) {
+        type ReadResp = ram::ReadResp<RAM_DATA_WIDTH>;
+
+        let (tok1, input) = recv(tok0, input_r);
+
+        let (tok2_0, resp_0) = recv_if(tok1, rd_resp_m0_r, input.resp[0], zero!<ReadResp>());
+        let (tok2_1, resp_1) = recv_if(tok1, rd_resp_m1_r, input.resp[1], zero!<ReadResp>());
+        let (tok2_2, resp_2) = recv_if(tok1, rd_resp_m2_r, input.resp[2], zero!<ReadResp>());
+        let (tok2_3, resp_3) = recv_if(tok1, rd_resp_m3_r, input.resp[3], zero!<ReadResp>());
+        let (tok2_4, resp_4) = recv_if(tok1, rd_resp_m4_r, input.resp[4], zero!<ReadResp>());
+        let (tok2_5, resp_5) = recv_if(tok1, rd_resp_m5_r, input.resp[5], zero!<ReadResp>());
+        let (tok2_6, resp_6) = recv_if(tok1, rd_resp_m6_r, input.resp[6], zero!<ReadResp>());
+        let (tok2_7, resp_7) = recv_if(tok1, rd_resp_m7_r, input.resp[7], zero!<ReadResp>());
+        let tok2 = join(tok2_0, tok2_1, tok2_2, tok2_3, tok2_4, tok2_5, tok2_6, tok2_7);
+
+        let content = (resp_0.data as CopyOrMatchContent) << (input.order[0] as CopyOrMatchContent << 3) |
+                      (resp_1.data as CopyOrMatchContent) << (input.order[1] as CopyOrMatchContent << 3) |
+                      (resp_2.data as CopyOrMatchContent) << (input.order[2] as CopyOrMatchContent << 3) |
+                      (resp_3.data as CopyOrMatchContent) << (input.order[3] as CopyOrMatchContent << 3) |
+                      (resp_4.data as CopyOrMatchContent) << (input.order[4] as CopyOrMatchContent << 3) |
+                      (resp_5.data as CopyOrMatchContent) << (input.order[5] as CopyOrMatchContent << 3) |
+                      (resp_6.data as CopyOrMatchContent) << (input.order[6] as CopyOrMatchContent << 3) |
+                      (resp_7.data as CopyOrMatchContent) << (input.order[7] as CopyOrMatchContent << 3);
+
+        let converted = std::convert_to_bits_msb0(input.resp);
+        let length = std::popcount(converted) << 3;
+
+        let output_data = SequenceExecutorPacket {
+            msg_type: SequenceExecutorMessageType::LITERAL,
+            length: length as CopyOrMatchLength,
+            content: content as CopyOrMatchContent,
+            last: input.last,
+        };
+
+        let tok3 = send(tok2, output_s, output_data);
+    }
+}
+
+fn handle_reapeated_offset_for_sequences
+    (seq: SequenceExecutorPacket, repeat_offsets: Offset[3], repeat_req: bool)
+    -> (SequenceExecutorPacket, Offset[3]) {
+    let modified_repeat_offsets = if repeat_req {
+        Offset[3]:[repeat_offsets[1], repeat_offsets[2], repeat_offsets[0] - Offset:1]
+    } else {
+        repeat_offsets
+    };
+
+    let (seq, final_repeat_offsets) = if seq.content == CopyOrMatchContent:0 {
+        fail!(
+            "match_offset_zero_not_allowed",
+            (zero!<SequenceExecutorPacket>(), Offset[3]:[Offset:0, ...]))
+    } else if seq.content == CopyOrMatchContent:1 {
+        let offset = modified_repeat_offsets[0];
+        (
+            SequenceExecutorPacket { content: offset as CopyOrMatchContent, ..seq },
+            Offset[3]:[
+                offset, repeat_offsets[1], repeat_offsets[2],
+            ],
+        )
+    } else if seq.content == CopyOrMatchContent:2 {
+        let offset = modified_repeat_offsets[1];
+        (
+            SequenceExecutorPacket { content: offset as CopyOrMatchContent, ..seq },
+            Offset[3]:[
+                offset, repeat_offsets[0], repeat_offsets[2],
+            ],
+        )
+    } else if seq.content == CopyOrMatchContent:3 {
+        let offset = modified_repeat_offsets[2];
+        (
+            SequenceExecutorPacket { content: offset as CopyOrMatchContent, ..seq },
+            Offset[3]:[
+                offset, repeat_offsets[0], repeat_offsets[1],
+            ],
+        )
+    } else {
+        let offset = seq.content as Offset - Offset:3;
+        (
+            SequenceExecutorPacket { content: offset as CopyOrMatchContent, ..seq },
+            Offset[3]:[
+                offset, repeat_offsets[0], repeat_offsets[1],
+            ],
+        )
+    };
+    (seq, final_repeat_offsets)
+}
+
+proc SequenceExecutor<HISTORY_BUFFER_SIZE_KB: u32,
+     RAM_SIZE: u32 = {ram_size(HISTORY_BUFFER_SIZE_KB)},
+     RAM_ADDR_WIDTH: u32 = {ram_addr_width(HISTORY_BUFFER_SIZE_KB)},
+     INIT_HB_PTR_ADDR: u32 = {u32:0}, INIT_HB_PTR_RAM: u32 = {u32:0},
+     INIT_HB_LENGTH: HistoryBufferLength = {HistoryBufferLength:0},
+     RAM_SIZE_TOTAL: u32 = {RAM_SIZE * RAM_NUM}>
+{
+    input_r: chan<SequenceExecutorPacket> in;
+    output_s: chan<ZstdDecodedPacket> out;
+    ram_comp_input_s: chan<RamWrRespHandlerData<RAM_ADDR_WIDTH>> out;
+    ram_comp_output_r: chan<HistoryBufferPtr<RAM_ADDR_WIDTH>> in;
+    ram_resp_input_s: chan<RamRdRespHandlerData> out;
+    ram_resp_output_r: chan<SequenceExecutorPacket> in;
+    rd_req_m0_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m1_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m2_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m3_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m4_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m5_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m6_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    rd_req_m7_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m0_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m1_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m2_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m3_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m4_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m5_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m6_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+    wr_req_m7_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out;
+
+    config(input_r: chan<SequenceExecutorPacket> in, output_s: chan<ZstdDecodedPacket> out,
+           rd_req_m0_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m1_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m2_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m3_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m4_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m5_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m6_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_req_m7_s: chan<ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>> out,
+           rd_resp_m0_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m1_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m2_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m3_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m4_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m5_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m6_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           rd_resp_m7_r: chan<ram::ReadResp<RAM_DATA_WIDTH>> in,
+           wr_req_m0_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m1_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m2_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m3_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m4_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m5_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m6_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_req_m7_s: chan<ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>> out,
+           wr_resp_m0_r: chan<ram::WriteResp> in,
+           wr_resp_m1_r: chan<ram::WriteResp> in,
+           wr_resp_m2_r: chan<ram::WriteResp> in,
+           wr_resp_m3_r: chan<ram::WriteResp> in,
+           wr_resp_m4_r: chan<ram::WriteResp> in,
+           wr_resp_m5_r: chan<ram::WriteResp> in,
+           wr_resp_m6_r: chan<ram::WriteResp> in,
+           wr_resp_m7_r: chan<ram::WriteResp> in
+    ) {
+        let (ram_comp_input_s, ram_comp_input_r) = chan<RamWrRespHandlerData<RAM_ADDR_WIDTH>, u32:1>;
+        let (ram_comp_output_s, ram_comp_output_r) = chan<HistoryBufferPtr<RAM_ADDR_WIDTH>, u32:1>;
+        let (ram_resp_input_s, ram_resp_input_r) = chan<RamRdRespHandlerData, u32:1>;
+        let (ram_resp_output_s, ram_resp_output_r) = chan<SequenceExecutorPacket, u32:1>;
+
+        spawn RamWrRespHandler<RAM_ADDR_WIDTH>(
+            ram_comp_input_r, ram_comp_output_s,
+            wr_resp_m0_r, wr_resp_m1_r, wr_resp_m2_r, wr_resp_m3_r,
+            wr_resp_m4_r, wr_resp_m5_r, wr_resp_m6_r, wr_resp_m7_r);
+
+        spawn RamRdRespHandler(
+            ram_resp_input_r, ram_resp_output_s,
+            rd_resp_m0_r, rd_resp_m1_r, rd_resp_m2_r,
+            rd_resp_m3_r, rd_resp_m4_r, rd_resp_m5_r, rd_resp_m6_r, rd_resp_m7_r);
+
+        (
+            input_r, output_s,
+            ram_comp_input_s, ram_comp_output_r,
+            ram_resp_input_s, ram_resp_output_r,
+            rd_req_m0_s, rd_req_m1_s, rd_req_m2_s, rd_req_m3_s,
+            rd_req_m4_s, rd_req_m5_s, rd_req_m6_s, rd_req_m7_s,
+            wr_req_m0_s, wr_req_m1_s, wr_req_m2_s, wr_req_m3_s,
+            wr_req_m4_s, wr_req_m5_s, wr_req_m6_s, wr_req_m7_s,
+        )
+    }
+
+    init {
+        const_assert!(INIT_HB_PTR_RAM < RAM_NUM);
+        const_assert!(INIT_HB_PTR_ADDR <= (std::unsigned_max_value<RAM_ADDR_WIDTH>() as u32));
+
+        type RamAddr = bits[RAM_ADDR_WIDTH];
+        let INIT_HB_PTR = HistoryBufferPtr {
+            number: INIT_HB_PTR_RAM as RamNumber, addr: INIT_HB_PTR_ADDR as RamAddr
+        };
+        SequenceExecutorState {
+            status: SequenceExecutorStatus::IDLE,
+            packet: zero!<SequenceExecutorPacket>(),
+            packet_valid: false,
+            hyp_ptr: INIT_HB_PTR,
+            real_ptr: INIT_HB_PTR,
+            hb_len: INIT_HB_LENGTH,
+            repeat_offsets: Offset[3]:[Offset:1, Offset:4, Offset:8],
+            repeat_req: false,
+            seq_cnt: false
+        }
+    }
+
+    next(tok0: token, state: SequenceExecutorState<RAM_ADDR_WIDTH>) {
+        type Status = SequenceExecutorStatus;
+        type State = SequenceExecutorState<RAM_ADDR_WIDTH>;
+        type MsgType = SequenceExecutorMessageType;
+        type Packet = SequenceExecutorPacket;
+        type ReadReq = ram::ReadReq<RAM_ADDR_WIDTH, RAM_NUM_PARTITIONS>;
+        type ReadResp = ram::ReadResp<RAM_DATA_WIDTH>;
+        type WriteReq = ram::WriteReq<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>;
+        type WriteResp = ram::WriteResp;
+
+        const ZERO_READ_REQS = ReadReq[RAM_NUM]:[zero!<ReadReq>(), ...];
+        const ZERO_WRITE_REQS = WriteReq[RAM_NUM]:[zero!<WriteReq>(), ...];
+        const ZERO_ORDER = RamOrder[RAM_NUM]:[RamOrder:0, ...];
+
+        // Recieve literals and sequences from the input channel ...
+        let do_recv_input = !state.packet_valid && state.status != Status::SEQUENCE_READ &&
+                            state.status != Status::SEQUENCE_WRITE;
+        let (tok1_0, input_packet, input_packet_valid) =
+            recv_if_non_blocking(tok0, input_r, do_recv_input, zero!<Packet>());
+
+        // ... or our own sequences from the looped channel
+        let do_recv_ram =
+            (state.status == Status::SEQUENCE_READ || state.status == Status::SEQUENCE_WRITE);
+        let (tok1_1, ram_packet, ram_packet_valid) =
+            recv_if_non_blocking(tok0, ram_resp_output_r, do_recv_ram, zero!<Packet>());
+
+        // Read RAM write completion, used for monitoring the real state
+        // of the RAM and eventually changing the state to IDLE.
+        // Going through the IDLE state is required for changing between
+        // Literals and Sequences (and the other way around) and between every
+        // Sequence read from the input (original sequence from the ZSTD stream).
+        let (tok1_2, real_ptr, real_ptr_valid) =
+            recv_non_blocking(tok0, ram_comp_output_r, zero!<HistoryBufferPtr>());
+        if real_ptr_valid {
+            trace_fmt!("SequenceExecutor:: Received completion update");
+        } else { };
+
+        let real_ptr = if real_ptr_valid { real_ptr } else { state.real_ptr };
+        let tok1 = join(tok1_0, tok1_1, tok1_2);
+
+        // Since we either get data from input, from frame, or from state,
+        // we are always working on a single packet. The current state
+        // can be use to determine the source of the packet.
+        let (packet, packet_valid) = if input_packet_valid {
+            (input_packet, true)
+        } else if ram_packet_valid {
+            (ram_packet, true)
+        } else {
+            (state.packet, state.packet_valid)
+        };
+
+        // if we are in the IDLE state and have a valid packet sotred in the state,
+        // or we have a new packet from the input go to the corresponding
+        // processing step immediately. (added to be able to process a single
+        // literal in one next() evaluation)
+        let status = match (state.status, packet_valid, packet.msg_type) {
+            (Status::IDLE, true, MsgType::LITERAL) => Status::LITERAL_WRITE,
+            (Status::IDLE, true, MsgType::SEQUENCE) => Status::SEQUENCE_READ,
+            _ => state.status,
+        };
+
+        let NO_VALID_PACKET_STATE = State { packet, packet_valid, real_ptr, ..state };
+        let (write_reqs, read_reqs, order, new_state) = match (
+            status, packet_valid, packet.msg_type
+        ) {
+            // Handling LITERAL_WRITE
+            (Status::LITERAL_WRITE, true, MsgType::LITERAL) => {
+                trace_fmt!("SequenceExecutor:: Handling LITERAL packet in LITERAL_WRITE step");
+                let (write_reqs, new_hyp_ptr) =
+                    literal_packet_to_write_reqs<HISTORY_BUFFER_SIZE_KB>(state.hyp_ptr, packet);
+                let new_repeat_req = packet.length == CopyOrMatchLength:0;
+                let hb_add = (packet.length >> 3) as HistoryBufferLength;
+                let new_hb_len = std::mod_pow2(state.hb_len + hb_add, RAM_SIZE_TOTAL);
+
+                (
+                    write_reqs, ZERO_READ_REQS, ZERO_ORDER,
+                    State {
+                        status: Status::LITERAL_WRITE,
+                        packet: zero!<SequenceExecutorPacket>(),
+                        packet_valid: false,
+                        hyp_ptr: new_hyp_ptr,
+                        real_ptr,
+                        repeat_offsets: state.repeat_offsets,
+                        repeat_req: new_repeat_req,
+                        hb_len: new_hb_len,
+                        seq_cnt: false
+                    },
+                )
+            },
+            (Status::LITERAL_WRITE, _, _) => {
+                let status =
+                    if real_ptr == state.hyp_ptr { Status::IDLE } else { Status::LITERAL_WRITE };
+                (
+                    ZERO_WRITE_REQS, ZERO_READ_REQS, ZERO_ORDER,
+                    State { status, ..NO_VALID_PACKET_STATE },
+                )
+            },
+            // Handling SEQUENCE_READ
+            (Status::SEQUENCE_READ, true, MsgType::SEQUENCE) => {
+                trace_fmt!("Handling SEQUENCE in SEQUENCE_READ state");
+                let (packet, new_repeat_offsets) = if !state.seq_cnt {
+                    handle_reapeated_offset_for_sequences(
+                        packet, state.repeat_offsets, state.repeat_req)
+                } else {
+                    (packet, state.repeat_offsets)
+                };
+                let (read_reqs, order, packet, packet_valid) = sequence_packet_to_read_reqs<
+                    HISTORY_BUFFER_SIZE_KB>(
+                    state.hyp_ptr, packet, state.hb_len);
+
+                (
+                    ZERO_WRITE_REQS, read_reqs, order,
+                    SequenceExecutorState {
+                        status: Status::SEQUENCE_WRITE,
+                        packet,
+                        packet_valid,
+                        hyp_ptr: state.hyp_ptr,
+                        real_ptr,
+                        repeat_offsets: new_repeat_offsets,
+                        repeat_req: false,
+                        hb_len: state.hb_len,
+                        seq_cnt: packet_valid
+                    },
+                )
+            },
+            (Status::SEQUENCE_READ, _, _) => {
+                let ZERO_RETURN = (ZERO_WRITE_REQS, ZERO_READ_REQS, ZERO_ORDER, zero!<State>());
+                fail!("should_no_happen", (ZERO_RETURN))
+            },
+            // Handling SEQUENCE_WRITE
+            (Status::SEQUENCE_WRITE, true, MsgType::LITERAL) => {
+                trace_fmt!("Handling LITERAL in SEQUENCE_WRITE state: {}", status);
+                let (write_reqs, new_hyp_ptr) =
+                    literal_packet_to_write_reqs<HISTORY_BUFFER_SIZE_KB>(state.hyp_ptr, packet);
+                let hb_add = packet.length as HistoryBufferLength;
+                let new_hb_len = std::mod_pow2(state.hb_len + hb_add, RAM_SIZE_TOTAL);
+
+                (
+                    write_reqs, ZERO_READ_REQS, ZERO_ORDER,
+                    SequenceExecutorState {
+                        status: zero!<SequenceExecutorStatus>(),
+                        packet: state.packet,
+                        packet_valid: state.packet_valid,
+                        hyp_ptr: new_hyp_ptr,
+                        real_ptr,
+                        repeat_offsets: state.repeat_offsets,
+                        repeat_req: state.repeat_req,
+                        hb_len: new_hb_len,
+                        seq_cnt: state.seq_cnt
+                    },
+                )
+            },
+            (Status::SEQUENCE_WRITE, _, _) => {
+                let status = if real_ptr == state.hyp_ptr {
+                    Status::IDLE
+                } else if state.seq_cnt {
+                    Status::SEQUENCE_READ
+                } else {
+                    Status::SEQUENCE_WRITE
+                };
+                (
+                    ZERO_WRITE_REQS, ZERO_READ_REQS, ZERO_ORDER,
+                    State { status, ..NO_VALID_PACKET_STATE },
+                )
+            },
+            // Handling IDLE
+            _ => {
+                let status = Status::IDLE;
+                (
+                    ZERO_WRITE_REQS, ZERO_READ_REQS, ZERO_ORDER,
+                    State { status, ..NO_VALID_PACKET_STATE },
+                )
+            },
+        };
+
+        let tok2_1 = send_if(tok1, wr_req_m0_s, (write_reqs[0]).mask != RAM_REQ_MASK_NONE, write_reqs[0]);
+        let tok2_2 = send_if(tok1, wr_req_m1_s, (write_reqs[1]).mask != RAM_REQ_MASK_NONE, write_reqs[1]);
+        let tok2_3 = send_if(tok1, wr_req_m2_s, (write_reqs[2]).mask != RAM_REQ_MASK_NONE, write_reqs[2]);
+        let tok2_4 = send_if(tok1, wr_req_m3_s, (write_reqs[3]).mask != RAM_REQ_MASK_NONE, write_reqs[3]);
+        let tok2_5 = send_if(tok1, wr_req_m4_s, (write_reqs[4]).mask != RAM_REQ_MASK_NONE, write_reqs[4]);
+        let tok2_6 = send_if(tok1, wr_req_m5_s, (write_reqs[5]).mask != RAM_REQ_MASK_NONE, write_reqs[5]);
+        let tok2_7 = send_if(tok1, wr_req_m6_s, (write_reqs[6]).mask != RAM_REQ_MASK_NONE, write_reqs[6]);
+        let tok2_8 = send_if(tok1, wr_req_m7_s, (write_reqs[7]).mask != RAM_REQ_MASK_NONE, write_reqs[7]);
+
+        // Write to output ask for completion
+        let (do_write, wr_resp_handler_data) = create_ram_wr_data(write_reqs, new_state.hyp_ptr);
+        if do_write {
+            trace_fmt!("Sending request to RamWrRespHandler: {:#x}", wr_resp_handler_data);
+        } else { };
+        let tok2_9 = send_if(tok1, ram_comp_input_s, do_write, wr_resp_handler_data);
+
+        let output_data = decode_literal_packet(packet);
+        if do_write { trace_fmt!("Sending output data: {:#x}", output_data); } else {  };
+        let tok2_10 = send_if(tok1, output_s, do_write, output_data);
+
+        // Ask for response
+        let tok2_11 = send_if(tok1, rd_req_m0_s, (read_reqs[0]).mask != RAM_REQ_MASK_NONE, read_reqs[0]);
+        let tok2_12 = send_if(tok1, rd_req_m1_s, (read_reqs[1]).mask != RAM_REQ_MASK_NONE, read_reqs[1]);
+        let tok2_13 = send_if(tok1, rd_req_m2_s, (read_reqs[2]).mask != RAM_REQ_MASK_NONE, read_reqs[2]);
+        let tok2_14 = send_if(tok1, rd_req_m3_s, (read_reqs[3]).mask != RAM_REQ_MASK_NONE, read_reqs[3]);
+        let tok2_15 = send_if(tok1, rd_req_m4_s, (read_reqs[4]).mask != RAM_REQ_MASK_NONE, read_reqs[4]);
+        let tok2_16 = send_if(tok1, rd_req_m5_s, (read_reqs[5]).mask != RAM_REQ_MASK_NONE, read_reqs[5]);
+        let tok2_17 = send_if(tok1, rd_req_m6_s, (read_reqs[6]).mask != RAM_REQ_MASK_NONE, read_reqs[6]);
+        let tok2_18 = send_if(tok1, rd_req_m7_s, (read_reqs[7]).mask != RAM_REQ_MASK_NONE, read_reqs[7]);
+
+        let (do_read, rd_resp_handler_data) =
+            create_ram_rd_data<RAM_ADDR_WIDTH, RAM_DATA_WIDTH, RAM_NUM_PARTITIONS>
+            (read_reqs, order, packet.last, new_state.packet_valid);
+        if do_read {
+            trace_fmt!("Sending request to RamRdRespHandler: {:#x}", rd_resp_handler_data);
+        } else { };
+        let tok2_19 = send_if(tok1, ram_resp_input_s, do_read, rd_resp_handler_data);
+
+        new_state
+    }
+}
+
+const LITERAL_TEST_INPUT_DATA = SequenceExecutorPacket[6]:[
+     SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:64,
+        content: CopyOrMatchContent:0xAA00BB11CC22DD33,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:64,
+        content: CopyOrMatchContent:0x447733220088CCFF,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:32,
+        content: CopyOrMatchContent:0x88AA0022,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:32,
+        content: CopyOrMatchContent:0xFFEEDD11,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:64,
+        content: CopyOrMatchContent:0x9DAF8B41C913EFDA,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:64,
+        content: CopyOrMatchContent:0x157D8C7EB8B97CA3,
+        last: true
+    },
+];
+
+const LITERAL_TEST_MEMORY_CONTENT:(TestRamAddr, RamData)[3][RAM_NUM] = [
+    [
+        (TestRamAddr:127, RamData:0x33),
+        (TestRamAddr:0, RamData:0xFF),
+        (TestRamAddr:1, RamData:0x22)
+    ],
+    [
+        (TestRamAddr:127, RamData:0xDD),
+        (TestRamAddr:0, RamData:0xCC),
+        (TestRamAddr:1, RamData:0x00)
+    ],
+    [
+        (TestRamAddr:127, RamData:0x22),
+        (TestRamAddr:0, RamData:0x88),
+        (TestRamAddr:1, RamData:0xAA)
+    ],
+    [
+        (TestRamAddr:127, RamData:0xCC),
+        (TestRamAddr:0, RamData:0x00),
+        (TestRamAddr:1, RamData:0x88)
+    ],
+    [
+        (TestRamAddr:127, RamData:0x11),
+        (TestRamAddr:0, RamData:0x22),
+        (TestRamAddr:1, RamData:0x11)
+    ],
+    [
+        (TestRamAddr:127, RamData:0xBB),
+        (TestRamAddr:0, RamData:0x33),
+        (TestRamAddr:1, RamData:0xDD)
+    ],
+    [
+        (TestRamAddr:127, RamData:0x00),
+        (TestRamAddr:0, RamData:0x77),
+        (TestRamAddr:1, RamData:0xEE)
+    ],
+    [
+        (TestRamAddr:127, RamData:0xAA),
+        (TestRamAddr:0, RamData:0x44),
+        (TestRamAddr:1, RamData:0xFF)
+    ],
+];
+
+#[test_proc]
+proc SequenceExecutorLiteralsTest {
+    terminator: chan<bool> out;
+
+    input_s: chan<SequenceExecutorPacket<TEST_RAM_ADDR_WIDTH>> out;
+    output_r: chan<ZstdDecodedPacket> in;
+
+    print_start_s: chan<()> out;
+    print_finish_r: chan<()> in;
+
+    ram_rd_req_s: chan<TestReadReq>[RAM_NUM] out;
+    ram_rd_resp_r: chan<TestReadResp>[RAM_NUM] in;
+    ram_wr_req_s: chan<TestWriteReq>[RAM_NUM] out;
+    ram_wr_resp_r: chan<TestWriteResp>[RAM_NUM] in;
+
+    config(terminator: chan<bool> out) {
+        let (input_s,  input_r) = chan<SequenceExecutorPacket<TEST_RAM_ADDR_WIDTH>>;
+        let (output_s, output_r) = chan<ZstdDecodedPacket>;
+
+        let (print_start_s, print_start_r) = chan<()>;
+        let (print_finish_s, print_finish_r) = chan<()>;
+
+        let (ram_rd_req_s,  ram_rd_req_r) = chan<TestReadReq>[RAM_NUM];
+        let (ram_rd_resp_s, ram_rd_resp_r) = chan<TestReadResp>[RAM_NUM];
+        let (ram_wr_req_s,  ram_wr_req_r) = chan<TestWriteReq>[RAM_NUM];
+        let (ram_wr_resp_s, ram_wr_resp_r) = chan<TestWriteResp>[RAM_NUM];
+
+        let INIT_HB_PTR_ADDR = u32:127;
+        spawn SequenceExecutor<
+            TEST_HISTORY_BUFFER_SIZE_KB,
+            TEST_RAM_SIZE,
+            TEST_RAM_ADDR_WIDTH,
+            INIT_HB_PTR_ADDR,
+        > (
+            input_r, output_s,
+            ram_rd_req_s[0], ram_rd_req_s[1], ram_rd_req_s[2], ram_rd_req_s[3],
+            ram_rd_req_s[4], ram_rd_req_s[5], ram_rd_req_s[6], ram_rd_req_s[7],
+            ram_rd_resp_r[0], ram_rd_resp_r[1], ram_rd_resp_r[2], ram_rd_resp_r[3],
+            ram_rd_resp_r[4], ram_rd_resp_r[5], ram_rd_resp_r[6], ram_rd_resp_r[7],
+            ram_wr_req_s[0], ram_wr_req_s[1], ram_wr_req_s[2], ram_wr_req_s[3],
+            ram_wr_req_s[4], ram_wr_req_s[5], ram_wr_req_s[6], ram_wr_req_s[7],
+            ram_wr_resp_r[0], ram_wr_resp_r[1], ram_wr_resp_r[2], ram_wr_resp_r[3],
+            ram_wr_resp_r[4], ram_wr_resp_r[5], ram_wr_resp_r[6], ram_wr_resp_r[7]
+        );
+
+        spawn ram_printer::RamPrinter<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_NUM_PARTITIONS,
+            TEST_RAM_ADDR_WIDTH, RAM_NUM>
+            (print_start_r, print_finish_s, ram_rd_req_s, ram_rd_resp_r);
+
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[0], ram_rd_resp_s[0], ram_wr_req_r[0], ram_wr_resp_s[0]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[1], ram_rd_resp_s[1], ram_wr_req_r[1], ram_wr_resp_s[1]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[2], ram_rd_resp_s[2], ram_wr_req_r[2], ram_wr_resp_s[2]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[3], ram_rd_resp_s[3], ram_wr_req_r[3], ram_wr_resp_s[3]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[4], ram_rd_resp_s[4], ram_wr_req_r[4], ram_wr_resp_s[4]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[5], ram_rd_resp_s[5], ram_wr_req_r[5], ram_wr_resp_s[5]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[6], ram_rd_resp_s[6], ram_wr_req_r[6], ram_wr_resp_s[6]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[7], ram_rd_resp_s[7], ram_wr_req_r[7], ram_wr_resp_s[7]);
+
+        (
+            terminator,
+            input_s, output_r,
+            print_start_s, print_finish_r,
+            ram_rd_req_s, ram_rd_resp_r,
+            ram_wr_req_s, ram_wr_resp_r
+        )
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        for (i, ()): (u32, ()) in range(u32:0, array_size(LITERAL_TEST_INPUT_DATA)) {
+            let tok = send(tok, input_s, LITERAL_TEST_INPUT_DATA[i]);
+            let (tok, recv_data) = recv(tok, output_r);
+            let expected = decode_literal_packet(LITERAL_TEST_INPUT_DATA[i]);
+            assert_eq(expected, recv_data);
+        }(());
+
+        for (i, ()): (u32, ()) in range(u32:0, RAM_NUM) {
+            for (j, ()): (u32, ()) in range(u32:0, array_size(LITERAL_TEST_MEMORY_CONTENT[0])) {
+                let addr = LITERAL_TEST_MEMORY_CONTENT[i][j].0;
+                let tok = send(tok, ram_rd_req_s[i], TestReadReq { addr, mask: RAM_REQ_MASK_ALL });
+                let (tok, resp) = recv(tok, ram_rd_resp_r[i]);
+                let expected = LITERAL_TEST_MEMORY_CONTENT[i][j].1;
+                assert_eq(expected, resp.data);
+            }(());
+        }(());
+
+        // Print RAM content
+        let tok = send(tok, print_start_s, ());
+        let (tok, _) = recv(tok, print_finish_r);
+
+        send(tok, terminator, true);
+    }
+}
+
+const SEQUENCE_TEST_INPUT_SEQUENCES = SequenceExecutorPacket[11]: [
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:9,
+        content: CopyOrMatchContent:13,
+        last: false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:1,
+        content: CopyOrMatchContent:7,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:1,
+        content: CopyOrMatchContent:8,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:5,
+        content: CopyOrMatchContent:13,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:3,
+        content: CopyOrMatchContent:3,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:1,
+        content: CopyOrMatchContent:1,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:0,
+        content: CopyOrMatchContent:0,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:1,
+        content: CopyOrMatchContent:3,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::LITERAL,
+        length: CopyOrMatchLength:0,
+        content: CopyOrMatchContent:0,
+        last:false
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:10,
+        content: CopyOrMatchContent:2,
+        last:true,
+    },
+    SequenceExecutorPacket {
+        msg_type: SequenceExecutorMessageType::SEQUENCE,
+        length: CopyOrMatchLength:1,
+        content: CopyOrMatchContent:3,
+        last:false
+    },
+];
+
+const SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS:ZstdDecodedPacket[11] = [
+    ZstdDecodedPacket {
+        data: BlockData:0x8C_7E_B8_B9_7C_A3_9D_AF,
+        length: BlockPacketLength:64,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0x7D,
+        length: BlockPacketLength:8,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB8,
+        length: BlockPacketLength:8,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB8,
+        length: BlockPacketLength:8,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB8_B9_7C_A3_9D,
+        length: BlockPacketLength:40,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB9_7C_A3,
+        length: BlockPacketLength:24,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB8,
+        length: BlockPacketLength:8,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0x7C,
+        length: BlockPacketLength:8,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0xB9_7C_A3_B8_B9_7C_A3_9D,
+        length: BlockPacketLength:64,
+        last: false
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0x7C_B8,
+        length: BlockPacketLength:16,
+        last: true
+    },
+    ZstdDecodedPacket {
+        data: BlockData:0x9D,
+        length: BlockPacketLength:8,
+        last: false
+    }
+];
+
+#[test_proc]
+proc SequenceExecutorSequenceTest {
+    terminator: chan<bool> out;
+
+    input_s: chan<SequenceExecutorPacket> out;
+    output_r: chan<ZstdDecodedPacket> in;
+
+    print_start_s: chan<()> out;
+    print_finish_r: chan<()> in;
+
+    ram_rd_req_s: chan<TestReadReq>[RAM_NUM] out;
+    ram_rd_resp_r: chan<TestReadResp>[RAM_NUM] in;
+    ram_wr_req_s: chan<TestWriteReq>[RAM_NUM] out;
+    ram_wr_resp_r: chan<TestWriteResp>[RAM_NUM] in;
+
+    config(terminator: chan<bool> out) {
+        let (input_s, input_r) = chan<SequenceExecutorPacket>;
+        let (output_s, output_r) = chan<ZstdDecodedPacket>;
+
+        let (print_start_s, print_start_r) = chan<()>;
+        let (print_finish_s, print_finish_r) = chan<()>;
+
+        let (ram_rd_req_s, ram_rd_req_r) = chan<TestReadReq>[RAM_NUM];
+        let (ram_rd_resp_s, ram_rd_resp_r) = chan<TestReadResp>[RAM_NUM];
+        let (ram_wr_req_s, ram_wr_req_r) = chan<TestWriteReq>[RAM_NUM];
+        let (ram_wr_resp_s, ram_wr_resp_r) = chan<TestWriteResp>[RAM_NUM];
+
+        let INIT_HB_PTR_ADDR = u32:127;
+        spawn SequenceExecutor<
+            TEST_HISTORY_BUFFER_SIZE_KB,
+            TEST_RAM_SIZE,
+            TEST_RAM_ADDR_WIDTH,
+            INIT_HB_PTR_ADDR,
+        > (
+            input_r, output_s,
+            ram_rd_req_s[0], ram_rd_req_s[1], ram_rd_req_s[2], ram_rd_req_s[3],
+            ram_rd_req_s[4], ram_rd_req_s[5], ram_rd_req_s[6], ram_rd_req_s[7],
+            ram_rd_resp_r[0], ram_rd_resp_r[1], ram_rd_resp_r[2], ram_rd_resp_r[3],
+            ram_rd_resp_r[4], ram_rd_resp_r[5], ram_rd_resp_r[6], ram_rd_resp_r[7],
+            ram_wr_req_s[0], ram_wr_req_s[1], ram_wr_req_s[2], ram_wr_req_s[3],
+            ram_wr_req_s[4], ram_wr_req_s[5], ram_wr_req_s[6], ram_wr_req_s[7],
+            ram_wr_resp_r[0], ram_wr_resp_r[1], ram_wr_resp_r[2], ram_wr_resp_r[3],
+            ram_wr_resp_r[4], ram_wr_resp_r[5], ram_wr_resp_r[6], ram_wr_resp_r[7]
+        );
+
+        spawn ram_printer::RamPrinter<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_NUM_PARTITIONS,
+            TEST_RAM_ADDR_WIDTH, RAM_NUM>
+            (print_start_r, print_finish_s, ram_rd_req_s, ram_rd_resp_r);
+
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[0], ram_rd_resp_s[0], ram_wr_req_r[0], ram_wr_resp_s[0]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[1], ram_rd_resp_s[1], ram_wr_req_r[1], ram_wr_resp_s[1]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[2], ram_rd_resp_s[2], ram_wr_req_r[2], ram_wr_resp_s[2]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[3], ram_rd_resp_s[3], ram_wr_req_r[3], ram_wr_resp_s[3]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[4], ram_rd_resp_s[4], ram_wr_req_r[4], ram_wr_resp_s[4]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[5], ram_rd_resp_s[5], ram_wr_req_r[5], ram_wr_resp_s[5]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[6], ram_rd_resp_s[6], ram_wr_req_r[6], ram_wr_resp_s[6]);
+        spawn ram::RamModel<
+            RAM_DATA_WIDTH, TEST_RAM_SIZE, RAM_WORD_PARTITION_SIZE,
+            TEST_RAM_SIMULTANEOUS_READ_WRITE_BEHAVIOR, TEST_RAM_INITIALIZED>
+            (ram_rd_req_r[7], ram_rd_resp_s[7], ram_wr_req_r[7], ram_wr_resp_s[7]);
+
+        (
+            terminator,
+            input_s, output_r,
+            print_start_s, print_finish_r,
+            ram_rd_req_s, ram_rd_resp_r, ram_wr_req_s, ram_wr_resp_r
+        )
+    }
+
+    init {  }
+
+    next(tok: token, state: ()) {
+        for (i, ()): (u32, ()) in range(u32:0, array_size(LITERAL_TEST_INPUT_DATA)) {
+            let tok = send(tok, input_s, LITERAL_TEST_INPUT_DATA[i]);
+            let (tok, recv_data) = recv(tok, output_r);
+            let expected = decode_literal_packet(LITERAL_TEST_INPUT_DATA[i]);
+            assert_eq(expected, recv_data);
+        }(());
+
+        // Print RAM content
+        let tok = send(tok, print_start_s, ());
+        let (tok, _) = recv(tok, print_finish_r);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[0]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[0], recv_data);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[1], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[1]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[2], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[2]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[3], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[3]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[4], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[4]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[5], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[5]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[6], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[6]);
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[7]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[7], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[8]);
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[9]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[8], recv_data);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[9], recv_data);
+
+        let tok = send(tok, input_s, SEQUENCE_TEST_INPUT_SEQUENCES[10]);
+        let (tok, recv_data) = recv(tok, output_r);
+        assert_eq(SEQUENCE_TEST_EXPECTED_SEQUENCE_RESULTS[10], recv_data);
+
+        // Print RAM content
+        let tok = send(tok, print_start_s, ());
+        let (tok, _) = recv(tok, print_finish_r);
+        send(tok, terminator, true);
+    }
+}


### PR DESCRIPTION
This PR adds `Repacketizer` proc. It is used at the end of the processing flow in the ZSTD decoder. It gathers the output of `SequenceExecutor` proc, removes the bits that are not marked as valid and creates new packets with payloads having only valid bits. Such packets are then send out to the output of the whole ZSTD decoder.

NOTE: this is based on https://github.com/google/xls/pull/1295 , please ignore commits from that branch when reviewing.
This is part of https://github.com/google/xls/issues/1211.