### PR TITLE
Fix frame header CC tests

### DIFF
--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -210,7 +210,6 @@ cc_test(
         ":frame_header_test_dslx",
     ],
     shard_count = 50,
-    tags = ["manual"],
     deps = [
         ":data_generator",
         "//xls/common:xls_gunit_main",
@@ -999,7 +998,6 @@ cc_test(
         ":zstd_dec_test.ir",
     ],
     shard_count = 50,
-    tags = ["manual"],
     deps = [
         ":data_generator",
         "//xls/common:xls_gunit_main",

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -158,7 +158,6 @@ cc_library(
         "//xls/common/file:get_runfile_path",
         "//xls/common/status:status_macros",
         "@com_google_absl//absl/algorithm:container",
-        "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",

--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -153,16 +153,16 @@ cc_library(
         "@zstd//:decodecorpus",
     ],
     deps = [
+        "//xls/common:subprocess",
+        "//xls/common/file:filesystem",
+        "//xls/common/file:get_runfile_path",
+        "//xls/common/status:status_macros",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:span",
-        "//xls/common:subprocess",
-        "//xls/common/file:filesystem",
-        "//xls/common/file:get_runfile_path",
-        "//xls/common/status:status_macros",
     ],
 )
 
@@ -213,8 +213,6 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":data_generator",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/types:span",
         "//xls/common:xls_gunit_main",
         "//xls/common/file:filesystem",
         "//xls/common/file:get_runfile_path",
@@ -230,8 +228,10 @@ cc_test(
         "//xls/ir:bits",
         "//xls/ir:ir_test_base",
         "//xls/ir:value",
-        "@zstd",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
+        "@zstd",
     ],
 )
 
@@ -1002,10 +1002,6 @@ cc_test(
     tags = ["manual"],
     deps = [
         ":data_generator",
-        "@com_google_absl//absl/container:flat_hash_map",
-        "@com_google_absl//absl/log",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/types:span",
         "//xls/common:xls_gunit_main",
         "//xls/common/file:filesystem",
         "//xls/common/file:get_runfile_path",
@@ -1020,8 +1016,12 @@ cc_test(
         "//xls/ir:ir_parser",
         "//xls/ir:value",
         "//xls/jit:jit_proc_runtime",
-        "@zstd",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/types:span",
         "@com_google_googletest//:gtest",
+        "@zstd",
     ],
 )
 

--- a/xls/modules/zstd/data_generator.cc
+++ b/xls/modules/zstd/data_generator.cc
@@ -60,9 +60,8 @@ static absl::StatusOr<SubprocessResult> CallDecodecorpus(
     absl::Span<const std::string> args,
     const std::optional<std::filesystem::path>& cwd = std::nullopt,
     std::optional<absl::Duration> timeout = std::nullopt) {
-  XLS_ASSIGN_OR_RETURN(
-      std::filesystem::path path,
-      xls::GetXlsRunfilePath("external/zstd/decodecorpus"));
+  XLS_ASSIGN_OR_RETURN(std::filesystem::path path,
+                       xls::GetXlsRunfilePath("external/zstd/decodecorpus"));
 
   std::vector<std::string> cmd = {path};
   cmd.insert(cmd.end(), args.begin(), args.end());

--- a/xls/modules/zstd/frame_header_test.cc
+++ b/xls/modules/zstd/frame_header_test.cc
@@ -24,12 +24,14 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
-#include "xls/common/fuzzing/fuzztest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/types/span.h"
+#include "external/zstd/lib/zstd.h"
+#include "external/zstd/lib/zstd_errors.h"
+#include "gtest/gtest.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/file/get_runfile_path.h"
+#include "xls/common/fuzzing/fuzztest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/dslx/create_import_data.h"
@@ -42,8 +44,6 @@
 #include "xls/ir/ir_test_base.h"
 #include "xls/ir/value.h"
 #include "xls/modules/zstd/data_generator.h"
-#include "external/zstd/lib/zstd.h"
-#include "external/zstd/lib/zstd_errors.h"
 
 namespace xls {
 namespace {

--- a/xls/modules/zstd/zstd_dec_test.cc
+++ b/xls/modules/zstd/zstd_dec_test.cc
@@ -33,11 +33,12 @@
 #include <utility>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "external/zstd/lib/zstd.h"
+#include "gtest/gtest.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/file/get_runfile_path.h"
 #include "xls/common/status/matchers.h"
@@ -53,7 +54,6 @@
 #include "xls/ir/value.h"
 #include "xls/jit/jit_proc_runtime.h"
 #include "xls/modules/zstd/data_generator.h"
-#include "external/zstd/lib/zstd.h"
 
 namespace xls {
 namespace {


### PR DESCRIPTION
Fixes https://github.com/google/xls/issues/1547

CC @proppy

This PR fixes the handling of `absl:Span` with test data input vectors for the `frame_header` tests.
It looks like we must copy the vectors over to the `ZSTDFrameHeader` struct and keep those there for the time of the test case execution and use `absl::Span` based on those copies.
Without this modification we observed that few of the test cases will always fail due to incorrect data under the `input_buffer` span. The interesting thing is that when we commented out all test cases except one of the failing ones (e.g. `FrameHeaderTest.Success`) we noticed that this particular test case started passing indicating that the issue can be triggered by execution of multiple test cases at the same time.

This PR also fixes some formatting errors that were picked up with `clang-format version 18.1.8 `