### PR TITLE
[DSLX:TS] Fix bugs in array-with-ellipsis type inference

### DIFF
--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -275,7 +275,7 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
 
   def test_empty_array_error(self):
     stderr = self._run('xls/dslx/tests/errors/empty_array.x')
-    self.assertIn('Cannot deduce the type of an empty array.', stderr)
+    self.assertIn('Empty array must have a type annotation', stderr)
 
   def test_invalid_array_expression_type(self):
     stderr = self._run(

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -1322,10 +1322,11 @@ TEST(TypecheckErrorTest, BadTypeForConstantArrayOfNumbers) {
 }
 
 TEST(TypecheckErrorTest, ConstantArrayEmptyMembersWrongCountVsDecl) {
-  EXPECT_THAT(Typecheck("const MY_ARRAY = u32[1]:[];"),
-              StatusIs(absl::StatusCode::kInvalidArgument,
-                       HasSubstr("uN[32][1] Annotated array size 1 does not "
-                                 "match inferred array size 0.")));
+  auto result = Typecheck("const MY_ARRAY = u32[1]:[];");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("uN[32][1] Array has zero elements "
+                                         "but type annotation size is 1")))
+      << result.status();
 }
 
 TEST(TypecheckTest, MatchNoArms) {
@@ -1449,6 +1450,21 @@ enum MyEnum : u2 {
 
 TEST(TypecheckTest, ArrayEllipsis) {
   XLS_EXPECT_OK(Typecheck("fn main() -> u8[2] { u8[2]:[0, ...] }"));
+}
+
+// See https://github.com/google/xls/issues/1587 #1
+TEST(TypecheckErrorTest, ArrayEllipsisTypeSmallerThanElements) {
+  auto result =
+      Typecheck("fn main() -> u32[2] { u32[2]:[u32:0, u32:1, u32:0, ...] }");
+  EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Annotated array size 2 is too small "
+                                         "for observed array member count 3")));
+}
+
+// See https://github.com/google/xls/issues/1587 #2
+TEST(TypecheckErrorTest, ArrayEllipsisTypeEqElementCount) {
+  XLS_EXPECT_OK(
+      Typecheck("fn main() -> u32[2] { u32[2]:[u32:0, u32:1, ...] }"));
 }
 
 TEST(TypecheckErrorTest, ArrayEllipsisNoTrailingElement) {


### PR DESCRIPTION
Fixes https://github.com/google/xls/issues/1587

Trying to interleave ellipsis and empty array handling was prone to bugs, so this splits out DeduceEmptyArray as it's significantly a special path that wants its own path. Seems clearer now.