### PR TITLE
[DSLX:TS] Error on ref to unbound parametrics.

### DIFF
--- a/xls/dslx/constexpr_evaluator.cc
+++ b/xls/dslx/constexpr_evaluator.cc
@@ -726,7 +726,7 @@ absl::StatusOr<absl::flat_hash_map<std::string, InterpValue>> MakeConstexprEnv(
   }
 
   // Collect all the freevars that are constexpr.
-  FreeVariables freevars = GetFreeVariables(node);
+  FreeVariables freevars = GetFreeVariablesByPos(node);
   VLOG(5) << "freevar count for `" << node->ToString()
           << "`: " << freevars.GetFreeVariableCount();
   freevars = freevars.DropBuiltinDefs();

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -242,9 +242,10 @@ FreeVariables GetFreeVariablesByLambda(
 // Note: the start_pos given is a way to approximate "free variable with
 // respect to this AST construct". i.e. all the references with defs that are
 // defined before this start_pos point are considered free. This gives an easy
-// way to say "everything defined inside the body we don't need to worry about,
-// only tell me about references to things before this lexical position in the
-// file.
+// way to say "everything defined inside the body we don't need to worry about
+// -- only tell me about references to things before this lexical position in
+// the file" -- "lexical position in the file" is an approximation for
+// "everything defined outside of (before) this AST construct".
 FreeVariables GetFreeVariablesByPos(const AstNode* node,
                                     const Pos* start_pos = nullptr);
 

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -236,8 +236,15 @@ FreeVariables GetFreeVariablesByLambda(
 //    const FOO = u32:42;
 //    fn main(x: u32) { FOO+x }
 //
-// And using the starting point of the function as the start_pos, the FOO will
-// be flagged as a free variable and returned.
+// And *using the starting point of the function* as the `start_pos`, the `FOO`
+// will be flagged as a free variable and returned.
+//
+// Note: the start_pos given is a way to approximate "free variable with
+// respect to this AST construct". i.e. all the references with defs that are
+// defined before this start_pos point are considered free. This gives an easy
+// way to say "everything defined inside the body we don't need to worry about,
+// only tell me about references to things before this lexical position in the
+// file.
 FreeVariables GetFreeVariablesByPos(const AstNode* node,
                                     const Pos* start_pos = nullptr);
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -1527,7 +1527,7 @@ TEST_F(ParserTest, MatchFreevars) {
     y => z,
 })",
                           {"x", "y", "z"});
-  FreeVariables fv = GetFreeVariables(e, &e->span().start());
+  FreeVariables fv = GetFreeVariablesByPos(e, &e->span().start());
   EXPECT_THAT(fv.Keys(), testing::ContainerEq(
                              absl::flat_hash_set<std::string>{"x", "y", "z"}));
 }
@@ -1538,7 +1538,7 @@ TEST_F(ParserTest, ForFreevars) {
     new_accum
 }(u32:0))",
                           {"range", "j"});
-  FreeVariables fv = GetFreeVariables(e, &e->span().start());
+  FreeVariables fv = GetFreeVariablesByPos(e, &e->span().start());
   EXPECT_THAT(fv.Keys(), testing::ContainerEq(
                              absl::flat_hash_set<std::string>{"j", "range"}));
 }

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -1282,7 +1282,7 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
   // So we suffix free variables for the function body onto the function
   // parameters.
   FreeVariables freevars =
-      GetFreeVariables(node->body(), &node->span().start());
+      GetFreeVariablesByPos(node->body(), &node->span().start());
   freevars = freevars.DropBuiltinDefs();
   std::vector<const NameDef*> relevant_name_defs;
   for (const auto& any_name_def : freevars.GetNameDefs()) {
@@ -3503,7 +3503,7 @@ absl::StatusOr<Value> InterpValueToValue(const InterpValue& iv) {
 absl::StatusOr<std::vector<ConstantDef*>> GetConstantDepFreevars(
     AstNode* node) {
   Span span = node->GetSpan().value();
-  FreeVariables free_variables = GetFreeVariables(node, &span.start());
+  FreeVariables free_variables = GetFreeVariablesByPos(node, &span.start());
   std::vector<std::pair<std::string, AnyNameDef>> freevars =
       free_variables.GetNameDefTuples();
   std::vector<ConstantDef*> constant_deps;

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1184,7 +1184,8 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
   def test_gh_1473(self):
     stderr = self._run('xls/dslx/tests/errors/gh_1473.x')
     self.assertIn(
-        'Parametric expression `umax(MAX_N_M, V)` refered to `V` which is not present in the parametric environment', stderr
+        'Parametric expression `umax(MAX_N_M, V)` refered to `V`'
+        ' which is not present in the parametric environment', stderr
     )
 
 

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1181,6 +1181,12 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
         'Expected type-reference to refer to a type definition', stderr
     )
 
+  def test_gh_1473(self):
+    stderr = self._run('xls/dslx/tests/errors/gh_1473.x')
+    self.assertIn(
+        'Parametric expression `umax(MAX_N_M, V)` refered to `V` which is not present in the parametric environment', stderr
+    )
+
 
 if __name__ == '__main__':
   test_base.main()

--- a/xls/dslx/tests/errors/gh_1473.x
+++ b/xls/dslx/tests/errors/gh_1473.x
@@ -1,0 +1,41 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import float32;
+
+pub fn umax<N: u32>(x: uN[N], y: uN[N]) -> uN[N] { if x > y { x } else { y } }
+
+pub fn uadd_with_overflow
+    <V: u32,
+     N: u32,
+     M: u32,
+     MAX_N_M: u32 = {umax(N, M)},
+     MAX_N_M_V: u32 = {umax(MAX_N_M, V)}>
+    (x: uN[N], y: uN[M]) -> (bool, uN[V]) {
+
+    let x_extended = widening_cast<uN[MAX_N_M_V + u32:1]>(x);
+    let y_extended = widening_cast<uN[MAX_N_M_V + u32:1]>(y);
+
+    let full_result: uN[MAX_N_M_V + u32:1] = x_extended + y_extended;
+    let narrowed_result = full_result as uN[V];
+    let overflow_detected = or_reduce(full_result[V as s32:]);
+
+    (overflow_detected, narrowed_result)
+}
+
+pub fn double_fraction_carry(f: float32::F32) -> (uN[float32::F32_FRACTION_SZ], u1) {
+    let f = f.fraction as uN[float32::F32_FRACTION_SZ + u32:1];
+    let (overflow, f_x2) = uadd_with_overflow(f, f);
+    (f_x2, overflow)
+}


### PR DESCRIPTION
Previously we'd get an internal error by running head-first into the bytecode interpreter and it returning us an unbound error from its execution.

This institutes a look-before-you-leap: we look for freevars from the parametric expression that are present in the parametric bindings, and check that those are present in the parametric environment map. If they are not, we provide a more precise and helpful error message.

Ideally we'd be even more aggressive about reporting parametrics that are unbound at the point of instantiation, that is what #1495 is for and why there's a bit of code stubbed out with a TODO in this PR -- there is some investigation needed for the examples that fail with that enabled, but this change strictly moves the ball forward by resolving the issue seen in #1473.

Fixes #1473
One step towards #1495