### PR TITLE
Generate clang-tidy comments in pull requests.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,3 +42,16 @@ jobs:
       - name: Bazel Test All (opt)
         run: |
           bazel test -c opt --noshow_progress --test_output=errors -- //...
+
+      - name: Create compilation DB
+        run: |
+          xls/dev_tools/make-compilation-db.sh
+          ls -l compile_commands.json
+
+      - name: Run clang-tidy on changes and report in PR
+        uses: ZedThree/clang-tidy-review@v0.19.0
+        with:
+          clang_tidy_version: 17
+          config_file: ".clang-tidy"
+
+        id: review

--- a/xls/fuzzer/run_fuzz.cc
+++ b/xls/fuzzer/run_fuzz.cc
@@ -189,9 +189,9 @@ absl::Status RunSample(const Sample& smp, const std::filesystem::path& run_dir,
   };
 
   // Pass on verbosity flags if available.
-  if (int64_t verbosity = absl::GetFlag(FLAGS_v); verbosity > 0) {
-    argv.push_back(absl::StrCat("--v=", verbosity));
-  }
+  if (int64_t verbosity = absl::GetFlag(FLAGS_v); verbosity > 0)
+    argv.push_back(absl::StrCat("--v=", verbosity));  // testing clang-tidy
+
   if (std::string vmodule = absl::GetFlag(FLAGS_vmodule); !vmodule.empty()) {
     argv.push_back(absl::StrCat("--vmodule=", absl::GetFlag(FLAGS_vmodule)));
   }


### PR DESCRIPTION
This only runs on changed files, so clang-tidy reports are useful and actionable.