### PR TITLE
[DSLX:TS] Fix mismatch errors for concat to be TypeInferenceErrors. 

### DIFF
--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -554,21 +554,39 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceConcat(const Binop* node,
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> rhs,
                        DeduceAndResolve(node->rhs(), ctx));
 
+  std::optional<BitsLikeProperties> lhs_bits_like = GetBitsLike(*lhs);
+  std::optional<BitsLikeProperties> rhs_bits_like = GetBitsLike(*rhs);
+  if (lhs_bits_like.has_value() && rhs_bits_like.has_value()) {
+    XLS_ASSIGN_OR_RETURN(bool lhs_is_signed, lhs_bits_like->is_signed.GetAsBool());
+    XLS_ASSIGN_OR_RETURN(bool rhs_is_signed, rhs_bits_like->is_signed.GetAsBool());
+    if (lhs_is_signed ||
+        rhs_is_signed) {
+      return TypeInferenceErrorStatus(
+          node->span(), nullptr,
+          absl::StrFormat("Concatenation requires operand types to both be "
+          "unsigned bits; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
+          ctx->file_table() );
+    }
+    XLS_ASSIGN_OR_RETURN(TypeDim new_size,
+                         lhs_bits_like->size.Add(rhs_bits_like->size));
+    return std::make_unique<BitsType>(/*signed=*/false, /*size=*/new_size);
+  }
+
   auto* lhs_array = dynamic_cast<ArrayType*>(lhs.get());
   auto* rhs_array = dynamic_cast<ArrayType*>(rhs.get());
-  bool lhs_is_array = lhs_array != nullptr;
-  bool rhs_is_array = rhs_array != nullptr;
+  bool lhs_is_array = lhs_array != nullptr && !lhs_bits_like.has_value();
+  bool rhs_is_array = rhs_array != nullptr && !rhs_bits_like.has_value();
 
   if (lhs_is_array != rhs_is_array) {
-    return ctx->TypeMismatchError(node->span(), node->lhs(), *lhs, node->rhs(),
-                                  *rhs,
+    return TypeInferenceErrorStatus(node->span(), nullptr, absl::StrFormat(
                                   "Attempting to concatenate array/non-array "
-                                  "values together.");
+                                  "values together; got lhs: `%s`; rhs: `%s`.",
+          lhs->ToString(), rhs->ToString()), ctx->file_table());
   }
 
   if (lhs_is_array && lhs_array->element_type() != rhs_array->element_type()) {
     return ctx->TypeMismatchError(
-        node->span(), nullptr, *lhs, nullptr, *rhs,
+        node->span(), nullptr, lhs_array->element_type(), nullptr, rhs_array->element_type(),
         "Array concatenation requires element types to be the same.");
   }
 
@@ -579,34 +597,16 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceConcat(const Binop* node,
         lhs_array->element_type().CloneToUnique(), new_size);
   }
 
-  auto* lhs_bits = dynamic_cast<BitsType*>(lhs.get());
-  auto* rhs_bits = dynamic_cast<BitsType*>(rhs.get());
-  bool lhs_is_bits = lhs_bits != nullptr;
-  bool rhs_is_bits = rhs_bits != nullptr;
-  if (!lhs_is_bits || !rhs_is_bits) {
-    if (lhs->HasEnum() || rhs->HasEnum()) {
-      return ctx->TypeMismatchError(
-          node->span(), node->lhs(), *lhs, node->rhs(), *rhs,
-          "Enum values must be cast to unsigned bits before concatenation.");
-    }
-    return ctx->TypeMismatchError(node->span(), node->lhs(), *lhs, node->rhs(),
-                                  *rhs,
-                                  "Concatenation requires operand types to be "
-                                  "either both-arrays or both-bits");
+  if (lhs->HasEnum() || rhs->HasEnum()) {
+    return TypeInferenceErrorStatus(
+        node->span(), nullptr,
+        absl::StrFormat("Enum values must be cast to unsigned bits before concatenation; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
+        ctx->file_table());
   }
-
-  if (lhs_bits->is_signed() || rhs_bits->is_signed()) {
-    return ctx->TypeMismatchError(
-        node->span(), node->lhs(), *lhs, node->rhs(), *rhs,
-        "Concatenation requires operand types to both be "
-        "unsigned bits");
-  }
-
-  XLS_RET_CHECK(lhs_bits != nullptr);
-  XLS_RET_CHECK(rhs_bits != nullptr);
-  XLS_ASSIGN_OR_RETURN(TypeDim new_size,
-                       lhs_bits->size().Add(rhs_bits->size()));
-  return std::make_unique<BitsType>(/*signed=*/false, /*size=*/new_size);
+  return TypeInferenceErrorStatus(node->span(), nullptr,
+                                absl::StrFormat("Concatenation requires operand types to be "
+                                "either both-arrays or both-bits; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
+                        ctx->file_table());
 }
 
 absl::StatusOr<std::unique_ptr<Type>> DeduceBinop(const Binop* node,

--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -557,15 +557,17 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceConcat(const Binop* node,
   std::optional<BitsLikeProperties> lhs_bits_like = GetBitsLike(*lhs);
   std::optional<BitsLikeProperties> rhs_bits_like = GetBitsLike(*rhs);
   if (lhs_bits_like.has_value() && rhs_bits_like.has_value()) {
-    XLS_ASSIGN_OR_RETURN(bool lhs_is_signed, lhs_bits_like->is_signed.GetAsBool());
-    XLS_ASSIGN_OR_RETURN(bool rhs_is_signed, rhs_bits_like->is_signed.GetAsBool());
-    if (lhs_is_signed ||
-        rhs_is_signed) {
+    XLS_ASSIGN_OR_RETURN(bool lhs_is_signed,
+                         lhs_bits_like->is_signed.GetAsBool());
+    XLS_ASSIGN_OR_RETURN(bool rhs_is_signed,
+                         rhs_bits_like->is_signed.GetAsBool());
+    if (lhs_is_signed || rhs_is_signed) {
       return TypeInferenceErrorStatus(
           node->span(), nullptr,
           absl::StrFormat("Concatenation requires operand types to both be "
-          "unsigned bits; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
-          ctx->file_table() );
+                          "unsigned bits; got lhs: `%s`; rhs: `%s`",
+                          lhs->ToString(), rhs->ToString()),
+          ctx->file_table());
     }
     XLS_ASSIGN_OR_RETURN(TypeDim new_size,
                          lhs_bits_like->size.Add(rhs_bits_like->size));
@@ -578,15 +580,18 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceConcat(const Binop* node,
   bool rhs_is_array = rhs_array != nullptr && !rhs_bits_like.has_value();
 
   if (lhs_is_array != rhs_is_array) {
-    return TypeInferenceErrorStatus(node->span(), nullptr, absl::StrFormat(
-                                  "Attempting to concatenate array/non-array "
-                                  "values together; got lhs: `%s`; rhs: `%s`.",
-          lhs->ToString(), rhs->ToString()), ctx->file_table());
+    return TypeInferenceErrorStatus(
+        node->span(), nullptr,
+        absl::StrFormat("Attempting to concatenate array/non-array "
+                        "values together; got lhs: `%s`; rhs: `%s`.",
+                        lhs->ToString(), rhs->ToString()),
+        ctx->file_table());
   }
 
   if (lhs_is_array && lhs_array->element_type() != rhs_array->element_type()) {
     return ctx->TypeMismatchError(
-        node->span(), nullptr, lhs_array->element_type(), nullptr, rhs_array->element_type(),
+        node->span(), nullptr, lhs_array->element_type(), nullptr,
+        rhs_array->element_type(),
         "Array concatenation requires element types to be the same.");
   }
 
@@ -600,13 +605,18 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceConcat(const Binop* node,
   if (lhs->HasEnum() || rhs->HasEnum()) {
     return TypeInferenceErrorStatus(
         node->span(), nullptr,
-        absl::StrFormat("Enum values must be cast to unsigned bits before concatenation; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
+        absl::StrFormat("Enum values must be cast to unsigned bits before "
+                        "concatenation; got lhs: `%s`; rhs: `%s`",
+                        lhs->ToString(), rhs->ToString()),
         ctx->file_table());
   }
-  return TypeInferenceErrorStatus(node->span(), nullptr,
-                                absl::StrFormat("Concatenation requires operand types to be "
-                                "either both-arrays or both-bits; got lhs: `%s`; rhs: `%s`", lhs->ToString(), rhs->ToString()),
-                        ctx->file_table());
+  return TypeInferenceErrorStatus(
+      node->span(), nullptr,
+      absl::StrFormat(
+          "Concatenation requires operand types to be "
+          "either both-arrays or both-bits; got lhs: `%s`; rhs: `%s`",
+          lhs->ToString(), rhs->ToString()),
+      ctx->file_table());
 }
 
 absl::StatusOr<std::unique_ptr<Type>> DeduceBinop(const Binop* node,

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2933,48 +2933,45 @@ TEST(TypecheckTest, ConcatU1U1) {
 }
 
 TEST(TypecheckErrorTest, ConcatU1S1) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: u1, y: s1) -> u2 { x ++ y }").status(),
-      IsPosError("TypeInferenceError", HasSubstr("Concatenation requires operand "
-                                           "types to both be unsigned bits")));
+  EXPECT_THAT(Typecheck("fn f(x: u1, y: s1) -> u2 { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand "
+                                   "types to both be unsigned bits")));
 }
 
 TEST(TypecheckErrorTest, ConcatS1S1) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: s1, y: s1) -> u2 { x ++ y }").status(),
-      IsPosError("TypeInferenceError", HasSubstr("Concatenation requires operand "
-                                           "types to both be unsigned bits")));
+  EXPECT_THAT(Typecheck("fn f(x: s1, y: s1) -> u2 { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand "
+                                   "types to both be unsigned bits")));
 }
 
 TEST(TypecheckTest, ConcatU2S1) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: u2, y: s1) -> u3 { x ++ y }").status(),
-      IsPosError("TypeInferenceError", HasSubstr("Concatenation requires operand "
-                                           "types to both be unsigned bits")));
+  EXPECT_THAT(Typecheck("fn f(x: u2, y: s1) -> u3 { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand "
+                                   "types to both be unsigned bits")));
 }
 
 TEST(TypecheckTest, ConcatU1Nil) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: u1, y: ()) -> () { x ++ y }").status(),
-      IsPosError("TypeInferenceError",
-                 HasSubstr("Concatenation requires operand types "
-                                 "to be either both-arrays or both-bits")));
+  EXPECT_THAT(Typecheck("fn f(x: u1, y: ()) -> () { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand types "
+                                   "to be either both-arrays or both-bits")));
 }
 
 TEST(TypecheckTest, ConcatS1Nil) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: s1, y: ()) -> () { x ++ y }").status(),
-      IsPosError("TypeInferenceError",
-                 HasSubstr("Concatenation requires operand types "
-                                 "to be either both-arrays or both-bits")));
+  EXPECT_THAT(Typecheck("fn f(x: s1, y: ()) -> () { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand types "
+                                   "to be either both-arrays or both-bits")));
 }
 
 TEST(TypecheckTest, ConcatNilNil) {
-  EXPECT_THAT(
-      Typecheck("fn f(x: (), y: ()) -> () { x ++ y }").status(),
-      IsPosError("TypeInferenceError",
-                 HasSubstr("Concatenation requires operand types to "
-                           "be either both-arrays or both-bits")));
+  EXPECT_THAT(Typecheck("fn f(x: (), y: ()) -> () { x ++ y }").status(),
+              IsPosError("TypeInferenceError",
+                         HasSubstr("Concatenation requires operand types to "
+                                   "be either both-arrays or both-bits")));
 }
 
 TEST(TypecheckTest, ConcatEnumU2) {
@@ -2987,7 +2984,8 @@ fn f(x: MyEnum, y: u2) -> () { x ++ y }
 )")
                   .status(),
               IsPosError("TypeInferenceError",
-                 HasSubstr("Enum values must be cast to unsigned bits before concatenation")));
+                         HasSubstr("Enum values must be cast to unsigned bits "
+                                   "before concatenation")));
 }
 
 TEST(TypecheckTest, ConcatU2Enum) {
@@ -3000,7 +2998,8 @@ fn f(x: u2, y: MyEnum) -> () { x ++ y }
 )")
                   .status(),
               IsPosError("TypeInferenceError",
-                 HasSubstr("Enum values must be cast to unsigned bits before concatenation")));
+                         HasSubstr("Enum values must be cast to unsigned bits "
+                                   "before concatenation")));
 }
 
 TEST(TypecheckTest, ConcatEnumEnum) {
@@ -3024,7 +3023,8 @@ fn f(x: S, y: S) -> () { x ++ y }
 )")
                   .status(),
               IsPosError("TypeInferenceError",
-                         HasSubstr("Concatenation requires operand types to be either both-arrays or both-bits")));
+                         HasSubstr("Concatenation requires operand types to be "
+                                   "either both-arrays or both-bits")));
 }
 
 TEST(TypecheckTest, ConcatUnWithXn) {
@@ -3034,9 +3034,12 @@ fn f(x: u32, y: xN[false][32]) -> xN[false][64] { x ++ y }
 }
 
 TEST(TypecheckTest, ConcatU1ArrayOfOneU8) {
-  EXPECT_THAT(Typecheck("fn f(x: u1, y: u8[1]) -> () { x ++ y }").status(),
-              IsPosError("TypeInferenceError",
-                 HasSubstr("Attempting to concatenate array/non-array values together")));
+  EXPECT_THAT(
+      Typecheck("fn f(x: u1, y: u8[1]) -> () { x ++ y }").status(),
+      IsPosError(
+          "TypeInferenceError",
+          HasSubstr(
+              "Attempting to concatenate array/non-array values together")));
 }
 
 TEST(TypecheckTest, ConcatArrayOfThreeU8ArrayOfOneU8) {
@@ -3066,9 +3069,12 @@ TEST(TypecheckTest, AssertBuiltinIsUnitType) {
 }
 
 TEST(TypecheckTest, ConcatNilArrayOfOneU8) {
-  EXPECT_THAT(Typecheck("fn f(x: (), y: u8[1]) -> () { x ++ y }").status(),
-              IsPosError("TypeInferenceError",
-                 HasSubstr("Attempting to concatenate array/non-array values together")));
+  EXPECT_THAT(
+      Typecheck("fn f(x: (), y: u8[1]) -> () { x ++ y }").status(),
+      IsPosError(
+          "TypeInferenceError",
+          HasSubstr(
+              "Attempting to concatenate array/non-array values together")));
 }
 
 TEST(TypecheckTest, ParametricStructWithoutAllParametricsBoundInReturnType) {


### PR DESCRIPTION
Fixes #1589 

The fundamental problem is that TypeMismatch errors are semantically
representing "we expected the type to be X but it was Y".

When you try to use that for operands that *are matched, but somehow not
right*, the internal formatting machinery is upset because it's looking
for a discrepancy that should be there as a precondition.

This switches the reporting to be TypeInferenceError, which is the more
correct error in this scenario, and also fixes a likely problem due to
not using `GetBitsLike` adding a test for concatenating with a properly
unsigned `xN`.