### PR TITLE
Fix type information correlation for transitive enum resolution

### DIFF
--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -358,6 +358,11 @@ dslx_lang_test(
     dslx_deps = [":constexpr_dslx"],
 )
 
+dslx_lang_test(
+    name = "import_enum_alias",
+    dslx_deps = [":mod_enum_importer_dslx"],
+)
+
 dslx_lang_test(name = "map")
 
 dslx_lang_test(name = "multiplies")

--- a/xls/dslx/tests/import_enum_alias.x
+++ b/xls/dslx/tests/import_enum_alias.x
@@ -1,4 +1,4 @@
-// Copyright 2020 The XLS Authors
+// Copyright 2024 The XLS Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import xls.dslx.tests.mod_imported;
+import xls.dslx.tests.mod_enum_importer;
 
-pub type MyEnumAlias = mod_imported::MyEnum;
-
-fn main(x: u8) -> MyEnumAlias { x as MyEnumAlias }
+// A module that imports an enum alias and uses it.
+fn main() -> mod_enum_importer::MyEnumAlias { mod_enum_importer::MyEnumAlias::FOO }
 
 #[test]
-fn main_test() {
-    assert_eq(main(u8:42), MyEnumAlias::FOO);
-    assert_eq(main(u8:64), MyEnumAlias::BAR);
-}
+fn test_main() { assert_eq(main(), mod_enum_importer::MyEnumAlias::FOO) }

--- a/xls/dslx/type_system/deduce_utils.cc
+++ b/xls/dslx/type_system/deduce_utils.cc
@@ -58,8 +58,8 @@ using ColonRefSubjectT =
 
 }  // namespace
 
-// Resolves a `TypeAlias` AST node to a `ColonRef` subject -- this requires us to
-// traverse through aliases transitively to find a subject.
+// Resolves a `TypeAlias` AST node to a `ColonRef` subject -- this requires us
+// to traverse through aliases transitively to find a subject.
 //
 // Has to be an enum or builtin-type name, given the context we're in: looking
 // for _values_ hanging off, e.g. in service of a `::` ref.
@@ -101,19 +101,23 @@ ResolveTypeAliasToDirectColonRefSubject(ImportData* import_data,
     current_type_definition = type_ref_type->type_ref()->type_definition();
   }
 
-  VLOG(5) << absl::StreamFormat("ResolveTypeDefToDirectColonRefSubject; arrived at type definition: `%s`", ToAstNode(current_type_definition)->ToString());
+  VLOG(5) << absl::StreamFormat(
+      "ResolveTypeDefToDirectColonRefSubject; arrived at type definition: `%s`",
+      ToAstNode(current_type_definition)->ToString());
 
   if (std::holds_alternative<ColonRef*>(current_type_definition)) {
     ColonRef* colon_ref = std::get<ColonRef*>(current_type_definition);
     type_info = import_data->GetRootTypeInfo(colon_ref->owner()).value();
-    XLS_ASSIGN_OR_RETURN(ColonRefSubjectT subject, ResolveColonRefSubjectForTypeChecking(
-                                           import_data, type_info, colon_ref));
+    XLS_ASSIGN_OR_RETURN(ColonRefSubjectT subject,
+                         ResolveColonRefSubjectForTypeChecking(
+                             import_data, type_info, colon_ref));
     XLS_RET_CHECK(std::holds_alternative<Module*>(subject));
     Module* module = std::get<Module*>(subject);
 
     // Grab the type definition being referred to by the `ColonRef` -- this is
     // what we now have to traverse to (or we may have arrived).
-    XLS_ASSIGN_OR_RETURN(current_type_definition, module->GetTypeDefinition(colon_ref->attr()));
+    XLS_ASSIGN_OR_RETURN(current_type_definition,
+                         module->GetTypeDefinition(colon_ref->attr()));
 
     if (std::holds_alternative<TypeAlias*>(current_type_definition)) {
       TypeAlias* new_alias = std::get<TypeAlias*>(current_type_definition);
@@ -338,7 +342,8 @@ absl::StatusOr<ColonRefSubjectT> ResolveColonRefSubjectForTypeChecking(
     const ColonRef* colon_ref) {
   XLS_RET_CHECK_EQ(colon_ref->owner(), type_info->module());
 
-  VLOG(5) << absl::StreamFormat("ResolveColonRefSubject for `%s`", colon_ref->ToString());
+  VLOG(5) << absl::StreamFormat("ResolveColonRefSubject for `%s`",
+                                colon_ref->ToString());
 
   // If the subject is a name reference we use a helper routine.
   if (std::holds_alternative<NameRef*>(colon_ref->subject())) {

--- a/xls/dslx/type_system/type_info.cc
+++ b/xls/dslx/type_system/type_info.cc
@@ -531,8 +531,9 @@ void TypeInfo::AddImport(Import* import, Module* module, TypeInfo* type_info) {
 }
 
 std::optional<const ImportedInfo*> TypeInfo::GetImported(Import* import) const {
-  CHECK_EQ(import->owner(), module_)
-      << absl::StreamFormat("Import node is owned by: `%s` vs this TypeInfo is for `%s`", import->owner()->name(), module_->name());
+  CHECK_EQ(import->owner(), module_) << absl::StreamFormat(
+      "Import node is owned by: `%s` vs this TypeInfo is for `%s`",
+      import->owner()->name(), module_->name());
   auto* self = GetRoot();
   auto it = self->imports_.find(import);
   if (it == self->imports_.end()) {

--- a/xls/dslx/type_system/type_info.cc
+++ b/xls/dslx/type_system/type_info.cc
@@ -532,8 +532,7 @@ void TypeInfo::AddImport(Import* import, Module* module, TypeInfo* type_info) {
 
 std::optional<const ImportedInfo*> TypeInfo::GetImported(Import* import) const {
   CHECK_EQ(import->owner(), module_)
-      << "Import node from: " << import->owner()->name() << " vs TypeInfo for "
-      << module_->name();
+      << absl::StreamFormat("Import node is owned by: `%s` vs this TypeInfo is for `%s`", import->owner()->name(), module_->name());
   auto* self = GetRoot();
   auto it = self->imports_.find(import);
   if (it == self->imports_.end()) {

--- a/xls/dslx/type_system/type_info.h
+++ b/xls/dslx/type_system/type_info.h
@@ -247,6 +247,9 @@ class TypeInfo {
   // Note that added type information and such will generally be owned by the
   // import cache.
   void AddImport(Import* import, Module* module, TypeInfo* type_info);
+
+  // Returns information on the imported module (its module AST node and
+  // top-level type information).
   std::optional<const ImportedInfo*> GetImported(Import* import) const;
   absl::StatusOr<const ImportedInfo*> GetImportedOrError(Import* import) const;
   const absl::flat_hash_map<Import*, ImportedInfo>& imports() const {


### PR DESCRIPTION
Fixes google/xls#1540

We were not passing type information for the appropriate module -- a type alias dereferenced a type /in a different module/ so we were obligated to look up the associated type information in the `ImportData`.

Fixes and adds a precondition check to the deduce_utils helper that would have given a closer/more clear proximate cause.