### PR TITLE
[DSLX] Add support for `MIN` attribute on builtin bits types.

### DIFF
--- a/docs_src/dslx_reference.md
+++ b/docs_src/dslx_reference.md
@@ -323,6 +323,9 @@ s3::MAX   // s3:0b011 the "maximum signed" value
 
 u3::ZERO  // u3:0b000 the "fill with zeros" value
 s3::ZERO  // s3:0b000 the "fill with zeros" value
+
+u3::MIN   // u3:0b000 the minimum u3 value
+s3::MIN   // s3:0b100 AKA s3:-4 the minimum s3 value
 ```
 
 #### Character Constants

--- a/docs_src/floating_point.md
+++ b/docs_src/floating_point.md
@@ -379,13 +379,10 @@ X operand                          | `sN[RESULT_SZ]` value
 ---------------------------------- | -----------------------
 `NaN`                              | `sN[RESULT_SZ]::ZERO`
 `+Inf`                             | `sN[RESULT_SZ]::MAX`
-`-Inf`                             | `sN[RESULT_SZ]::MIN`[^1]
+`-Inf`                             | `sN[RESULT_SZ]::MIN`
 +0.0, -0.0 or any subnormal number | `sN[RESULT_SZ]::ZERO`
 `> sN[RESULT_SZ]::MAX`             | `sN[RESULT_SZ]::MAX`
 `< sN[RESULT_SZ]::MIN`             | `sN[RESULT_SZ]::MIN`
-
-[^1]: Does not exist yet (https://github.com/google/xls/issues/1556) but used
-    here for clarity.
 
 ### `apfloat::to_uint`
 

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -61,6 +61,10 @@ absl::Status VerifyParentage(const AstNode* root);
 // well as that node itself).
 absl::flat_hash_set<const AstNode*> FlattenToSet(const AstNode* node);
 
+// Returns whether the given attribute is a known colon-ref attribute of a
+// builtin bits type.
+bool IsBuiltinBitsTypeAttr(std::string_view attr);
+
 // Returns whether node n is a parametric function.
 //
 // "n" may be null.

--- a/xls/dslx/interp_value.cc
+++ b/xls/dslx/interp_value.cc
@@ -106,6 +106,20 @@ std::string TagToString(InterpValueTag tag) {
   return InterpValue{InterpValueTag::kSBits, std::move(bits)};
 }
 
+/* static */ InterpValue InterpValue::MakeMinValue(bool is_signed,
+                                                   int64_t bit_count) {
+  auto bits = Bits(bit_count);
+  if (!is_signed) {
+    return InterpValue{InterpValueTag::kUBits, std::move(bits)};
+  }
+  // Set the highest bit to get the most-negative value in two's complement
+  // form.
+  if (bit_count > 0) {
+    bits = bits.UpdateWithSet(bit_count - 1, true);
+  }
+  return InterpValue{InterpValueTag::kSBits, std::move(bits)};
+}
+
 /* static */ InterpValue InterpValue::MakeSBits(int64_t bit_count,
                                                 int64_t value) {
   return InterpValue{InterpValueTag::kSBits,

--- a/xls/dslx/interp_value.h
+++ b/xls/dslx/interp_value.h
@@ -85,6 +85,7 @@ class InterpValue {
 
   static InterpValue MakeZeroValue(bool is_signed, int64_t bit_count);
   static InterpValue MakeMaxValue(bool is_signed, int64_t bit_count);
+  static InterpValue MakeMinValue(bool is_signed, int64_t bit_count);
 
   static InterpValue MakeUnit() { return MakeTuple({}); }
   static InterpValue MakeU8(uint8_t value) {

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -1494,7 +1494,7 @@ fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, F
 
 // Returns the signed integer part of the input float, truncating any
 // fractional bits if necessary.
-// Exceptional cases (note: MIN does not yet exist but used for clarity):
+// Exceptional cases:
 // NaN                  -> sN[RESULT_SZ]::ZERO
 // +Inf                 -> sN[RESULT_SZ]::MAX
 // -Inf                 -> sN[RESULT_SZ]::MIN

--- a/xls/dslx/tests/builtin_type_max.x
+++ b/xls/dslx/tests/builtin_type_max.x
@@ -16,11 +16,13 @@ import xls.dslx.tests.number_of_imported_type_import as noiti;
 
 type MyU128 = uN[128];
 type MyU256 = uN[256];
+type MyS65 = sN[65];
 
-fn main() -> MyU128 { MyU128::MAX }
+fn main() -> (MyU128, MyU128) { (MyU128::MAX, MyU128::MIN) }
 
 #[test]
 fn test_builtin_max_values() {
+    // unsigned types max
     assert_eq(u1:0x1, u1::MAX);
     assert_eq(u2:0x3, u2::MAX);
     assert_eq(u3:0x7, u3::MAX);
@@ -34,7 +36,13 @@ fn test_builtin_max_values() {
     assert_eq(u32:0xffff_ffff, noiti::my_type::MAX);
     assert_eq(u64:0xffff_ffff_ffff_ffff, u64::MAX);
 
-    // signed types
+    // unsigned types min
+    assert_eq(u1:0, u1::MIN);
+    assert_eq(u2:0, u2::MIN);
+    assert_eq(u3:0, u3::MIN);
+    assert_eq(u4:0, u4::MIN);
+
+    // signed types max
     assert_eq(s1:0b0, s1::MAX);
     assert_eq(s2:0b01, s2::MAX);
     assert_eq(s3:0b011, s3::MAX);
@@ -48,12 +56,19 @@ fn test_builtin_max_values() {
     assert_eq(s32:0x7fff_ffff, noiti::my_signed_type::MAX);
     assert_eq(s64:0x7fff_ffff_ffff_ffff, s64::MAX);
 
+    // signed types min
+    assert_eq(s1:0b1, s1::MIN);
+    assert_eq(s2:0b10, s2::MIN);
+    assert_eq(s3:0b100, s3::MIN);
+    assert_eq(s8:-128, s8::MIN);
+    assert_eq(MyS65:0b10000000000000000000000000000000000000000000000000000000000000000, MyS65::MIN);
+
     // TODO(https://github.com/google/xls/issues/711): the following syntax is not
     // permitted at the moment, an alias is required.
     //
     // assert_eq(uN[128]:0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, uN[128]::MAX);
     assert_eq(MyU128:0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, MyU128::MAX);
-    assert_eq(MyU128:0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, main());
+    assert_eq((MyU128:0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff, MyU128:0), main());
     assert_eq(
         MyU256:0xffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff_ffff,
         MyU256::MAX);

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -954,10 +954,7 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceColonRefToBuiltinNameDef(
   if (auto it = sized_type_keywords.find(builtin_name_def->identifier());
       it != sized_type_keywords.end()) {
     auto [is_signed, size] = it->second;
-    if (node->attr() == "MAX") {
-      return std::make_unique<BitsType>(is_signed, size);
-    }
-    if (node->attr() == "ZERO") {
+    if (IsBuiltinBitsTypeAttr(node->attr())) {
       return std::make_unique<BitsType>(is_signed, size);
     }
     return TypeInferenceErrorStatus(
@@ -989,15 +986,15 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceColonRefToArrayType(
                         resolved->ToString()),
         ctx->file_table());
   }
-  if (node->attr() != "MAX" && node->attr() != "ZERO") {
-    return TypeInferenceErrorStatus(
-        node->span(), nullptr,
-        absl::StrFormat("Type '%s' does not have attribute '%s'.",
-                        array_type->ToString(), node->attr()),
-        ctx->file_table());
+  if (IsBuiltinBitsTypeAttr(node->attr())) {
+    VLOG(5) << "DeduceColonRefToArrayType result: " << resolved->ToString();
+    return resolved;
   }
-  VLOG(5) << "DeduceColonRefToArrayType result: " << resolved->ToString();
-  return resolved;
+  return TypeInferenceErrorStatus(
+      node->span(), nullptr,
+      absl::StrFormat("Type '%s' does not have attribute '%s'.",
+                      array_type->ToString(), node->attr()),
+      ctx->file_table());
 }
 
 absl::StatusOr<std::unique_ptr<Type>> DeduceColonRef(const ColonRef* node,

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2329,6 +2329,7 @@ fn main() {
 TEST(TypecheckTest, AttrViaColonRef) {
   XLS_EXPECT_OK(Typecheck("fn f() -> u8 { u8::ZERO }"));
   XLS_EXPECT_OK(Typecheck("fn f() -> u8 { u8::MAX }"));
+  XLS_EXPECT_OK(Typecheck("fn f() -> u8 { u8::MIN }"));
 }
 
 TEST(TypecheckTest, ColonRefTypeAlias) {
@@ -2336,6 +2337,14 @@ TEST(TypecheckTest, ColonRefTypeAlias) {
 type MyU8 = u8;
 fn f() -> u8 { MyU8::MAX }
 fn g() -> u8 { MyU8::ZERO }
+fn h() -> u8 { MyU8::MIN }
+)"));
+}
+
+TEST(TypecheckTest, MinAttrUsedInConstAsserts) {
+  XLS_EXPECT_OK(Typecheck(R"(
+const_assert!(u8::MIN == u8:0);
+const_assert!(s4::MIN == s4:-8);
 )"));
 }
 

--- a/xls/ir/value.h
+++ b/xls/ir/value.h
@@ -110,7 +110,8 @@ class Value {
     return Value(ValueKind::kToken, std::vector<Value>({}));
   }
   static Value Bool(bool enabled) {
-    return Value(UBits(/*value=*/enabled, /*bit_count=*/1));
+    return Value(
+        UBits(/*value=*/static_cast<uint64_t>(enabled), /*bit_count=*/1));
   }
 
   Value() : kind_(ValueKind::kInvalid), payload_(nullptr) {}


### PR DESCRIPTION
In similar fashion to how `ZERO` and `MAX` already existed.

Fixes #1556 