### PR TITLE
[dslx:ls] Add support for DocumentHighlight capability.

### DIFF
--- a/xls/dslx/lsp/language_server_adapter.h
+++ b/xls/dslx/lsp/language_server_adapter.h
@@ -94,6 +94,12 @@ class LanguageServerAdapter {
       std::string_view uri, const verible::lsp::Position& position,
       std::string_view new_name) const;
 
+  // See
+  // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight
+  absl::StatusOr<std::vector<verible::lsp::DocumentHighlight>>
+  DocumentHighlight(std::string_view uri,
+                    const verible::lsp::Position& position) const;
+
  private:
   class ParseData;
 


### PR DESCRIPTION
Fixes #1660

Sample view when some logging is added to confirm it's the feature is being triggered appropriately:

![Screenshot from 2024-10-13 16-55-33](https://github.com/user-attachments/assets/a8e9e361-3b24-4041-bf17-7532b1fba78d)
