### PR TITLE
[DSLX:TS] Fully qualify struct type in error message when strings would otherwise be identical

### DIFF
--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1193,10 +1193,11 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
     # virtue of being defined in two different modules, we fully qualify the
     # module where the struct came from in the error message.
     stderr = self._run('xls/dslx/tests/errors/nominal_type_mismatch.x')
-    self.assertIn(
+    self.assertRegex(
+        stderr,
         'Type mismatch:\n'
-        '   xls/dslx/tests/errors/mod_simple_struct.x:MyStruct {}\n'
-        'vs xls/dslx/tests/errors/mod_simple_struct_duplicate.x:MyStruct {}\n', stderr
+        '   .*/dslx/tests/errors/mod_simple_struct.x:MyStruct {}\n'
+        'vs .*/dslx/tests/errors/mod_simple_struct_duplicate.x:MyStruct {}\n'
     )
 
 

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1188,6 +1188,17 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
         ' which is not present in the parametric environment', stderr
     )
 
+  def test_nominal_type_mismatch(self):
+    # When the types are structurally identical and also have the same name by
+    # virtue of being defined in two different modules, we fully qualify the
+    # module where the struct came from in the error message.
+    stderr = self._run('xls/dslx/tests/errors/nominal_type_mismatch.x')
+    self.assertIn(
+        'Type mismatch:\n'
+        '   xls/dslx/tests/errors/mod_simple_struct.x:MyStruct {}\n'
+        'vs xls/dslx/tests/errors/mod_simple_struct_duplicate.x:MyStruct {}\n', stderr
+    )
+
 
 if __name__ == '__main__':
   test_base.main()

--- a/xls/dslx/tests/errors/mod_simple_struct_duplicate.x
+++ b/xls/dslx/tests/errors/mod_simple_struct_duplicate.x
@@ -1,0 +1,19 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this is intended to be a structural duplicate of the type in
+// `mod_simple_struct.x`.
+pub struct MyStruct {
+    // Empty.
+}

--- a/xls/dslx/tests/errors/nominal_type_mismatch.x
+++ b/xls/dslx/tests/errors/nominal_type_mismatch.x
@@ -1,0 +1,27 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import xls.dslx.tests.errors.mod_simple_struct;
+import xls.dslx.tests.errors.mod_simple_struct_duplicate;
+
+fn id(x: mod_simple_struct::MyStruct) -> mod_simple_struct::MyStruct {
+    x
+}
+
+fn main() -> bool {
+    // Even though this is structurally the same it is nominally different, and
+    // we still want to get a good (non confusing) error message.
+    let other_definition = mod_simple_struct_duplicate::MyStruct{};
+    id(other_definition)
+}

--- a/xls/dslx/type_system/deduce_struct_instance.cc
+++ b/xls/dslx/type_system/deduce_struct_instance.cc
@@ -101,7 +101,7 @@ absl::StatusOr<ValidatedStructMembers> ValidateStructMembersSubset(
                          DeduceAndResolve(expr, ctx));
     XLS_RET_CHECK(!expr_type->IsMeta())
         << "name: " << name << " expr: " << expr->ToString()
-        << " type: " << expr_type->ToString();
+        << " type: " << *expr_type;
 
     result.args.push_back(InstantiateArg{std::move(expr_type), expr->span()});
     std::optional<const Type*> maybe_type =
@@ -109,7 +109,7 @@ absl::StatusOr<ValidatedStructMembers> ValidateStructMembersSubset(
 
     if (maybe_type.has_value()) {
       XLS_RET_CHECK(!maybe_type.value()->IsMeta())
-          << maybe_type.value()->ToString();
+          << *maybe_type.value();
       result.member_types.push_back(maybe_type.value()->CloneToUnique());
     } else {
       return TypeInferenceErrorStatus(

--- a/xls/dslx/type_system/deduce_struct_instance.cc
+++ b/xls/dslx/type_system/deduce_struct_instance.cc
@@ -108,8 +108,7 @@ absl::StatusOr<ValidatedStructMembers> ValidateStructMembersSubset(
         struct_type.GetMemberTypeByName(name);
 
     if (maybe_type.has_value()) {
-      XLS_RET_CHECK(!maybe_type.value()->IsMeta())
-          << *maybe_type.value();
+      XLS_RET_CHECK(!maybe_type.value()->IsMeta()) << *maybe_type.value();
       result.member_types.push_back(maybe_type.value()->CloneToUnique());
     } else {
       return TypeInferenceErrorStatus(

--- a/xls/dslx/type_system/format_type_mismatch.cc
+++ b/xls/dslx/type_system/format_type_mismatch.cc
@@ -259,8 +259,18 @@ absl::StatusOr<std::string> FormatTypeMismatch(const Type& lhs,
 
   if (callbacks.match_count() == 0) {
     lines.push_back("Type mismatch:");
-    lines.push_back(absl::StrFormat("   %s", lhs.ToString()));
-    lines.push_back(absl::StrFormat("vs %s", rhs.ToString()));
+    std::string lhs_string = lhs.ToString();
+    std::string rhs_string = rhs.ToString();
+    // If the text of the LHS and RHS are identical (e.g. structs with the same
+    // names that are defined in different modules are the cause of the
+    // mismatch) we try to fully qualify type names in order to not give a
+    // confusing error message.
+    if (lhs_string == rhs_string) {
+      lhs_string = lhs.ToStringFullyQualified();
+      rhs_string = rhs.ToStringFullyQualified();
+    }
+    lines.push_back(absl::StrFormat("   %s", lhs_string));
+    lines.push_back(absl::StrFormat("vs %s", rhs_string));
   } else {
     lines.push_back(absl::StrFormat("%sMismatched elements %swithin%s type:",
                                     kAnsiReset, kAnsiBoldOn, kAnsiBoldOff));

--- a/xls/dslx/type_system/maybe_explain_error.cc
+++ b/xls/dslx/type_system/maybe_explain_error.cc
@@ -42,9 +42,11 @@ absl::Status XlsTypeErrorStatus(const Span& span, const Type& lhs,
                         "%s",
                         span.ToString(), message, type_diff));
   }
+  std::string lhs_str = lhs.ToErrorString();
+  std::string rhs_str = rhs.ToErrorString();
   return absl::InvalidArgumentError(
       absl::StrFormat("XlsTypeError: %s %s vs %s: %s", span.ToString(),
-                      lhs.ToErrorString(), rhs.ToErrorString(), message));
+                      lhs_str, rhs_str, message));
 }
 
 // Creates an XlsTypeErrorStatus using the data within the type mismatch struct.

--- a/xls/dslx/type_system/maybe_explain_error.cc
+++ b/xls/dslx/type_system/maybe_explain_error.cc
@@ -45,8 +45,8 @@ absl::Status XlsTypeErrorStatus(const Span& span, const Type& lhs,
   std::string lhs_str = lhs.ToErrorString();
   std::string rhs_str = rhs.ToErrorString();
   return absl::InvalidArgumentError(
-      absl::StrFormat("XlsTypeError: %s %s vs %s: %s", span.ToString(),
-                      lhs_str, rhs_str, message));
+      absl::StrFormat("XlsTypeError: %s %s vs %s: %s", span.ToString(), lhs_str,
+                      rhs_str, message));
 }
 
 // Creates an XlsTypeErrorStatus using the data within the type mismatch struct.

--- a/xls/dslx/type_system/parametric_instantiator.cc
+++ b/xls/dslx/type_system/parametric_instantiator.cc
@@ -89,7 +89,7 @@ absl::StatusOr<TypeAndParametricEnv> InstantiateFunction(
     absl::Span<absl::Nonnull<const ParametricBinding*> const>
         parametric_bindings) {
   VLOG(5) << "Function instantiation @ " << span
-          << " type: " << function_type.ToString();
+          << " type: " << function_type;
   VLOG(5) << " typed-parametrics: " << ToString(typed_parametrics);
   VLOG(5) << " arg types:              " << ToTypesString(args);
   VLOG(5) << " explicit bindings:   " << ToString(explicit_bindings);
@@ -109,7 +109,7 @@ absl::StatusOr<TypeAndParametricEnv> InstantiateStruct(
     absl::Span<absl::Nonnull<const ParametricBinding*> const>
         parametric_bindings) {
   VLOG(5) << "Struct instantiation @ " << span
-          << " type: " << struct_type.ToString();
+          << " type: " << struct_type;
   VLOG(5) << " arg types:           " << ToTypesString(args);
   VLOG(5) << " member types:        " << ToString(member_types);
   VLOG(5) << " typed-parametrics: " << ToString(typed_parametrics);

--- a/xls/dslx/type_system/parametric_instantiator.cc
+++ b/xls/dslx/type_system/parametric_instantiator.cc
@@ -88,8 +88,7 @@ absl::StatusOr<TypeAndParametricEnv> InstantiateFunction(
     const absl::flat_hash_map<std::string, InterpValue>& explicit_bindings,
     absl::Span<absl::Nonnull<const ParametricBinding*> const>
         parametric_bindings) {
-  VLOG(5) << "Function instantiation @ " << span
-          << " type: " << function_type;
+  VLOG(5) << "Function instantiation @ " << span << " type: " << function_type;
   VLOG(5) << " typed-parametrics: " << ToString(typed_parametrics);
   VLOG(5) << " arg types:              " << ToTypesString(args);
   VLOG(5) << " explicit bindings:   " << ToString(explicit_bindings);
@@ -108,8 +107,7 @@ absl::StatusOr<TypeAndParametricEnv> InstantiateStruct(
     absl::Span<const ParametricWithType> typed_parametrics,
     absl::Span<absl::Nonnull<const ParametricBinding*> const>
         parametric_bindings) {
-  VLOG(5) << "Struct instantiation @ " << span
-          << " type: " << struct_type;
+  VLOG(5) << "Struct instantiation @ " << span << " type: " << struct_type;
   VLOG(5) << " arg types:           " << ToTypesString(args);
   VLOG(5) << " member types:        " << ToString(member_types);
   VLOG(5) << " typed-parametrics: " << ToString(typed_parametrics);

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -735,7 +735,10 @@ absl::StatusOr<std::unique_ptr<Type>> EnumType::MapSize(
                                     members_);
 }
 
-std::string EnumType::ToStringInternal(FullyQualify) const {
+std::string EnumType::ToStringInternal(FullyQualify fully_qualify) const {
+  if (fully_qualify == FullyQualify::kYes) {
+    return absl::StrCat(enum_def_.span().filename(), ":", enum_def_.identifier());
+  }
   return enum_def_.identifier();
 }
 

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -737,7 +737,8 @@ absl::StatusOr<std::unique_ptr<Type>> EnumType::MapSize(
 
 std::string EnumType::ToStringInternal(FullyQualify fully_qualify) const {
   if (fully_qualify == FullyQualify::kYes) {
-    return absl::StrCat(enum_def_.span().filename(), ":", enum_def_.identifier());
+    return absl::StrCat(enum_def_.span().filename(), ":",
+                        enum_def_.identifier());
   }
   return enum_def_.identifier();
 }

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -69,7 +69,8 @@ Type::~Type() = default;
   result.reserve(ts.size());
   for (const auto& t : ts) {
     CHECK(t != nullptr);
-    VLOG(10) << "CloneSpan; cloning: " << t->ToStringInternal(FullyQualify::kNo);
+    VLOG(10) << "CloneSpan; cloning: "
+             << t->ToStringInternal(FullyQualify::kNo);
     result.push_back(t->CloneToUnique());
   }
   return result;
@@ -392,7 +393,8 @@ bool BitsConstructorType::operator==(const Type& other) const {
   return false;
 }
 
-std::string BitsConstructorType::ToStringInternal(FullyQualify fully_qualify) const {
+std::string BitsConstructorType::ToStringInternal(
+    FullyQualify fully_qualify) const {
   return absl::StrFormat("xN[is_signed=%s]", is_signed_.ToString());
 }
 
@@ -429,8 +431,7 @@ BitsType::BitsType(bool is_signed, TypeDim size)
     : is_signed_(is_signed), size_(std::move(size)) {}
 
 bool BitsType::operator==(const Type& other) const {
-  VLOG(10) << "BitsType::operator==; this: " << *this
-           << " other: " << other;
+  VLOG(10) << "BitsType::operator==; this: " << *this << " other: " << other;
   if (auto* t = dynamic_cast<const BitsType*>(&other)) {
     return t->is_signed_ == is_signed_ && t->size_ == size_;
   }
@@ -484,7 +485,8 @@ bool StructType::HasToken() const {
 
 std::string StructType::ToErrorString() const {
   return absl::StrFormat("struct '%s' structure: %s",
-                         nominal_type().identifier(), ToStringInternal(FullyQualify::kNo));
+                         nominal_type().identifier(),
+                         ToStringInternal(FullyQualify::kNo));
 }
 
 std::string StructType::ToStringInternal(FullyQualify fully_qualify) const {
@@ -501,7 +503,8 @@ std::string StructType::ToStringInternal(FullyQualify fully_qualify) const {
   }
   std::string struct_name = nominal_type().identifier();
   if (fully_qualify == FullyQualify::kYes) {
-    struct_name = absl::StrCat(nominal_type().span().filename(), ":", struct_name);
+    struct_name =
+        absl::StrCat(nominal_type().span().filename(), ":", struct_name);
   }
   return absl::StrCat(struct_name, " {", guts, "}");
 }
@@ -520,8 +523,9 @@ absl::StatusOr<int64_t> StructType::GetMemberIndex(
   XLS_ASSIGN_OR_RETURN(std::vector<std::string> names, GetMemberNames());
   auto it = std::find(names.begin(), names.end(), name);
   if (it == names.end()) {
-    return absl::NotFoundError(absl::StrFormat(
-        "Name not present in tuple type %s: %s", ToStringInternal(FullyQualify::kNo), name));
+    return absl::NotFoundError(
+        absl::StrFormat("Name not present in tuple type %s: %s",
+                        ToStringInternal(FullyQualify::kNo), name));
   }
   return std::distance(names.begin(), it);
 }
@@ -683,12 +687,13 @@ absl::StatusOr<std::unique_ptr<Type>> ArrayType::MapSize(
 }
 
 std::string ArrayType::ToStringInternal(FullyQualify fully_qualify) const {
-  return absl::StrFormat("%s[%s]", element_type_->ToStringInternal(fully_qualify), size_.ToString());
+  return absl::StrFormat("%s[%s]",
+                         element_type_->ToStringInternal(fully_qualify),
+                         size_.ToString());
 }
 
 bool ArrayType::operator==(const Type& other) const {
-  VLOG(10) << "ArrayType::operator==; this: " << *this
-           << " other: " << other;
+  VLOG(10) << "ArrayType::operator==; this: " << *this << " other: " << other;
   if (auto* o = dynamic_cast<const ArrayType*>(&other)) {
     return size_ == o->size_ && *element_type_ == *o->element_type_;
   }
@@ -730,7 +735,9 @@ absl::StatusOr<std::unique_ptr<Type>> EnumType::MapSize(
                                     members_);
 }
 
-std::string EnumType::ToStringInternal(FullyQualify) const { return enum_def_.identifier(); }
+std::string EnumType::ToStringInternal(FullyQualify) const {
+  return enum_def_.identifier();
+}
 
 std::vector<TypeDim> EnumType::GetAllDims() const {
   std::vector<TypeDim> result;
@@ -779,10 +786,12 @@ std::vector<const Type*> FunctionType::GetParams() const {
 
 std::string FunctionType::ToStringInternal(FullyQualify fully_qualify) const {
   std::string params_str = absl::StrJoin(
-      params_, ", ", [fully_qualify](std::string* out, const std::unique_ptr<Type>& t) {
+      params_, ", ",
+      [fully_qualify](std::string* out, const std::unique_ptr<Type>& t) {
         absl::StrAppend(out, t->ToStringInternal(fully_qualify));
       });
-  return absl::StrFormat("(%s) -> %s", params_str, return_type_->ToStringInternal(fully_qualify));
+  return absl::StrFormat("(%s) -> %s", params_str,
+                         return_type_->ToStringInternal(fully_qualify));
 }
 
 std::vector<TypeDim> FunctionType::GetAllDims() const {
@@ -813,7 +822,8 @@ ChannelType::ChannelType(std::unique_ptr<Type> payload_type,
 }
 
 std::string ChannelType::ToStringInternal(FullyQualify fully_qualify) const {
-  return absl::StrFormat("chan(%s, dir=%s)", payload_type_->ToStringInternal(fully_qualify),
+  return absl::StrFormat("chan(%s, dir=%s)",
+                         payload_type_->ToStringInternal(fully_qualify),
                          direction_ == ChannelDirection::kIn ? "in" : "out");
 }
 
@@ -854,7 +864,8 @@ absl::StatusOr<bool> IsSigned(const Type& c) {
     std::optional<bool> signedness = enum_type->is_signed();
     if (!signedness.has_value()) {
       return absl::InvalidArgumentError(
-          "Signedness not present for EnumType: " + c.ToStringInternal(FullyQualify::kNo));
+          "Signedness not present for EnumType: " +
+          c.ToStringInternal(FullyQualify::kNo));
     }
     return signedness.value();
   }

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -201,9 +201,7 @@ class Type {
   virtual bool operator==(const Type& other) const = 0;
   bool operator!=(const Type& other) const { return !(*this == other); }
 
-  std::string ToString() const {
-    return ToStringInternal(FullyQualify::kNo);
-  }
+  std::string ToString() const { return ToStringInternal(FullyQualify::kNo); }
   std::string ToStringFullyQualified() const {
     return ToStringInternal(FullyQualify::kYes);
   }
@@ -323,7 +321,8 @@ class MetaType : public Type {
   std::unique_ptr<Type>& wrapped() { return wrapped_; }
 
   std::string ToStringInternal(FullyQualify fully_qualify) const override {
-    return absl::StrCat("typeof(", wrapped_->ToStringInternal(fully_qualify), ")");
+    return absl::StrCat("typeof(", wrapped_->ToStringInternal(fully_qualify),
+                        ")");
   }
 
  private:
@@ -347,7 +346,9 @@ class TokenType : public Type {
     return v.HandleToken(*this);
   }
   bool operator==(const Type& other) const override { return other.IsToken(); }
-  std::string ToStringInternal(FullyQualify fully_qualify) const override { return "token"; }
+  std::string ToStringInternal(FullyQualify fully_qualify) const override {
+    return "token";
+  }
   std::vector<TypeDim> GetAllDims() const override { return {}; }
   absl::StatusOr<TypeDim> GetTotalBitCount() const override {
     return TypeDim(InterpValue::MakeU32(0));
@@ -510,7 +511,8 @@ class ArrayType : public Type {
  public:
   ArrayType(std::unique_ptr<Type> element_type, const TypeDim& size)
       : element_type_(std::move(element_type)), size_(size) {
-    CHECK(!element_type_->IsMeta()) << element_type_->ToStringInternal(FullyQualify::kNo);
+    CHECK(!element_type_->IsMeta())
+        << element_type_->ToStringInternal(FullyQualify::kNo);
   }
 
   absl::Status Accept(TypeVisitor& v) const override {

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -201,10 +201,22 @@ class Type {
   virtual bool operator==(const Type& other) const = 0;
   bool operator!=(const Type& other) const { return !(*this == other); }
 
+  // Returns a string representation of this type.
   std::string ToString() const { return ToStringInternal(FullyQualify::kNo); }
+
+  // Returns a string representation of this type, but for nominal type
+  // entities, like structs and enums, prefixes the struct/enum name with the
+  // module in which it is defined.
+  //
+  // This can help disambiguate cases where the same struct name is used in
+  // different modules and they are not compatible with each other, we need to
+  // report a non-confusing error by qualifying which struct/enum we're
+  // referring to more precisely.
   std::string ToStringFullyQualified() const {
     return ToStringInternal(FullyQualify::kYes);
   }
+
+  // Converts the type to a string with given `fully_qualify` mode request.
   virtual std::string ToStringInternal(FullyQualify fully_qualify) const = 0;
 
   // Variation on `ToString()` to be used in user-facing error reporting.

--- a/xls/dslx/type_system/type_test.cc
+++ b/xls/dslx/type_system/type_test.cc
@@ -176,7 +176,8 @@ TEST(TypeTest, EmptyStructTypeIsNotUnit) {
   Span fake_span(Pos(fs_path, 0, 0), Pos(fs_path, 0, 0));
   auto* struct_def = module.Make<StructDef>(
       fake_span, module.Make<NameDef>(fake_span, "S", nullptr),
-      std::vector<ParametricBinding*>{}, std::vector<StructMember>{}, /*is_public=*/false);
+      std::vector<ParametricBinding*>{}, std::vector<StructMember>{},
+      /*is_public=*/false);
   std::vector<std::unique_ptr<Type>> members;
   StructType s(std::move(members), *struct_def);
   EXPECT_THAT(s.GetTotalBitCount(), IsOkAndHolds(TypeDim::CreateU32(0)));

--- a/xls/dslx/type_system/unwrap_meta_type.cc
+++ b/xls/dslx/type_system/unwrap_meta_type.cc
@@ -40,7 +40,7 @@ absl::StatusOr<std::unique_ptr<Type>> UnwrapMetaType(std::unique_ptr<Type> t,
 
 absl::StatusOr<const Type*> UnwrapMetaType(const Type& t) {
   const MetaType* metatype = dynamic_cast<const MetaType*>(&t);
-  XLS_RET_CHECK(metatype != nullptr) << t.ToString() << " was not a metatype.";
+  XLS_RET_CHECK(metatype != nullptr) << t << " was not a metatype.";
   return metatype->wrapped().get();
 }
 


### PR DESCRIPTION
Fixes #1500 

* Adds `ToStringInternal(FullyQualify)` on types.
* `ToString` defaults to `FullyQualify::kNo`
* Switch a few spots that were using ostreams from using `ToString()` explicitly to using the `operator<<` which is defined to be `ToString()`
* In the case where we get a type mismatch where the "want" and "got" are identical, instead we do `ToStringFullyQualified()` and use that instead.