### PR TITLE
[c_api] Break C API monolith into multiple sub-targets.

### DIFF
--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -155,25 +155,54 @@ cc_library(
 )
 
 cc_library(
+    name = "c_api_impl_helpers",
+    srcs = ["c_api_impl_helpers.cc"],
+    hdrs = ["c_api_impl_helpers.h"],
+    deps = [
+        ":c_api_format_preference",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status:statusor",
+        "//xls/ir:format_preference",
+    ],
+)
+
+cc_library(
+    name = "c_api_format_preference",
+    hdrs = ["c_api_format_preference.h"],
+)
+
+cc_library(
+    name = "c_api_vast",
+    srcs = ["c_api_vast.cc"],
+    hdrs = ["c_api_vast.h"],
+    deps = [
+        ":c_api_format_preference",
+        ":c_api_impl_helpers",
+        "//xls/codegen/vast",
+        "//xls/ir:source_location",
+    ],
+)
+
+cc_library(
     name = "c_api",
     srcs = ["c_api.cc"],
     hdrs = ["c_api.h"],
     deps = [
+        ":c_api_impl_helpers",
+        ":c_api_vast",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
         ":runtime_build_actions",
-        "//xls/codegen/vast",
         "//xls/common:init_xls",
         "//xls/interpreter:ir_interpreter",
         "//xls/ir",
         "//xls/ir:events",
         "//xls/ir:format_preference",
         "//xls/ir:ir_parser",
-        "//xls/ir:source_location",
         "//xls/ir:type",
         "//xls/ir:value",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -182,12 +211,12 @@ cc_test(
     srcs = ["c_api_test.cc"],
     deps = [
         ":c_api",
-        "//xls/common:xls_gunit_main",
+        "@com_google_absl//absl/cleanup",
+        "@com_google_googletest//:gtest",
         "//xls/common/file:filesystem",
         "//xls/common/file:temp_directory",
         "//xls/common/status:matchers",
+        "//xls/common:xls_gunit_main",
         "//xls/dslx:default_dslx_stdlib_path",
-        "@com_google_absl//absl/cleanup",
-        "@com_google_googletest//:gtest",
     ],
 )

--- a/xls/public/c_api_format_preference.h
+++ b/xls/public/c_api_format_preference.h
@@ -1,0 +1,37 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_PUBLIC_C_API_FORMAT_PREFERENCE_H_
+#define XLS_PUBLIC_C_API_FORMAT_PREFERENCE_H_
+
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+extern "C" {
+
+// Note: We define the format preference enum with a fixed width integer type
+// for clarity of the exposed ABI.
+typedef int32_t xls_format_preference;
+enum {
+  xls_format_preference_default,
+  xls_format_preference_binary,
+  xls_format_preference_signed_decimal,
+  xls_format_preference_unsigned_decimal,
+  xls_format_preference_hex,
+  xls_format_preference_plain_binary,
+  xls_format_preference_plain_hex,
+};
+
+}  // extern "C"
+
+#endif  // XLS_PUBLIC_C_API_FORMAT_PREFERENCE_H_

--- a/xls/public/c_api_impl_helpers.cc
+++ b/xls/public/c_api_impl_helpers.cc
@@ -1,0 +1,74 @@
+#include "xls/public/c_api_impl_helpers.h"
+
+#include <filesystem>
+#include <vector>
+
+#include "absl/log/check.h"
+
+namespace xls {
+
+std::vector<std::filesystem::path> ToCpp(const char* additional_search_paths[],
+                                         size_t additional_search_paths_count) {
+  std::vector<std::filesystem::path> additional_search_paths_cpp;
+  additional_search_paths_cpp.reserve(additional_search_paths_count);
+  for (size_t i = 0; i < additional_search_paths_count; ++i) {
+    const char* additional_search_path = additional_search_paths[i];
+    CHECK(additional_search_path != nullptr);
+    additional_search_paths_cpp.push_back(additional_search_path);
+  }
+  return additional_search_paths_cpp;
+}
+
+char* ToOwnedCString(const std::string& s) { return strdup(s.c_str()); }
+
+// Helper function that we can use to adapt to the common C API pattern when
+// we're returning an `absl::StatusOr<std::string>` value.
+bool ReturnStringHelper(absl::StatusOr<std::string>& to_return,
+                        char** error_out, char** value_out) {
+  if (to_return.ok()) {
+    *value_out = ToOwnedCString(to_return.value());
+    *error_out = nullptr;
+    return true;
+  }
+
+  *value_out = nullptr;
+  *error_out = ToOwnedCString(to_return.status().ToString());
+  return false;
+}
+
+// Converts a C-API-given format preference value into the XLS internal enum --
+// since these values can be out of normal enum class range when passed to the
+// API, we validate here.
+bool FormatPreferenceFromC(xls_format_preference c_pref,
+                           xls::FormatPreference* cpp_pref, char** error_out) {
+  switch (c_pref) {
+    case xls_format_preference_default:
+      *cpp_pref = xls::FormatPreference::kDefault;
+      break;
+    case xls_format_preference_binary:
+      *cpp_pref = xls::FormatPreference::kBinary;
+      break;
+    case xls_format_preference_signed_decimal:
+      *cpp_pref = xls::FormatPreference::kSignedDecimal;
+      break;
+    case xls_format_preference_unsigned_decimal:
+      *cpp_pref = xls::FormatPreference::kUnsignedDecimal;
+      break;
+    case xls_format_preference_hex:
+      *cpp_pref = xls::FormatPreference::kHex;
+      break;
+    case xls_format_preference_plain_binary:
+      *cpp_pref = xls::FormatPreference::kPlainBinary;
+      break;
+    case xls_format_preference_plain_hex:
+      *cpp_pref = xls::FormatPreference::kPlainHex;
+      break;
+    default:
+      *error_out = ToOwnedCString(
+          absl::StrFormat("Invalid format preference value: %d", c_pref));
+      return false;
+  }
+  return true;
+}
+
+}  // namespace xls

--- a/xls/public/c_api_impl_helpers.cc
+++ b/xls/public/c_api_impl_helpers.cc
@@ -1,3 +1,17 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "xls/public/c_api_impl_helpers.h"
 
 #include <filesystem>

--- a/xls/public/c_api_impl_helpers.cc
+++ b/xls/public/c_api_impl_helpers.cc
@@ -14,7 +14,7 @@
 
 #include "xls/public/c_api_impl_helpers.h"
 
-#include <filesystem>
+#include <filesystem>  // NOLINT
 #include <vector>
 
 #include "absl/log/check.h"

--- a/xls/public/c_api_impl_helpers.h
+++ b/xls/public/c_api_impl_helpers.h
@@ -20,7 +20,7 @@
 #define XLS_PUBLIC_C_API_IMPL_HELPERS_H_
 
 #include <cstddef>
-#include <filesystem>
+#include <filesystem>  // NOLINT
 #include <vector>
 
 #include "absl/status/statusor.h"

--- a/xls/public/c_api_impl_helpers.h
+++ b/xls/public/c_api_impl_helpers.h
@@ -1,0 +1,54 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implementation helper functions for implementing the public C API -- note
+// these are not helpers for /using/ the C API, and so will not need to be
+// included by client code.
+
+#ifndef XLS_PUBLIC_C_API_IMPL_HELPERS_H_
+#define XLS_PUBLIC_C_API_IMPL_HELPERS_H_
+
+#include <cstddef>
+#include <filesystem>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "xls/ir/format_preference.h"
+#include "xls/public/c_api_format_preference.h"
+
+namespace xls {
+
+// Converts a C-API-given format preference value into the XLS internal enum --
+// since these values can be out of normal enum class range when passed to the
+// API, we validate here.
+bool FormatPreferenceFromC(xls_format_preference c_pref,
+                           xls::FormatPreference* cpp_pref, char** error_out);
+
+// Helper function that we can use to adapt to the common C API pattern when
+// we're returning an `absl::StatusOr<std::string>` value.
+bool ReturnStringHelper(absl::StatusOr<std::string>& to_return,
+                        char** error_out, char** value_out);
+
+// Returns the payload of `s` as a C string allocated by libc and owned by the
+// caller.
+char* ToOwnedCString(const std::string& s);
+
+// Converts the C representation of filesystem search paths into a C++
+// representation.
+std::vector<std::filesystem::path> ToCpp(const char* additional_search_paths[],
+                                         size_t additional_search_paths_count);
+
+}  // namespace xls
+
+#endif  // XLS_PUBLIC_C_API_IMPL_HELPERS_H_

--- a/xls/public/c_api_vast.cc
+++ b/xls/public/c_api_vast.cc
@@ -1,0 +1,229 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/c_api_vast.h"
+
+#include "xls/codegen/vast/vast.h"
+#include "xls/ir/source_location.h"
+#include "xls/public/c_api_impl_helpers.h"
+
+extern "C" {
+
+struct xls_vast_verilog_file* xls_vast_make_verilog_file(
+    xls_vast_file_type file_type) {
+  auto* value = new xls::verilog::VerilogFile(
+      static_cast<xls::verilog::FileType>(file_type));
+  return reinterpret_cast<xls_vast_verilog_file*>(value);
+}
+
+void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f) {
+  delete reinterpret_cast<xls::verilog::VerilogFile*>(f);
+}
+
+struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
+    struct xls_vast_verilog_file* f, const char* name) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::Module* cpp_module =
+      cpp_file->AddModule(name, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_verilog_module*>(cpp_module);
+}
+
+void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
+                                       const char* path) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  cpp_file->AddInclude(path, xls::SourceInfo());
+}
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddInput(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddOutput(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_type = reinterpret_cast<xls::verilog::DataType*>(type);
+  xls::verilog::LogicRef* logic_ref =
+      cpp_module->AddWire(name, cpp_type, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_logic_ref*>(logic_ref);
+}
+
+char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f) {
+  const auto* cpp_file = reinterpret_cast<const xls::verilog::VerilogFile*>(f);
+  std::string result = cpp_file->Emit();
+  return xls::ToOwnedCString(result);
+}
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
+    struct xls_vast_verilog_file* f) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::DataType* type = cpp_file->ScalarType(xls::SourceInfo());
+  return reinterpret_cast<xls_vast_data_type*>(type);
+}
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_bit_vector_type(
+    struct xls_vast_verilog_file* f, int64_t bit_count, bool is_signed) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::DataType* type =
+      cpp_file->BitVectorType(bit_count, xls::SourceInfo(), is_signed);
+  return reinterpret_cast<xls_vast_data_type*>(type);
+}
+
+void xls_vast_verilog_module_add_member_instantiation(
+    struct xls_vast_verilog_module* m, struct xls_vast_instantiation* member) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_instantiation =
+      reinterpret_cast<xls::verilog::Instantiation*>(member);
+  cpp_module->AddModuleMember(cpp_instantiation);
+}
+
+void xls_vast_verilog_module_add_member_continuous_assignment(
+    struct xls_vast_verilog_module* m,
+    struct xls_vast_continuous_assignment* member) {
+  auto* cpp_module = reinterpret_cast<xls::verilog::Module*>(m);
+  auto* cpp_member =
+      reinterpret_cast<xls::verilog::ContinuousAssignment*>(member);
+  cpp_module->AddModuleMember(cpp_member);
+}
+
+struct xls_vast_literal* xls_vast_verilog_file_make_plain_literal(
+    struct xls_vast_verilog_file* f, int32_t value) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  xls::verilog::Literal* cpp_literal =
+      cpp_file->PlainLiteral(value, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_literal*>(cpp_literal);
+}
+
+bool xls_vast_verilog_file_make_literal(struct xls_vast_verilog_file* f,
+                                        struct xls_bits* bits,
+                                        xls_format_preference format_preference,
+                                        bool emit_bit_count, char** error_out,
+                                        struct xls_vast_literal** literal_out) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  auto* cpp_bits = reinterpret_cast<xls::Bits*>(bits);
+  xls::FormatPreference cpp_pref;
+  if (!xls::FormatPreferenceFromC(format_preference, &cpp_pref, error_out)) {
+    return false;
+  }
+  xls::verilog::Literal* cpp_literal = cpp_file->Make<xls::verilog::Literal>(
+      xls::SourceInfo(), *cpp_bits, cpp_pref, emit_bit_count);
+  *error_out = nullptr;
+  *literal_out = reinterpret_cast<xls_vast_literal*>(cpp_literal);
+  return true;
+}
+
+struct xls_vast_continuous_assignment*
+xls_vast_verilog_file_make_continuous_assignment(
+    struct xls_vast_verilog_file* f, struct xls_vast_expression* lhs,
+    struct xls_vast_expression* rhs) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  auto* cpp_lhs = reinterpret_cast<xls::verilog::Expression*>(lhs);
+  auto* cpp_rhs = reinterpret_cast<xls::verilog::Expression*>(rhs);
+  auto* cpp_assignment = cpp_file->Make<xls::verilog::ContinuousAssignment>(
+      xls::SourceInfo(), cpp_lhs, cpp_rhs);
+  return reinterpret_cast<xls_vast_continuous_assignment*>(cpp_assignment);
+}
+
+struct xls_vast_instantiation* xls_vast_verilog_file_make_instantiation(
+    struct xls_vast_verilog_file* f, const char* module_name,
+    const char* instance_name, const char** parameter_port_names,
+    struct xls_vast_expression** parameter_expressions, size_t parameter_count,
+    const char** connection_port_names,
+    struct xls_vast_expression** connection_expressions,
+    size_t connection_count) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+
+  std::vector<xls::verilog::Connection> parameters;
+  parameters.reserve(parameter_count);
+  for (size_t i = 0; i < parameter_count; ++i) {
+    auto* cpp_expression =
+        reinterpret_cast<xls::verilog::Expression*>(parameter_expressions[i]);
+    parameters.push_back(
+        xls::verilog::Connection{parameter_port_names[i], cpp_expression});
+  }
+
+  std::vector<xls::verilog::Connection> connections;
+  connections.reserve(connection_count);
+  for (size_t i = 0; i < connection_count; ++i) {
+    auto* cpp_expression =
+        reinterpret_cast<xls::verilog::Expression*>(connection_expressions[i]);
+    connections.push_back(
+        xls::verilog::Connection{connection_port_names[i], cpp_expression});
+  }
+
+  auto* cpp_instantiation = cpp_file->Make<xls::verilog::Instantiation>(
+      xls::SourceInfo(), module_name, instance_name,
+      absl::MakeConstSpan(parameters), absl::MakeConstSpan(connections));
+  return reinterpret_cast<xls_vast_instantiation*>(cpp_instantiation);
+}
+
+struct xls_vast_expression* xls_vast_literal_as_expression(
+    struct xls_vast_literal* v) {
+  auto* cpp_literal = reinterpret_cast<xls::verilog::Literal*>(v);
+  auto* cpp_expression = static_cast<xls::verilog::Expression*>(cpp_literal);
+  return reinterpret_cast<xls_vast_expression*>(cpp_expression);
+}
+
+struct xls_vast_expression* xls_vast_logic_ref_as_expression(
+    struct xls_vast_logic_ref* v) {
+  auto* cpp_v = reinterpret_cast<xls::verilog::LogicRef*>(v);
+  auto* cpp_expression = static_cast<xls::verilog::Expression*>(cpp_v);
+  return reinterpret_cast<xls_vast_expression*>(cpp_expression);
+}
+
+struct xls_vast_expression* xls_vast_slice_as_expression(
+    struct xls_vast_slice* v) {
+  auto* cpp_v = reinterpret_cast<xls::verilog::Slice*>(v);
+  auto* cpp_expression = static_cast<xls::verilog::Expression*>(cpp_v);
+  return reinterpret_cast<xls_vast_expression*>(cpp_expression);
+}
+
+struct xls_vast_indexable_expression*
+xls_vast_logic_ref_as_indexable_expression(
+    struct xls_vast_logic_ref* logic_ref) {
+  auto* cpp_logic_ref = reinterpret_cast<xls::verilog::LogicRef*>(logic_ref);
+  auto* cpp_indexable_expression =
+      static_cast<xls::verilog::IndexableExpression*>(cpp_logic_ref);
+  return reinterpret_cast<xls_vast_indexable_expression*>(
+      cpp_indexable_expression);
+}
+
+struct xls_vast_slice* xls_vast_verilog_file_make_slice_i64(
+    struct xls_vast_verilog_file* f,
+    struct xls_vast_indexable_expression* subject, int64_t hi, int64_t lo) {
+  auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
+  auto* cpp_subject =
+      reinterpret_cast<xls::verilog::IndexableExpression*>(subject);
+  xls::verilog::Slice* cpp_slice =
+      cpp_file->Slice(cpp_subject, hi, lo, xls::SourceInfo());
+  return reinterpret_cast<xls_vast_slice*>(cpp_slice);
+}
+
+}  // extern "C"

--- a/xls/public/c_api_vast.h
+++ b/xls/public/c_api_vast.h
@@ -1,0 +1,141 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// VAST (Verilog AST) APIs
+//
+// Note that these are expected to be *less* stable than other public C APIs,
+// as they are exposing a useful implementation library present within XLS.
+//
+// Per usual, in a general sense, no promises are made around API or ABI
+// stability overall. However, seems worth noting these are effectively
+// "protected" APIs, use with particular caution around stability. See
+// `xls/protected/BUILD` for how we tend to think about "protected" APIs in the
+// project.
+
+#ifndef XLS_PUBLIC_C_API_VAST_H_
+#define XLS_PUBLIC_C_API_VAST_H_
+
+#include <stddef.h>  // NOLINT(modernize-deprecated-headers)
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+#include "xls/public/c_api_format_preference.h"
+
+extern "C" {
+
+// Opaque structs.
+struct xls_vast_verilog_file;
+struct xls_vast_verilog_module;
+struct xls_vast_node;
+struct xls_vast_expression;
+struct xls_vast_logic_ref;
+struct xls_vast_data_type;
+struct xls_vast_indexable_expression;
+struct xls_vast_slice;
+struct xls_vast_literal;
+struct xls_vast_instantiation;
+struct xls_vast_continuous_assignment;
+
+// Note: We define the enum with a fixed width integer type for clarity of the
+// exposed ABI.
+typedef int32_t xls_vast_file_type;
+enum {
+  xls_vast_file_type_verilog,
+  xls_vast_file_type_system_verilog,
+};
+
+// Note: caller owns the returned verilog file object, to be freed by
+// `xls_vast_verilog_file_free`.
+struct xls_vast_verilog_file* xls_vast_make_verilog_file(
+    xls_vast_file_type file_type);
+
+void xls_vast_verilog_file_free(struct xls_vast_verilog_file* f);
+
+struct xls_vast_verilog_module* xls_vast_verilog_file_add_module(
+    struct xls_vast_verilog_file* f, const char* name);
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_scalar_type(
+    struct xls_vast_verilog_file* f);
+
+struct xls_vast_data_type* xls_vast_verilog_file_make_bit_vector_type(
+    struct xls_vast_verilog_file* f, int64_t bit_count, bool is_signed);
+
+void xls_vast_verilog_module_add_member_instantiation(
+    struct xls_vast_verilog_module* m, struct xls_vast_instantiation* member);
+void xls_vast_verilog_module_add_member_continuous_assignment(
+    struct xls_vast_verilog_module* m,
+    struct xls_vast_continuous_assignment* member);
+
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_input(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_output(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
+struct xls_vast_logic_ref* xls_vast_verilog_module_add_wire(
+    struct xls_vast_verilog_module* m, const char* name,
+    struct xls_vast_data_type* type);
+// TODO(cdleary): 2024-09-05 Add xls_vast_verilog_module_add_wire_with_expr
+
+struct xls_vast_continuous_assignment*
+xls_vast_verilog_file_make_continuous_assignment(
+    struct xls_vast_verilog_file* f, struct xls_vast_expression* lhs,
+    struct xls_vast_expression* rhs);
+
+struct xls_vast_instantiation* xls_vast_verilog_file_make_instantiation(
+    struct xls_vast_verilog_file* f, const char* module_name,
+    const char* instance_name, const char** parameter_port_names,
+    struct xls_vast_expression** parameter_expressions, size_t parameter_count,
+    const char** connection_port_names,
+    struct xls_vast_expression** connection_expressions,
+    size_t connection_count);
+
+void xls_vast_verilog_file_add_include(struct xls_vast_verilog_file* f,
+                                       const char* path);
+
+struct xls_vast_slice* xls_vast_verilog_file_make_slice_i64(
+    struct xls_vast_verilog_file* f,
+    struct xls_vast_indexable_expression* subject, int64_t hi, int64_t lo);
+
+struct xls_vast_literal* xls_vast_verilog_file_make_plain_literal(
+    struct xls_vast_verilog_file* f, int32_t value);
+
+// Creates a VAST literal with an arbitrary bit count.
+//
+// Returns an error if the given format preference is invalid.
+bool xls_vast_verilog_file_make_literal(struct xls_vast_verilog_file* f,
+                                        struct xls_bits* bits,
+                                        xls_format_preference format_preference,
+                                        bool emit_bit_count, char** error_out,
+                                        struct xls_vast_literal** literal_out);
+
+// Casts to turn the given node to an expression, where possible.
+struct xls_vast_expression* xls_vast_literal_as_expression(
+    struct xls_vast_literal* v);
+struct xls_vast_expression* xls_vast_logic_ref_as_expression(
+    struct xls_vast_logic_ref* v);
+struct xls_vast_expression* xls_vast_slice_as_expression(
+    struct xls_vast_slice* v);
+
+struct xls_vast_indexable_expression*
+xls_vast_logic_ref_as_indexable_expression(
+    struct xls_vast_logic_ref* logic_ref);
+
+// Emits/formats the contents of the given verilog file to a string.
+//
+// Note: caller owns the returned string, to be freed by `xls_c_str_free`.
+char* xls_vast_verilog_file_emit(const struct xls_vast_verilog_file* f);
+
+}  // extern "C"
+
+#endif  // XLS_PUBLIC_C_API_VAST_H_


### PR DESCRIPTION
Since VAST is now in there (as a conceptually "protected" / more prone to change API) with the other public APIs seemed like a good time to break it into some translation units before introducing more "protected" APIs e.g. for DSLX inspection.