### PR TITLE
Start of C API, amenable to FFI binding.

### DIFF
--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -145,3 +145,24 @@ cc_library(
         "//xls/ir:ir_parser",
     ],
 )
+
+cc_library(
+    name = "c_api",
+    srcs = ["c_api.cc"],
+    hdrs = ["c_api.h"],
+    deps = [
+        ":runtime_build_actions",
+    ],
+)
+
+cc_test(
+    name = "c_api_test",
+    srcs = ["c_api_test.cc"],
+    deps = [
+        ":c_api",
+        "//xls/common:xls_gunit",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+    ],
+)
+

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -1,0 +1,85 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/c_api.h"
+
+#include "xls/public/runtime_build_actions.h"
+
+namespace {
+
+std::vector<std::filesystem::path> ToCpp(const char* additional_search_paths[],
+                                         size_t additional_search_paths_count) {
+  std::vector<std::filesystem::path> additional_search_paths_cpp;
+  additional_search_paths_cpp.reserve(additional_search_paths_count);
+  for (size_t i = 0; i < additional_search_paths_count; ++i) {
+    const char* additional_search_path = additional_search_paths[i];
+    CHECK(additional_search_path != nullptr);
+    additional_search_paths_cpp.push_back(additional_search_path);
+  }
+  return additional_search_paths_cpp;
+}
+
+char* ToOwnedCString(const std::string& s) { return strdup(s.c_str()); }
+
+}  // namespace
+
+extern "C" {
+
+bool ConvertDslxToIr(const char* dslx, const char* path,
+                     const char* module_name, const char* dslx_stdlib_path,
+                     const char* additional_search_paths[],
+                     size_t additional_search_paths_count, char** error_out,
+                     char** ir_out) {
+  CHECK(dslx != nullptr);
+  CHECK(path != nullptr);
+  CHECK(dslx_stdlib_path != nullptr);
+
+  std::vector<std::filesystem::path> additional_search_paths_cpp =
+      ToCpp(additional_search_paths, additional_search_paths_count);
+
+  absl::StatusOr<std::string> result = xls::ConvertDslxToIr(
+      dslx, path, module_name, dslx_stdlib_path, additional_search_paths_cpp);
+  if (result.ok()) {
+    *ir_out = ToOwnedCString(result.value());
+    return true;
+  }
+
+  *ir_out = nullptr;
+  *error_out = ToOwnedCString(result.status().ToString());
+  return false;
+}
+
+bool ConvertDslxPathToIr(const char* path, const char* dslx_stdlib_path,
+                         const char* additional_search_paths[],
+                         size_t additional_search_paths_count, char** error_out,
+                         char** ir_out) {
+  CHECK(path != nullptr);
+  CHECK(dslx_stdlib_path != nullptr);
+
+  std::vector<std::filesystem::path> additional_search_paths_cpp =
+      ToCpp(additional_search_paths, additional_search_paths_count);
+
+  absl::StatusOr<std::string> result = xls::ConvertDslxPathToIr(
+      path, dslx_stdlib_path, additional_search_paths_cpp);
+  if (result.ok()) {
+    *ir_out = ToOwnedCString(result.value());
+    return true;
+  }
+
+  *ir_out = nullptr;
+  *error_out = ToOwnedCString(result.status().ToString());
+  return false;
+}
+
+}  // extern "C"

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -1,0 +1,53 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_PUBLIC_C_API_H_
+#define XLS_PUBLIC_C_API_H_
+
+#include <stddef.h>
+
+// C API that exposes the functionality in various public headers in a way that
+// C-based FFI facilities can easily wrap.
+//
+// Note that StatusOr from C++ is generally translated as:
+//      StatusOr<T> MyFunction(...) =>
+//      bool MyFunction(..., char** error_out, T* out)
+//
+// The boolean return value indicates "ok" -- if not ok, the `error_out` value
+// will be populated with an error string indicating what went wrong -- the
+// string will be owned by the caller and will need to be deallocated in the
+// case of error.
+//
+// Caller-owned C strings are created using C standard library facilities and
+// thus should be deallocated via `free`.
+//
+// **WARNING**: These are *not* meant to be *ABI-stable* -- assume you have to
+// re-compile against this header for any given XLS commit.
+
+extern "C" {
+
+bool ConvertDslxToIr(const char* dslx, const char* path,
+                     const char* module_name, const char* dslx_stdlib_path,
+                     const char* additional_search_paths[],
+                     size_t additional_search_paths_count, char** error_out,
+                     char** ir_out);
+
+bool ConvertDslxPathToIr(const char* path, const char* dslx_stdlib_path,
+                         const char* additional_search_paths[],
+                         size_t additional_search_paths_count, char** error_out,
+                         char** ir_out);
+
+}  // extern "C"
+
+#endif  // XLS_PUBLIC_C_API_H_

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/c_api.h"
+
+#include <string>
+
+#include "absl/cleanup/cleanup.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/file/temp_directory.h"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/default_dslx_stdlib_path.h"
+
+namespace {
+
+using testing::HasSubstr;
+
+// Smoke test for ConvertDslxToIr C API.
+TEST(XlsCApiTest, ConvertDslxToIrSimple) {
+  const std::string kProgram = "fn id(x: u32) -> u32 { x }";
+  const char* additional_search_paths[] = {};
+  char* error_out = nullptr;
+  char* ir_out = nullptr;
+  bool ok = ConvertDslxToIr(kProgram.c_str(), "my_module.x", "my_module",
+                            /*dslx_stdlib_path=*/xls::kDefaultDslxStdlibPath,
+                            additional_search_paths, 0, &error_out, &ir_out);
+
+  absl::Cleanup free_cstrs([&] {
+    free(error_out);
+    free(ir_out);
+  });
+
+  // We should get IR and no error.
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(error_out, nullptr);
+  ASSERT_NE(ir_out, nullptr);
+
+  EXPECT_THAT(ir_out, HasSubstr("fn __my_module__id"));
+}
+
+TEST(XlsCApiTest, ConvertDslxToIrError) {
+  const std::string kInvalidProgram = "@!";
+  const char* additional_search_paths[] = {};
+  char* error_out = nullptr;
+  char* ir_out = nullptr;
+
+  absl::Cleanup free_cstrs([&] {
+    free(error_out);
+    free(ir_out);
+  });
+
+  bool ok = ConvertDslxToIr(kInvalidProgram.c_str(), "my_module.x", "my_module",
+                            /*dslx_stdlib_path=*/xls::kDefaultDslxStdlibPath,
+                            additional_search_paths, 0, &error_out, &ir_out);
+  ASSERT_FALSE(ok);
+
+  // We should get an error and not get IR.
+  ASSERT_NE(error_out, nullptr);
+  ASSERT_EQ(ir_out, nullptr);
+
+  EXPECT_THAT(error_out, HasSubstr("Unrecognized character: '@'"));
+}
+
+// Smoke test for ConvertDslxPathToIr C API.
+TEST(XlsCApiTest, ConvertDslxPathToIr) {
+  const std::string kProgram = "fn id(x: u32) -> u32 { x }";
+
+  XLS_ASSERT_OK_AND_ASSIGN(xls::TempDirectory tempdir,
+                           xls::TempDirectory::Create());
+  const std::filesystem::path module_path = tempdir.path() / "my_module.x";
+  XLS_ASSERT_OK(xls::SetFileContents(module_path, kProgram));
+
+  const char* additional_search_paths[] = {};
+  char* error_out = nullptr;
+  char* ir_out = nullptr;
+  bool ok = ConvertDslxPathToIr(
+      module_path.c_str(), /*dslx_stdlib_path=*/xls::kDefaultDslxStdlibPath,
+      additional_search_paths, 0, &error_out, &ir_out);
+
+  absl::Cleanup free_cstrs([&] {
+    free(error_out);
+    free(ir_out);
+  });
+
+  // We should get IR and no error.
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(error_out, nullptr);
+  ASSERT_NE(ir_out, nullptr);
+
+  EXPECT_THAT(ir_out, HasSubstr("fn __my_module__id"));
+}
+
+}  // namespace


### PR DESCRIPTION
One step towards a possible `libxls.so` public-and-released artifact -- this starts to expose just the DSLX to IR APIs as canaries to see if we can do what we need to e.g. via Python CFFI.