### PR TITLE
Add start of C API for VAST

### DIFF
--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -171,6 +171,7 @@ cc_library(
         "//xls/ir:ir_parser",
         "//xls/ir:type",
         "//xls/ir:value",
+        "//xls/codegen/vast",
     ],
 )
 

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -505,4 +505,11 @@ struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
   return reinterpret_cast<xls_vast_data_type*>(type);
 }
 
+struct xls_vast_data_type* xls_vast_verilog_file_make_bit_vector_type(
+    struct xls_vast_verilog_file* f, int64_t bit_count, bool is_signed) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::DataType* type = cpp_file->BitVectorType(bit_count, xls::SourceInfo(), is_signed);
+  return reinterpret_cast<xls_vast_data_type*>(type);
+}
+
 }  // extern "C"

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -462,10 +462,37 @@ void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
   cpp_file->AddInclude(path, xls::SourceInfo());
 }
 
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref = cpp_module->AddInput(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref = cpp_module->AddOutput(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref = cpp_module->AddWire(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
 char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f) {
   const auto* cpp_file = reinterpret_cast<const xls::verilog::VerilogFile*>(f);
   std::string result = cpp_file->Emit();
   return ToOwnedCString(result);
+}
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(struct xls_vast_verilog_file* f) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::DataType* type = cpp_file->ScalarType(xls::SourceInfo());
+  return reinterpret_cast<xls_vast_data_type*>(type);
 }
 
 }  // extern "C"

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -462,24 +462,33 @@ void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
   cpp_file->AddInclude(path, xls::SourceInfo());
 }
 
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
   auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
   auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
-  xls::verilog::LogicRef* logic_ref = cpp_module->AddInput(name, cpp_type, xls::SourceInfo());
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddInput(name, cpp_type, xls::SourceInfo());
   return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
 }
 
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
   auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
   auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
-  xls::verilog::LogicRef* logic_ref = cpp_module->AddOutput(name, cpp_type, xls::SourceInfo());
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddOutput(name, cpp_type, xls::SourceInfo());
   return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
 }
 
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type) {
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
   auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
   auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
-  xls::verilog::LogicRef* logic_ref = cpp_module->AddWire(name, cpp_type, xls::SourceInfo());
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddWire(name, cpp_type, xls::SourceInfo());
   return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
 }
 
@@ -489,7 +498,8 @@ char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f) {
   return ToOwnedCString(result);
 }
 
-struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(struct xls_vast_verilog_file* f) {
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
+    struct xls_vast_verilog_file* f) {
   auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
   xls::verilog::DataType* type = cpp_file->ScalarType(xls::SourceInfo());
   return reinterpret_cast<xls_vast_data_type*>(type);

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -508,7 +508,8 @@ struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
 struct xls_vast_data_type* xls_vast_verilog_file_make_bit_vector_type(
     struct xls_vast_verilog_file* f, int64_t bit_count, bool is_signed) {
   auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
-  xls::verilog::DataType* type = cpp_file->BitVectorType(bit_count, xls::SourceInfo(), is_signed);
+  xls::verilog::DataType* type =
+      cpp_file->BitVectorType(bit_count, xls::SourceInfo(), is_signed);
   return reinterpret_cast<xls_vast_data_type*>(type);
 }
 

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -30,6 +30,7 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "xls/codegen/vast/vast.h"
 #include "xls/common/init_xls.h"
 #include "xls/interpreter/function_interpreter.h"
 #include "xls/ir/events.h"
@@ -40,7 +41,6 @@
 #include "xls/ir/type.h"
 #include "xls/ir/value.h"
 #include "xls/public/runtime_build_actions.h"
-#include "xls/codegen/vast/vast.h"
 
 namespace {
 
@@ -437,8 +437,10 @@ bool xls_interpret_function(struct xls_function* function, size_t argc,
 
 // -- VAST
 
-struct xls_vast_verilog_file* xls_vast_make_verilog_file(xls_vast_file_type file_type) {
-  auto* value = new xls::verilog::VerilogFile(static_cast<xls::verilog::FileType>(file_type));
+struct xls_vast_verilog_file* xls_vast_make_verilog_file(
+    xls_vast_file_type file_type) {
+  auto* value = new xls::verilog::VerilogFile(
+      static_cast<xls::verilog::FileType>(file_type));
   return reinterpret_cast<xls_vast_verilog_file*>(value);
 }
 
@@ -446,13 +448,16 @@ void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f) {
   delete reinterpret_cast<xls::verilog::VerilogFile*>(f);
 }
 
-struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(struct xls_vast_verilog_file* f, const char* name) {
+struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
+    struct xls_vast_verilog_file* f, const char* name) {
   auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
-  xls::verilog::Module* cpp_module = cpp_file->AddModule(name, xls::SourceInfo());
+  xls::verilog::Module* cpp_module =
+      cpp_file->AddModule(name, xls::SourceInfo());
   return reinterpret_cast<xls_vast_verilog_module*>(cpp_module);
 }
 
-void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f, const char* path) {
+void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
+                                       const char* path) {
   auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
   cpp_file->AddInclude(path, xls::SourceInfo());
 }

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -195,6 +195,8 @@ bool xls_interpret_function(struct xls_function* function, size_t argc,
 // Opaque structs.
 struct xls_vast_verilog_file;
 struct xls_vast_verilog_module;
+struct xls_vast_logic_ref;
+struct xls_vast_data_type;
 
 // Note: We define the enum with a fixed width integer type for clarity of the
 // exposed ABI.
@@ -213,6 +215,13 @@ void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
 
 struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
     struct xls_vast_verilog_file* f, const char* name);
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(struct xls_vast_verilog_file* f);
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
+// TODO(cdleary): 2024-09-05 Add xls_vast_verilog_module_add_wire_with_expr
 
 void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
                                        const char* path);

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -181,6 +181,38 @@ bool xls_interpret_function(struct xls_function* function, size_t argc,
                             const struct xls_value** args, char** error_out,
                             struct xls_value** result_out);
 
+// -- VAST (Verilog AST) APIs
+//
+// Note that these are expected to be *less* stable than the above APIs, as
+// they are exposing a useful implementation library present within XLS.
+//
+// Per usual, in a general sense, no promises are made around API or ABI
+// stability overall. However, seems worth noting these are effectively
+// "protected" APIs, use with particular caution around stability. See
+// `xls/protected/BUILD` for how we tend to think about "protected" APIs in the
+// project.
+
+// Opaque structs.
+struct xls_vast_verilog_file;
+struct xls_vast_verilog_module;
+
+// Note: We define the enum with a fixed width integer type for clarity of the
+// exposed ABI.
+typedef int32_t xls_vast_file_type;
+enum {
+  xls_vast_file_type_verilog,
+  xls_vast_file_type_system_verilog,
+};
+
+struct xls_vast_verilog_file* xls_vast_make_verilog_file(xls_vast_file_type file_type);
+void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
+
+struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(struct xls_vast_verilog_file* f, const char* name);
+void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f, const char* path);
+
+char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f);
+
+
 }  // extern "C"
 
 #endif  // XLS_PUBLIC_C_API_H_

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -216,11 +216,18 @@ void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
 struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
     struct xls_vast_verilog_file* f, const char* name);
 
-struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(struct xls_vast_verilog_file* f);
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
+    struct xls_vast_verilog_file* f);
 
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
-struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(struct xls_vast_verilog_module* m, const char* name, struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
 // TODO(cdleary): 2024-09-05 Add xls_vast_verilog_module_add_wire_with_expr
 
 void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -204,15 +204,22 @@ enum {
   xls_vast_file_type_system_verilog,
 };
 
+// Note: caller owns the returned verilog file object, to be freed by
+// `xls_vast_verilog_file_free`.
 struct xls_vast_verilog_file* xls_vast_make_verilog_file(
     xls_vast_file_type file_type);
+
 void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
 
 struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
     struct xls_vast_verilog_file* f, const char* name);
+
 void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
                                        const char* path);
 
+// Emits/formats the contents of the given verilog file to a string.
+//
+// Note: caller owns the returned string, to be freed by `xls_c_str_free`.
 char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f);
 
 }  // extern "C"

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -204,14 +204,16 @@ enum {
   xls_vast_file_type_system_verilog,
 };
 
-struct xls_vast_verilog_file* xls_vast_make_verilog_file(xls_vast_file_type file_type);
+struct xls_vast_verilog_file* xls_vast_make_verilog_file(
+    xls_vast_file_type file_type);
 void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
 
-struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(struct xls_vast_verilog_file* f, const char* name);
-void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f, const char* path);
+struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
+    struct xls_vast_verilog_file* f, const char* name);
+void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
+                                       const char* path);
 
 char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f);
-
 
 }  // extern "C"
 

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -219,6 +219,9 @@ struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
 struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
     struct xls_vast_verilog_file* f);
 
+struct xls_vast_data_type* xls_vast_verilog_file_make_bit_vector_type(
+    struct xls_vast_verilog_file* f, int64_t bit_count, bool is_signed);
+
 struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(
     struct xls_vast_verilog_module* m, const char* name,
     struct xls_vast_data_type* type);

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -323,7 +323,8 @@ TEST(XlsCApiTest, VastAddIncludesAndEmit) {
 
   // Add input/output and a wire.
   xls_vast_data_type* scalar = xls_vast_verilog_file_make_scalar_type(f);
-  xls_vast_verilog_module_add_input(m, "my_input", scalar);
+  xls_vast_data_type* u8 = xls_vast_verilog_file_make_bit_vector_type(f, 8, false);
+  xls_vast_verilog_module_add_input(m, "my_input", u8);
   xls_vast_verilog_module_add_output(m, "my_output", scalar);
   xls_vast_verilog_module_add_wire(m, "my_wire", scalar);
 
@@ -333,7 +334,7 @@ TEST(XlsCApiTest, VastAddIncludesAndEmit) {
   const std::string_view kWant = R"(`include "one_include.v"
 `include "another_include.v"
 module my_empty_module(
-  input wire my_input,
+  input wire [7:0] my_input,
   output wire my_output
 );
   wire my_wire;

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -308,4 +308,26 @@ TEST(XlsCApiTest, InterpretDslxFailFunction) {
             "ABORTED: Assertion failure via fail! @ my_module.x:2:8-2:33");
 }
 
+TEST(XlsCApiTest, VastAddIncludesAndEmit) {
+  xls_vast_verilog_file* f = xls_vast_make_verilog_file(xls_vast_file_type_verilog);
+  ASSERT_NE(f, nullptr);
+  absl::Cleanup free_file([&] { xls_vast_verilog_file_free(f); });
+
+  xls_vast_verilog_file_add_include(f, "one_include.v");
+  xls_vast_verilog_file_add_include(f, "another_include.v");
+
+  xls_vast_verilog_module* m = xls_vast_verilog_file_add_module(f, "my_empty_module");
+  ASSERT_NE(m, nullptr);
+
+  char* emitted = xls_vast_verilog_file_emit(f);
+  ASSERT_NE(emitted, nullptr);
+  absl::Cleanup free_emitted([&] { xls_c_str_free(emitted); });
+  EXPECT_EQ(std::string_view{emitted}, R"(`include "one_include.v"
+`include "another_include.v"
+module my_empty_module;
+
+endmodule
+)");
+}
+
 }  // namespace

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -309,14 +309,16 @@ TEST(XlsCApiTest, InterpretDslxFailFunction) {
 }
 
 TEST(XlsCApiTest, VastAddIncludesAndEmit) {
-  xls_vast_verilog_file* f = xls_vast_make_verilog_file(xls_vast_file_type_verilog);
+  xls_vast_verilog_file* f =
+      xls_vast_make_verilog_file(xls_vast_file_type_verilog);
   ASSERT_NE(f, nullptr);
   absl::Cleanup free_file([&] { xls_vast_verilog_file_free(f); });
 
   xls_vast_verilog_file_add_include(f, "one_include.v");
   xls_vast_verilog_file_add_include(f, "another_include.v");
 
-  xls_vast_verilog_module* m = xls_vast_verilog_file_add_module(f, "my_empty_module");
+  xls_vast_verilog_module* m =
+      xls_vast_verilog_file_add_module(f, "my_empty_module");
   ASSERT_NE(m, nullptr);
 
   char* emitted = xls_vast_verilog_file_emit(f);

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -321,15 +321,25 @@ TEST(XlsCApiTest, VastAddIncludesAndEmit) {
       xls_vast_verilog_file_add_module(f, "my_empty_module");
   ASSERT_NE(m, nullptr);
 
+  // Add input/output and a wire.
+  xls_vast_data_type* scalar = xls_vast_verilog_file_make_scalar_type(f);
+  xls_vast_verilog_module_add_input(m, "my_input", scalar);
+  xls_vast_verilog_module_add_output(m, "my_output", scalar);
+  xls_vast_verilog_module_add_wire(m, "my_wire", scalar);
+
   char* emitted = xls_vast_verilog_file_emit(f);
   ASSERT_NE(emitted, nullptr);
   absl::Cleanup free_emitted([&] { xls_c_str_free(emitted); });
-  EXPECT_EQ(std::string_view{emitted}, R"(`include "one_include.v"
+  const std::string_view kWant = R"(`include "one_include.v"
 `include "another_include.v"
-module my_empty_module;
-
+module my_empty_module(
+  input wire my_input,
+  output wire my_output
+);
+  wire my_wire;
 endmodule
-)");
+)";
+  EXPECT_EQ(std::string_view{emitted}, kWant);
 }
 
 }  // namespace

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -323,7 +323,8 @@ TEST(XlsCApiTest, VastAddIncludesAndEmit) {
 
   // Add input/output and a wire.
   xls_vast_data_type* scalar = xls_vast_verilog_file_make_scalar_type(f);
-  xls_vast_data_type* u8 = xls_vast_verilog_file_make_bit_vector_type(f, 8, false);
+  xls_vast_data_type* u8 =
+      xls_vast_verilog_file_make_bit_vector_type(f, 8, false);
   xls_vast_verilog_module_add_input(m, "my_input", u8);
   xls_vast_verilog_module_add_output(m, "my_output", scalar);
   xls_vast_verilog_module_add_wire(m, "my_wire", scalar);


### PR DESCRIPTION
Planned for use in more (Rust-based) OSS tooling (to consolidate on improving one set of verilog generation capabilities).