### PR TITLE
[c_api] Add `xls_dslx_type_is_signed_bits` function.

### DIFF
--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -140,7 +140,8 @@ class TypeDimMap {
   // For the use case where the caller is starting with a map of known concrete
   // values, or has nothing but that. Equivalent to constructing and then
   // `Insert()`ing them all.
-  TypeDimMap(const absl::flat_hash_map<std::string, InterpValue>& values);
+  explicit TypeDimMap(
+      const absl::flat_hash_map<std::string, InterpValue>& values);
 
   // Disallow copy; if we wanted this to work, we'd need to fix up `env_` in the
   // copy to point to its own `dims_`.

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -287,4 +287,19 @@ bool xls_dslx_interp_value_convert_to_ir(struct xls_dslx_interp_value* v,
   return true;
 }
 
+bool xls_dslx_type_is_signed_bits(const struct xls_dslx_type* type,
+                                  char** error_out, bool* result_out) {
+  const auto* cpp_type = reinterpret_cast<const xls::dslx::Type*>(type);
+  absl::StatusOr<bool> is_signed_or = xls::dslx::IsSigned(*cpp_type);
+  if (!is_signed_or.ok()) {
+    *error_out = xls::ToOwnedCString(is_signed_or.status().ToString());
+    *result_out = false;
+    return false;
+  }
+
+  *error_out = nullptr;
+  *result_out = is_signed_or.value();
+  return true;
+}
+
 }  // extern "C"

--- a/xls/public/c_api_dslx.h
+++ b/xls/public/c_api_dslx.h
@@ -146,8 +146,14 @@ bool xls_dslx_type_info_get_const_expr(
     struct xls_dslx_type_info* type_info, struct xls_dslx_expr* expr,
     char** error_out, struct xls_dslx_interp_value** result_out);
 
+// -- type
+
 bool xls_dslx_type_get_total_bit_count(const struct xls_dslx_type*,
                                        char** error_out, int64_t* result_out);
+
+// Returns whether the given type is a bits-like type with signedness 'true'.
+bool xls_dslx_type_is_signed_bits(const struct xls_dslx_type*, char** error_out,
+                                  bool* result_out);
 
 }  // extern "C"
 

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -494,7 +494,7 @@ TEST(XlsCApiTest, DslxInspectTypeDefinitions) {
   const char kProgram[] = R"(const EIGHT = u5:8;
 
 struct MyStruct {
-    some_field: u42,
+    some_field: s42,
     other_field: u64,
 }
 
@@ -577,6 +577,12 @@ enum MyEnum : u5 {
         xls_dslx_type_info_get_type_type_annotation(type_info,
                                                     member1_type_annotation);
 
+    bool is_signed;
+    ASSERT_TRUE(xls_dslx_type_is_signed_bits(member0_type, &error, &is_signed));
+    EXPECT_TRUE(is_signed);
+    ASSERT_TRUE(xls_dslx_type_is_signed_bits(member1_type, &error, &is_signed));
+    EXPECT_FALSE(is_signed);
+
     ASSERT_TRUE(xls_dslx_type_get_total_bit_count(member0_type, &error,
                                                   &total_bit_count));
     EXPECT_EQ(total_bit_count, 42);
@@ -631,6 +637,13 @@ enum MyEnum : u5 {
         << "got not-ok result from get-total-bit-count; error: " << error;
     ASSERT_EQ(error, nullptr);
     EXPECT_EQ(total_bit_count, 5);
+
+    // Check the signedness of the underlying type.
+    bool is_signed = true;
+    ASSERT_TRUE(
+        xls_dslx_type_is_signed_bits(enum_def_type, &error, &is_signed));
+    ASSERT_EQ(error, nullptr);
+    EXPECT_FALSE(is_signed);
   }
 }
 


### PR DESCRIPTION
Queries whether a type is a bits type with signedness 'true'.

Over time we'll want more detailed helpers for inspecting and interpreting type as its various subtypes, but for purposes of generating some early bridge code this gets us most of what we need.