### PR TITLE
[dslx:fmt] Better formatting of a long struct field expression.

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1319,6 +1319,14 @@ static DocRef FmtStructMembersBreak(
 
         DocRef field_expr = Fmt(*expr, comments, arena);
 
+        // This is the document we want to emit both when we:
+        // - Know it fits in flat mode
+        // - Know the start of the document (i.e. the leader on the RHS
+        //   expression) can be emitted in flat mode
+        //
+        // That's why it has a `break1` in it (instead of a space) and a
+        // reassessment of whether to enter break mode for the field
+        // expression.
         DocRef on_flat =
             ConcatN(arena, {arena.MakeText(name), arena.colon(), arena.break1(),
                             arena.MakeGroup(field_expr)});

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1307,14 +1307,14 @@ static DocRef FmtStructMembersBreak(
   return FmtJoin<std::pair<std::string, Expr*>>(
       members, Joiner::kCommaHardlineTrailingCommaAlways,
       [](const auto& member, const Comments& comments, DocArena& arena) {
-        const auto& [name, expr] = member;
+        const auto& [field_name, expr] = member;
         // If the expression is an identifier that matches its corresponding
         // struct member name, we canonically use the shorthand notation of just
         // providing the identifier and leaving the member name implicitly as
         // the same symbol.
         if (const NameRef* name_ref = dynamic_cast<const NameRef*>(expr);
-            name_ref != nullptr && name_ref->identifier() == name) {
-          return arena.MakeText(name);
+            name_ref != nullptr && name_ref->identifier() == field_name) {
+          return arena.MakeText(field_name);
         }
 
         DocRef field_expr = Fmt(*expr, comments, arena);
@@ -1328,16 +1328,16 @@ static DocRef FmtStructMembersBreak(
         // reassessment of whether to enter break mode for the field
         // expression.
         DocRef on_flat =
-            ConcatN(arena, {arena.MakeText(name), arena.colon(), arena.break1(),
+            ConcatN(arena, {arena.MakeText(field_name), arena.colon(), arena.break1(),
                             arena.MakeGroup(field_expr)});
         DocRef nest_field_expr =
-            ConcatN(arena, {arena.MakeText(name), arena.colon(),
+            ConcatN(arena, {arena.MakeText(field_name), arena.colon(),
                             arena.hard_line(), arena.MakeNest(field_expr)});
 
         DocRef on_other;
         if (expr->IsBlockedExprWithLeader()) {
-          DocRef leader = arena.MakeConcat(
-              arena.space(), FmtBlockedExprLeader(*expr, comments, arena));
+          DocRef leader = ConcatN(arena, {
+              arena.MakeText(field_name), arena.colon(), arena.space(), FmtBlockedExprLeader(*expr, comments, arena)});
           on_other = arena.MakeModeSelect(leader, /*on_flat=*/on_flat,
                                           /*on_break=*/nest_field_expr);
         } else {

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1328,16 +1328,17 @@ static DocRef FmtStructMembersBreak(
         // reassessment of whether to enter break mode for the field
         // expression.
         DocRef on_flat =
-            ConcatN(arena, {arena.MakeText(field_name), arena.colon(), arena.break1(),
-                            arena.MakeGroup(field_expr)});
+            ConcatN(arena, {arena.MakeText(field_name), arena.colon(),
+                            arena.break1(), arena.MakeGroup(field_expr)});
         DocRef nest_field_expr =
             ConcatN(arena, {arena.MakeText(field_name), arena.colon(),
                             arena.hard_line(), arena.MakeNest(field_expr)});
 
         DocRef on_other;
         if (expr->IsBlockedExprWithLeader()) {
-          DocRef leader = ConcatN(arena, {
-              arena.MakeText(field_name), arena.colon(), arena.space(), FmtBlockedExprLeader(*expr, comments, arena)});
+          DocRef leader = ConcatN(
+              arena, {arena.MakeText(field_name), arena.colon(), arena.space(),
+                      FmtBlockedExprLeader(*expr, comments, arena)});
           on_other = arena.MakeModeSelect(leader, /*on_flat=*/on_flat,
                                           /*on_break=*/nest_field_expr);
         } else {

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -52,6 +52,9 @@
 namespace xls::dslx {
 namespace {
 
+DocRef FmtBlockedExprLeader(const Expr& e, const Comments& comments,
+                            DocArena& arena);
+
 // Note: if a comment doc is emitted (i.e. return value has_value()) it does not
 // have a trailing hard-line. This is for consistency with other emission
 // routines which generally don't emit any whitespace afterwards, just their
@@ -1314,9 +1317,26 @@ static DocRef FmtStructMembersBreak(
           return arena.MakeText(name);
         }
 
-        return ConcatNGroup(arena,
-                            {arena.MakeText(name), arena.colon(), arena.space(),
-                             arena.MakeGroup(Fmt(*expr, comments, arena))});
+        DocRef field_expr = Fmt(*expr, comments, arena);
+
+        DocRef on_flat =
+            ConcatN(arena, {arena.MakeText(name), arena.colon(), arena.break1(),
+                            arena.MakeGroup(field_expr)});
+        DocRef nest_field_expr =
+            ConcatN(arena, {arena.MakeText(name), arena.colon(),
+                            arena.hard_line(), arena.MakeNest(field_expr)});
+
+        DocRef on_other;
+        if (expr->IsBlockedExprWithLeader()) {
+          DocRef leader = arena.MakeConcat(
+              arena.space(), FmtBlockedExprLeader(*expr, comments, arena));
+          on_other = arena.MakeModeSelect(leader, /*on_flat=*/on_flat,
+                                          /*on_break=*/nest_field_expr);
+        } else {
+          on_other = arena.MakeFlatChoice(on_flat, nest_field_expr);
+        }
+
+        return arena.MakeNestIfFlatFits(on_flat, on_other);
       },
       comments, arena);
 }

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1621,7 +1621,8 @@ fn f(b: bool) -> MyStruct {
         },
     }
 }
-)", /*want=*/R"(struct MyStruct { field: u32 }
+)",
+      /*want=*/R"(struct MyStruct { field: u32 }
 
 const TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT = true;
 

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1588,6 +1588,56 @@ fn f() -> MyStruct {
 )");
 }
 
+TEST_F(ModuleFmtTest, StructInstantiationWithExactSizedCondExpr) {
+  Run(
+      R"(struct MyStruct { field: u32 }
+
+const TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT = true;
+
+fn f(b: bool) -> MyStruct {
+    MyStruct {
+        field: if TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT {
+            u32:42
+        } else {
+            u32:64
+        },
+    }
+}
+)");
+}
+
+TEST_F(ModuleFmtTest, StructInstantiationWithExactOneCharOverlyLargeCondExpr) {
+  Run(
+      R"(struct MyStruct { field: u32 }
+
+const TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT = true;
+
+fn f(b: bool) -> MyStruct {
+    MyStruct {
+        field: if TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT {
+            u32:42
+        } else {
+            u32:64
+        },
+    }
+}
+)", /*want=*/R"(struct MyStruct { field: u32 }
+
+const TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT = true;
+
+fn f(b: bool) -> MyStruct {
+    MyStruct {
+        field:
+            if TESTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT {
+                u32:42
+            } else {
+                u32:64
+            },
+    }
+}
+)");
+}
+
 TEST_F(ModuleFmtTest, SimpleParametricStructInstantiation) {
   Run(
       R"(import mol;

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -2348,5 +2348,22 @@ pub fn f(a: A) -> A { if a.B[0].value == u32:0 { zero!<A>() } else { a } }
 )");
 }
 
+TEST_F(ModuleFmtTest, LongStructInstanceFieldExpr) {
+  Run(R"(struct X { xxxxxxxxxxxxxxxxxxx: bool, yyyyyyyyyyyyyyyyyyy: u32 }
+
+const aaaaaaaaaaaaaaaaaaaaaaaaa = u32:0;
+const bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb = u32:0;
+const ccccccccccccccccccccccccc = bool:false;
+
+fn f() -> X {
+    X {
+        xxxxxxxxxxxxxxxxxxx:
+            aaaaaaaaaaaaaaaaaaaaaaaaa == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb,
+        yyyyyyyyyyyyyyyyyyy: u32:0,
+    }
+}
+)");
+}
+
 }  // namespace
 }  // namespace xls::dslx


### PR DESCRIPTION
Fixes google/xls#1633