### PR TITLE
autoformat comments on proc members and functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ compile_commands.json
 xls_clang-tidy.out
 user.bazelrc
 .vscode
+.cache

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -51,6 +51,67 @@
 namespace xls::dslx {
 namespace {
 
+// Note: if a comment doc is emitted (i.e. return value has_value()) it does not
+// have a trailing hard-line. This is for consistency with other emission
+// routines which generally don't emit any whitespace afterwards, just their
+// doc.
+std::optional<DocRef> EmitCommentsBetween(
+    std::optional<Pos> start_pos, const Pos& limit_pos,
+    const Comments& comments, DocArena& arena,
+    std::optional<Span>* last_comment_span) {
+  if (!start_pos.has_value()) {
+    start_pos = Pos(limit_pos.filename(), 0, 0);
+  }
+  // Due to the hack in AdjustCommentLimit, we can end up looking for a comment
+  // between the fictitious end of a comment and the end of a block. Just don't
+  // return anything in that case.
+  if (start_pos >= limit_pos) {
+    return std::nullopt;
+  }
+  const Span span(start_pos.value(), limit_pos);
+
+  VLOG(3) << "Looking for comments in span: " << span;
+
+  std::vector<DocRef> pieces;
+
+  std::vector<const CommentData*> items = comments.GetComments(span);
+  VLOG(3) << "Found " << items.size() << " comment data items";
+  std::optional<Span> previous_comment_span;
+  for (size_t i = 0; i < items.size(); ++i) {
+    const CommentData* comment_data = items[i];
+
+    // If the previous comment line and this comment line are abutted (i.e.
+    // contiguous lines with comments), we don't put a newline between them.
+    if (previous_comment_span.has_value() &&
+        previous_comment_span->start().lineno() + 1 !=
+            comment_data->span.start().lineno()) {
+      VLOG(3) << "previous comment span: " << previous_comment_span.value()
+              << " this comment span: " << comment_data->span
+              << " -- inserting hard line";
+      pieces.push_back(arena.hard_line());
+    }
+
+    pieces.push_back(arena.MakePrefixedReflow(
+        "//",
+        std::string{absl::StripTrailingAsciiWhitespace(comment_data->text)}));
+
+    if (i + 1 != items.size()) {
+      pieces.push_back(arena.hard_line());
+    }
+
+    previous_comment_span = comment_data->span;
+    if (last_comment_span != nullptr) {
+      *last_comment_span = comment_data->span;
+    }
+  }
+
+  if (pieces.empty()) {
+    return std::nullopt;
+  }
+
+  return ConcatN(arena, pieces);
+}
+
 // If there is a '.' modifier in the attribute given by s (e.g. if it's of the
 // form "ProcName.config") strips off the trailing modifier and returns the
 // stem.
@@ -522,65 +583,6 @@ DocRef Fmt(const Binop& n, const Comments& comments, DocArena& arena) {
                             lhs_ref,
                             rhs_ref,
                         });
-}
-
-// Note: if a comment doc is emitted (i.e. return value has_value()) it does not
-// have a trailing hard-line. This is for consistency with other emission
-// routines which generally don't emit any whitespace afterwards, just their
-// doc.
-static std::optional<DocRef> EmitCommentsBetween(
-    std::optional<Pos> start_pos, const Pos& limit_pos,
-    const Comments& comments, DocArena& arena,
-    std::optional<Span>* last_comment_span) {
-  if (!start_pos.has_value()) {
-    start_pos = Pos(limit_pos.filename(), 0, 0);
-  }
-  // Due to the hack in AdjustCommentLimit, we can end up looking for a comment
-  // between the fictitious end of a comment and the end of a block. Just don't
-  // return anything in that case.
-  if (start_pos >= limit_pos) {
-    return std::nullopt;
-  }
-  const Span span(start_pos.value(), limit_pos);
-
-  VLOG(3) << "Looking for comments in span: " << span;
-
-  std::vector<DocRef> pieces;
-
-  std::vector<const CommentData*> items = comments.GetComments(span);
-  VLOG(3) << "Found " << items.size() << " comment data items";
-  std::optional<Span> previous_comment_span;
-  for (size_t i = 0; i < items.size(); ++i) {
-    const CommentData* comment_data = items[i];
-
-    // If the previous comment line and this comment line are abutted (i.e.
-    // contiguous lines with comments), we don't put a newline between them.
-    if (previous_comment_span.has_value() &&
-        previous_comment_span->start().lineno() + 1 !=
-            comment_data->span.start().lineno()) {
-      VLOG(3) << "previous comment span: " << previous_comment_span.value()
-              << " this comment span: " << comment_data->span
-              << " -- inserting hard line";
-      pieces.push_back(arena.hard_line());
-    }
-
-    pieces.push_back(arena.MakePrefixedReflow(
-        "//",
-        std::string{absl::StripTrailingAsciiWhitespace(comment_data->text)}));
-
-    if (i + 1 != items.size()) {
-      pieces.push_back(arena.hard_line());
-    }
-
-    previous_comment_span = comment_data->span;
-    *last_comment_span = comment_data->span;
-  }
-
-  if (pieces.empty()) {
-    return std::nullopt;
-  }
-
-  return ConcatN(arena, pieces);
 }
 
 // EOL-terminated comments we say, in the AST, that the entity's limit was at
@@ -1743,30 +1745,73 @@ static DocRef Fmt(const Proc& n, const Comments& comments, DocArena& arena) {
   signature_pieces.push_back(arena.break1());
   signature_pieces.push_back(arena.ocurl());
 
+  // Mapping from function to comment data -- we emit these last so if we're
+  // reordering them we want to make sure they stay associated with the
+  // appropriate comments.
+  absl::flat_hash_map<const Function*, std::vector<const CommentData*>> fn_to_comments;
+
+  Pos last_stmt_limit = n.body_span().start();
+
+  // We update this with the position that's relevant for config start comments.
+  std::optional<Pos> config_comment_start_pos;
+  std::optional<Pos> init_comment_start_pos;
+  std::optional<Pos> next_comment_start_pos;
+
   std::vector<DocRef> stmt_pieces;
   for (const ProcStmt& stmt : n.stmts()) {
     absl::visit(Visitor{
-                    [](const Function*) {
-                      // We will emit these below.
+                    [&](const Function* f) {
+                      // Note: we will emit these below.
+                      //
+                      // Though we defer emission, we still want to grab relevant comments.
+                      if (f == &n.config()) {
+                        config_comment_start_pos = last_stmt_limit;
+                      } else if (f == &n.init()) {
+                        init_comment_start_pos = last_stmt_limit;
+                      } else if (f == &n.next()) {
+                        next_comment_start_pos = last_stmt_limit;
+                      } else {
+                        LOG(FATAL) << "Unexpected proc member function: " << f->identifier() << " @ " << f->span();
+                      }
+                      last_stmt_limit = f->span().limit();
                     },
                     [&](const ProcMember* n) {
+                      if (std::optional<DocRef> maybe_doc = EmitCommentsBetween(last_stmt_limit, n->span().start(), comments, arena, nullptr)) {
+                        stmt_pieces.push_back(arena.MakeConcat(maybe_doc.value(), arena.hard_line()));
+                      }
                       stmt_pieces.push_back(Fmt(*n, comments, arena));
                       stmt_pieces.push_back(arena.semi());
                       stmt_pieces.push_back(arena.hard_line());
+                      last_stmt_limit = n->span().limit();
                     },
                     [&](const TypeAlias* n) {
+                      if (std::optional<DocRef> maybe_doc = EmitCommentsBetween(last_stmt_limit, n->span().start(), comments, arena, nullptr)) {
+                        stmt_pieces.push_back(arena.MakeConcat(maybe_doc.value(), arena.hard_line()));
+                      }
                       stmt_pieces.push_back(Fmt(*n, comments, arena));
                       stmt_pieces.push_back(arena.semi());
                       stmt_pieces.push_back(arena.hard_line());
+                      last_stmt_limit = n->span().limit();
                     },
                     [&](const ConstAssert* n) {
+                      if (std::optional<DocRef> maybe_doc = EmitCommentsBetween(last_stmt_limit, n->span().start(), comments, arena, nullptr)) {
+                        stmt_pieces.push_back(arena.MakeConcat(maybe_doc.value(), arena.hard_line()));
+                      }
                       stmt_pieces.push_back(Fmt(*n, comments, arena));
                       stmt_pieces.push_back(arena.semi());
                       stmt_pieces.push_back(arena.hard_line());
+                      last_stmt_limit = n->span().limit();
                     },
                 },
                 stmt);
   }
+
+  CHECK(config_comment_start_pos.has_value());
+  std::optional<DocRef> config_comment = EmitCommentsBetween(config_comment_start_pos, n.config().span().start(), comments, arena, nullptr);
+  CHECK(init_comment_start_pos.has_value());
+  std::optional<DocRef> init_comment = EmitCommentsBetween(init_comment_start_pos, n.init().span().start(), comments, arena, nullptr);
+  CHECK(next_comment_start_pos.has_value());
+  std::optional<DocRef> next_comment = EmitCommentsBetween(next_comment_start_pos, n.next().span().start(), comments, arena, nullptr);
 
   std::vector<DocRef> config_pieces = {
       arena.MakeText("config"),
@@ -1802,6 +1847,23 @@ static DocRef Fmt(const Proc& n, const Comments& comments, DocArena& arena) {
       arena.ccurl(),
   };
 
+  auto nest_and_hardline = [&](std::optional<DocRef> doc_ref) {
+    if (!doc_ref.has_value()) {
+      return arena.empty();
+    }
+    return arena.MakeNest(arena.MakeConcat(doc_ref.value(), arena.hard_line()));
+  };
+
+  DocRef config_comment_doc_ref = config_comment.has_value()
+    ? nest_and_hardline(config_comment.value())
+    : arena.empty();
+  DocRef init_comment_doc_ref = init_comment.has_value()
+    ? nest_and_hardline(init_comment.value())
+    : arena.empty();
+  DocRef next_comment_doc_ref = next_comment.has_value()
+    ? nest_and_hardline(next_comment.value())
+    : arena.empty();
+
   std::vector<DocRef> proc_pieces = {
       ConcatNGroup(arena, signature_pieces),
       arena.hard_line(),
@@ -1812,12 +1874,15 @@ static DocRef Fmt(const Proc& n, const Comments& comments, DocArena& arena) {
                              arena.MakeNest(ConcatNGroup(arena, stmt_pieces)),
                              arena.hard_line(),
                          }),
+      config_comment_doc_ref,
       arena.MakeNest(ConcatNGroup(arena, config_pieces)),
       arena.hard_line(),
       arena.hard_line(),
+      init_comment_doc_ref,
       arena.MakeNest(ConcatNGroup(arena, init_pieces)),
       arena.hard_line(),
       arena.hard_line(),
+      next_comment_doc_ref,
       arena.MakeNest(ConcatNGroup(arena, next_pieces)),
       arena.hard_line(),
       arena.ccurl(),

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1765,8 +1765,10 @@ static DocRef Fmt(const Proc& n, const Comments& comments, DocArena& arena) {
             [&](const Function* f) {
               // Note: we will emit these below.
               //
-              // Though we defer emission, we still want to grab relevant
-              // comments.
+              // Though we defer emission, we still want to grab data to tell
+              // us the relevant comment span. The relevant comment span is
+              // from the "last statement's limit position" to this function's
+              // start position.
               if (f == &n.config()) {
                 config_comment_start_pos = last_stmt_limit;
               } else if (f == &n.init()) {

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1492,6 +1492,29 @@ TEST_F(ModuleFmtTest, SimpleProc) {
 )");
 }
 
+TEST_F(ModuleFmtTest, SimpleProcWithComments) {
+  Run(
+      R"(// Proc-level comment.
+pub proc p {
+    // Member-level comment on cin.
+    cin: chan<u32> in;
+    // Member-level comment on cout.
+    cout: chan<u32> out;
+    // Type alias comment.
+    type MyType = u32;
+
+    // Config-level comment.
+    config() { () }
+
+    // Init-level comment.
+    init { () }
+
+    // Next-level comment.
+    next(state: ()) { () }
+}
+)");
+}
+
 TEST_F(ModuleFmtTest, SimpleProcEmptyConfigBlock) {
   Run(
       R"(pub proc p {

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -553,7 +553,7 @@ class AstCloner : public AstNodeVisitor {
         .members = new_members,
     };
     Proc* p =
-        module_->Make<Proc>(n->span(), new_name_def, new_parametric_bindings,
+        module_->Make<Proc>(n->span(), n->body_span(), new_name_def, new_parametric_bindings,
                             new_body, n->is_public());
     new_name_def->set_definer(p);
     old_to_new_[n] = p;

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -553,8 +553,8 @@ class AstCloner : public AstNodeVisitor {
         .members = new_members,
     };
     Proc* p =
-        module_->Make<Proc>(n->span(), n->body_span(), new_name_def, new_parametric_bindings,
-                            new_body, n->is_public());
+        module_->Make<Proc>(n->span(), n->body_span(), new_name_def,
+                            new_parametric_bindings, new_body, n->is_public());
     new_name_def->set_definer(p);
     old_to_new_[n] = p;
     return absl::OkStatus();

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -2370,7 +2370,8 @@ absl::StatusOr<T*> Parser::ParseProcLike(bool is_public,
   }
 
   Pos obrace_pos;
-  XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kOBrace, nullptr, "'{' at start of proc-like", &obrace_pos));
+  XLS_RETURN_IF_ERROR(DropTokenOrError(
+      TokenKind::kOBrace, nullptr, "'{' at start of proc-like", &obrace_pos));
 
   // Helper, if "f" is already non-null we give back an appropriate error
   // message given the "peek" token that names the function.
@@ -2540,9 +2541,9 @@ absl::StatusOr<T*> Parser::ParseProcLike(bool is_public,
   XLS_ASSIGN_OR_RETURN(Token cbrace, PopTokenOrError(TokenKind::kCBrace));
   const Span span(leading_token.span().start(), cbrace.span().limit());
   const Span body_span(obrace_pos, cbrace.span().limit());
-  auto* proc_like =
-      module_->Make<T>(span, body_span, name_def, std::move(parametric_bindings),
-                       proc_like_body, is_public);
+  auto* proc_like = module_->Make<T>(span, body_span, name_def,
+                                     std::move(parametric_bindings),
+                                     proc_like_body, is_public);
 
   // Now that the proc is defined we can set a bunch of links to point at it.
   proc_like_body.config->set_proc(proc_like);

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -2369,7 +2369,8 @@ absl::StatusOr<T*> Parser::ParseProcLike(bool is_public,
                          ParseParametricBindings(proc_bindings));
   }
 
-  XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kOBrace));
+  Pos obrace_pos;
+  XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kOBrace, nullptr, "'{' at start of proc-like", &obrace_pos));
 
   // Helper, if "f" is already non-null we give back an appropriate error
   // message given the "peek" token that names the function.
@@ -2538,8 +2539,9 @@ absl::StatusOr<T*> Parser::ParseProcLike(bool is_public,
 
   XLS_ASSIGN_OR_RETURN(Token cbrace, PopTokenOrError(TokenKind::kCBrace));
   const Span span(leading_token.span().start(), cbrace.span().limit());
+  const Span body_span(obrace_pos, cbrace.span().limit());
   auto* proc_like =
-      module_->Make<T>(span, name_def, std::move(parametric_bindings),
+      module_->Make<T>(span, body_span, name_def, std::move(parametric_bindings),
                        proc_like_body, is_public);
 
   // Now that the proc is defined we can set a bunch of links to point at it.

--- a/xls/dslx/frontend/proc.cc
+++ b/xls/dslx/frontend/proc.cc
@@ -54,11 +54,12 @@ absl::StatusOr<ProcStmt> ToProcStmt(AstNode* n) {
 
 // -- class ProcLike
 
-ProcLike::ProcLike(Module* owner, Span span, NameDef* name_def,
+ProcLike::ProcLike(Module* owner, Span span, Span body_span, NameDef* name_def,
                    std::vector<ParametricBinding*> parametric_bindings,
                    ProcLikeBody body, bool is_public)
     : AstNode(owner),
       span_(std::move(span)),
+      body_span_(std::move(body_span)),
       name_def_(name_def),
       parametric_bindings_(std::move(parametric_bindings)),
       body_(std::move(body)),

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -109,9 +109,7 @@ class ProcLike : public AstNode {
 
   // Returns the span of the body block, i.e. from the opening '{' as the start
   // to the closing '}' as the limit.
-  const Span& body_span() const {
-    return body_span_;
-  }
+  const Span& body_span() const { return body_span_; }
 
   std::optional<Span> GetSpan() const override { return span_; }
 

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -95,7 +95,7 @@ bool HasMemberNamed(const ProcLikeBody& proc_body, std::string_view name);
 
 class ProcLike : public AstNode {
  public:
-  ProcLike(Module* owner, Span span, NameDef* name_def,
+  ProcLike(Module* owner, Span span, Span body_span, NameDef* name_def,
            std::vector<ParametricBinding*> parametric_bindings,
            ProcLikeBody body, bool is_public);
 
@@ -106,6 +106,13 @@ class ProcLike : public AstNode {
 
   NameDef* name_def() const { return name_def_; }
   const Span& span() const { return span_; }
+
+  // Returns the span of the body block, i.e. from the opening '{' as the start
+  // to the closing '}' as the limit.
+  const Span& body_span() const {
+    return body_span_;
+  }
+
   std::optional<Span> GetSpan() const override { return span_; }
 
   const std::string& identifier() const { return name_def_->identifier(); }
@@ -150,6 +157,7 @@ class ProcLike : public AstNode {
 
  private:
   Span span_;
+  Span body_span_;
   NameDef* name_def_;
   std::vector<ParametricBinding*> parametric_bindings_;
 

--- a/xls/dslx/type_system/deduce_utils_test.cc
+++ b/xls/dslx/type_system/deduce_utils_test.cc
@@ -102,7 +102,7 @@ TEST(ProcConfigIrConverterTest, ResolveProcNameRef) {
       .members = {},
   };
   Proc* original_proc = module.Make<Proc>(
-      Span::Fake(), name_def, /*parametric_bindings=*/bindings, proc_body,
+      Span::Fake(), /*body_span=*/Span::Fake(), name_def, /*parametric_bindings=*/bindings, proc_body,
       /*is_public=*/true);
   XLS_ASSERT_OK(module.AddTop(original_proc, /*make_collision_error=*/nullptr));
   name_def->set_definer(original_proc);
@@ -168,7 +168,7 @@ TEST(ProcConfigIrConverterTest, ResolveProcColonRef) {
       .members = members,
   };
   Proc* original_proc = import_module->Make<Proc>(
-      Span::Fake(), name_def, bindings, proc_body, /*is_public=*/true);
+      Span::Fake(), /*body_span=*/Span::Fake(), name_def, bindings, proc_body, /*is_public=*/true);
   XLS_ASSERT_OK(
       import_module->AddTop(original_proc, /*make_collision_error=*/nullptr));
   name_def->set_definer(original_proc);

--- a/xls/dslx/type_system/deduce_utils_test.cc
+++ b/xls/dslx/type_system/deduce_utils_test.cc
@@ -101,9 +101,10 @@ TEST(ProcConfigIrConverterTest, ResolveProcNameRef) {
       .init = init,
       .members = {},
   };
-  Proc* original_proc = module.Make<Proc>(
-      Span::Fake(), /*body_span=*/Span::Fake(), name_def, /*parametric_bindings=*/bindings, proc_body,
-      /*is_public=*/true);
+  Proc* original_proc =
+      module.Make<Proc>(Span::Fake(), /*body_span=*/Span::Fake(), name_def,
+                        /*parametric_bindings=*/bindings, proc_body,
+                        /*is_public=*/true);
   XLS_ASSERT_OK(module.AddTop(original_proc, /*make_collision_error=*/nullptr));
   name_def->set_definer(original_proc);
 
@@ -168,7 +169,8 @@ TEST(ProcConfigIrConverterTest, ResolveProcColonRef) {
       .members = members,
   };
   Proc* original_proc = import_module->Make<Proc>(
-      Span::Fake(), /*body_span=*/Span::Fake(), name_def, bindings, proc_body, /*is_public=*/true);
+      Span::Fake(), /*body_span=*/Span::Fake(), name_def, bindings, proc_body,
+      /*is_public=*/true);
   XLS_ASSERT_OK(
       import_module->AddTop(original_proc, /*make_collision_error=*/nullptr));
   name_def->set_definer(original_proc);

--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -2923,7 +2923,7 @@ absl::StatusOr<AnnotatedProc> AstGenerator::GenerateProc(
       .members = proc_properties_.members,
   };
   Proc* proc = module_->Make<Proc>(
-      fake_span_, name_def,
+      fake_span_, /*body_span=*/fake_span_, name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(), body,
       /*is_public=*/false);
   name_def->set_definer(proc);


### PR DESCRIPTION
Fixes #1531 

Leverage the existing `EmitCommentsBetween` helper.

Procs are slightly interesting because we also reorder the proc functions into their canonical order.

As a result, during the pre-pass we emit members with their associated comments, but gather up spans that are relevant to the proc member functions.

Once the pre-pass is complete we can emit the member functions with comments.

Added a "body span" to the `ProcLike` type so we know where the brace open/close are for the `proc` body.