### PR TITLE
Add test that `fail!`s and run it via the C API.

### DIFF
--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -69,6 +69,15 @@ bool xls_mangle_dslx_name(const char* module_name, const char* function_name,
 bool xls_parse_typed_value(const char* input, char** error_out,
                            struct xls_value** xls_value_out);
 
+// Returns a new token XLS value which the caller must free.
+struct xls_value* xls_value_make_token();
+
+// Returns a new `bits[1]:1` XLS value which the caller must free.
+struct xls_value* xls_value_make_true();
+
+// Returns a new `bits[1]:0` XLS value which the caller must free.
+struct xls_value* xls_value_make_false();
+
 // Returns a string representation of the given value `v`.
 bool xls_value_to_string(const struct xls_value* v, char** string_out);
 


### PR DESCRIPTION
Previously it was accessing a `StatusOr` error variant via `.value()` due to not collapsing the interpreter events correctly.

Also adds value APIs that enable us to invoke "itok" calling convention functions.