### PR TITLE
[DSLX] Allow "leader" of a blocky expression to be inline with a fall-back to nesting the whole construct.

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1415,8 +1415,11 @@ static DocRef Fmt(const ConstantDef& n, const Comments& comments,
   leader_pieces.push_back(arena.space());
 
   DocRef lhs = ConcatNGroup(arena, leader_pieces);
+  // Reduce the width by 1 so we know we can emit the semi inline.
+  DocRef rhs_before_semi =
+      arena.MakeReduceTextWidth(Fmt(*n.value(), comments, arena), 1);
   DocRef rhs = ConcatNGroup(arena, {
-                                       Fmt(*n.value(), comments, arena),
+                                       rhs_before_semi,
                                        arena.semi(),
                                    });
   return arena.MakeConcat(lhs, rhs);
@@ -2257,36 +2260,6 @@ static DocRef Fmt(const StructDef& n, const Comments& comments,
 
   pieces.push_back(arena.ccurl());
   return JoinWithAttr(attr, ConcatNGroup(arena, pieces), arena);
-}
-
-static DocRef Fmt(const ConstantDef& n, const Comments& comments,
-                  DocArena& arena) {
-  std::vector<DocRef> leader_pieces;
-  if (n.is_public()) {
-    leader_pieces.push_back(arena.Make(Keyword::kPub));
-    leader_pieces.push_back(arena.break1());
-  }
-  leader_pieces.push_back(arena.Make(Keyword::kConst));
-  leader_pieces.push_back(arena.break1());
-  leader_pieces.push_back(arena.MakeText(n.identifier()));
-  if (n.type_annotation() != nullptr) {
-    leader_pieces.push_back(arena.colon());
-    leader_pieces.push_back(arena.space());
-    leader_pieces.push_back(Fmt(*n.type_annotation(), comments, arena));
-  }
-  leader_pieces.push_back(arena.break1());
-  leader_pieces.push_back(arena.equals());
-  leader_pieces.push_back(arena.space());
-
-  DocRef lhs = ConcatNGroup(arena, leader_pieces);
-  // Reduce the width by 1 so we know we can emit the semi inline.
-  DocRef rhs_before_semi =
-      arena.MakeReduceTextWidth(Fmt(*n.value(), comments, arena), 1);
-  DocRef rhs = ConcatNGroup(arena, {
-                                       rhs_before_semi,
-                                       arena.semi(),
-                                   });
-  return arena.MakeConcat(lhs, rhs);
 }
 
 static DocRef FmtEnumMember(const EnumMember& n, const Comments& comments,

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1355,7 +1355,7 @@ static DocRef FmtConditionalMultiline(const Conditional& n,
   pieces.push_back(arena.hard_line());
   pieces.push_back(arena.ccurl());
 
-  return ConcatN(arena, pieces);
+  return ConcatNGroup(arena, pieces);
 }
 
 DocRef Fmt(const Conditional& n, const Comments& comments, DocArena& arena) {

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -448,6 +448,22 @@ TEST_F(FunctionFmtTest, ConditionalWithElseIf) {
   EXPECT_EQ(got, want);
 }
 
+TEST_F(FunctionFmtTest, ConditionalWithElseIfAfterLet) {
+  const std::string_view original =
+      R"(fn f(a: bool[2], x: u32[3]) -> u32 {
+    let result = if a[0] {
+        x[0]
+    } else if a[1] {
+        x[1]
+    } else {
+        x[2]
+    };
+    result
+})";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string got, DoFmt(original));
+  EXPECT_EQ(got, original);
+}
+
 TEST_F(FunctionFmtTest, ConditionalWithUnnecessaryParens) {
   const std::string_view original =
       "fn f(a:u32,b:u32)->u32{if(a<b){a}else if(b<a){b}else{a}}";

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -640,7 +640,7 @@ inline bool WeakerThan(Precedence x, Precedence y) {
 // (i.e. can produce runtime values).
 class Expr : public AstNode {
  public:
-  Expr(Module* owner, Span span) : AstNode(owner), span_(std::move(span)) {}
+  Expr(Module* owner, Span span) : AstNode(owner), span_(span) {}
 
   ~Expr() override;
 
@@ -694,7 +694,7 @@ class Expr : public AstNode {
  protected:
   virtual std::string ToStringInternal() const = 0;
 
-  void UpdateSpan(Span new_span) { span_ = std::move(new_span); }
+  void UpdateSpan(Span new_span) { span_ = new_span; }
 
  private:
   Span span_;
@@ -1816,7 +1816,7 @@ class Match : public Expr {
 class Attr : public Expr {
  public:
   Attr(Module* owner, Span span, Expr* lhs, std::string attr)
-      : Expr(owner, std::move(span)), lhs_(lhs), attr_(std::move(attr)) {}
+      : Expr(owner, span), lhs_(lhs), attr_(std::move(attr)) {}
 
   ~Attr() override;
 

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -45,7 +45,7 @@ pub fn qnan<EXP_SZ: u32, FRACTION_SZ: u32>() -> APFloat<EXP_SZ, FRACTION_SZ> {
     APFloat<EXP_SZ, FRACTION_SZ> {
         sign: bits[1]:0,
         bexp: std::mask_bits<EXP_SZ>() as bits[EXP_SZ],
-        fraction: bits[FRACTION_SZ]:1 << ((FRACTION_SZ - u32:1) as bits[FRACTION_SZ])
+        fraction: bits[FRACTION_SZ]:1 << ((FRACTION_SZ - u32:1) as bits[FRACTION_SZ]),
     }
 }
 
@@ -68,7 +68,9 @@ pub fn is_nan<EXP_SZ: u32, FRACTION_SZ: u32>(x: APFloat<EXP_SZ, FRACTION_SZ>) ->
 // Returns a positive or a negative infinity depending upon the given sign parameter.
 pub fn inf<EXP_SZ: u32, FRACTION_SZ: u32>(sign: bits[1]) -> APFloat<EXP_SZ, FRACTION_SZ> {
     APFloat<EXP_SZ, FRACTION_SZ> {
-        sign, bexp: std::mask_bits<EXP_SZ>(), fraction: bits[FRACTION_SZ]:0
+        sign,
+        bexp: std::mask_bits<EXP_SZ>(),
+        fraction: bits[FRACTION_SZ]:0,
     }
 }
 
@@ -118,7 +120,9 @@ fn zero_test() {
 pub fn one<EXP_SZ: u32, FRACTION_SZ: u32>(sign: bits[1]) -> APFloat<EXP_SZ, FRACTION_SZ> {
     const MASK_SZ: u32 = EXP_SZ - u32:1;
     APFloat<EXP_SZ, FRACTION_SZ> {
-        sign, bexp: std::mask_bits<MASK_SZ>() as bits[EXP_SZ], fraction: bits[FRACTION_SZ]:0
+        sign,
+        bexp: std::mask_bits<MASK_SZ>() as bits[EXP_SZ],
+        fraction: bits[FRACTION_SZ]:0,
     }
 }
 
@@ -249,7 +253,7 @@ pub fn unflatten<EXP_SZ: u32, FRACTION_SZ: u32, TOTAL_SZ: u32 = {u32:1 + EXP_SZ 
     APFloat<EXP_SZ, FRACTION_SZ> {
         sign: (x >> (SIGN_OFFSET as bits[TOTAL_SZ])) as bits[1],
         bexp: (x >> (FRACTION_SZ as bits[TOTAL_SZ])) as bits[EXP_SZ],
-        fraction: x as bits[FRACTION_SZ]
+        fraction: x as bits[FRACTION_SZ],
     }
 }
 
@@ -476,109 +480,145 @@ fn cast_from_fixed_using_rz_test() {
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:3),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:1), fraction: uN[FRAC_SZ]:0b10000
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:1),
+            fraction: uN[FRAC_SZ]:0b10000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:3),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:1), fraction: uN[FRAC_SZ]:0b10000
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:1),
+            fraction: uN[FRAC_SZ]:0b10000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b111000),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5), fraction: uN[FRAC_SZ]:0b11000
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5),
+            fraction: uN[FRAC_SZ]:0b11000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b111000),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5), fraction: uN[FRAC_SZ]:0b11000
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5),
+            fraction: uN[FRAC_SZ]:0b11000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b1110000),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11000
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b1110000),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11000
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11000,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b111111),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b111111),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:5),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b1111110),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b1111110),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b1111111),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b1111111),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:6),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b01111111111111111),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:15), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:15),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b01111111111111111),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:15), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:15),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b00000011111111111),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b00000011111111111),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(sN[17]:0b00000011111111000),
         Float {
-            sign: false, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10), fraction: uN[FRAC_SZ]:0b11111
+            sign: false,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
         cast_from_fixed_using_rz<EXP_SZ, FRAC_SZ>(-sN[17]:0b00000011111111000),
         Float {
-            sign: true, bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10), fraction: uN[FRAC_SZ]:0b11111
+            sign: true,
+            bexp: bias<EXP_SZ, FRAC_SZ>(sN[EXP_SZ]:10),
+            fraction: uN[FRAC_SZ]:0b11111,
         });
 
     assert_eq(
@@ -685,11 +725,11 @@ fn upcast_test() {
     let one_f64 = one<F64_EXP_SZ, F64_FRACTION_SZ>(u1:0);
     let one_dot_5_bf16 = APFloat<BF16_EXP_SZ, BF16_FRACTION_SZ> {
         fraction: u7:1 << (BF16_FRACTION_SZ - u32:1),
-    ..one_bf16
+        ..one_bf16
     };
     let one_dot_5_f64 = APFloat<F64_EXP_SZ, F64_FRACTION_SZ> {
         fraction: u52:1 << (F64_FRACTION_SZ - u32:1),
-    ..one_f64
+        ..one_f64
     };
     let denormal_bf16 = APFloat<BF16_EXP_SZ, BF16_FRACTION_SZ> { bexp: u8:0, ..one_dot_5_bf16 };
     let zero_f64 = zero<F64_EXP_SZ, F64_FRACTION_SZ>(u1:0);
@@ -758,12 +798,11 @@ pub fn downcast_fractional_rne<TO_FRACTION_SZ: u32, FROM_FRACTION_SZ: u32, EXP_S
         APFloat {
             sign: f.sign,
             bexp: if renormalize { f.bexp + uN[EXP_SZ]:1 } else { f.bexp },
-            fraction:
-            if round_up {
+            fraction: if round_up {
                 truncated_fraction + uN[TO_FRACTION_SZ]:1
             } else {
                 truncated_fraction
-            }
+            },
         }
     }
 }
@@ -881,7 +920,9 @@ pub fn normalize<EXP_SZ: u32, FRACTION_SZ: u32, WIDE_FRACTION: u32 = {FRACTION_S
         (true, _) => zero_value,
         // Normalize.
         _ => APFloat {
-            sign, bexp: exp - (leading_zeros as bits[EXP_SZ]), fraction: normalized_fraction
+            sign,
+            bexp: exp - (leading_zeros as bits[EXP_SZ]),
+            fraction: normalized_fraction,
         },
     }
 }
@@ -913,7 +954,7 @@ pub fn ldexp<EXP_SZ: u32, FRACTION_SZ: u32>
     let result = Float {
         sign: fraction.sign,
         bexp: bias<EXP_SZ, FRACTION_SZ>(exp as sN[EXP_SZ]),
-        fraction: fraction.fraction
+        fraction: fraction.fraction,
     };
 
     // Handle overflow.
@@ -922,12 +963,12 @@ pub fn ldexp<EXP_SZ: u32, FRACTION_SZ: u32>
     // Handle underflow, taking into account the case that underflow rounds back
     // up to a normal number. If this was not a DAZ module, we'd have to deal with
     // denormal 'result' here.
-    let underflow_result = if exp == (MIN_EXPONENT - s33:1) &&
-    fraction.fraction == std::mask_bits<FRACTION_SZ>() {
-        Float { sign: fraction.sign, bexp: uN[EXP_SZ]:1, fraction: uN[FRACTION_SZ]:0 }
-    } else {
-        zero<EXP_SZ, FRACTION_SZ>(fraction.sign)
-    };
+    let underflow_result =
+        if exp == (MIN_EXPONENT - s33:1) && fraction.fraction == std::mask_bits<FRACTION_SZ>() {
+            Float { sign: fraction.sign, bexp: uN[EXP_SZ]:1, fraction: uN[FRACTION_SZ]:0 }
+        } else {
+            zero<EXP_SZ, FRACTION_SZ>(fraction.sign)
+        };
 
     let result = if exp < MIN_EXPONENT { underflow_result } else { result };
     // Flush subnormal output.
@@ -1461,11 +1502,11 @@ fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, F
         // Clamp if out of bounds, infinite.
         if x.sign { INT_MIN } else { INT_MAX }
     } else if is_nan(x) {
-        uN[MAX_FRACTION_SZ]:0
+    uN[MAX_FRACTION_SZ]:0
     } else if exp < sN[EXP_SZ]:0 {
-        uN[MAX_FRACTION_SZ]:0
+    uN[MAX_FRACTION_SZ]:0
     } else if exp == sN[EXP_SZ]:0 {
-        uN[MAX_FRACTION_SZ]:1
+    uN[MAX_FRACTION_SZ]:1
     } else {
         // For most cases, we need to either shift the "ones" place from FRACTION_SZ + 1 bits down
         // closer to 0 (if the effective exponent is negative) else we need to move it away from 0
@@ -2041,7 +2082,9 @@ pub fn add<EXP_SZ: u32, FRACTION_SZ: u32>
 
     // Finally (finally!), construct the output float.
     APFloat<EXP_SZ, FRACTION_SZ> {
-        sign: result_sign, bexp: result_exponent, fraction: result_fraction as uN[FRACTION_SZ]
+        sign: result_sign,
+        bexp: result_exponent,
+        fraction: result_fraction as uN[FRACTION_SZ],
     }
 }
 
@@ -2489,7 +2532,7 @@ pub fn fma<EXP_SZ: u32, FRACTION_SZ: u32>
     APFloat<EXP_SZ, FRACTION_SZ> {
         sign: result_sign,
         bexp: result_exp as uN[EXP_SZ],
-        fraction: result_fraction as uN[FRACTION_SZ]
+        fraction: result_fraction as uN[FRACTION_SZ],
     }
 }
 

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -1502,11 +1502,11 @@ fn to_signed_or_unsigned_int<RESULT_SZ: u32, RESULT_SIGNED: bool, EXP_SZ: u32, F
         // Clamp if out of bounds, infinite.
         if x.sign { INT_MIN } else { INT_MAX }
     } else if is_nan(x) {
-    uN[MAX_FRACTION_SZ]:0
+        uN[MAX_FRACTION_SZ]:0
     } else if exp < sN[EXP_SZ]:0 {
-    uN[MAX_FRACTION_SZ]:0
+        uN[MAX_FRACTION_SZ]:0
     } else if exp == sN[EXP_SZ]:0 {
-    uN[MAX_FRACTION_SZ]:1
+        uN[MAX_FRACTION_SZ]:1
     } else {
         // For most cases, we need to either shift the "ones" place from FRACTION_SZ + 1 bits down
         // closer to 0 (if the effective exponent is negative) else we need to move it away from 0

--- a/xls/dslx/stdlib/bfloat16.x
+++ b/xls/dslx/stdlib/bfloat16.x
@@ -118,7 +118,9 @@ pub fn increment_fraction(input: BF16) -> BF16 {
         (true, true) => inf(input.sign),
         // Significand overflowed, normalize.
         (true, false) => BF16 {
-            sign: input.sign, bexp: input.bexp + u8:1, fraction: new_fraction[1+:u7]
+            sign: input.sign,
+            bexp: input.bexp + u8:1,
+            fraction: new_fraction[1+:u7],
         },
         // No normalization required.
         (_, _) => BF16 { sign: input.sign, bexp: input.bexp, fraction: new_fraction[:7] },

--- a/xls/dslx/tests/basic_sv_multiline_struct_attr.x
+++ b/xls/dslx/tests/basic_sv_multiline_struct_attr.x
@@ -26,7 +26,7 @@ fn main() -> u32 {
     f(
         Point {
             some_super_long_and_wordy_field_name: u32:42,
-            another_long_and_wordy_field_reach_line_limit: u32:64
+            another_long_and_wordy_field_reach_line_limit: u32:64,
         })
 }
 

--- a/xls/modules/rle/rle_enc_test_utils.x
+++ b/xls/modules/rle/rle_enc_test_utils.x
@@ -42,7 +42,7 @@ proc GenerateCount {
             GeneratorState {
                 cur_sym: sym + u32:1,
                 cur_rep: u32:0,
-                target_rep: if next_rep == u32:0 { u32:1 } else { next_rep }
+                target_rep: if next_rep == u32:0 { u32:1 } else { next_rep },
             }
         } else {
             GeneratorState { cur_sym: sym, cur_rep: reps, target_rep: state.target_rep }


### PR DESCRIPTION
Fixes #1617

I took assignment on this one because it doesn't fit the normal mold of the autoformatter and pretty printing DSL.

To recap the ideas in the pretty printing DSL (this is a standard technique for pretty printing across programming languages):

- You are always either in flat mode or break mode
- Every entity in the tree has a "flat requirement" -- how many chars it takes up if it's emitted inline
- You can wrap an entity in a "group" to have it reconsider, at that level of the tree, whether its contents can be emitted in flat mode or break mode; i.e. you can request a transition from "multi-line mode" to "single line mode" for any given subtree

The hypothesis of the pretty printing DSL is that /often/ you can write a "heisen-description" where you can describe how an entity is emitted in a uniform way, regardless of whether you're in flat mode or break mode. The more /irregular/ you make your formatting rules, i.e. "in this situation I want this to happen, in this other situation I want this other thing to happen", the less you can write a single unified heisen-description for an entity like an AST node.

And so the reason this construct is a bit challenging is we a) need some context from the outside environment and b) some knowledge about the construct being emitted. Namely, we want to know if we're "shoved over" by something like a let binding, and we're about to emit a "blocky" expression (i.e. one that kind of acts like a block in having multiple lines/statements inside of it), which has a "leader" of some sort (i.e. the callee expression for an invocation, the conditional test for a conditional expr, etc.). In that case we want to know if the "leader" will fit on the current line. If not, we want to nest and emit the expression in that nesting.

Because we need this special knowledge in the course of emitting the doc tree (in ast_fmt.cc) we ask if the AST node on the right hand side of the let is a blocky expression. If it is, we ask how long the "leader" is to determine if we should nest or try to emit the leader inline.

For this purpose we make a `arena.MakeModeSelect(DocRef inline_req, DocRef on_flat, DocRef on_break)` helper -- if the `inline_req` has a flat requirement that can be satisfied, we emit `on_flat`, otherwise we emit `on_break`. Note that, while we consider the requirement for `inline_req`, we do not emit it into the formatted text. This is where we put the "leader" doc, to indicate whether we want to emit the next doc with a request for flat mode. When we format the blocky-with-leader constructs in flat mode, the leader is emitted inline, and the doc tree decides after that whether we should switch into break mode through use of a `Group`.