### PR TITLE
[DSLX:TS] Fix for ColonRef to enum value within proc parametrics.

### DIFF
--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -2725,8 +2725,14 @@ absl::Status FunctionConverter::HandleColonRef(const ColonRef* node) {
           [&](ArrayTypeAnnotation* array_type) -> absl::Status {
             // Type checking currently ensures that we're not taking a '::' on
             // anything other than a bits type.
-            XLS_ASSIGN_OR_RETURN(xls::Type * input_type,
-                                 ResolveTypeToIr(array_type));
+            xls::Type* input_type;
+            {
+              XLS_ASSIGN_OR_RETURN(
+                  TypeInfo * type_info,
+                  import_data_->GetRootTypeInfo(array_type->owner()));
+              ScopedTypeInfoSwap stis(this, type_info);
+              XLS_ASSIGN_OR_RETURN(input_type, ResolveTypeToIr(array_type));
+            }
             xls::BitsType* bits_type = input_type->AsBitsOrDie();
             const int64_t bit_count = bits_type->bit_count();
             XLS_ASSIGN_OR_RETURN(
@@ -3527,6 +3533,7 @@ absl::StatusOr<EnumDef*> FunctionConverter::DerefEnum(TypeDefinition node) {
 absl::StatusOr<std::unique_ptr<Type>> FunctionConverter::ResolveType(
     const AstNode* node) {
   XLS_RET_CHECK(current_type_info_ != nullptr);
+  XLS_RET_CHECK_EQ(current_type_info_->module(), node->owner());
   std::optional<const Type*> t = current_type_info_->GetItem(node);
   if (!t.has_value()) {
     return IrConversionErrorStatus(

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -691,6 +691,17 @@ dslx_lang_test(
 
 # Library defined to be imported.
 xls_dslx_library(
+    name = "mod_u16_type_alias_dslx",
+    srcs = ["mod_u16_type_alias.x"],
+)
+
+dslx_lang_test(
+    name = "import_u16_type_alias",
+    dslx_deps = [":mod_u16_type_alias_dslx"],
+)
+
+# Library defined to be imported.
+xls_dslx_library(
     name = "mod_imported_struct_of_enum_dslx",
     srcs = [":mod_imported_struct_of_enum.x"],
 )

--- a/xls/dslx/tests/import_u16_type_alias.x
+++ b/xls/dslx/tests/import_u16_type_alias.x
@@ -1,0 +1,20 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import xls.dslx.tests.mod_u16_type_alias;
+
+fn main() -> mod_u16_type_alias::T { mod_u16_type_alias::T::MAX }
+
+#[test]
+fn test_main() { assert_eq(u16:0xffff, main()) }

--- a/xls/dslx/tests/mod_u16_type_alias.x
+++ b/xls/dslx/tests/mod_u16_type_alias.x
@@ -1,0 +1,16 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const W = s32:16;
+pub type T = bits[W as u32];

--- a/xls/dslx/type_system/BUILD
+++ b/xls/dslx/type_system/BUILD
@@ -133,6 +133,7 @@ cc_library(
         ":type_info",
         ":type_zero_value",
         ":unwrap_meta_type",
+        ":scoped_fn_stack_entry",
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/base:nullability",
         "@com_google_absl//absl/cleanup",
@@ -821,6 +822,7 @@ cc_library(
     srcs = ["typecheck_function.cc"],
     hdrs = ["typecheck_function.h"],
     deps = [
+        "//xls/common/logging:log_lines",
         ":deduce",
         ":deduce_ctx",
         ":parametric_env",

--- a/xls/dslx/type_system/scoped_fn_stack_entry.cc
+++ b/xls/dslx/type_system/scoped_fn_stack_entry.cc
@@ -28,11 +28,6 @@ ScopedFnStackEntry::ScopedFnStackEntry(DeduceCtx* ctx, Module* module)
   ctx->AddFnStackEntry(FnStackEntry::MakeTop(module));
 }
 
-// Args:
-//  expect_popped: Indicates that we expect, in the destructor for this scope,
-//    that the entry will have already been popped. Generally this is `false`
-//    since we expect the entry to be on the top of the fn stack in the
-//    destructor, in which case we automatically pop it.
 ScopedFnStackEntry::ScopedFnStackEntry(Function& fn, DeduceCtx* ctx,
                                        WithinProc within_proc,
                                        bool expect_popped)
@@ -42,10 +37,6 @@ ScopedFnStackEntry::ScopedFnStackEntry(Function& fn, DeduceCtx* ctx,
   ctx->AddFnStackEntry(FnStackEntry::Make(fn, ParametricEnv(), within_proc));
 }
 
-// Called when we close out a scope. We can't use this object as a scope
-// guard easily because we want to be able to detect if we return an
-// absl::Status early, so we have to manually put end-of-scope calls at usage
-// points.
 void ScopedFnStackEntry::Finish() {
   if (expect_popped_) {
     CHECK_EQ(ctx_->fn_stack().size(), depth_before_);

--- a/xls/dslx/type_system/scoped_fn_stack_entry.h
+++ b/xls/dslx/type_system/scoped_fn_stack_entry.h
@@ -32,8 +32,15 @@ namespace xls::dslx {
 // the "happy paths".
 class ScopedFnStackEntry {
  public:
-  ScopedFnStackEntry(DeduceCtx* ctx, Module* module);
+  // Creates a scoped function-stack entry *for the top level* of the given
+  // `module`.
+  static ScopedFnStackEntry MakeForTop(DeduceCtx* ctx, Module* module) {
+    return ScopedFnStackEntry(ctx, module);
+  }
 
+  // Creates a scoped function-stack entry for `fn`, where we indicate whether
+  // `fn` is within a proc via the `within_proc` value.
+  //
   // Args:
   //  expect_popped: Indicates that we expect, on the call to Finish(),
   //    that the entry will have already been popped. Generally this is `false`
@@ -49,6 +56,8 @@ class ScopedFnStackEntry {
   void Finish();
 
  private:
+  ScopedFnStackEntry(DeduceCtx* ctx, Module* module);
+
   DeduceCtx* ctx_;
   int64_t depth_before_;
   bool expect_popped_;

--- a/xls/dslx/type_system/type_info.cc
+++ b/xls/dslx/type_system/type_info.cc
@@ -363,9 +363,10 @@ std::string TypeInfo::GetTypeInfoTreeString() const {
 }
 
 std::optional<Type*> TypeInfo::GetItem(const AstNode* key) const {
-  CHECK_EQ(key->owner(), module_)
-      << key->owner()->name() << " vs " << module_->name()
-      << " key: " << key->ToString();
+  CHECK_EQ(key->owner(), module_) << absl::StreamFormat(
+      "attempted to get type information for AST node: `%s`; but it is from "
+      "module `%s` and type information is for module `%s`",
+      key->ToString(), key->owner()->name(), module_->name());
   auto it = dict_.find(key);
   if (it != dict_.end()) {
     return it->second.get();

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2488,6 +2488,28 @@ proc bar_proc {
       ParseAndTypecheck(kProgram, "fake_main_path.x", "main", &import_data));
 }
 
+// See https://github.com/google/xls/issues/1540#issuecomment-2291819096
+TEST(TypecheckTest, ImportedTypeAliasAttributeGithubIssue1540) {
+  constexpr std::string_view kImported = R"(
+pub const W = s32:16;
+pub type T = bits[W as u32];
+)";
+  constexpr std::string_view kProgram = R"(
+import imported;
+
+fn f() -> imported::T {
+  imported::T::MAX
+}
+)";
+  auto import_data = CreateImportDataForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule imported,
+      ParseAndTypecheck(kImported, "imported.x", "imported", &import_data));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule main,
+      ParseAndTypecheck(kProgram, "fake_main_path.x", "main", &import_data));
+}
+
 TEST(TypecheckTest, MissingWideningCastFromValueError) {
   constexpr std::string_view kProgram = R"(
 fn main(x: u32) -> u64 {


### PR DESCRIPTION
Towards google/xls#1540 -- in particular fixes the example given in this comment:

https://github.com/google/xls/issues/1540#issuecomment-2297711953

When deducing a ColonRef we get the root type information for the subject, create a new context to deduce the entity being referred to, and we should accordingly push a top level entry onto the function stack for that referred-to module.

Previously we were copying the most recent entry in the function stack, which for a parametric proc indicated we were typechecking within a proc function, which caused the wrong things to happen downstream in the code.

Tightened up some of the invariant checks as well for when we expect there to be a single top-level entry on the function stack.