### PR TITLE
Update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Set up the environment with the following inputs '...'
+2. Execute the command '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (this can be helpful for troubleshooting):**
+ - OS: [e.g. Ubuntu]
+ - Versions [e.g. 22.04]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: XLS Discussions
+    url:  https://github.com/google/xls/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/enhancement-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement-proposal.yml
@@ -1,0 +1,34 @@
+name: Enhancement Proposal
+description: Submit an enhancement proposal
+title: "[Enhancement]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For things that are hard to do with XLS, we'd love to hear about them! Some requests:
+        * Please keep it short
+        * Please include code samples where possible
+        * Please use pictures or diagrams where possible
+        * Focus on the problem more than the requested solution - for problems we address, we may brainstorm with you on a solution.
+  - type: textarea
+    id: what-do
+    attributes:
+      label: What's hard to do? (limit 100 words)
+      description: Provide an expression of the result you want to achieve. This can be a snippet of SystemVerilog, maybe a diagram, or a written description.
+    validations:
+      required: true
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current best alternative workaround (limit 100 words)
+      description: What happens if we do nothing? What will you do instead?
+    validations:
+      required: true
+  - type: textarea
+    id: best-case
+    attributes:
+      label: Your view of the "best case XLS enhancement" (limit 100 words)
+      description: Please do include this, but don't overthink it. Focus on the result and not the "inside XLS mechanism," since there could be multiple ways to address this.
+    validations:
+      required: true


### PR DESCRIPTION
This updates the XLS issue flow by adding an interstitial step to present users with 3 choices: Bug report, Enhancement proposal, and a link to GitHub discussions.  The Enhancement proposal is a form with specific inputs to aid our triaging process. Previews are below:

**Interstitial "new issue" screen:**
<img width="778" alt="01-Issue-Select" src="https://github.com/google/xls/assets/7234566/c36aea86-a993-490d-a6cc-f4d601cdab06">

**Bug report:**
<img width="740" alt="02-Issue-Bug-Report" src="https://github.com/google/xls/assets/7234566/7377b886-25bc-40a2-84d5-4a3ef236f2ff">

**Enhancement proposal form:**
<img width="750" alt="03-Issue-Enhancement-Proposal" src="https://github.com/google/xls/assets/7234566/34413a6b-0aca-49b8-a884-9c14d93f9b0b">
