### PR TITLE
[DSLX:LSP] Add basic support for inlay hints on let bindings.

### DIFF
--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -15,8 +15,6 @@
 """Provides helper that loads external repositories with third-party code."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
-
 load("//dependency_support/boost:workspace.bzl", repo_boost = "repo")
 load("//dependency_support/llvm:workspace.bzl", repo_llvm = "repo")
 load("//dependency_support/rules_hdl:workspace.bzl", repo_rules_hdl = "repo")
@@ -297,14 +295,12 @@ def load_external_repositories():
         urls = ["https://github.com/grailbio/bazel-compilation-database/archive/940cedacdb8a1acbce42093bf67f3a5ca8b265f7.tar.gz"],
     )
 
-    # Tagged 2024-06-19, current as of 2024-06-26
-    # NOTE FOR REVIEWER: this should be reverted before submission, once the
-    # Verible PR has landed.
+    # Current as of 2024-08-23
     http_archive(
         name = "verible",
-	integrity = "sha256-xW00EjPjGkmxsdGZ5Q5/pzEndhKdPj1VfpkX6dB8H7w=",
-        strip_prefix = "verible-461d2da9ef195625a6e0ca367d43a02ff658d962",
-        urls = ["https://github.com/cdleary/verible/archive/461d2da9ef195625a6e0ca367d43a02ff658d962.tar.gz"],
+        sha256 = "0f6e2f0cad335c9aca903aaa014f2a55d40c5c4dbfe4666474771f5c08e4a42c",
+        strip_prefix = "verible-17e909b09b279e5c1f5cd6a07404691babe3d3c3",
+        urls = ["https://github.com/chipsalliance/verible/archive/17e909b09b279e5c1f5cd6a07404691babe3d3c3.tar.gz"],
         patch_args = ["-p1"],
         patches = ["//dependency_support/verible:visibility.patch"],
     )

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -295,12 +295,13 @@ def load_external_repositories():
         urls = ["https://github.com/grailbio/bazel-compilation-database/archive/940cedacdb8a1acbce42093bf67f3a5ca8b265f7.tar.gz"],
     )
 
-    # Current as of 2024-08-23
+    # Tagged 2024-08-23, current as of 2024-08-24
+    VERIBLE_TAG = 'v0.0-3756-gda9a0f8c'
     http_archive(
         name = "verible",
-        sha256 = "0f6e2f0cad335c9aca903aaa014f2a55d40c5c4dbfe4666474771f5c08e4a42c",
-        strip_prefix = "verible-17e909b09b279e5c1f5cd6a07404691babe3d3c3",
-        urls = ["https://github.com/chipsalliance/verible/archive/17e909b09b279e5c1f5cd6a07404691babe3d3c3.tar.gz"],
+        sha256 = "0d45e646ce8cf618c55e614f827aead0377c34035be04b843aee225ea5be4527",
+        strip_prefix = "verible-" + VERIBLE_TAG.lstrip('v'),
+        urls = ["https://github.com/chipsalliance/verible/archive/refs/tags/" + VERIBLE_TAG + ".tar.gz"],
         patch_args = ["-p1"],
         patches = ["//dependency_support/verible:visibility.patch"],
     )

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -296,7 +296,7 @@ def load_external_repositories():
     )
 
     # Tagged 2024-08-23, current as of 2024-08-24
-    VERIBLE_TAG = 'v0.0-3756-gda9a0f8c'
+    VERIBLE_TAG = "v0.0-3756-gda9a0f8c"
     http_archive(
         name = "verible",
         sha256 = "0d45e646ce8cf618c55e614f827aead0377c34035be04b843aee225ea5be4527",

--- a/dependency_support/load_external.bzl
+++ b/dependency_support/load_external.bzl
@@ -15,6 +15,8 @@
 """Provides helper that loads external repositories with third-party code."""
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:local.bzl", "local_repository")
+
 load("//dependency_support/boost:workspace.bzl", repo_boost = "repo")
 load("//dependency_support/llvm:workspace.bzl", repo_llvm = "repo")
 load("//dependency_support/rules_hdl:workspace.bzl", repo_rules_hdl = "repo")
@@ -296,11 +298,13 @@ def load_external_repositories():
     )
 
     # Tagged 2024-06-19, current as of 2024-06-26
+    # NOTE FOR REVIEWER: this should be reverted before submission, once the
+    # Verible PR has landed.
     http_archive(
         name = "verible",
-        sha256 = "8c5d13bdc4f4bc756b0f6d31b61cc8aba75dfcfcf22822244ac9c0ccb43db814",
-        strip_prefix = "verible-0.0-3704-g1d393d43",
-        urls = ["https://github.com/chipsalliance/verible/archive/refs/tags/v0.0-3704-g1d393d43.tar.gz"],
+	integrity = "sha256-xW00EjPjGkmxsdGZ5Q5/pzEndhKdPj1VfpkX6dB8H7w=",
+        strip_prefix = "verible-461d2da9ef195625a6e0ca367d43a02ff658d962",
+        urls = ["https://github.com/cdleary/verible/archive/461d2da9ef195625a6e0ca367d43a02ff658d962.tar.gz"],
         patch_args = ["-p1"],
         patches = ["//dependency_support/verible:visibility.patch"],
     )

--- a/xls/dslx/frontend/module.cc
+++ b/xls/dslx/frontend/module.cc
@@ -106,6 +106,16 @@ std::vector<const AstNode*> Module::FindIntercepting(const Pos& target) const {
   return found;
 }
 
+std::vector<const AstNode*> Module::FindContained(const Span& target) const {
+  std::vector<const AstNode*> found;
+  for (const auto& node : nodes_) {
+    if (std::optional<Span> node_span = node->GetSpan(); node_span.has_value() && target.Contains(node_span.value())) {
+      found.push_back(node.get());
+    }
+  }
+  return found;
+}
+
 std::optional<Function*> Module::GetFunction(std::string_view target_name) {
   for (ModuleMember& member : top_) {
     if (std::holds_alternative<Function*>(member)) {

--- a/xls/dslx/frontend/module.cc
+++ b/xls/dslx/frontend/module.cc
@@ -109,7 +109,8 @@ std::vector<const AstNode*> Module::FindIntercepting(const Pos& target) const {
 std::vector<const AstNode*> Module::FindContained(const Span& target) const {
   std::vector<const AstNode*> found;
   for (const auto& node : nodes_) {
-    if (std::optional<Span> node_span = node->GetSpan(); node_span.has_value() && target.Contains(node_span.value())) {
+    if (std::optional<Span> node_span = node->GetSpan();
+        node_span.has_value() && target.Contains(node_span.value())) {
       found.push_back(node.get());
     }
   }

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -228,6 +228,9 @@ class Module : public AstNode {
   // "target" position.
   std::vector<const AstNode*> FindIntercepting(const Pos& target) const;
 
+  // Finds all the AST nodes that fall within the given span.
+  std::vector<const AstNode*> FindContained(const Span& target) const;
+
   // Tags this module as having the given module-level annotation "annotation".
   void AddAnnotation(ModuleAnnotation annotation) {
     annotations_.insert(annotation);

--- a/xls/dslx/lsp/dslx_ls.cc
+++ b/xls/dslx/lsp/dslx_ls.cc
@@ -71,6 +71,7 @@ InitializeResult InitializeServer(const nlohmann::json& params) {
       {"change", 2},        // Incremental updates
   };
   capabilities["documentSymbolProvider"] = true;
+  capabilities["inlayHintProvider"] = true;
   capabilities["definitionProvider"] = {
       {"dynamicRegistration", false},
       {"linkSupport", true},

--- a/xls/dslx/lsp/dslx_ls.cc
+++ b/xls/dslx/lsp/dslx_ls.cc
@@ -204,6 +204,19 @@ absl::Status RealMain() {
             params.textDocument.uri);
       });
 
+  dispatcher.AddRequestHandler(
+      "textDocument/inlayHint",
+      [&](const verible::lsp::InlayHintParams& params) {
+        auto inlay_hints_or = language_server_adapter.InlayHint(
+            params.textDocument.uri, params.range);
+        if (inlay_hints_or.ok()) {
+          return std::move(inlay_hints_or).value();
+        }
+        LspLog() << "could not determine inlay hints; status: "
+                 << inlay_hints_or.status() << "\n";
+        return std::vector<verible::lsp::InlayHint>{};
+      });
+
   // Main loop. Feeding the stream-splitter that then calls the dispatcher.
   absl::Status status = absl::OkStatus();
   while (status.ok() && !shutdown_requested) {

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -244,7 +244,7 @@ LanguageServerAdapter::InlayHint(std::string_view uri,
         const Type& type = *maybe_type.value();
         results.push_back(verible::lsp::InlayHint{
             .position = ConvertPosToLspPosition(name_def_tree->span().limit()),
-            .label = absl::StrCat(": ", type.ToString()),
+            .label = absl::StrCat(": ", type.ToInlayHintString()),
             .kind = verible::lsp::InlayHintKind::kType,
             .paddingRight = true,
         });

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -214,15 +214,16 @@ LanguageServerAdapter::ProvideImportLinks(std::string_view uri) const {
 }
 
 absl::StatusOr<std::vector<verible::lsp::InlayHint>>
-LanguageServerAdapter::InlayHint(
-    std::string_view uri, const verible::lsp::Range& range) const {
+LanguageServerAdapter::InlayHint(std::string_view uri,
+                                 const verible::lsp::Range& range) const {
   std::vector<verible::lsp::InlayHint> results;
   if (const ParseData* parsed = FindParsedForUri(uri); parsed && parsed->ok()) {
     const Span want_span = ConvertLspRangeToSpan(uri, range);
     const Module& module = parsed->module();
     const TypeInfo& type_info = parsed->type_info();
     // Get let bindings in the AST that fall in the given range.
-    const std::vector<const AstNode*> contained = module.FindContained(want_span);
+    const std::vector<const AstNode*> contained =
+        module.FindContained(want_span);
     for (const AstNode* node : contained) {
       if (node->kind() == AstNodeKind::kLet) {
         const auto* let = down_cast<const Let*>(node);
@@ -235,15 +236,17 @@ LanguageServerAdapter::InlayHint(
         if (!maybe_type.has_value()) {
           // Should not happen, but if it does somehow we don't want to crash
           // the language server.
-          LspLog() << "No type information available for: " << name_def_tree->ToString() << " @ " << name_def_tree->span();
+          LspLog() << "No type information available for: "
+                   << name_def_tree->ToString() << " @ "
+                   << name_def_tree->span();
           continue;
         }
         const Type& type = *maybe_type.value();
         results.push_back(verible::lsp::InlayHint{
-          .position = ConvertPosToLspPosition(name_def_tree->span().limit()),
-          .label = absl::StrCat(": ", type.ToString()),
-          .kind = verible::lsp::InlayHintKind::kType,
-          .paddingRight = true,
+            .position = ConvertPosToLspPosition(name_def_tree->span().limit()),
+            .label = absl::StrCat(": ", type.ToString()),
+            .kind = verible::lsp::InlayHintKind::kType,
+            .paddingRight = true,
         });
       }
     }

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -213,4 +213,42 @@ LanguageServerAdapter::ProvideImportLinks(std::string_view uri) const {
   return result;
 }
 
+absl::StatusOr<std::vector<verible::lsp::InlayHint>>
+LanguageServerAdapter::InlayHint(
+    std::string_view uri, const verible::lsp::Range& range) const {
+  std::vector<verible::lsp::InlayHint> results;
+  if (const ParseData* parsed = FindParsedForUri(uri); parsed && parsed->ok()) {
+    const Span want_span = ConvertLspRangeToSpan(uri, range);
+    const Module& module = parsed->module();
+    const TypeInfo& type_info = parsed->type_info();
+    // Get let bindings in the AST that fall in the given range.
+    const std::vector<const AstNode*> contained = module.FindContained(want_span);
+    for (const AstNode* node : contained) {
+      if (node->kind() == AstNodeKind::kLet) {
+        const auto* let = down_cast<const Let*>(node);
+        if (let->type_annotation() != nullptr) {
+          // Already has a type annotated, no need for inlay.
+          continue;
+        }
+        const auto* name_def_tree = let->name_def_tree();
+        std::optional<Type*> maybe_type = type_info.GetItem(name_def_tree);
+        if (!maybe_type.has_value()) {
+          // Should not happen, but if it does somehow we don't want to crash
+          // the language server.
+          LspLog() << "No type information available for: " << name_def_tree->ToString() << " @ " << name_def_tree->span();
+          continue;
+        }
+        const Type& type = *maybe_type.value();
+        results.push_back(verible::lsp::InlayHint{
+          .position = ConvertPosToLspPosition(name_def_tree->span().limit()),
+          .label = absl::StrCat(": ", type.ToString()),
+          .kind = verible::lsp::InlayHintKind::kType,
+          .paddingRight = true,
+        });
+      }
+    }
+  }
+  return results;
+}
+
 }  // namespace xls::dslx

--- a/xls/dslx/lsp/language_server_adapter.h
+++ b/xls/dslx/lsp/language_server_adapter.h
@@ -80,6 +80,10 @@ class LanguageServerAdapter {
   std::vector<verible::lsp::DocumentLink> ProvideImportLinks(
       std::string_view uri) const;
 
+  absl::StatusOr<std::vector<verible::lsp::InlayHint>>
+  InlayHint(
+      std::string_view uri, const verible::lsp::Range& range) const;
+
  private:
   struct ParseData;
 
@@ -104,6 +108,10 @@ class LanguageServerAdapter {
     const Module& module() const {
       CHECK_OK(tmc.status());
       return *tmc->tm.module;
+    }
+    const TypeInfo& type_info() const {
+      CHECK_OK(tmc.status());
+      return *tmc->tm.type_info;
     }
     const Comments& comments() const {
       CHECK_OK(tmc.status());

--- a/xls/dslx/lsp/language_server_adapter.h
+++ b/xls/dslx/lsp/language_server_adapter.h
@@ -80,8 +80,7 @@ class LanguageServerAdapter {
   std::vector<verible::lsp::DocumentLink> ProvideImportLinks(
       std::string_view uri) const;
 
-  absl::StatusOr<std::vector<verible::lsp::InlayHint>>
-  InlayHint(
+  absl::StatusOr<std::vector<verible::lsp::InlayHint>> InlayHint(
       std::string_view uri, const verible::lsp::Range& range) const;
 
  private:

--- a/xls/dslx/lsp/language_server_adapter_test.cc
+++ b/xls/dslx/lsp/language_server_adapter_test.cc
@@ -193,5 +193,28 @@ fn messy() {
 )");
 }
 
+TEST(LanguageServerAdapterTest, InlayHintForLetStatement) {
+  LanguageServerAdapter adapter(kDefaultDslxStdlibPath, /*dslx_paths=*/{"."});
+  constexpr std::string_view kUri = "memfile://test.x";
+  XLS_ASSERT_OK(adapter.Update(kUri, R"(fn f(x: u32) -> u32 {
+  let y = x;
+  let z = y;
+  z
+})"));
+
+  const auto kInputRange =
+      verible::lsp::Range{.start = verible::lsp::Position{1, 0},
+                          .end = verible::lsp::Position{2, 0}};
+  XLS_ASSERT_OK_AND_ASSIGN(std::vector<verible::lsp::InlayHint> hints,
+                           adapter.InlayHint(kUri, kInputRange));
+
+  ASSERT_EQ(hints.size(), 1);
+
+  const verible::lsp::InlayHint& hint = hints.at(0);
+  verible::lsp::Position want_position{1, 7};
+  EXPECT_TRUE(hint.position == want_position) << "got: " << DebugString(hint.position) << " want: " << DebugString(want_position);
+  EXPECT_EQ(hint.label, ": uN[32]");
+}
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/lsp/language_server_adapter_test.cc
+++ b/xls/dslx/lsp/language_server_adapter_test.cc
@@ -212,7 +212,9 @@ TEST(LanguageServerAdapterTest, InlayHintForLetStatement) {
 
   const verible::lsp::InlayHint& hint = hints.at(0);
   verible::lsp::Position want_position{1, 7};
-  EXPECT_TRUE(hint.position == want_position) << "got: " << DebugString(hint.position) << " want: " << DebugString(want_position);
+  EXPECT_TRUE(hint.position == want_position)
+      << "got: " << DebugString(hint.position)
+      << " want: " << DebugString(want_position);
   EXPECT_EQ(hint.label, ": uN[32]");
 }
 

--- a/xls/dslx/lsp/lsp_type_utils.cc
+++ b/xls/dslx/lsp/lsp_type_utils.cc
@@ -22,13 +22,15 @@
 
 namespace xls::dslx {
 
+verible::lsp::Position ConvertPosToLspPosition(const Pos& pos) {
+  return verible::lsp::Position{.line = static_cast<int>(pos.lineno()),
+                .character = static_cast<int>(pos.colno())};
+}
+
 verible::lsp::Range ConvertSpanToLspRange(const Span& span) {
-  verible::lsp::Range result = {
-      .start = {.line = static_cast<int>(span.start().lineno()),
-                .character = static_cast<int>(span.start().colno())},
-      .end = {.line = static_cast<int>(span.limit().lineno()),
-              .character = static_cast<int>(span.limit().colno())}};
-  return result;
+  return verible::lsp::Range{
+      .start = ConvertPosToLspPosition(span.start()),
+      .end = ConvertPosToLspPosition(span.limit())};
 }
 
 verible::lsp::Location ConvertSpanToLspLocation(const Span& span) {

--- a/xls/dslx/lsp/lsp_type_utils.cc
+++ b/xls/dslx/lsp/lsp_type_utils.cc
@@ -24,13 +24,12 @@ namespace xls::dslx {
 
 verible::lsp::Position ConvertPosToLspPosition(const Pos& pos) {
   return verible::lsp::Position{.line = static_cast<int>(pos.lineno()),
-                .character = static_cast<int>(pos.colno())};
+                                .character = static_cast<int>(pos.colno())};
 }
 
 verible::lsp::Range ConvertSpanToLspRange(const Span& span) {
-  return verible::lsp::Range{
-      .start = ConvertPosToLspPosition(span.start()),
-      .end = ConvertPosToLspPosition(span.limit())};
+  return verible::lsp::Range{.start = ConvertPosToLspPosition(span.start()),
+                             .end = ConvertPosToLspPosition(span.limit())};
 }
 
 verible::lsp::Location ConvertSpanToLspLocation(const Span& span) {

--- a/xls/dslx/lsp/lsp_type_utils.h
+++ b/xls/dslx/lsp/lsp_type_utils.h
@@ -24,7 +24,9 @@
 
 namespace xls::dslx {
 
+verible::lsp::Position ConvertPosToLspPosition(const Pos& pos);
 verible::lsp::Range ConvertSpanToLspRange(const Span& span);
+
 verible::lsp::Location ConvertSpanToLspLocation(const Span& span);
 
 // Note: DSLX positions have filenames included in them, whereas LSP positions

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -381,6 +381,8 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceLet(const Let* node,
                                     *node->owner(), ctx);
   }
 
+  ctx->type_info()->SetItem(node->name_def_tree(), *rhs);
+
   return Type::MakeUnit();
 }
 

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -557,7 +557,7 @@ std::vector<TypeDim> StructType::GetAllDims() const {
 }
 
 std::unique_ptr<Type> StructType::AddNominalTypeDims(
-    absl::flat_hash_map<std::string, TypeDim> added_dims_by_identifier) const {
+    const absl::flat_hash_map<std::string, TypeDim>& added_dims_by_identifier) const {
   absl::flat_hash_map<std::string, TypeDim> combined_dims =
       nominal_type_dims_by_identifier_;
   for (const ParametricBinding* binding : struct_def_.parametric_bindings()) {
@@ -577,7 +577,7 @@ std::unique_ptr<Type> StructType::AddNominalTypeDims(
     const auto it = added_dims_by_identifier.find(binding->identifier());
     if (it != added_dims_by_identifier.end()) {
       combined_dims.insert_or_assign(binding->identifier(),
-                                     std::move(it->second));
+                                     it->second.Clone());
     }
   }
   std::vector<std::unique_ptr<Type>> cloned_members;

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -740,8 +740,7 @@ std::string ArrayType::ToStringInternal(FullyQualify fully_qualify) const {
 }
 
 std::string ArrayType::ToInlayHintString() const {
-  return absl::StrFormat("%s[%s]",
-                         element_type_->ToInlayHintString(),
+  return absl::StrFormat("%s[%s]", element_type_->ToInlayHintString(),
                          size_.ToString());
 }
 

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -693,6 +693,14 @@ std::string TupleType::ToStringInternal(FullyQualify fully_qualify) const {
   return absl::StrCat("(", guts, ")");
 }
 
+std::string TupleType::ToInlayHintString() const {
+  std::string guts = absl::StrJoin(
+      members_, ", ", [](std::string* out, const std::unique_ptr<Type>& m) {
+        absl::StrAppend(out, m->ToInlayHintString());
+      });
+  return absl::StrCat("(", guts, ")");
+}
+
 std::vector<TypeDim> TupleType::GetAllDims() const {
   std::vector<TypeDim> results;
   for (const std::unique_ptr<Type>& t : members_) {
@@ -728,6 +736,12 @@ absl::StatusOr<std::unique_ptr<Type>> ArrayType::MapSize(
 std::string ArrayType::ToStringInternal(FullyQualify fully_qualify) const {
   return absl::StrFormat("%s[%s]",
                          element_type_->ToStringInternal(fully_qualify),
+                         size_.ToString());
+}
+
+std::string ArrayType::ToInlayHintString() const {
+  return absl::StrFormat("%s[%s]",
+                         element_type_->ToInlayHintString(),
                          size_.ToString());
 }
 

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -557,7 +557,8 @@ std::vector<TypeDim> StructType::GetAllDims() const {
 }
 
 std::unique_ptr<Type> StructType::AddNominalTypeDims(
-    const absl::flat_hash_map<std::string, TypeDim>& added_dims_by_identifier) const {
+    const absl::flat_hash_map<std::string, TypeDim>& added_dims_by_identifier)
+    const {
   absl::flat_hash_map<std::string, TypeDim> combined_dims =
       nominal_type_dims_by_identifier_;
   for (const ParametricBinding* binding : struct_def_.parametric_bindings()) {
@@ -576,8 +577,7 @@ std::unique_ptr<Type> StructType::AddNominalTypeDims(
     }
     const auto it = added_dims_by_identifier.find(binding->identifier());
     if (it != added_dims_by_identifier.end()) {
-      combined_dims.insert_or_assign(binding->identifier(),
-                                     it->second.Clone());
+      combined_dims.insert_or_assign(binding->identifier(), it->second.Clone());
     }
   }
   std::vector<std::unique_ptr<Type>> cloned_members;

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -264,6 +264,16 @@ class Type {
   //
   // For example, for structs, this does not show the internal structure, just
   // the nominal part (the struct name).
+  //
+  // e.g. consider:
+  //
+  // ```dslx-snippet
+  // fn f(s: MyStruct) -> MyStruct {
+  //   let s = MyStruct{foo: u32:42, ..s};
+  //        ^~~~~ inlay hint goes here as ": MyStruct"
+  //   s
+  // }
+  // ```
   virtual std::string ToInlayHintString() const { return ToString(); }
 
   // Returns whether this type contains an enum type (transitively).
@@ -563,6 +573,8 @@ class TupleType : public Type {
 
   explicit TupleType(std::vector<std::unique_ptr<Type>> members);
 
+  std::string ToInlayHintString() const override;
+
   absl::Status Accept(TypeVisitor& v) const override {
     return v.HandleTuple(*this);
   }
@@ -627,6 +639,8 @@ class ArrayType : public Type {
   bool HasEnum() const override { return element_type_->HasEnum(); }
   bool HasToken() const override { return element_type_->HasToken(); }
   bool IsAggregate() const override { return true; }
+
+  std::string ToInlayHintString() const override;
 
   bool operator==(const Type& other) const override;
 

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -382,10 +382,10 @@ class MetaType : public Type {
   }
 
   std::unique_ptr<Type> AddNominalTypeDims(
-      absl::flat_hash_map<std::string, TypeDim> dims_by_identifier)
+      const absl::flat_hash_map<std::string, TypeDim>& dims_by_identifier)
       const override {
     return std::make_unique<MetaType>(
-        wrapped_->AddNominalTypeDims(std::move(dims_by_identifier)));
+        wrapped_->AddNominalTypeDims(dims_by_identifier));
   }
 
   std::unique_ptr<Type> CloneToUnique() const override {

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -264,9 +264,7 @@ class Type {
   //
   // For example, for structs, this does not show the internal structure, just
   // the nominal part (the struct name).
-  virtual std::string ToInlayHintString() const {
-    return ToString();
-  }
+  virtual std::string ToInlayHintString() const { return ToString(); }
 
   // Returns whether this type contains an enum type (transitively).
   virtual bool HasEnum() const = 0;

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -259,6 +259,15 @@ class Type {
   // Variation on `ToString()` to be used in user-facing error reporting.
   virtual std::string ToErrorString() const { return ToString(); }
 
+  // Returns an "inlay hint" representation of this type that will be shown
+  // e.g. in a code editor when a type is inferred.
+  //
+  // For example, for structs, this does not show the internal structure, just
+  // the nominal part (the struct name).
+  virtual std::string ToInlayHintString() const {
+    return ToString();
+  }
+
   // Returns whether this type contains an enum type (transitively).
   virtual bool HasEnum() const = 0;
 
@@ -307,7 +316,7 @@ class Type {
   // during the creation of that instance of the type, the deduction system
   // would call this function with the `dims` being `5` and `6`, in that order.
   virtual std::unique_ptr<Type> AddNominalTypeDims(
-      absl::flat_hash_map<std::string, TypeDim>) const {
+      const absl::flat_hash_map<std::string, TypeDim>&) const {
     return CloneToUnique();
   }
 
@@ -480,6 +489,10 @@ class StructType : public Type {
   // definition if one is available.
   std::string ToErrorString() const override;
 
+  std::string ToInlayHintString() const override {
+    return nominal_type().identifier();
+  }
+
   // Returns an InvalidArgument error status if this TupleType does not have
   // named members.
   absl::StatusOr<std::vector<std::string>> GetMemberNames() const;
@@ -520,7 +533,7 @@ class StructType : public Type {
   const std::vector<std::unique_ptr<Type>>& members() const { return members_; }
 
   std::unique_ptr<Type> AddNominalTypeDims(
-      absl::flat_hash_map<std::string, TypeDim> dims_by_identifier)
+      const absl::flat_hash_map<std::string, TypeDim>& dims_by_identifier)
       const override;
 
  private:

--- a/xls/dslx/type_system/type_test.cc
+++ b/xls/dslx/type_system/type_test.cc
@@ -199,8 +199,10 @@ TEST(TypeTest, TestUnit) {
 TEST(TypeTest, TestTwoTupleOfStruct) {
   Module module("test", /*fs_path=*/std::nullopt);
   StructType s = CreateSimpleStruct(module);
-  std::unique_ptr<TupleType> t2 = TupleType::Create2(s.CloneToUnique(), s.CloneToUnique());
-  EXPECT_EQ("(S { x: uN[8], y: uN[1] }, S { x: uN[8], y: uN[1] })", t2->ToString());
+  std::unique_ptr<TupleType> t2 =
+      TupleType::Create2(s.CloneToUnique(), s.CloneToUnique());
+  EXPECT_EQ("(S { x: uN[8], y: uN[1] }, S { x: uN[8], y: uN[1] })",
+            t2->ToString());
   EXPECT_EQ("(S, S)", t2->ToInlayHintString());
   EXPECT_EQ("tuple", t2->GetDebugTypeName());
   EXPECT_EQ(false, t2->HasEnum());

--- a/xls/dslx/type_system/type_test.cc
+++ b/xls/dslx/type_system/type_test.cc
@@ -153,6 +153,7 @@ StructType CreateStructWithParametricExpr(Module& module) {
 TEST(TypeTest, TestU32) {
   BitsType t(false, 32);
   EXPECT_EQ("uN[32]", t.ToString());
+  EXPECT_EQ("uN[32]", t.ToInlayHintString());
   EXPECT_EQ("ubits", t.GetDebugTypeName());
   EXPECT_EQ(false, t.is_signed());
   EXPECT_EQ(false, t.HasEnum());
@@ -164,6 +165,7 @@ TEST(TypeTest, TestU32) {
 TEST(TypeTest, TestUnit) {
   TupleType t({});
   EXPECT_EQ("()", t.ToString());
+  EXPECT_EQ("()", t.ToInlayHintString());
   EXPECT_EQ("tuple", t.GetDebugTypeName());
   EXPECT_EQ(false, t.HasEnum());
   EXPECT_TRUE(t.GetAllDims().empty());
@@ -173,6 +175,7 @@ TEST(TypeTest, TestUnit) {
 TEST(TypeTest, TestArrayOfU32) {
   ArrayType t(std::make_unique<BitsType>(false, 32), TypeDim::CreateU32(1));
   EXPECT_EQ("uN[32][1]", t.ToString());
+  EXPECT_EQ("uN[32][1]", t.ToInlayHintString());
   EXPECT_EQ("array", t.GetDebugTypeName());
   EXPECT_EQ(false, t.HasEnum());
   std::vector<TypeDim> want_dims = {TypeDim::CreateU32(1),
@@ -195,6 +198,7 @@ TEST(TypeTest, TestEnum) {
   EXPECT_TRUE(t.HasEnum());
   EXPECT_EQ(std::vector<TypeDim>{TypeDim::CreateU32(2)}, t.GetAllDims());
   EXPECT_EQ("MyEnum", t.ToString());
+  EXPECT_EQ("MyEnum", t.ToInlayHintString());
   EXPECT_EQ("fake.x:MyEnum", t.ToStringFullyQualified());
 }
 
@@ -212,6 +216,7 @@ TEST(TypeTest, FromInterpValueSbits) {
   XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Type> ct,
                            Type::FromInterpValue(s8_m1));
   EXPECT_EQ(ct->ToString(), "sN[8]");
+  EXPECT_EQ(ct->ToInlayHintString(), "sN[8]");
 }
 
 TEST(TypeTest, FromInterpValueArrayU2) {
@@ -241,6 +246,7 @@ TEST(TypeTest, FromInterpValueTupleOfTwoNumbers) {
   });
   XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Type> ct, Type::FromInterpValue(v));
   EXPECT_EQ(ct->ToString(), "(uN[2], sN[3])");
+  EXPECT_EQ(ct->ToInlayHintString(), "(uN[2], sN[3])");
   EXPECT_FALSE(ct->IsUnit());
   EXPECT_THAT(ct->GetTotalBitCount(), IsOkAndHolds(TypeDim::CreateU32(5)));
 }
@@ -324,6 +330,7 @@ TEST(TypeTest, EmptyStructTypeIsNotUnit) {
   EXPECT_FALSE(s.HasEnum());
   EXPECT_FALSE(s.IsUnit());
   EXPECT_EQ(s.ToString(), "S {}");
+  EXPECT_EQ(s.ToInlayHintString(), "S");
   EXPECT_EQ(s.ToStringFullyQualified(), "relpath/to/test.x:S {}");
 }
 


### PR DESCRIPTION
Was dependent on https://github.com/chipsalliance/verible/pull/2241, which is now submitted.