### PR TITLE
CI: run bazel with --noshow_progress to be less noisy in output.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Bazel Build Tools (opt)
         run: |
-          bazel build -c opt --test_output=errors -- //xls/dslx:interpreter_main //xls/dslx/ir_convert:ir_converter_main //xls/tools:opt_main //xls/tools:codegen_main
+          bazel build -c opt --noshow_progress --test_output=errors -- //xls/dslx:interpreter_main //xls/dslx/ir_convert:ir_converter_main //xls/tools:opt_main //xls/tools:codegen_main
 
       - name: Bazel Test All (opt)
         run: |
-          bazel test -c opt --test_output=errors -- //xls/...
+          bazel test -c opt --noshow_progress --test_output=errors -- //xls/...

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Bazel Build Fuzz Driver (opt)
         run: |
-          bazel build -c opt xls/fuzzer:run_fuzz_multiprocess
+          bazel build -c opt --noshow_progress xls/fuzzer:run_fuzz_multiprocess
 
       - name: Bazel Run Fuzz (opt)
         run: |

--- a/.github/workflows/nightly-macos.yml
+++ b/.github/workflows/nightly-macos.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Bazel Build Tools (opt)
         run: |
-          bazel build -c opt --test_output=errors -- //xls/dslx:interpreter_main //xls/dslx/ir_convert:ir_converter_main //xls/tools:opt_main //xls/tools:codegen_main
+          bazel build -c opt --noshow_progress --test_output=errors -- //xls/dslx:interpreter_main //xls/dslx/ir_convert:ir_converter_main //xls/tools:opt_main //xls/tools:codegen_main


### PR DESCRIPTION
The github action terminal output can't deal with the in-place update of the Compiling status updates and spams endless lines with the regular refresh, hiding actual potential issues in a wall of text.