### PR TITLE
dependency_support: rules_hdl: bump repository

### DIFF
--- a/dependency_support/rules_hdl/workspace.bzl
+++ b/dependency_support/rules_hdl/workspace.bzl
@@ -37,9 +37,9 @@ def repo():
         sha256 = "fd9e99f6ccb9e946755f9bc444abefbdd1eedb32c372c56dcacc7eb486aed178",
     )
 
-    # Current as of 2024-02-01
-    git_hash = "b99dfa1869f340c0e598522960ff514345b40a7b"
-    archive_sha256 = "2a6da82f4f51aefa38ddf82291d49846736dd6abf95f3ea149129eb985ae09ed"
+    # Current as of 2024-03-01
+    git_hash = "ca20ad4e71888c3b9c3c28639cef70bcf2275c4d"
+    archive_sha256 = "57dbbb2764690730bf621837e0332c87a919623cfbca9870195849dfc096d51f"
 
     maybe(
         http_archive,


### PR DESCRIPTION
Bump [bazel_rules_hdl](https://github.com/hdl/bazel_rules_hdl) to a version with fix for segfaults and freezes of openroad (https://github.com/hdl/bazel_rules_hdl/pull/285, openroad fix: https://github.com/The-OpenROAD-Project/OpenSTA/pull/227).
This should fix failures of physical design flows which block https://github.com/google/xls/issues/1211. The example of failing flow is available in [this](https://github.com/google/xls/actions/runs/7990320599/job/21818879438?pr=1213#step:8:24507) CI run.

CC @proppy 