### PR TITLE
Fix assert handling in JitSerialProcRuntime

### DIFF
--- a/xls/interpreter/BUILD
+++ b/xls/interpreter/BUILD
@@ -407,6 +407,7 @@ cc_library(
 cc_test(
     name = "serial_proc_runtime_test",
     srcs = ["serial_proc_runtime_test.cc"],
+    data = ["force_assert.ir"],
     deps = [
         ":channel_queue",
         ":interpreter_proc_runtime",
@@ -415,14 +416,18 @@ cc_test(
         ":proc_runtime",
         ":proc_runtime_test_base",
         ":serial_proc_runtime",
-        "@com_google_absl//absl/status:statusor",
         "//xls/common:xls_gunit_main",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:matchers",
         "//xls/common/status:status_macros",
         "//xls/ir",
+        "//xls/ir:ir_parser",
         "//xls/ir:value",
         "//xls/jit:jit_channel_queue",
         "//xls/jit:jit_proc_runtime",
         "//xls/jit:proc_jit",
+        "@com_google_absl//absl/status:statusor",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/xls/interpreter/force_assert.ir
+++ b/xls/interpreter/force_assert.ir
@@ -1,0 +1,22 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package force_assert
+
+proc tile_0_0(my_token: token, state: (), init={()}) {
+  literal.1: bits[1] = literal(value=0)
+  assert.2: token = assert(my_token, literal.1, message="Assertion failure via fail!", label="forced_assert")
+
+  next (assert.2, state)
+}

--- a/xls/interpreter/serial_proc_runtime.cc
+++ b/xls/interpreter/serial_proc_runtime.cc
@@ -27,6 +27,7 @@
 #include "xls/common/status/status_macros.h"
 #include "xls/interpreter/channel_queue.h"
 #include "xls/interpreter/proc_evaluator.h"
+#include "xls/ir/events.h"
 #include "xls/ir/package.h"
 
 namespace xls {
@@ -90,6 +91,9 @@ SerialProcRuntime::TickInternal() {
                                   element.instance->GetName());
     XLS_ASSIGN_OR_RETURN(TickResult tick_result,
                          element.evaluator->Tick(*element.continuation));
+    const InterpreterEvents& events =
+        this->GetInterpreterEvents(element.instance);
+    XLS_RETURN_IF_ERROR(InterpreterEventsToStatus(events));
     VLOG(3) << "Tick result: " << tick_result;
 
     progress_made |= tick_result.progress_made;


### PR DESCRIPTION
Fixes https://github.com/google/xls/issues/1394

This PR adds 2 test cases for the `SerialProcRuntime`. Those test cases launch the simulation of a simple IR design with a proc that contains only the `assert()` operation.
One test case uses `CreateInterpreterSerialProcRuntime()` and the second uses `CreateJitSerialProcRuntime()`. It is expected that Tick'ing the simulation will result in an error due to the `assert()` operation in the simulated IR. The error is handled by the test logic so that the test case succeeds when `Tick()` returns `absl::StatusCode::kAborted` status.

As described in https://github.com/google/xls/issues/1394 initially, only the Interpreter-based simulation was able to catch asserts.
In order to fix this for the JIT runtime, another check of the `assert_msgs` event queue was added in the part of the code common for both SerialProcRuntimes.