### PR TITLE
replace `polyfill.io` to reduce supply chain risk

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,7 +91,7 @@ markdown_extensions:
   - footnotes
   - attr_list
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 plugins:
   - exclude:


### PR DESCRIPTION
replace `polyfill.io` to reduce supply chain risk.

ref: https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk
polyfillpolyfill/polyfill-service#2834