### PR TITLE
Use c-headers if the c++ reqplacement does not containd necessary sym…

### DIFF
--- a/xls/common/file/filesystem.cc
+++ b/xls/common/file/filesystem.cc
@@ -14,13 +14,6 @@
 
 #include "xls/common/file/filesystem.h"
 
-// portable location of PATH_MAX
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 1
-#endif
-#include <limits.h>
-
-// Other system headers
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -377,12 +370,13 @@ absl::StatusOr<std::vector<std::filesystem::path>> FindFilesMatchingRegex(
 }
 
 absl::StatusOr<std::filesystem::path> GetRealPath(const std::string& path) {
+  constexpr int kPathMax = 8192;  // more portable than using PATH_MAX
   struct stat statbuf;
   XLS_RET_CHECK(lstat(path.c_str(), &statbuf) != -1) << strerror(errno);
   // If the file is a link, then dereference it.
   if ((statbuf.st_mode & S_IFMT) == S_IFLNK) {
-    char buf[PATH_MAX];
-    ssize_t len = readlink(path.c_str(), buf, PATH_MAX - 1);
+    char buf[kPathMax];
+    ssize_t len = readlink(path.c_str(), buf, sizeof(buf) - 1);
     XLS_RET_CHECK(len != -1) << strerror(errno);
     buf[len] = '\0';
     return buf;

--- a/xls/common/file/temp_directory.cc
+++ b/xls/common/file/temp_directory.cc
@@ -14,7 +14,8 @@
 
 #include "xls/common/file/temp_directory.h"
 
-#include <cstdlib>     // NOLINT (needed for mkdtemp())
+#include <stdlib.h>     // NOLINT (needed for mkdtemp())
+
 #include <filesystem>  // NOLINT
 #include <string>
 #include <system_error>  // NOLINT

--- a/xls/common/file/temp_file.cc
+++ b/xls/common/file/temp_file.cc
@@ -16,9 +16,9 @@
 
 #include <fcntl.h>
 #include <unistd.h>
+#include <stdlib.h>     // NOLINT (needed for mkostemps())
 
 #include <cerrno>
-#include <cstdlib>     // NOLINT (needed for mkostemps())
 #include <filesystem>  // NOLINT
 #include <string>
 #include <string_view>

--- a/xls/common/file/temp_file_test.cc
+++ b/xls/common/file/temp_file_test.cc
@@ -15,8 +15,8 @@
 #include "xls/common/file/temp_file.h"
 
 #include <unistd.h>
+#include <stdlib.h>     // NOLINT (needed for mkdtemp())
 
-#include <cstdlib>     // NOLINT (needed for mkdtemp())
 #include <filesystem>  // NOLINT
 #include <string>
 #include <system_error>

--- a/xls/common/strerror.cc
+++ b/xls/common/strerror.cc
@@ -14,7 +14,8 @@
 
 #include "xls/common/strerror.h"
 
-#include <cstring>  // NOLINT needed for strerror_r
+#include <string.h>  // NOLINT needed for strerror_r
+
 #include <string>
 #include <type_traits>
 

--- a/xls/common/subprocess.cc
+++ b/xls/common/subprocess.cc
@@ -19,11 +19,11 @@
 #include <spawn.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <signal.h>  // NOLINT
 #include <unistd.h>
 
 #include <atomic>
 #include <cerrno>
-#include <csignal>  // NOLINT(misc-include-cleaner)
 #include <cstdlib>
 #include <cstring>
 #include <ctime>

--- a/xls/dslx/bytecode/interpreter_stack.h
+++ b/xls/dslx/bytecode/interpreter_stack.h
@@ -16,7 +16,6 @@
 #define XLS_DSLX_BYTECODE_INTERPRETER_STACK_H_
 
 #include <cstdint>
-#include <memory>
 #include <optional>
 #include <string>
 #include <utility>

--- a/xls/dslx/command_line_utils.cc
+++ b/xls/dslx/command_line_utils.cc
@@ -14,9 +14,9 @@
 
 #include "xls/dslx/command_line_utils.h"
 
+#include <stdio.h>  // NOLINT(modernize-deprecated-headers)
 #include <unistd.h>
 
-#include <cstdio>
 #include <functional>
 #include <iostream>
 #include <string>

--- a/xls/dslx/cpp_transpiler/BUILD
+++ b/xls/dslx/cpp_transpiler/BUILD
@@ -33,13 +33,13 @@ cc_library(
     hdrs = ["cpp_transpiler.h"],
     deps = [
         ":cpp_type_generator",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
         "//xls/common/status:status_macros",
         "//xls/dslx:import_data",
         "//xls/dslx/frontend:ast",
         "//xls/dslx/type_system:type_info",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -48,14 +48,6 @@ cc_library(
     srcs = ["cpp_emitter.cc"],
     hdrs = ["cpp_emitter.h"],
     deps = [
-        "@com_google_absl//absl/base:no_destructor",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/container:flat_hash_set",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/types:variant",
         "//xls/common:case_converters",
         "//xls/common:indent",
         "//xls/common/status:ret_check",
@@ -68,6 +60,14 @@ cc_library(
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:ast_utils",
         "//xls/dslx/type_system:type_info",
+        "@com_google_absl//absl/base:no_destructor",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:variant",
     ],
 )
 
@@ -77,12 +77,6 @@ cc_library(
     hdrs = ["cpp_type_generator.h"],
     deps = [
         ":cpp_emitter",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings",
-        "@com_google_absl//absl/strings:str_format",
-        "@com_google_absl//absl/types:variant",
         "//xls/common:indent",
         "//xls/common:visitor",
         "//xls/common/status:status_macros",
@@ -93,6 +87,12 @@ cc_library(
         "//xls/dslx/bytecode:bytecode_interpreter",
         "//xls/dslx/frontend:ast",
         "//xls/dslx/type_system:type_info",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
+        "@com_google_absl//absl/types:variant",
     ],
 )
 
@@ -105,8 +105,6 @@ cc_test(
     deps = [
         ":cpp_transpiler",
         ":cpp_type_generator",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings:str_format",
         "//xls/common:golden_files",
         "//xls/common:source_location",
         "//xls/common:xls_gunit_main",
@@ -114,6 +112,8 @@ cc_test(
         "//xls/dslx:create_import_data",
         "//xls/dslx:import_data",
         "//xls/dslx:parse_and_typecheck",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest",
     ],
 )
@@ -125,11 +125,6 @@ cc_binary(
     deps = [
         ":cpp_transpiler",
         ":cpp_type_generator",
-        "@com_google_absl//absl/flags:flag",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/strings",
         "//xls/common:exit_status",
         "//xls/common:init_xls",
         "//xls/common/file:filesystem",
@@ -139,6 +134,12 @@ cc_binary(
         "//xls/dslx:import_data",
         "//xls/dslx:parse_and_typecheck",
         "//xls/dslx:warning_kind",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/types:span",
     ],
 )
 
@@ -154,11 +155,11 @@ cc_test(
     srcs = ["test_types_test.cc"],
     deps = [
         ":test_types_lib",
-        "@com_google_absl//absl/status",
         "//xls/common:xls_gunit_main",
         "//xls/common/status:matchers",
         "//xls/ir:bits",
         "//xls/ir:value",
+        "@com_google_absl//absl/status",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/xls/dslx/cpp_transpiler/cpp_transpiler_main.cc
+++ b/xls/dslx/cpp_transpiler/cpp_transpiler_main.cc
@@ -22,6 +22,7 @@
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_split.h"
+#include "absl/types/span.h"
 #include "xls/common/exit_status.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/init_xls.h"

--- a/xls/dslx/error_printer.cc
+++ b/xls/dslx/error_printer.cc
@@ -15,10 +15,10 @@
 #include "xls/dslx/error_printer.h"
 
 #include <unistd.h>
+#include <stdio.h>  // NOLINT for fileno
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdio>
 #include <functional>
 #include <iostream>
 #include <string>

--- a/xls/passes/arith_simplification_pass_test.cc
+++ b/xls/passes/arith_simplification_pass_test.cc
@@ -14,7 +14,8 @@
 
 #include "xls/passes/arith_simplification_pass.h"
 
-#include <cstdint>
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers) needed for UINT64_C
+
 #include <cstdlib>
 #include <memory>
 #include <string>

--- a/xls/synthesis/openroad/json_metrics_server_main.cc
+++ b/xls/synthesis/openroad/json_metrics_server_main.cc
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdlib.h>  // NOLINT (for setenv)
+
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <filesystem>  // NOLINT
 #include <memory>
 #include <string>

--- a/xls/tools/lec_main.cc
+++ b/xls/tools/lec_main.cc
@@ -14,9 +14,9 @@
 
 // Tool to prove or disprove logical equivalence of XLS IR and a netlist.
 
+#include <signal.h>  // NOLINT (clang-tidy can't find symbols in csignal)
 #include <unistd.h>
 
-#include <csignal>  // IWYU pragma: keep
 #include <cstdint>
 #include <cstring>
 #include <filesystem>  // NOLINT


### PR DESCRIPTION
…bols.

Not always do the c++ replacement header (e.g. <cstdint> vs. <stdint.h>) provide all the symbols needed. In these cases, replace the 'new' recommended headers with the old-school c headers.

Reduces misc-include-cleaner warnings from 50-ish to 13-ish.