### PR TITLE
[DSLX:LS] Add support for prepareRename and rename

### DIFF
--- a/xls/dslx/frontend/ast_node.h
+++ b/xls/dslx/frontend/ast_node.h
@@ -149,7 +149,8 @@ class AstNode {
 
   Module* owner() const { return owner_; }
 
-  // Marks this node as the parent of all its child nodes.
+  // Marks this node as the parent of all its child nodes as given by
+  // `GetChildren()`.
   void SetParentage();
 
   // Warning: try to avoid using this in any new code!

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -372,6 +372,22 @@ absl::StatusOr<std::vector<AstNode*>> CollectUnder(AstNode* root,
   return nodes;
 }
 
+absl::StatusOr<std::vector<const NameRef*>> CollectNameRefsUnder(
+    const AstNode* root, const NameDef* to) {
+  XLS_ASSIGN_OR_RETURN(std::vector<const AstNode*> nodes,
+                       CollectUnder(root, /*want_types*/ true));
+  std::vector<const NameRef*> results;
+  for (const AstNode* n : nodes) {
+    if (const auto* name_ref = dynamic_cast<const NameRef*>(n);
+        name_ref != nullptr &&
+        std::holds_alternative<const NameDef*>(name_ref->name_def()) &&
+        std::get<const NameDef*>(name_ref->name_def()) == to) {
+      results.push_back(name_ref);
+    }
+  }
+  return results;
+}
+
 absl::StatusOr<std::vector<const AstNode*>> CollectUnder(const AstNode* root,
                                                          bool want_types) {
   // Implementation note: delegate to non-const version and turn result values

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -171,6 +171,9 @@ std::optional<BitVectorMetadata> ExtractBitVectorMetadata(
 absl::StatusOr<std::vector<AstNode*>> CollectUnder(AstNode* root,
                                                    bool want_types);
 
+absl::StatusOr<std::vector<const NameRef*>> CollectNameRefsUnder(
+    const AstNode* root, const NameDef* to);
+
 absl::StatusOr<std::vector<const AstNode*>> CollectUnder(const AstNode* root,
                                                          bool want_types);
 

--- a/xls/dslx/frontend/module.cc
+++ b/xls/dslx/frontend/module.cc
@@ -202,6 +202,16 @@ const EnumDef* Module::FindEnumDef(const Span& span) const {
   return down_cast<const EnumDef*>(FindNode(AstNodeKind::kEnumDef, span));
 }
 
+bool Module::IsPublicMember(const AstNode& node) const {
+  for (const ModuleMember& member : top_) {
+    const AstNode* member_node = ToAstNode(member);
+    if (member_node == &node) {
+      return IsPublic(member);
+    }
+  }
+  return false;
+}
+
 std::optional<ModuleMember*> Module::FindMemberWithName(
     std::string_view target) {
   for (ModuleMember& member : top_) {

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -179,6 +179,9 @@ class Module : public AstNode {
   // an identifier.
   std::optional<ModuleMember*> FindMemberWithName(std::string_view target);
 
+  // Returns whether the given node is a public member of this module.
+  bool IsPublicMember(const AstNode& node) const;
+
   const StructDef* FindStructDef(const Span& span) const;
 
   const EnumDef* FindEnumDef(const Span& span) const;

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -325,9 +325,10 @@ absl::StatusOr<std::unique_ptr<Module>> Parser::ParseModule(
       }
 
       if (peek->IsKeyword(Keyword::kConst)) {
-        XLS_ASSIGN_OR_RETURN(ConstantDef * def,
+        XLS_ASSIGN_OR_RETURN(ConstantDef * constant_def,
                              ParseConstantDef(/*is_public=*/true, *bindings));
-        XLS_RETURN_IF_ERROR(module_->AddTop(def, make_collision_error));
+        XLS_RETURN_IF_ERROR(
+            module_->AddTop(constant_def, make_collision_error));
         continue;
       }
 
@@ -445,15 +446,15 @@ absl::StatusOr<std::unique_ptr<Module>> Parser::ParseModule(
         break;
       }
       case Keyword::kStruct: {
-        XLS_ASSIGN_OR_RETURN(StructDef * struct_,
+        XLS_ASSIGN_OR_RETURN(StructDef * struct_def,
                              ParseStruct(/*is_public=*/false, *bindings));
-        XLS_RETURN_IF_ERROR(module_->AddTop(struct_, make_collision_error));
+        XLS_RETURN_IF_ERROR(module_->AddTop(struct_def, make_collision_error));
         break;
       }
       case Keyword::kEnum: {
-        XLS_ASSIGN_OR_RETURN(EnumDef * enum_,
+        XLS_ASSIGN_OR_RETURN(EnumDef * enum_def,
                              ParseEnumDef(/*is_public=*/false, *bindings));
-        XLS_RETURN_IF_ERROR(module_->AddTop(enum_, make_collision_error));
+        XLS_RETURN_IF_ERROR(module_->AddTop(enum_def, make_collision_error));
         break;
       }
       case Keyword::kConst: {

--- a/xls/dslx/lsp/BUILD
+++ b/xls/dslx/lsp/BUILD
@@ -67,6 +67,7 @@ cc_library(
         "//xls/dslx:warning_kind",
         "//xls/dslx/fmt:ast_fmt",
         "//xls/dslx/frontend:ast",
+        "//xls/dslx/frontend:ast_utils",
         "//xls/dslx/frontend:bindings",
         "//xls/dslx/frontend:comment_data",
         "//xls/dslx/frontend:module",

--- a/xls/dslx/lsp/find_definition.cc
+++ b/xls/dslx/lsp/find_definition.cc
@@ -54,9 +54,10 @@ const NameDef* GetNameDef(
 
 }  // namespace
 
-std::optional<const NameDef*> FindDefinition(const Module& m, const Pos& selected,
-                                   const TypeInfo& type_info,
-                                   ImportData& import_data) {
+std::optional<const NameDef*> FindDefinition(const Module& m,
+                                             const Pos& selected,
+                                             const TypeInfo& type_info,
+                                             ImportData& import_data) {
   std::vector<const AstNode*> intercepting = m.FindIntercepting(selected);
   VLOG(3) << "Found " << intercepting.size()
           << " nodes intercepting selected position: " << selected;

--- a/xls/dslx/lsp/find_definition.cc
+++ b/xls/dslx/lsp/find_definition.cc
@@ -54,10 +54,9 @@ const NameDef* GetNameDef(
 
 }  // namespace
 
-std::optional<Span> FindDefinition(const Module& m, const Pos& selected,
+std::optional<const NameDef*> FindDefinition(const Module& m, const Pos& selected,
                                    const TypeInfo& type_info,
-                                   ImportData& import_data,
-                                   const NameDef** name_def) {
+                                   ImportData& import_data) {
   std::vector<const AstNode*> intercepting = m.FindIntercepting(selected);
   VLOG(3) << "Found " << intercepting.size()
           << " nodes intercepting selected position: " << selected;
@@ -112,10 +111,7 @@ std::optional<Span> FindDefinition(const Module& m, const Pos& selected,
           << selected;
 
   if (defs.size() == 1) {
-    if (name_def != nullptr) {
-      *name_def = defs.at(0).to;
-    }
-    return defs.at(0).to->GetSpan();
+    return defs.at(0).to;
   }
   if (defs.size() > 1) {
     // Find the reference that is "most containing" (i.e. outer-most).
@@ -138,10 +134,7 @@ std::optional<Span> FindDefinition(const Module& m, const Pos& selected,
     VLOG(3) << "Most containing; reference is to: `" << reference.to->ToString()
             << "` @ "
             << reference.to->span().ToString(import_data.file_table());
-    if (name_def != nullptr) {
-      *name_def = reference.to;
-    }
-    return reference.to->GetSpan();
+    return reference.to;
   }
 
   return std::nullopt;

--- a/xls/dslx/lsp/find_definition.h
+++ b/xls/dslx/lsp/find_definition.h
@@ -27,12 +27,12 @@ namespace xls::dslx {
 
 // Looks up what (if any) reference is present in the module at position
 // "selected", and, if there is one present, resolve it to a defining construct,
-// and returns the span of that name definition.
+// and returns that name definition.
 //
 // For example:
 //
 //    fn f() -> u32 { u32:42 }
-//    ---^ found definition
+//    ---^ found definition (returned NameDef)
 //
 //    fn main() -> u32 { f() }
 //    -------------------^ selected pos

--- a/xls/dslx/lsp/find_definition.h
+++ b/xls/dslx/lsp/find_definition.h
@@ -41,7 +41,8 @@ namespace xls::dslx {
 // colon-reference to a construct in another module will return nullopt.
 std::optional<Span> FindDefinition(const Module& m, const Pos& selected,
                                    const TypeInfo& type_info,
-                                   ImportData& import_data);
+                                   ImportData& import_data,
+                                   const NameDef** name_def_out = nullptr);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/lsp/find_definition.h
+++ b/xls/dslx/lsp/find_definition.h
@@ -39,10 +39,9 @@ namespace xls::dslx {
 //
 // Note that this currently only supports resolution in a single file, e.g. a
 // colon-reference to a construct in another module will return nullopt.
-std::optional<Span> FindDefinition(const Module& m, const Pos& selected,
+std::optional<const NameDef*> FindDefinition(const Module& m, const Pos& selected,
                                    const TypeInfo& type_info,
-                                   ImportData& import_data,
-                                   const NameDef** name_def_out = nullptr);
+                                   ImportData& import_data);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/lsp/find_definition.h
+++ b/xls/dslx/lsp/find_definition.h
@@ -39,9 +39,10 @@ namespace xls::dslx {
 //
 // Note that this currently only supports resolution in a single file, e.g. a
 // colon-reference to a construct in another module will return nullopt.
-std::optional<const NameDef*> FindDefinition(const Module& m, const Pos& selected,
-                                   const TypeInfo& type_info,
-                                   ImportData& import_data);
+std::optional<const NameDef*> FindDefinition(const Module& m,
+                                             const Pos& selected,
+                                             const TypeInfo& type_info,
+                                             ImportData& import_data);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -362,8 +362,8 @@ LanguageServerAdapter::Rename(std::string_view uri,
 
     const Pos pos = ConvertLspPositionToPos(uri, position, file_table);
     VLOG(1) << "FindDefinition; uri: " << uri << " pos: " << pos;
-    std::optional<const NameDef*> maybe_name_def = xls::dslx::FindDefinition(parsed->module(), pos, parsed->type_info(),
-                              parsed->import_data);
+    std::optional<const NameDef*> maybe_name_def = xls::dslx::FindDefinition(
+        parsed->module(), pos, parsed->type_info(), parsed->import_data);
     if (!maybe_name_def.has_value()) {
       VLOG(1) << "No definition found for attempted rename to: `" << new_name
               << "`";

--- a/xls/dslx/lsp/language_server_adapter.h
+++ b/xls/dslx/lsp/language_server_adapter.h
@@ -84,6 +84,13 @@ class LanguageServerAdapter {
   absl::StatusOr<std::vector<verible::lsp::InlayHint>> InlayHint(
       std::string_view uri, const verible::lsp::Range& range) const;
 
+  absl::StatusOr<std::optional<verible::lsp::Range>> PrepareRename(
+      std::string_view uri, const verible::lsp::Position& position) const;
+
+  absl::StatusOr<std::optional<verible::lsp::WorkspaceEdit>> Rename(
+      std::string_view uri, const verible::lsp::Position& position,
+      std::string_view new_name) const;
+
  private:
   struct ParseData;
 

--- a/xls/dslx/lsp/language_server_adapter_test.cc
+++ b/xls/dslx/lsp/language_server_adapter_test.cc
@@ -33,6 +33,7 @@
 namespace xls::dslx {
 namespace {
 
+using status_testing::IsOkAndHolds;
 using status_testing::StatusIs;
 
 std::string DebugString(const verible::lsp::Position& pos) {
@@ -262,6 +263,92 @@ fn main() { imported::f() }
       .end = verible::lsp::Position{0, 8},
   };
   EXPECT_TRUE(definition_location.range == kWantRange);
+}
+
+TEST(LanguageServerAdapterTest, RenameForParameter) {
+  LanguageServerAdapter adapter(kDefaultDslxStdlibPath, /*dslx_paths=*/{"."});
+  constexpr std::string_view kUri = "memfile://test.x";
+  XLS_ASSERT_OK(adapter.Update(kUri, R"(fn f(x: u32) -> u32 {
+  let y = x;
+  let z = y;
+  z
+})"));
+
+  const auto kWantRange =
+      verible::lsp::Range{.start = verible::lsp::Position{0, 5},
+                          .end = verible::lsp::Position{0, 6}};
+  XLS_ASSERT_OK_AND_ASSIGN(std::optional<verible::lsp::Range> to_rename,
+                           adapter.PrepareRename(kUri, kWantRange.start));
+  ASSERT_TRUE(to_rename.has_value());
+  EXPECT_TRUE(kWantRange == to_rename.value());
+
+  // Rename from the use position should also work and resolve to the same
+  // definition span.
+  verible::lsp::Position use_pos{1, 10};
+  XLS_ASSERT_OK_AND_ASSIGN(to_rename, adapter.PrepareRename(kUri, use_pos));
+  ASSERT_TRUE(to_rename.has_value());
+  EXPECT_TRUE(kWantRange == to_rename.value());
+
+  // See what edits come out.
+  XLS_ASSERT_OK_AND_ASSIGN(std::optional<verible::lsp::WorkspaceEdit> edit,
+                           adapter.Rename(kUri, kWantRange.start, "foo"));
+  ASSERT_TRUE(edit.has_value());
+
+  EXPECT_EQ(edit->changes.at(kUri).size(), 2);
+}
+
+TEST(LanguageServerAdapterTest, RenameForModuleScopedConstant) {
+  LanguageServerAdapter adapter(kDefaultDslxStdlibPath, /*dslx_paths=*/{"."});
+  constexpr std::string_view kUri = "memfile://test.x";
+  XLS_ASSERT_OK(adapter.Update(kUri, R"(const FOO = u32:42;
+
+const BAR: u32 = FOO + FOO;)"));
+
+  const auto kWantRange =
+      verible::lsp::Range{.start = verible::lsp::Position{0, 6},
+                          .end = verible::lsp::Position{0, 9}};
+  XLS_ASSERT_OK_AND_ASSIGN(std::optional<verible::lsp::Range> to_rename,
+                           adapter.PrepareRename(kUri, kWantRange.start));
+  ASSERT_TRUE(to_rename.has_value());
+  EXPECT_TRUE(kWantRange == to_rename.value());
+
+  // Rename from the use position should also work and resolve to the same
+  // definition span.
+  verible::lsp::Position use_pos{2, 17};
+  XLS_ASSERT_OK_AND_ASSIGN(to_rename, adapter.PrepareRename(kUri, use_pos));
+  ASSERT_TRUE(to_rename.has_value());
+  EXPECT_TRUE(kWantRange == to_rename.value());
+
+  // See what edits come out.
+  XLS_ASSERT_OK_AND_ASSIGN(std::optional<verible::lsp::WorkspaceEdit> edit,
+                           adapter.Rename(kUri, kWantRange.start, "FT"));
+  ASSERT_TRUE(edit.has_value());
+
+  EXPECT_EQ(edit->changes.at(kUri).size(), 3);
+}
+
+// Currently we cannot rename across files so we refuse to rename `pub`
+// visibility members.
+TEST(LanguageServerAdapterTest, RenameForPublicModuleScopedConstant) {
+  LanguageServerAdapter adapter(kDefaultDslxStdlibPath, /*dslx_paths=*/{"."});
+  constexpr std::string_view kUri = "memfile://test.x";
+  XLS_ASSERT_OK(adapter.Update(kUri, R"(pub const FOO = u32:42;
+
+const BAR: u32 = FOO + FOO;)"));
+
+  const auto kWantRange =
+      verible::lsp::Range{.start = verible::lsp::Position{0, 10},
+                          .end = verible::lsp::Position{0, 13}};
+  XLS_ASSERT_OK_AND_ASSIGN(std::optional<verible::lsp::Range> to_rename,
+                           adapter.PrepareRename(kUri, kWantRange.start));
+  ASSERT_TRUE(to_rename.has_value());
+  EXPECT_TRUE(kWantRange == to_rename.value());
+
+  // See what edits come out.
+  absl::StatusOr<std::optional<verible::lsp::WorkspaceEdit>> edit =
+      adapter.Rename(kUri, kWantRange.start, "FT");
+  XLS_EXPECT_OK(edit.status());
+  EXPECT_EQ(edit.value(), std::nullopt);
 }
 
 }  // namespace


### PR DESCRIPTION
Works for intra-function and intra-module definitions.

Support is not present for cross-workspace renames yet.

![image](https://github.com/user-attachments/assets/a1eb838d-5d00-442f-b1f7-6568ae58afb1)
