### PR TITLE
[DSLX] Fixes for casting to/from `xN` (bits constructor) based type, adds docs and more tests

### DIFF
--- a/docs_src/dslx_reference.md
+++ b/docs_src/dslx_reference.md
@@ -312,6 +312,32 @@ s0
 Signed numbers differ in their behavior from unsigned numbers primarily via
 operations like comparisons, (variable width) multiplications, and divisions.
 
+#### Parametric Signedness
+
+The DSL also has a way to make a function parameterized on the signedness of a
+type, via the `xN` type constructor:
+
+```dslx
+// Parametric function that gives back a zero bits value of arbitrary
+// signedness and size.
+fn p<S: bool, N: u32>() -> xN[S][N] { xN[S][N]:0 }
+
+#[test]
+fn test_parametric_signedness() {
+  assert_eq(p<false, u32:32>(), u32:0);
+  assert_eq(p<true, u32:32>(), s32:0);
+  assert_eq(p<true, u32:64>(), s64:0);
+}
+```
+
+The above example shows that `xN[false][u32:32]` is an equivalent type to
+`u32`, and `xN[true][u32:64]` is an equivalent type to `s64`.
+
+The name `xN` indicates that it can be either `uN` or `sN` based on the first
+"signedness" given to the type constructor, which should be a `bool`. After the
+signedness is given, the bit-width for the type is provided, and that gives all
+the information to describe an arbitrary-signedness bit type.
+
 #### Bit Type Attributes
 
 Bit types have helpful type-level attributes that provide limit values, similar

--- a/xls/dslx/bytecode/bytecode_emitter_test.cc
+++ b/xls/dslx/bytecode/bytecode_emitter_test.cc
@@ -271,6 +271,22 @@ fn do_ternary() -> u32 {
 006 jump_dest)");
 }
 
+TEST(BytecodeEmitterTest, CastToXbits) {
+  constexpr std::string_view kProgram = R"(#[test]
+fn main(x: u1) -> s1 {
+  x as xN[true][1]
+})";
+
+  ImportData import_data(CreateImportDataForTest());
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<BytecodeFunction> bf,
+                           EmitBytecodes(&import_data, kProgram, "main"));
+
+  EXPECT_EQ(BytecodesToString(bf->bytecodes(), /*source_locs=*/false,
+                              import_data.file_table()),
+            R"(000 load 0
+001 cast xN[is_signed=1][1])");
+}
+
 TEST(BytecodeEmitterTest, Shadowing) {
   constexpr std::string_view kProgram = R"(#[test]
 fn f() -> u32 {

--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -655,7 +655,7 @@ absl::Status BytecodeInterpreter::EvalCast(const Bytecode& bytecode,
 
   int64_t from_bit_count = from_value.GetBits().value().bit_count();
 
-  // If the thing we're casing from is bits like, and the thing we're casting
+  // If the thing we're casting from is bits like, and the thing we're casting
   // to is bits, like, we use the `ResizeBitsValue` helper.
   if (std::optional<BitsLikeProperties> to_bits_like = GetBitsLike(to);
       to_bits_like.has_value()) {

--- a/xls/dslx/ir_convert/ir_conversion_utils_test.cc
+++ b/xls/dslx/ir_convert/ir_conversion_utils_test.cc
@@ -109,4 +109,17 @@ TEST(IrConversionUtilsTest, TypeToIr) {
   EXPECT_EQ(bits_type->GetFlatBitCount(), 8);
 }
 
+TEST(IrConversionUtilsTest, BitsConstructorTypeToIr) {
+  Package package("p");
+  const ParametricEnv bindings;
+
+  TypeDim is_signed = TypeDim::CreateBool(true);
+  TypeDim size = TypeDim::CreateU32(4);
+  auto element_type = std::make_unique<BitsConstructorType>(is_signed);
+  auto s4 = std::make_unique<ArrayType>(std::move(element_type), size);
+
+  XLS_ASSERT_OK_AND_ASSIGN(xls::Type * type, TypeToIr(&package, *s4, bindings));
+  EXPECT_EQ(type->ToString(), "bits[4]");
+}
+
 }  // namespace xls::dslx

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -1434,7 +1434,7 @@ fn test_fp_lt_2() {
 // Helper to convert to a signed or unsigned integer as raw bits.
 // to_int and to_uint to interpret the bits as signed or unsigned, respectively.
 fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, FRACTION_SZ: u32>
-    (x: APFloat<EXP_SZ, FRACTION_SZ>) -> xN[RESULT_SIGNED][RESULT_SZ] {
+    (x: APFloat<EXP_SZ, FRACTION_SZ>) -> bits[RESULT_SZ] {
     const WIDE_FRACTION: u32 = FRACTION_SZ + u32:1;
     const MAX_FRACTION_SZ: u32 = std::umax(RESULT_SZ, WIDE_FRACTION);
 
@@ -1481,15 +1481,14 @@ fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, F
         }
     };
 
-    type ReturnT = xN[RESULT_SIGNED][RESULT_SZ];
     if RESULT_SIGNED {
         // Reduce to the target size, preserving signedness.
         let result = result as sN[RESULT_SZ];
         let result = if !x.sign { result } else { -result };
-        result as ReturnT
+        result as bits[RESULT_SZ]
     } else {
         // Already unsigned, just size correctly.
-        result as ReturnT
+        result as bits[RESULT_SZ]
     }
 }
 

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -1434,7 +1434,7 @@ fn test_fp_lt_2() {
 // Helper to convert to a signed or unsigned integer as raw bits.
 // to_int and to_uint to interpret the bits as signed or unsigned, respectively.
 fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, FRACTION_SZ: u32>
-    (x: APFloat<EXP_SZ, FRACTION_SZ>) -> bits[RESULT_SZ] {
+    (x: APFloat<EXP_SZ, FRACTION_SZ>) -> xN[RESULT_SIGNED][RESULT_SZ] {
     const WIDE_FRACTION: u32 = FRACTION_SZ + u32:1;
     const MAX_FRACTION_SZ: u32 = std::umax(RESULT_SZ, WIDE_FRACTION);
 
@@ -1481,14 +1481,15 @@ fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, F
         }
     };
 
+    type ReturnT = xN[RESULT_SIGNED][RESULT_SZ];
     if RESULT_SIGNED {
         // Reduce to the target size, preserving signedness.
         let result = result as sN[RESULT_SZ];
         let result = if !x.sign { result } else { -result };
-        result as bits[RESULT_SZ]
+        result as ReturnT
     } else {
         // Already unsigned, just size correctly.
-        result as bits[RESULT_SZ]
+        result as ReturnT
     }
 }
 

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -608,6 +608,8 @@ dslx_lang_test(
     convert_to_ir = False,
 )
 
+dslx_lang_test(name = "casts_to_xn")
+
 dslx_lang_test(
     name = "cast_to_array",
     # Note: no meaningful function to convert.

--- a/xls/dslx/tests/casts_to_xn.x
+++ b/xls/dslx/tests/casts_to_xn.x
@@ -1,0 +1,60 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn test_casts() {
+    assert_eq(s1:1, u1:1 as xN[true][1]);
+    assert_eq(u1:1, s1:1 as xN[false][1]);
+}
+
+#[test]
+fn test_widening_casts() {
+    assert_eq(s2:0b11, s1:1 as xN[true][2]);
+    assert_eq(u2:0b01, u1:1 as xN[false][2]);
+
+    assert_eq(s2:0b11, xN[true][1]:1 as s2);
+    assert_eq(u2:0b01, xN[false][1]:1 as u2);
+}
+
+fn p<S: bool, N: u32>(x: bits[N]) -> xN[S][N] { x as xN[S][N] }
+
+fn q<S: bool, O: u32, N: u32>(x: sN[N]) -> xN[S][O] { x as xN[S][O] }
+
+// Create a main entry point with a bunch of conversions so we can test IR conversions as well.
+fn main() -> (u1, u2, u3, s1, s2, s3, s4, s4, s4) {
+    let a = p<false>(u1::MAX);
+    let b = p<false>(u2::MAX);
+    let c = p<false>(u3::MAX);
+    let d = p<true>(u1::MAX);
+    let e = p<true>(u2::MAX);
+    let f = p<true>(u3::MAX);
+    let g = q<true, u32:4>(s1:0b1);
+    let h = q<true, u32:4>(s2:0b11);
+    let i = q<true, u32:4>(s3:0b111);
+    (a, b, c, d, e, f, g, h, i)
+}
+
+#[test]
+fn test_parametric_conversion() {
+    let (a, b, c, d, e, f, g, h, i) = main();
+    assert_eq(a, u1:0b1);
+    assert_eq(b, u2:0b11);
+    assert_eq(c, u3:0b111);
+    assert_eq(d, s1:0b1);
+    assert_eq(e, s2:0b11);
+    assert_eq(f, s3:0b111);
+    assert_eq(g, s4:0b1111);
+    assert_eq(h, s4:0b1111);
+    assert_eq(i, s4:0b1111);
+}

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -783,6 +783,14 @@ std::vector<TypeDim> ArrayType::GetAllDims() const {
 }
 
 absl::StatusOr<TypeDim> ArrayType::GetTotalBitCount() const {
+  // For the bits constructor (xN) although the element type is "sizeless"
+  // (i.e. like `bits`, `xN[false]` doesn't have a size on its own, it needs to
+  // be placed in an array), when it is instantiated via an array type it has
+  // the given size; i.e. the size of `xN[false][N]` is `N`.
+  if (IsBitsConstructor(element_type())) {
+    return size_;
+  }
+
   XLS_ASSIGN_OR_RETURN(TypeDim elem_bits, element_type_->GetTotalBitCount());
   return elem_bits.Mul(size_);
 }

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -262,6 +262,14 @@ fn f() -> (bool, u32)[2] { [p(u4:0), p(s8:0)] }
   XLS_EXPECT_OK(Typecheck(program));
 }
 
+TEST(TypecheckTest, XbitsCast) {
+  std::string program = R"(
+fn f(x: u1) -> s1 { x as xN[true][1] }
+fn g() -> s1 { u1:0 as xN[true][1] }
+)";
+  XLS_EXPECT_OK(Typecheck(program));
+}
+
 TEST(TypecheckTest, ParametricPlusGlobal) {
   std::string program = R"(
 const GLOBAL = u32:4;


### PR DESCRIPTION
Fixes #1572 

Development details -- note that `xN` is the first place where the concept of "BitsLike" became load bearing, any place that assumed `ArrayType` in the hierarchy now has to consider that `ArrayType` could be indicating something that's effectively a bits type; i.e. `BitsLike`. Going forward we always want to use `BitsLike` as the test for a type and whether it's effectively a bits type, there were a few spots here that were missed when the `xN` bits type constructor was introduced.