### PR TITLE
[c_api] Add start of C API for DSLX, including inspecting module-scoped type definitions.

### DIFF
--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -2195,7 +2195,7 @@ class EnumDef : public AstNode {
   NameDef* name_def() const { return name_def_; }
 
   const std::vector<EnumMember>& values() const { return values_; }
-  std::vector<EnumMember>& values() { return values_; }
+  std::vector<EnumMember>& mutable_values() { return values_; }
 
   TypeAnnotation* type_annotation() const { return type_annotation_; }
   bool is_public() const { return is_public_; }
@@ -2274,7 +2274,7 @@ class StructDef : public AstNode {
   }
 
   const std::vector<StructMember>& members() const { return members_; }
-  std::vector<StructMember>& members() { return members_; }
+  std::vector<StructMember>& mutable_members() { return members_; }
 
   bool is_public() const { return public_; }
   const Span& span() const { return span_; }

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -270,8 +270,7 @@ inline std::vector<AstNode*> ToAstNodes(absl::Span<NodeT* const> source) {
 // Abstract base class for type annotations.
 class TypeAnnotation : public AstNode {
  public:
-  TypeAnnotation(Module* owner, Span span)
-      : AstNode(owner), span_(std::move(span)) {}
+  TypeAnnotation(Module* owner, Span span) : AstNode(owner), span_(span) {}
 
   ~TypeAnnotation() override;
 
@@ -2105,7 +2104,7 @@ class AllOnesMacro : public Expr {
 class Slice : public AstNode {
  public:
   Slice(Module* owner, Span span, Expr* start, Expr* limit)
-      : AstNode(owner), span_(std::move(span)), start_(start), limit_(limit) {}
+      : AstNode(owner), span_(span), start_(start), limit_(limit) {}
 
   ~Slice() override;
 
@@ -2194,7 +2193,10 @@ class EnumDef : public AstNode {
   const Span& span() const { return span_; }
   std::optional<Span> GetSpan() const override { return span_; }
   NameDef* name_def() const { return name_def_; }
+
   const std::vector<EnumMember>& values() const { return values_; }
+  std::vector<EnumMember>& values() { return values_; }
+
   TypeAnnotation* type_annotation() const { return type_annotation_; }
   bool is_public() const { return is_public_; }
 
@@ -2270,7 +2272,10 @@ class StructDef : public AstNode {
   const std::vector<ParametricBinding*>& parametric_bindings() const {
     return parametric_bindings_;
   }
+
   const std::vector<StructMember>& members() const { return members_; }
+  std::vector<StructMember>& members() { return members_; }
+
   bool is_public() const { return public_; }
   const Span& span() const { return span_; }
   std::optional<Span> GetSpan() const override { return span_; }

--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -192,13 +192,13 @@ cc_library(
     srcs = ["c_api_dslx.cc"],
     hdrs = ["c_api_dslx.h"],
     deps = [
-        "//xls/common:visitor",
-        "@com_google_absl//absl/types:variant",
-        "//xls/dslx:warning_kind",
-        "//xls/dslx/type_system:unwrap_meta_type",
         ":c_api_impl_helpers",
-        "//xls/dslx:parse_and_typecheck",
+        "@com_google_absl//absl/types:variant",
+        "//xls/common:visitor",
         "//xls/dslx:create_import_data",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/dslx/type_system:unwrap_meta_type",
+        "//xls/dslx:warning_kind",
     ],
 )
 
@@ -211,10 +211,6 @@ cc_library(
         ":c_api_format_preference",
         ":c_api_impl_helpers",
         ":c_api_vast",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings:str_format",
         ":runtime_build_actions",
         "//xls/common:init_xls",
         "//xls/interpreter:ir_interpreter",
@@ -225,6 +221,10 @@ cc_library(
         "//xls/ir:ir_parser",
         "//xls/ir:type",
         "//xls/ir:value",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -188,13 +188,33 @@ cc_library(
 )
 
 cc_library(
+    name = "c_api_dslx",
+    srcs = ["c_api_dslx.cc"],
+    hdrs = ["c_api_dslx.h"],
+    deps = [
+        "//xls/common:visitor",
+        "@com_google_absl//absl/types:variant",
+        "//xls/dslx:warning_kind",
+        "//xls/dslx/type_system:unwrap_meta_type",
+        ":c_api_impl_helpers",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/dslx:create_import_data",
+    ],
+)
+
+cc_library(
     name = "c_api",
     srcs = ["c_api.cc"],
     hdrs = ["c_api.h"],
     deps = [
+        ":c_api_dslx",
         ":c_api_format_preference",
         ":c_api_impl_helpers",
         ":c_api_vast",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings:str_format",
         ":runtime_build_actions",
         "//xls/common:init_xls",
         "//xls/interpreter:ir_interpreter",
@@ -205,10 +225,6 @@ cc_library(
         "//xls/ir:ir_parser",
         "//xls/ir:type",
         "//xls/ir:value",
-        "@com_google_absl//absl/log:check",
-        "@com_google_absl//absl/status",
-        "@com_google_absl//absl/status:statusor",
-        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -18,6 +18,7 @@
 #include <stddef.h>  // NOLINT(modernize-deprecated-headers)
 
 #include "xls/public/c_api_format_preference.h"
+#include "xls/public/c_api_dslx.h"
 #include "xls/public/c_api_vast.h"
 
 // C API that exposes the functionality in various public headers in a way that

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -17,8 +17,8 @@
 
 #include <stddef.h>  // NOLINT(modernize-deprecated-headers)
 
-#include "xls/public/c_api_format_preference.h"
 #include "xls/public/c_api_dslx.h"
+#include "xls/public/c_api_format_preference.h"
 #include "xls/public/c_api_vast.h"
 
 // C API that exposes the functionality in various public headers in a way that

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -238,6 +238,12 @@ struct xls_dslx_type_annotation* xls_dslx_struct_member_get_type(
   return reinterpret_cast<xls_dslx_type_annotation*>(cpp_type_annotation);
 }
 
+char* xls_dslx_struct_member_get_name(struct xls_dslx_struct_member* member) {
+  auto* cpp_member = reinterpret_cast<xls::dslx::StructMember*>(member);
+  const std::string& name = cpp_member->name;
+  return xls::ToOwnedCString(name);
+}
+
 bool xls_dslx_type_info_get_const_expr(
     struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr,
     char** error_out, struct xls_dslx_interp_value** result_out) {

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -1,0 +1,278 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/public/c_api_dslx.h"
+
+#include "absl/types/variant.h"
+#include "xls/common/visitor.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/parse_and_typecheck.h"
+#include "xls/dslx/type_system/unwrap_meta_type.h"
+#include "xls/dslx/warning_kind.h"
+#include "xls/public/c_api_impl_helpers.h"
+
+namespace {
+template <typename T>
+inline const struct xls_dslx_type* GetMetaTypeHelper(
+    struct xls_dslx_type_info* type_info, T* c_node) {
+  auto* cpp_type_info = reinterpret_cast<xls::dslx::TypeInfo*>(type_info);
+  auto* cpp_node = reinterpret_cast<xls::dslx::AstNode*>(c_node);
+  std::optional<xls::dslx::Type*> maybe_type = cpp_type_info->GetItem(cpp_node);
+  if (!maybe_type.has_value()) {
+    return nullptr;
+  }
+  CHECK(maybe_type.value() != nullptr);
+  // Should always have a metatype as its associated type.
+  absl::StatusOr<const xls::dslx::Type*> unwrapped_or =
+      xls::dslx::UnwrapMetaType(*maybe_type.value());
+  CHECK(unwrapped_or.ok());
+  return reinterpret_cast<const struct xls_dslx_type*>(unwrapped_or.value());
+}
+}  // namespace
+
+extern "C" {
+
+struct xls_dslx_import_data* xls_dslx_import_data_create(
+    const char* dslx_stdlib_path, const char* additional_search_paths[],
+    size_t additional_search_paths_count) {
+  std::filesystem::path cpp_stdlib_path{dslx_stdlib_path};
+  std::vector<std::filesystem::path> cpp_additional_search_paths =
+      xls::ToCpp(additional_search_paths, additional_search_paths_count);
+  xls::dslx::ImportData import_data = CreateImportData(
+      cpp_stdlib_path, cpp_additional_search_paths, xls::dslx::kAllWarningsSet);
+  return reinterpret_cast<xls_dslx_import_data*>(
+      new xls::dslx::ImportData{std::move(import_data)});
+}
+
+void xls_dslx_import_data_free(struct xls_dslx_import_data* x) {
+  delete reinterpret_cast<xls::dslx::ImportData*>(x);
+}
+
+void xls_dslx_typechecked_module_free(struct xls_dslx_typechecked_module* tm) {
+  delete reinterpret_cast<xls::dslx::TypecheckedModule*>(tm);
+}
+
+struct xls_dslx_module* xls_dslx_typechecked_module_get_module(
+    struct xls_dslx_typechecked_module* tm) {
+  auto* cpp_tm = reinterpret_cast<xls::dslx::TypecheckedModule*>(tm);
+  xls::dslx::Module* cpp_module = cpp_tm->module;
+  return reinterpret_cast<xls_dslx_module*>(cpp_module);
+}
+
+struct xls_dslx_type_info* xls_dslx_typechecked_module_get_type_info(
+    struct xls_dslx_typechecked_module* tm) {
+  auto* cpp_tm = reinterpret_cast<xls::dslx::TypecheckedModule*>(tm);
+  xls::dslx::TypeInfo* cpp_type_info = cpp_tm->type_info;
+  return reinterpret_cast<xls_dslx_type_info*>(cpp_type_info);
+}
+
+bool xls_dslx_parse_and_typecheck(
+    const char* text, const char* path, const char* module_name,
+    struct xls_dslx_import_data* import_data, char** error_out,
+    struct xls_dslx_typechecked_module** result_out) {
+  auto* cpp_import_data = reinterpret_cast<xls::dslx::ImportData*>(import_data);
+
+  absl::StatusOr<xls::dslx::TypecheckedModule> tm_or =
+      xls::dslx::ParseAndTypecheck(text, path, module_name, cpp_import_data);
+  if (tm_or.ok()) {
+    auto* tm_on_heap =
+        new xls::dslx::TypecheckedModule{std::move(tm_or).value()};
+    *result_out = reinterpret_cast<xls_dslx_typechecked_module*>(tm_on_heap);
+    *error_out = nullptr;
+    return true;
+  }
+
+  *result_out = nullptr;
+  *error_out = xls::ToOwnedCString(tm_or.status().ToString());
+  return false;
+}
+
+int64_t xls_dslx_module_get_type_definition_count(
+    struct xls_dslx_module* module) {
+  auto* cpp_module = reinterpret_cast<xls::dslx::Module*>(module);
+  return cpp_module->GetTypeDefinitions().size();
+}
+
+xls_dslx_type_definition_kind xls_dslx_module_get_type_definition_kind(
+    struct xls_dslx_module* module, int64_t i) {
+  auto* cpp_module = reinterpret_cast<xls::dslx::Module*>(module);
+  xls::dslx::TypeDefinition cpp_type_definition =
+      cpp_module->GetTypeDefinitions().at(i);
+  return absl::visit(xls::Visitor{
+                         [](const xls::dslx::StructDef*) {
+                           return xls_dslx_type_definition_kind_struct_def;
+                         },
+                         [](const xls::dslx::EnumDef*) {
+                           return xls_dslx_type_definition_kind_enum_def;
+                         },
+                         [](const xls::dslx::TypeAlias*) {
+                           return xls_dslx_type_definition_kind_type_alias;
+                         },
+                         [](const xls::dslx::ColonRef*) {
+                           return xls_dslx_type_definition_kind_colon_ref;
+                         },
+                     },
+                     cpp_type_definition);
+}
+
+struct xls_dslx_struct_def* xls_dslx_module_get_type_definition_as_struct_def(
+    struct xls_dslx_module* module, int64_t i) {
+  auto* cpp_module = reinterpret_cast<xls::dslx::Module*>(module);
+  xls::dslx::TypeDefinition cpp_type_definition =
+      cpp_module->GetTypeDefinitions().at(i);
+  auto* cpp_struct_def = std::get<xls::dslx::StructDef*>(cpp_type_definition);
+  return reinterpret_cast<xls_dslx_struct_def*>(cpp_struct_def);
+}
+
+struct xls_dslx_enum_def* xls_dslx_module_get_type_definition_as_enum_def(
+    struct xls_dslx_module* module, int64_t i) {
+  auto* cpp_module = reinterpret_cast<xls::dslx::Module*>(module);
+  xls::dslx::TypeDefinition cpp_type_definition =
+      cpp_module->GetTypeDefinitions().at(i);
+  auto* cpp_enum_def = std::get<xls::dslx::EnumDef*>(cpp_type_definition);
+  return reinterpret_cast<xls_dslx_enum_def*>(cpp_enum_def);
+}
+
+char* xls_dslx_struct_def_get_identifier(struct xls_dslx_struct_def* n) {
+  auto* cpp_struct_def = reinterpret_cast<xls::dslx::StructDef*>(n);
+  std::string result = cpp_struct_def->identifier();
+  return xls::ToOwnedCString(result);
+}
+
+// -- enum_def
+
+char* xls_dslx_enum_def_get_identifier(struct xls_dslx_enum_def* n) {
+  auto* cpp_enum_def = reinterpret_cast<xls::dslx::EnumDef*>(n);
+  std::string result = cpp_enum_def->identifier();
+  return xls::ToOwnedCString(result);
+}
+
+int64_t xls_dslx_enum_def_get_member_count(struct xls_dslx_enum_def* n) {
+  auto* cpp_enum_def = reinterpret_cast<xls::dslx::EnumDef*>(n);
+  return static_cast<int64_t>(cpp_enum_def->values().size());
+}
+
+struct xls_dslx_enum_member* xls_dslx_enum_def_get_member(
+    struct xls_dslx_enum_def* n, int64_t i) {
+  auto* cpp_enum_def = reinterpret_cast<xls::dslx::EnumDef*>(n);
+  xls::dslx::EnumMember& cpp_member = cpp_enum_def->values().at(i);
+  return reinterpret_cast<xls_dslx_enum_member*>(&cpp_member);
+}
+
+char* xls_dslx_enum_member_get_name(struct xls_dslx_enum_member* m) {
+  auto* cpp_member = reinterpret_cast<xls::dslx::EnumMember*>(m);
+  return xls::ToOwnedCString(cpp_member->name_def->identifier());
+}
+
+struct xls_dslx_expr* xls_dslx_enum_member_get_value(struct xls_dslx_enum_member* m) {
+  auto* cpp_member = reinterpret_cast<xls::dslx::EnumMember*>(m);
+  xls::dslx::Expr* cpp_value = cpp_member->value;
+  return reinterpret_cast<xls_dslx_expr*>(cpp_value);
+}
+
+// -- type_info
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_struct_def(
+    struct xls_dslx_type_info* type_info,
+    struct xls_dslx_struct_def* struct_def) {
+  return GetMetaTypeHelper(type_info, struct_def);
+}
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_enum_def(
+    struct xls_dslx_type_info* type_info, struct xls_dslx_enum_def* enum_def) {
+  return GetMetaTypeHelper(type_info, enum_def);
+}
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_type_annotation(
+    struct xls_dslx_type_info* type_info,
+    struct xls_dslx_type_annotation* type_annotation) {
+  return GetMetaTypeHelper(type_info, type_annotation);
+}
+
+bool xls_dslx_type_get_total_bit_count(const struct xls_dslx_type* type,
+                                       char** error_out, int64_t* result_out) {
+  const auto* cpp_type = reinterpret_cast<const xls::dslx::Type*>(type);
+  absl::StatusOr<xls::dslx::TypeDim> bit_count_or =
+      cpp_type->GetTotalBitCount();
+  if (!bit_count_or.ok()) {
+    *result_out = 0;
+    *error_out = xls::ToOwnedCString(bit_count_or.status().ToString());
+    return false;
+  }
+
+  absl::StatusOr<int64_t> width_or = bit_count_or->GetAsInt64();
+  if (!width_or.ok()) {
+    *result_out = 0;
+    *error_out = xls::ToOwnedCString(width_or.status().ToString());
+    return false;
+  }
+
+  *result_out = width_or.value();
+  *error_out = nullptr;
+  return true;
+}
+
+struct xls_dslx_struct_member* xls_dslx_struct_def_get_member(
+    struct xls_dslx_struct_def* struct_def, int64_t i) {
+  auto* cpp_struct_def = reinterpret_cast<xls::dslx::StructDef*>(struct_def);
+  xls::dslx::StructMember& cpp_member = cpp_struct_def->members().at(i);
+  return reinterpret_cast<xls_dslx_struct_member*>(&cpp_member);
+}
+
+struct xls_dslx_type_annotation* xls_dslx_struct_member_get_type(
+    struct xls_dslx_struct_member* member) {
+  auto* cpp_member = reinterpret_cast<xls::dslx::StructMember*>(member);
+  xls::dslx::TypeAnnotation* cpp_type_annotation = cpp_member->type;
+  return reinterpret_cast<xls_dslx_type_annotation*>(cpp_type_annotation);
+}
+
+bool xls_dslx_type_info_get_const_expr(struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr, char** error_out, struct xls_dslx_interp_value** result_out) {
+  auto* cpp_type_info = reinterpret_cast<xls::dslx::TypeInfo*>(type_info);
+  auto* cpp_expr = reinterpret_cast<xls::dslx::Expr*>(expr);
+  absl::StatusOr<xls::dslx::InterpValue> value_or = cpp_type_info->GetConstExpr(cpp_expr);
+  if (!value_or.ok()) {
+    *result_out = nullptr;
+    *error_out = xls::ToOwnedCString(value_or.status().ToString());
+    return false;
+  }
+
+  auto* heap = new xls::dslx::InterpValue{std::move(value_or).value()};
+  *result_out = reinterpret_cast<xls_dslx_interp_value*>(heap);
+  *error_out = nullptr;
+  return true;
+}
+
+// -- interp_value
+
+void xls_dslx_interp_value_free(struct xls_dslx_interp_value* v) {
+  auto* cpp_interp_value = reinterpret_cast<xls::dslx::InterpValue*>(v);
+  delete cpp_interp_value;
+}
+
+bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v, char** error_out, struct xls_value** result_out) {
+  auto* cpp_interp_value = reinterpret_cast<xls::dslx::InterpValue*>(v);
+  absl::StatusOr<xls::Value> ir_value_or = cpp_interp_value->ConvertToIr();
+  if (!ir_value_or.ok()) {
+    *error_out = xls::ToOwnedCString(ir_value_or.status().ToString());
+    *result_out = nullptr;
+    return false;
+  }
+
+  auto* heap = new xls::Value{std::move(ir_value_or).value()};
+  *result_out = reinterpret_cast<xls_value*>(heap);
+  *error_out = nullptr;
+  return true;
+}
+
+}  // extern "C"

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -166,7 +166,7 @@ int64_t xls_dslx_enum_def_get_member_count(struct xls_dslx_enum_def* n) {
 struct xls_dslx_enum_member* xls_dslx_enum_def_get_member(
     struct xls_dslx_enum_def* n, int64_t i) {
   auto* cpp_enum_def = reinterpret_cast<xls::dslx::EnumDef*>(n);
-  xls::dslx::EnumMember& cpp_member = cpp_enum_def->values().at(i);
+  xls::dslx::EnumMember& cpp_member = cpp_enum_def->mutable_values().at(i);
   return reinterpret_cast<xls_dslx_enum_member*>(&cpp_member);
 }
 
@@ -227,7 +227,7 @@ bool xls_dslx_type_get_total_bit_count(const struct xls_dslx_type* type,
 struct xls_dslx_struct_member* xls_dslx_struct_def_get_member(
     struct xls_dslx_struct_def* struct_def, int64_t i) {
   auto* cpp_struct_def = reinterpret_cast<xls::dslx::StructDef*>(struct_def);
-  xls::dslx::StructMember& cpp_member = cpp_struct_def->members().at(i);
+  xls::dslx::StructMember& cpp_member = cpp_struct_def->mutable_members().at(i);
   return reinterpret_cast<xls_dslx_struct_member*>(&cpp_member);
 }
 

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -175,7 +175,8 @@ char* xls_dslx_enum_member_get_name(struct xls_dslx_enum_member* m) {
   return xls::ToOwnedCString(cpp_member->name_def->identifier());
 }
 
-struct xls_dslx_expr* xls_dslx_enum_member_get_value(struct xls_dslx_enum_member* m) {
+struct xls_dslx_expr* xls_dslx_enum_member_get_value(
+    struct xls_dslx_enum_member* m) {
   auto* cpp_member = reinterpret_cast<xls::dslx::EnumMember*>(m);
   xls::dslx::Expr* cpp_value = cpp_member->value;
   return reinterpret_cast<xls_dslx_expr*>(cpp_value);
@@ -237,10 +238,13 @@ struct xls_dslx_type_annotation* xls_dslx_struct_member_get_type(
   return reinterpret_cast<xls_dslx_type_annotation*>(cpp_type_annotation);
 }
 
-bool xls_dslx_type_info_get_const_expr(struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr, char** error_out, struct xls_dslx_interp_value** result_out) {
+bool xls_dslx_type_info_get_const_expr(
+    struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr,
+    char** error_out, struct xls_dslx_interp_value** result_out) {
   auto* cpp_type_info = reinterpret_cast<xls::dslx::TypeInfo*>(type_info);
   auto* cpp_expr = reinterpret_cast<xls::dslx::Expr*>(expr);
-  absl::StatusOr<xls::dslx::InterpValue> value_or = cpp_type_info->GetConstExpr(cpp_expr);
+  absl::StatusOr<xls::dslx::InterpValue> value_or =
+      cpp_type_info->GetConstExpr(cpp_expr);
   if (!value_or.ok()) {
     *result_out = nullptr;
     *error_out = xls::ToOwnedCString(value_or.status().ToString());
@@ -260,7 +264,9 @@ void xls_dslx_interp_value_free(struct xls_dslx_interp_value* v) {
   delete cpp_interp_value;
 }
 
-bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v, char** error_out, struct xls_value** result_out) {
+bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v,
+                                         char** error_out,
+                                         struct xls_value** result_out) {
   auto* cpp_interp_value = reinterpret_cast<xls::dslx::InterpValue*>(v);
   absl::StatusOr<xls::Value> ir_value_or = cpp_interp_value->ConvertToIr();
   if (!ir_value_or.ok()) {

--- a/xls/public/c_api_dslx.h
+++ b/xls/public/c_api_dslx.h
@@ -1,0 +1,149 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// DSLX (Domain Specific Language "X") APIs
+//
+// Note that these are expected to be *less* stable than other public C APIs,
+// as they are exposing a useful implementation library present within XLS.
+//
+// Per usual, in a general sense, no promises are made around API or ABI
+// stability overall. However, seems worth noting these are effectively
+// "protected" APIs, use with particular caution around stability. See
+// `xls/protected/BUILD` for how we tend to think about "protected" APIs in the
+// project.
+
+#ifndef XLS_PUBLIC_C_API_DSLX_H_
+#define XLS_PUBLIC_C_API_DSLX_H_
+
+#include <stddef.h>  // NOLINT(modernize-deprecated-headers)
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+extern "C" {
+
+typedef int32_t xls_dslx_type_definition_kind;
+enum {
+  xls_dslx_type_definition_kind_type_alias,
+  xls_dslx_type_definition_kind_struct_def,
+  xls_dslx_type_definition_kind_enum_def,
+  xls_dslx_type_definition_kind_colon_ref,
+};
+
+// Opaque structs.
+struct xls_dslx_typechecked_module;
+struct xls_dslx_import_data;
+struct xls_dslx_module;
+struct xls_dslx_type_definition;
+struct xls_dslx_struct_def;
+struct xls_dslx_enum_def;
+struct xls_dslx_type_alias;
+struct xls_dslx_type_info;
+struct xls_dslx_type;
+struct xls_dslx_type_annotation;
+
+struct xls_dslx_import_data* xls_dslx_import_data_create(
+    const char* dslx_stdlib_path, const char* additional_search_paths[],
+    size_t additional_search_paths_count);
+
+void xls_dslx_import_data_free(struct xls_dslx_import_data*);
+
+bool xls_dslx_parse_and_typecheck(
+    const char* text, const char* path, const char* module_name,
+    struct xls_dslx_import_data* import_data, char** error_out,
+    struct xls_dslx_typechecked_module** result_out);
+
+void xls_dslx_typechecked_module_free(struct xls_dslx_typechecked_module* tm);
+
+struct xls_dslx_module* xls_dslx_typechecked_module_get_module(
+    struct xls_dslx_typechecked_module*);
+struct xls_dslx_type_info* xls_dslx_typechecked_module_get_type_info(
+    struct xls_dslx_typechecked_module*);
+
+int64_t xls_dslx_module_get_type_definition_count(
+    struct xls_dslx_module* module);
+
+xls_dslx_type_definition_kind xls_dslx_module_get_type_definition_kind(
+    struct xls_dslx_module* module, int64_t i);
+
+struct xls_dslx_struct_def* xls_dslx_module_get_type_definition_as_struct_def(
+    struct xls_dslx_module* module, int64_t i);
+
+struct xls_dslx_enum_def* xls_dslx_module_get_type_definition_as_enum_def(
+    struct xls_dslx_module* module, int64_t i);
+
+struct xls_dslx_type_alias* xls_dslx_module_get_type_definition_as_type_alias(
+    struct xls_dslx_module* module, int64_t i);
+
+// -- struct_def
+
+// Note: the return value is owned by the caller and must be freed via
+// `xls_c_str_free`.
+char* xls_dslx_struct_def_get_identifier(struct xls_dslx_struct_def*);
+
+bool xls_dslx_struct_def_is_parametric(struct xls_dslx_struct_def*);
+int64_t xls_dslx_struct_def_get_member_count(struct xls_dslx_struct_def*);
+
+struct xls_dslx_struct_member* xls_dslx_struct_def_get_member(
+    struct xls_dslx_struct_def*, int64_t);
+
+// Note: return value is owned by the caller, free via `xls_c_str_free`.
+char* xls_dslx_struct_member_get_name(struct xls_dslx_struct_member*);
+
+struct xls_dslx_type_annotation* xls_dslx_struct_member_get_type(
+    struct xls_dslx_struct_member*);
+
+// -- enum_def
+
+char* xls_dslx_enum_def_get_identifier(struct xls_dslx_enum_def*);
+
+int64_t xls_dslx_enum_def_get_member_count(struct xls_dslx_enum_def*);
+
+struct xls_dslx_enum_member* xls_dslx_enum_def_get_member(
+    struct xls_dslx_enum_def*, int64_t);
+
+// Note: return value is owned by the caller, free via `xls_c_str_free`.
+char* xls_dslx_enum_member_get_name(struct xls_dslx_enum_member*);
+
+struct xls_dslx_expr* xls_dslx_enum_member_get_value(struct xls_dslx_enum_member*);
+
+// -- interp_value
+
+bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v, char** error_out, struct xls_value** result_out);
+
+void xls_dslx_interp_value_free(struct xls_dslx_interp_value*);
+
+// -- type_info
+
+// Note: if there is no type information available for the given entity these
+// may return null; however, if type checking has completed successfully this
+// should not occur in practice.
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_struct_def(
+    struct xls_dslx_type_info*, struct xls_dslx_struct_def*);
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_enum_def(
+    struct xls_dslx_type_info*, struct xls_dslx_enum_def*);
+
+const struct xls_dslx_type* xls_dslx_type_info_get_type_type_annotation(
+    struct xls_dslx_type_info*, struct xls_dslx_type_annotation*);
+
+// Note: the outparam is owned by the caller and must be freed via
+// `xls_dslx_interp_value_free`.
+bool xls_dslx_type_info_get_const_expr(struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr, char** error_out, struct xls_dslx_interp_value** result_out);
+
+bool xls_dslx_type_get_total_bit_count(const struct xls_dslx_type*,
+                                       char** error_out, int64_t* result_out);
+
+}  // extern "C"
+
+#endif  // XLS_PUBLIC_C_API_DSLX_H_

--- a/xls/public/c_api_dslx.h
+++ b/xls/public/c_api_dslx.h
@@ -114,11 +114,14 @@ struct xls_dslx_enum_member* xls_dslx_enum_def_get_member(
 // Note: return value is owned by the caller, free via `xls_c_str_free`.
 char* xls_dslx_enum_member_get_name(struct xls_dslx_enum_member*);
 
-struct xls_dslx_expr* xls_dslx_enum_member_get_value(struct xls_dslx_enum_member*);
+struct xls_dslx_expr* xls_dslx_enum_member_get_value(
+    struct xls_dslx_enum_member*);
 
 // -- interp_value
 
-bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v, char** error_out, struct xls_value** result_out);
+bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v,
+                                         char** error_out,
+                                         struct xls_value** result_out);
 
 void xls_dslx_interp_value_free(struct xls_dslx_interp_value*);
 
@@ -139,7 +142,9 @@ const struct xls_dslx_type* xls_dslx_type_info_get_type_type_annotation(
 
 // Note: the outparam is owned by the caller and must be freed via
 // `xls_dslx_interp_value_free`.
-bool xls_dslx_type_info_get_const_expr(struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr, char** error_out, struct xls_dslx_interp_value** result_out);
+bool xls_dslx_type_info_get_const_expr(
+    struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr,
+    char** error_out, struct xls_dslx_interp_value** result_out);
 
 bool xls_dslx_type_get_total_bit_count(const struct xls_dslx_type*,
                                        char** error_out, int64_t* result_out);

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -595,16 +595,18 @@ enum MyEnum : u5 {
     xls_dslx_expr* member2_expr = xls_dslx_enum_member_get_value(member2);
 
     xls_dslx_interp_value* member2_value = nullptr;
-    ASSERT_TRUE(xls_dslx_type_info_get_const_expr(type_info, member2_expr, &error, &member2_value));
+    ASSERT_TRUE(xls_dslx_type_info_get_const_expr(type_info, member2_expr,
+                                                  &error, &member2_value));
     absl::Cleanup free_member2_value(
         [=] { xls_dslx_interp_value_free(member2_value); });
     ASSERT_NE(member2_value, nullptr);
 
     xls_value* member2_ir_value = nullptr;
-    ASSERT_TRUE(xls_dslx_interp_value_convert_to_ir(member2_value, &error, &member2_ir_value));
+    ASSERT_TRUE(xls_dslx_interp_value_convert_to_ir(member2_value, &error,
+                                                    &member2_ir_value));
     absl::Cleanup free_member2_ir_value(
         [=] { xls_value_free(member2_ir_value); });
-    
+
     char* value_str = nullptr;
     ASSERT_TRUE(xls_value_to_string(member2_ir_value, &value_str));
     absl::Cleanup free_value_str([=] { xls_c_str_free(value_str); });

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -507,7 +507,8 @@ enum MyEnum : u5 {
   const char* additional_search_paths[] = {};
 
   xls_dslx_import_data* import_data = xls_dslx_import_data_create(
-      xls::kDefaultDslxStdlibPath, additional_search_paths, 0);
+      std::string{xls::kDefaultDslxStdlibPath}.c_str(),
+      additional_search_paths, 0);
   ASSERT_NE(import_data, nullptr);
   absl::Cleanup free_import_data(
       [=] { xls_dslx_import_data_free(import_data); });

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -507,8 +507,8 @@ enum MyEnum : u5 {
   const char* additional_search_paths[] = {};
 
   xls_dslx_import_data* import_data = xls_dslx_import_data_create(
-      std::string{xls::kDefaultDslxStdlibPath}.c_str(),
-      additional_search_paths, 0);
+      std::string{xls::kDefaultDslxStdlibPath}.c_str(), additional_search_paths,
+      0);
   ASSERT_NE(import_data, nullptr);
   absl::Cleanup free_import_data(
       [=] { xls_dslx_import_data_free(import_data); });

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -490,4 +490,135 @@ endmodule
   EXPECT_EQ(std::string_view{emitted}, kWant);
 }
 
+TEST(XlsCApiTest, DslxInspectTypeDefinitions) {
+  const char kProgram[] = R"(const EIGHT = u5:8;
+
+struct MyStruct {
+    some_field: u42,
+    other_field: u64,
+}
+
+enum MyEnum : u5 {
+    A = u5:2,
+    B = u5:4,
+    C = EIGHT,
+}
+)";
+  const char* additional_search_paths[] = {};
+
+  xls_dslx_import_data* import_data = xls_dslx_import_data_create(
+      xls::kDefaultDslxStdlibPath, additional_search_paths, 0);
+  ASSERT_NE(import_data, nullptr);
+  absl::Cleanup free_import_data(
+      [=] { xls_dslx_import_data_free(import_data); });
+
+  xls_dslx_typechecked_module* tm = nullptr;
+  char* error = nullptr;
+  bool ok = xls_dslx_parse_and_typecheck(kProgram, "foo.x", "foo", import_data,
+                                         &error, &tm);
+  absl::Cleanup free_tm([=] { xls_dslx_typechecked_module_free(tm); });
+  ASSERT_TRUE(ok) << "got not-ok result from parse-and-typecheck; error: "
+                  << error;
+  ASSERT_EQ(error, nullptr);
+  ASSERT_NE(tm, nullptr);
+
+  xls_dslx_module* module = xls_dslx_typechecked_module_get_module(tm);
+  xls_dslx_type_info* type_info = xls_dslx_typechecked_module_get_type_info(tm);
+
+  int64_t type_definition_count =
+      xls_dslx_module_get_type_definition_count(module);
+  ASSERT_EQ(type_definition_count, 2);
+
+  xls_dslx_type_definition_kind kind0 =
+      xls_dslx_module_get_type_definition_kind(module, 0);
+  xls_dslx_type_definition_kind kind1 =
+      xls_dslx_module_get_type_definition_kind(module, 1);
+  EXPECT_EQ(kind0, xls_dslx_type_definition_kind_struct_def);
+  EXPECT_EQ(kind1, xls_dslx_type_definition_kind_enum_def);
+
+  {
+    xls_dslx_struct_def* struct_def =
+        xls_dslx_module_get_type_definition_as_struct_def(module, 0);
+    char* identifier = xls_dslx_struct_def_get_identifier(struct_def);
+    absl::Cleanup free_identifier([=] { xls_c_str_free(identifier); });
+    EXPECT_EQ(std::string_view{identifier}, std::string_view{"MyStruct"});
+
+    // Get the concrete type that this resolves to.
+    const xls_dslx_type* struct_def_type =
+        xls_dslx_type_info_get_type_struct_def(type_info, struct_def);
+    int64_t total_bit_count = 0;
+    ASSERT_TRUE(xls_dslx_type_get_total_bit_count(struct_def_type, &error,
+                                                  &total_bit_count))
+        << "got not-ok result from get-total-bit-count; error: " << error;
+    ASSERT_EQ(error, nullptr);
+    EXPECT_EQ(total_bit_count, 42 + 64);
+
+    // Get the two members and see how many bits they resolve to.
+    xls_dslx_struct_member* member0 =
+        xls_dslx_struct_def_get_member(struct_def, 0);
+    xls_dslx_struct_member* member1 =
+        xls_dslx_struct_def_get_member(struct_def, 1);
+
+    xls_dslx_type_annotation* member0_type_annotation =
+        xls_dslx_struct_member_get_type(member0);
+    xls_dslx_type_annotation* member1_type_annotation =
+        xls_dslx_struct_member_get_type(member1);
+
+    const xls_dslx_type* member0_type =
+        xls_dslx_type_info_get_type_type_annotation(type_info,
+                                                    member0_type_annotation);
+    const xls_dslx_type* member1_type =
+        xls_dslx_type_info_get_type_type_annotation(type_info,
+                                                    member1_type_annotation);
+
+    ASSERT_TRUE(xls_dslx_type_get_total_bit_count(member0_type, &error,
+                                                  &total_bit_count));
+    EXPECT_EQ(total_bit_count, 42);
+
+    ASSERT_TRUE(xls_dslx_type_get_total_bit_count(member1_type, &error,
+                                                  &total_bit_count));
+    EXPECT_EQ(total_bit_count, 64);
+  }
+
+  {
+    xls_dslx_enum_def* enum_def =
+        xls_dslx_module_get_type_definition_as_enum_def(module, 1);
+    char* enum_identifier = xls_dslx_enum_def_get_identifier(enum_def);
+    absl::Cleanup free_enum_identifier(
+        [=] { xls_c_str_free(enum_identifier); });
+    EXPECT_EQ(std::string_view{enum_identifier}, std::string_view{"MyEnum"});
+
+    int64_t enum_member_count = xls_dslx_enum_def_get_member_count(enum_def);
+    EXPECT_EQ(enum_member_count, 3);
+
+    xls_dslx_enum_member* member2 = xls_dslx_enum_def_get_member(enum_def, 2);
+    xls_dslx_expr* member2_expr = xls_dslx_enum_member_get_value(member2);
+
+    xls_dslx_interp_value* member2_value = nullptr;
+    ASSERT_TRUE(xls_dslx_type_info_get_const_expr(type_info, member2_expr, &error, &member2_value));
+    absl::Cleanup free_member2_value(
+        [=] { xls_dslx_interp_value_free(member2_value); });
+    ASSERT_NE(member2_value, nullptr);
+
+    xls_value* member2_ir_value = nullptr;
+    ASSERT_TRUE(xls_dslx_interp_value_convert_to_ir(member2_value, &error, &member2_ir_value));
+    absl::Cleanup free_member2_ir_value(
+        [=] { xls_value_free(member2_ir_value); });
+    
+    char* value_str = nullptr;
+    ASSERT_TRUE(xls_value_to_string(member2_ir_value, &value_str));
+    absl::Cleanup free_value_str([=] { xls_c_str_free(value_str); });
+    EXPECT_EQ(std::string_view{value_str}, "bits[5]:8");
+
+    const xls_dslx_type* enum_def_type =
+        xls_dslx_type_info_get_type_enum_def(type_info, enum_def);
+    int64_t total_bit_count = 0;
+    ASSERT_TRUE(xls_dslx_type_get_total_bit_count(enum_def_type, &error,
+                                                  &total_bit_count))
+        << "got not-ok result from get-total-bit-count; error: " << error;
+    ASSERT_EQ(error, nullptr);
+    EXPECT_EQ(total_bit_count, 5);
+  }
+}
+
 }  // namespace

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -559,6 +559,11 @@ enum MyEnum : u5 {
     xls_dslx_struct_member* member1 =
         xls_dslx_struct_def_get_member(struct_def, 1);
 
+    char* member0_name = xls_dslx_struct_member_get_name(member0);
+    absl::Cleanup free_member0_name([=] { xls_c_str_free(member0_name); });
+    ASSERT_NE(member0_name, nullptr);
+    EXPECT_EQ(std::string_view{member0_name}, "some_field");
+
     xls_dslx_type_annotation* member0_type_annotation =
         xls_dslx_struct_member_get_type(member0);
     xls_dslx_type_annotation* member1_type_annotation =
@@ -593,6 +598,11 @@ enum MyEnum : u5 {
 
     xls_dslx_enum_member* member2 = xls_dslx_enum_def_get_member(enum_def, 2);
     xls_dslx_expr* member2_expr = xls_dslx_enum_member_get_value(member2);
+
+    char* member2_name = xls_dslx_enum_member_get_name(member2);
+    absl::Cleanup free_member2_name([=] { xls_c_str_free(member2_name); });
+    ASSERT_NE(member2_name, nullptr);
+    EXPECT_EQ(std::string_view{member2_name}, "C");
 
     xls_dslx_interp_value* member2_value = nullptr;
     ASSERT_TRUE(xls_dslx_type_info_get_const_expr(type_info, member2_expr,


### PR DESCRIPTION
Draft PR as this is dependent on #1621 landing (after which this will subsequently be rebased).

Note that this uses the multi-translation-unit structured added in the previous PR, adding a new one for DSLX "protected" APIs.