### PR TITLE
[DSLX:LS] Diagnostics updates for dependent modules.

### DIFF
--- a/xls/codegen/vast/dslx_builder.cc
+++ b/xls/codegen/vast/dslx_builder.cc
@@ -292,9 +292,10 @@ DslxBuilder::DslxBuilder(
     : additional_search_paths_(
           WrapOptionalPathInVector(additional_search_path)),
       dslx_stdlib_path_(dslx_stdlib_path),
-      import_data_(dslx::CreateImportData(
-          dslx_stdlib_path_, additional_search_paths_,
-          /*enabled_warnings=*/dslx::kDefaultWarningsSet)),
+      import_data_(
+          dslx::CreateImportData(dslx_stdlib_path_, additional_search_paths_,
+                                 /*enabled_warnings=*/dslx::kDefaultWarningsSet,
+                                 std::make_unique<dslx::RealFilesystem>())),
       module_(std::string(main_module_name), /*fs_path=*/std::nullopt,
               import_data_.file_table()),
       resolver_(resolver),
@@ -527,7 +528,8 @@ absl::StatusOr<dslx::Import*> DslxBuilder::GetOrImportModule(
                                return dslx::TypecheckModule(
                                    module, &import_data_, &warnings_);
                              },
-                             import_tokens, &import_data_, dslx::Span::Fake()));
+                             import_tokens, &import_data_, dslx::Span::Fake(),
+                             import_data_.vfs()));
 
     auto* name_def = resolver_->MakeNameDef(*this, dslx::Span::Fake(), tail);
     VLOG(2) << "Creating import node via name definition `"
@@ -734,7 +736,8 @@ absl::StatusOr<std::string> DslxBuilder::FormatModule() {
   const std::string file_name = module_.name() + ".x";
   auto import_data =
       dslx::CreateImportData(dslx_stdlib_path_, additional_search_paths_,
-                             /*enabled_warnings=*/dslx::kDefaultWarningsSet);
+                             /*enabled_warnings=*/dslx::kDefaultWarningsSet,
+                             std::make_unique<dslx::RealFilesystem>());
   dslx::Fileno fileno = import_data.file_table().GetOrCreate(file_name);
   dslx::Scanner scanner(import_data.file_table(), fileno, text);
   dslx::Parser parser(module_.name(), &scanner);

--- a/xls/dev_tools/repl.cc
+++ b/xls/dev_tools/repl.cc
@@ -312,7 +312,8 @@ absl::Status CommandReload() {
   dslx::ImportData import_data(dslx::CreateImportData(
       /*dslx_stdlib_path=*/"",
       /*additional_search_paths=*/{},
-      /*enabled_warnings=*/dslx::kDefaultWarningsSet));
+      /*enabled_warnings=*/dslx::kDefaultWarningsSet,
+      std::make_unique<dslx::RealFilesystem>()));
 
   dslx::FileTable& file_table = import_data.file_table();
 

--- a/xls/dslx/BUILD
+++ b/xls/dslx/BUILD
@@ -318,6 +318,7 @@ cc_library(
         ":import_record",
         ":interp_bindings",
         ":warning_kind",
+        "//xls/common/file:filesystem",
         "//xls/common/status:ret_check",
         "//xls/common/status:status_macros",
         "//xls/dslx/bytecode:bytecode_cache_interface",

--- a/xls/dslx/cpp_transpiler/cpp_transpiler_main.cc
+++ b/xls/dslx/cpp_transpiler/cpp_transpiler_main.cc
@@ -70,9 +70,9 @@ absl::Status RealMain(const std::filesystem::path& module_path,
                       std::string_view namespaces) {
   XLS_ASSIGN_OR_RETURN(std::string module_text, GetFileContents(module_path));
 
-  ImportData import_data(
-      CreateImportData(dslx_stdlib_path, /*additional_search_paths=*/dslx_paths,
-                       kDefaultWarningsSet));
+  ImportData import_data(CreateImportData(
+      dslx_stdlib_path, /*additional_search_paths=*/dslx_paths,
+      kDefaultWarningsSet, std::make_unique<RealFilesystem>()));
   XLS_ASSIGN_OR_RETURN(TypecheckedModule module,
                        ParseAndTypecheck(module_text, std::string(module_path),
                                          "source", &import_data));

--- a/xls/dslx/create_import_data.cc
+++ b/xls/dslx/create_import_data.cc
@@ -29,15 +29,17 @@ namespace xls::dslx {
 ImportData CreateImportData(
     const std::filesystem::path& stdlib_path,
     absl::Span<const std::filesystem::path> additional_search_paths,
-    WarningKindSet warnings) {
-  ImportData import_data(stdlib_path, additional_search_paths, warnings);
+    WarningKindSet warnings, std::unique_ptr<VirtualizableFilesystem> vfs) {
+  ImportData import_data(stdlib_path, additional_search_paths, warnings,
+                         std::move(vfs));
   import_data.SetBytecodeCache(std::make_unique<BytecodeCache>(&import_data));
   return import_data;
 }
 
 ImportData CreateImportDataForTest() {
   ImportData import_data(xls::kDefaultDslxStdlibPath,
-                         /*additional_search_paths=*/{}, kDefaultWarningsSet);
+                         /*additional_search_paths=*/{}, kDefaultWarningsSet,
+                         std::make_unique<RealFilesystem>());
   import_data.SetBytecodeCache(std::make_unique<BytecodeCache>(&import_data));
   return import_data;
 }
@@ -45,7 +47,8 @@ ImportData CreateImportDataForTest() {
 std::unique_ptr<ImportData> CreateImportDataPtrForTest() {
   auto import_data = absl::WrapUnique(
       new ImportData(xls::kDefaultDslxStdlibPath,
-                     /*additional_search_paths=*/{}, kDefaultWarningsSet));
+                     /*additional_search_paths=*/{}, kDefaultWarningsSet,
+                     std::make_unique<RealFilesystem>()));
   import_data->SetBytecodeCache(
       std::make_unique<BytecodeCache>(import_data.get()));
   return import_data;

--- a/xls/dslx/create_import_data.h
+++ b/xls/dslx/create_import_data.h
@@ -32,7 +32,7 @@ namespace xls::dslx {
 ImportData CreateImportData(
     const std::filesystem::path& stdlib_path,
     absl::Span<const std::filesystem::path> additional_search_paths,
-    WarningKindSet warnings);
+    WarningKindSet warnings, std::unique_ptr<VirtualizableFilesystem> vfs);
 
 // Creates an ImportData with reasonable defaults (standard path to the stdlib
 // and no additional search paths).

--- a/xls/dslx/dslx_fmt.cc
+++ b/xls/dslx/dslx_fmt.cc
@@ -78,7 +78,8 @@ absl::Status RealMain(std::string_view input_path,
 
   ImportData import_data =
       CreateImportData(xls::kDefaultDslxStdlibPath,
-                       /*additional_search_paths=*/{}, kNoWarningsSet);
+                       /*additional_search_paths=*/{}, kNoWarningsSet,
+                       std::make_unique<RealFilesystem>());
   std::string formatted;
   if (mode == "autofmt") {
     std::vector<CommentData> comments;

--- a/xls/dslx/import_data.cc
+++ b/xls/dslx/import_data.cc
@@ -32,6 +32,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+#include "xls/common/file/filesystem.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/dslx/bytecode/bytecode_cache_interface.h"
@@ -45,6 +46,19 @@
 #include "xls/dslx/type_system/type_info.h"
 
 namespace xls::dslx {
+
+absl::Status RealFilesystem::FileExists(const std::filesystem::path& path) {
+  return xls::FileExists(path);
+}
+
+absl::StatusOr<std::string> RealFilesystem::GetFileContents(
+    const std::filesystem::path& path) {
+  return xls::GetFileContents(path);
+}
+
+absl::StatusOr<std::filesystem::path> RealFilesystem::GetCurrentDirectory() {
+  return xls::GetCurrentDirectory();
+}
 
 /* static */ absl::StatusOr<ImportTokens> ImportTokens::FromString(
     std::string_view module_name) {
@@ -183,6 +197,10 @@ absl::Status ImportData::AddToImporterStack(
       return RecursiveImportErrorStatus(importer_span, existing.imported_from,
                                         cycle, file_table());
     }
+  }
+
+  if (importer_stack_observer_ != nullptr) {
+    importer_stack_observer_(importer_span, imported);
   }
 
   VLOG(3) << "Adding import span to stack: "

--- a/xls/dslx/import_routines.h
+++ b/xls/dslx/import_routines.h
@@ -28,27 +28,30 @@ namespace xls::dslx {
 // Type-checking callback lambda.
 using TypecheckModuleFn = std::function<absl::StatusOr<TypeInfo*>(Module*)>;
 
-// Imports the module identified (globally) by 'subject'.
+// Imports the module identified (globally) by `subject`.
 //
 // Importing means: locating, parsing, typechecking, and caching in the import
 // cache.
 //
-// Resolves against an existing import in 'cache' if it is present.
+// Resolves against an existing import in `import_data` if it is present.
 //
 // Args:
 //  ftypecheck: Function that can be used to get type information for a module.
 //  subject: Tokens that globally uniquely identify the module to import; e.g.
-//      something built-in like ('std',) for the standard library or something
-//      fully qualified like ('xls', 'lib', 'math').
-//  cache: Cache that we resolve against so we don't waste resources
+//      something built-in like `{"std"}` for the standard library or something
+//      fully qualified like `{"xls", "lib", "math"}`.
+//  import_data: Cache that we resolve against so we don't waste resources
 //      re-importing things in the import DAG.
+//  import_span: Indicates the "importer" (i.e. the AST node, lexically) that
+//      caused this attempt to import.
 //
 // Returns:
 //  The imported module information.
 absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
                                      const ImportTokens& subject,
                                      ImportData* import_data,
-                                     const Span& import_span);
+                                     const Span& import_span,
+                                     VirtualizableFilesystem& vfs);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/interp_value_from_string.cc
+++ b/xls/dslx/interp_value_from_string.cc
@@ -37,7 +37,7 @@ absl::StatusOr<InterpValue> InterpValueFromString(
   ImportData import_data = CreateImportData(
       dslx_stdlib_path,
       /*additional_search_paths=*/absl::Span<const std::filesystem::path>{},
-      kDefaultWarningsSet);
+      kDefaultWarningsSet, std::make_unique<RealFilesystem>());
   XLS_ASSIGN_OR_RETURN(TypecheckedModule tm,
                        ParseAndTypecheck(program, "cmdline_constant.x",
                                          "cmdline_constant", &import_data));

--- a/xls/dslx/ir_convert/ir_converter.cc
+++ b/xls/dslx/ir_convert/ir_converter.cc
@@ -550,8 +550,9 @@ absl::StatusOr<PackageConversionData> ConvertFilesToPackage(
         "path to know where to resolve the entry function");
   }
   for (std::string_view path : paths) {
-    ImportData import_data(CreateImportData(stdlib_path, dslx_paths,
-                                            convert_options.enabled_warnings));
+    ImportData import_data(CreateImportData(
+        stdlib_path, dslx_paths, convert_options.enabled_warnings,
+        std::make_unique<RealFilesystem>()));
     XLS_ASSIGN_OR_RETURN(std::string text, GetFileContents(path));
     XLS_ASSIGN_OR_RETURN(std::string module_name, PathToName(path));
     XLS_RETURN_IF_ERROR(AddContentsToPackage(

--- a/xls/dslx/lsp/BUILD
+++ b/xls/dslx/lsp/BUILD
@@ -54,6 +54,9 @@ cc_library(
     srcs = ["language_server_adapter.cc"],
     hdrs = ["language_server_adapter.h"],
     deps = [
+        "//xls/common/file:filesystem",
+        "//xls/common/status:ret_check",
+        ":import_sensitivity",
         ":document_symbols",
         ":find_definition",
         ":lsp_type_utils",
@@ -145,5 +148,28 @@ cc_library(
         "@com_google_absl//absl/types:variant",
         "@verible//common/lsp:lsp-protocol",
         "@verible//common/lsp:lsp-protocol-enums",
+    ],
+)
+
+cc_library(
+    name = "import_sensitivity",
+    srcs = ["import_sensitivity.cc"],
+    hdrs = ["import_sensitivity.h"],
+    deps = [
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/container:btree",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
+cc_test(
+    name = "import_sensitivity_test",
+    srcs = ["import_sensitivity_test.cc"],
+    deps = [
+        ":import_sensitivity",
+        "@com_google_googletest//:gtest",
+        "//xls/common:xls_gunit_main",
     ],
 )

--- a/xls/dslx/lsp/import_sensitivity.cc
+++ b/xls/dslx/lsp/import_sensitivity.cc
@@ -1,0 +1,74 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/dslx/lsp/import_sensitivity.h"
+
+#include "absl/log/log.h"
+#include "absl/strings/str_join.h"
+
+namespace xls::dslx {
+
+void ImportSensitivity::NoteImportAttempt(std::string_view importer_uri,
+                                          std::string_view imported_uri) {
+  imported_to_importers_[imported_uri].insert(std::string{importer_uri});
+}
+
+std::vector<std::string> ImportSensitivity::GatherAllSensitiveToChangeIn(
+    std::string_view uri) {
+  // We maintain a set for O(1) checking of whether a file has already been
+  // placed in the result, but we keep a vector for stable dependency ordering
+  // and avoiding non-deterministic behavior.
+  absl::flat_hash_set<std::string> result_set = {std::string{uri}};
+  std::vector<std::string> result = {std::string{uri}};
+
+  auto add_result = [&](std::string_view to_add) {
+    auto [it, inserted] = result_set.insert(std::string{to_add});
+    if (inserted) {
+      result.push_back(std::string{to_add});
+    }
+  };
+
+  // We note which ones we've already checked and we keep a worklist of things
+  // we need to check, seeded with the ones we know import `uri`.
+  absl::flat_hash_set<std::string> checked;
+  std::vector<std::string> to_check(imported_to_importers_[uri].begin(),
+                                    imported_to_importers_[uri].end());
+
+  for (const std::string& s : to_check) {
+    add_result(s);
+  }
+
+  while (!to_check.empty()) {
+    // Pluck off the `to_check` worklist.
+    std::string uri = to_check.back();
+    to_check.pop_back();
+
+    auto [it, inserted] = checked.insert(uri);
+    if (!inserted) {
+      continue;
+    }
+
+    const absl::btree_set<std::string>& importers = imported_to_importers_[uri];
+    for (const std::string& s : importers) {
+      add_result(s);
+    }
+    to_check.insert(to_check.end(), importers.begin(), importers.end());
+  }
+
+  VLOG(5) << "GatherAllSensitiveToChangeIn; uri: " << uri
+          << " result: " << absl::StrJoin(result, ", ");
+  return result;
+}
+
+}  // namespace xls::dslx

--- a/xls/dslx/lsp/import_sensitivity.h
+++ b/xls/dslx/lsp/import_sensitivity.h
@@ -1,0 +1,44 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_DSLX_LSP_IMPORT_SENSITIVITY_H_
+#define XLS_DSLX_LSP_IMPORT_SENSITIVITY_H_
+
+#include <string>
+#include <string_view>
+
+#include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+
+namespace xls::dslx {
+
+// Tracks import attempts that are made by DSLX file URIs in order to determine
+// which we should try to re-evaluate when there's a change.
+class ImportSensitivity {
+ public:
+  void NoteImportAttempt(std::string_view importer_uri,
+                         std::string_view imported_uri);
+
+  std::vector<std::string> GatherAllSensitiveToChangeIn(std::string_view uri);
+
+ private:
+  // Note: we use a btree set for the values for stable ordering of results.
+  absl::flat_hash_map<std::string, absl::btree_set<std::string>>
+      imported_to_importers_;
+};
+
+}  // namespace xls::dslx
+
+#endif  // XLS_DSLX_LSP_IMPORT_SENSITIVITY_H_

--- a/xls/dslx/lsp/import_sensitivity_test.cc
+++ b/xls/dslx/lsp/import_sensitivity_test.cc
@@ -1,0 +1,63 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/dslx/lsp/import_sensitivity.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace xls::dslx {
+namespace {
+
+TEST(ImportSensitivityTest, SingleImport) {
+  ImportSensitivity s;
+  s.NoteImportAttempt("outer.x", "inner.x");
+
+  auto sensitive_to_outer = s.GatherAllSensitiveToChangeIn("outer.x");
+  ASSERT_EQ(sensitive_to_outer.size(), 1);
+  EXPECT_THAT(sensitive_to_outer, testing::UnorderedElementsAre("outer.x"));
+
+  auto sensitive_to_inner = s.GatherAllSensitiveToChangeIn("inner.x");
+  EXPECT_EQ(sensitive_to_inner.size(), 2);
+  EXPECT_THAT(sensitive_to_inner,
+              testing::UnorderedElementsAre("outer.x", "inner.x"));
+}
+
+TEST(ImportSensitivityTest, TwoLevelLinear) {
+  ImportSensitivity s;
+  s.NoteImportAttempt("middle.x", "inner.x");
+  s.NoteImportAttempt("outer.x", "middle.x");
+
+  auto sensitive_to_inner = s.GatherAllSensitiveToChangeIn("inner.x");
+  EXPECT_EQ(sensitive_to_inner.size(), 3);
+  EXPECT_THAT(sensitive_to_inner,
+              testing::UnorderedElementsAre("outer.x", "middle.x", "inner.x"));
+}
+
+TEST(ImportSensitivityTest, Diamond) {
+  ImportSensitivity s;
+  s.NoteImportAttempt("middle0.x", "leaf.x");
+  s.NoteImportAttempt("middle1.x", "leaf.x");
+  s.NoteImportAttempt("outer.x", "middle0.x");
+  s.NoteImportAttempt("outer.x", "middle1.x");
+
+  auto sensitive_to_inner = s.GatherAllSensitiveToChangeIn("leaf.x");
+  EXPECT_EQ(sensitive_to_inner.size(), 4);
+  EXPECT_THAT(sensitive_to_inner,
+              testing::UnorderedElementsAre("outer.x", "middle0.x", "middle1.x",
+                                            "leaf.x"));
+}
+
+}  // namespace
+}  // namespace xls::dslx

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -32,11 +32,13 @@
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
-#include "nlohmann/json.hpp"
 #include "external/verible/common/lsp/lsp-file-utils.h"
 #include "external/verible/common/lsp/lsp-protocol-enums.h"
 #include "external/verible/common/lsp/lsp-protocol.h"
+#include "nlohmann/json.hpp"
 #include "xls/common/casts.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/dslx/create_import_data.h"
 #include "xls/dslx/extract_module_name.h"
@@ -137,6 +139,47 @@ absl::StatusOr<std::string> MaybeRelpathToUri(
 
 }  // namespace
 
+// Implements an overlay on top of the underlying filesystem that prefers the
+// language server's versions when they are present.
+//
+// TODO(cdleary): 2024-10-20 Note that this is not currently hooked into
+// workspace file creation/deletion events explicitly, so everything comes via
+// textual updates.
+class LanguageServerFilesystem : public VirtualizableFilesystem {
+ public:
+  explicit LanguageServerFilesystem(LanguageServerAdapter& parent)
+      : parent_(parent) {}
+
+  absl::Status FileExists(const std::filesystem::path& path) override {
+    std::string uri = verible::lsp::PathToLSPUri(path.c_str());
+    auto it = parent_.vfs_contents().find(uri);
+    if (it == parent_.vfs_contents().end()) {
+      return xls::FileExists(path);
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<std::string> GetFileContents(
+      const std::filesystem::path& path) override {
+    // First we check if it exists in the virtual layer.
+    std::string uri = verible::lsp::PathToLSPUri(path.c_str());
+    auto it = parent_.vfs_contents().find(uri);
+    if (it == parent_.vfs_contents().end()) {
+      return xls::GetFileContents(path);
+    }
+
+    return it->second;
+  }
+
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override {
+    return xls::GetCurrentDirectory();
+  }
+
+ private:
+  LanguageServerAdapter& parent_;
+};
+
 LanguageServerAdapter::LanguageServerAdapter(
     std::string_view stdlib,
     const std::vector<std::filesystem::path>& dslx_paths)
@@ -150,8 +193,21 @@ LanguageServerAdapter::ParseData* LanguageServerAdapter::FindParsedForUri(
   return nullptr;
 }
 
-absl::Status LanguageServerAdapter::Update(std::string_view file_uri,
-                                           std::string_view dslx_code) {
+absl::Status LanguageServerAdapter::Update(
+    std::string_view file_uri, std::optional<std::string_view> dslx_code) {
+  // Either update or get the last contents from the virtual filesystem map.
+  if (dslx_code.has_value()) {
+    vfs_contents_[file_uri] = std::string{dslx_code.value()};
+  } else {
+    auto it = vfs_contents_.find(file_uri);
+    if (it == vfs_contents_.end()) {
+      return absl::NotFoundError(absl::StrCat(
+          "Could not find previous contents for file URI: ", file_uri));
+    }
+    dslx_code = it->second;
+  }
+  XLS_RET_CHECK(dslx_code.has_value());
+
   const absl::Time start = absl::Now();
   absl::StatusOr<std::string> module_name_or = ExtractModuleName(file_uri);
   if (!module_name_or.ok()) {
@@ -164,12 +220,26 @@ absl::Status LanguageServerAdapter::Update(std::string_view file_uri,
   std::unique_ptr<ParseData>& insert_value = inserted.first->second;
 
   ImportData import_data =
-      CreateImportData(stdlib_, dslx_paths_, kAllWarningsSet);
+      CreateImportData(stdlib_, dslx_paths_, kAllWarningsSet,
+                       std::make_unique<LanguageServerFilesystem>(*this));
+
+  import_data.SetImporterStackObserver(
+      [&](const Span& importer_span, const std::filesystem::path& imported) {
+        std::string_view importer_filename =
+            importer_span.GetFilename(import_data.file_table());
+        CHECK(absl::StartsWith(importer_filename, "file://") ||
+              absl::StartsWith(importer_filename, "memfile://"))
+            << "importer_filename: " << importer_filename
+            << " imported: " << imported;
+        std::string imported_uri = verible::lsp::PathToLSPUri(imported.c_str());
+        import_sensitivity_.NoteImportAttempt(importer_filename, imported_uri);
+      });
+
   const std::string& module_name = module_name_or.value();
 
   std::vector<CommentData> comments;
   absl::StatusOr<TypecheckedModule> typechecked_module =
-      ParseAndTypecheck(dslx_code, /*path=*/file_uri,
+      ParseAndTypecheck(dslx_code.value(), /*path=*/file_uri,
                         /*module_name=*/module_name, &import_data, &comments);
 
   if (typechecked_module.ok()) {

--- a/xls/dslx/run_routines/run_routines.cc
+++ b/xls/dslx/run_routines/run_routines.cc
@@ -483,8 +483,9 @@ absl::StatusOr<ParseAndProveResult> ParseAndProve(
   const absl::Time start = absl::Now();
   TestResultData result(start, /*test_cases=*/{});
 
-  auto import_data = CreateImportData(options.dslx_stdlib_path,
-                                      options.dslx_paths, options.warnings);
+  auto import_data =
+      CreateImportData(options.dslx_stdlib_path, options.dslx_paths,
+                       options.warnings, std::make_unique<RealFilesystem>());
   FileTable& file_table = import_data.file_table();
   absl::StatusOr<TypecheckedModule> tm_or =
       ParseAndTypecheck(program, filename, module_name, &import_data);
@@ -657,8 +658,9 @@ absl::StatusOr<TestResultData> AbstractTestRunner::ParseAndTest(
   const absl::Time start = absl::Now();
   TestResultData result(start, /*test_cases=*/{});
 
-  auto import_data = CreateImportData(options.dslx_stdlib_path,
-                                      options.dslx_paths, options.warnings);
+  auto import_data =
+      CreateImportData(options.dslx_stdlib_path, options.dslx_paths,
+                       options.warnings, std::make_unique<RealFilesystem>());
   FileTable& file_table = import_data.file_table();
 
   absl::StatusOr<TypecheckedModule> tm_or =

--- a/xls/dslx/type_system/typecheck_main.cc
+++ b/xls/dslx/type_system/typecheck_main.cc
@@ -63,7 +63,8 @@ absl::Status RealMain(absl::Span<const std::filesystem::path> dslx_paths,
                       std::optional<std::filesystem::path> output_path) {
   ImportData import_data(CreateImportData(
       dslx_stdlib_path,
-      /*additional_search_paths=*/dslx_paths, kDefaultWarningsSet));
+      /*additional_search_paths=*/dslx_paths, kDefaultWarningsSet,
+      std::make_unique<RealFilesystem>()));
   XLS_ASSIGN_OR_RETURN(std::string input_contents, GetFileContents(input_path));
   XLS_ASSIGN_OR_RETURN(std::string module_name, PathToName(input_path.c_str()));
   absl::StatusOr<TypecheckedModule> tm_or = ParseAndTypecheck(

--- a/xls/dslx/type_system/typecheck_module.cc
+++ b/xls/dslx/type_system/typecheck_module.cc
@@ -220,7 +220,7 @@ absl::Status TypecheckModuleMember(const ModuleMember& member, Module* module,
     XLS_ASSIGN_OR_RETURN(
         ModuleInfo * imported,
         DoImport(ctx->typecheck_module(), ImportTokens(import->subject()),
-                 import_data, import->span()));
+                 import_data, import->span(), import_data->vfs()));
     ctx->type_info()->AddImport(import, &imported->module(),
                                 imported->type_info());
   } else if (std::holds_alternative<ConstantDef*>(member) ||

--- a/xls/flows/ir_wrapper.h
+++ b/xls/flows/ir_wrapper.h
@@ -196,10 +196,11 @@ class IrWrapper {
  private:
   // Construct this object with a default ImportData.
   explicit IrWrapper()
-      : import_data_(dslx::CreateImportData(
-            xls::kDefaultDslxStdlibPath,
-            /*additional_search_paths=*/{},
-            /*enabled_warnings=*/dslx::kAllWarningsSet)) {}
+      : import_data_(
+            dslx::CreateImportData(xls::kDefaultDslxStdlibPath,
+                                   /*additional_search_paths=*/{},
+                                   /*enabled_warnings=*/dslx::kAllWarningsSet,
+                                   std::make_unique<dslx::RealFilesystem>())) {}
 
   // Pointers to the each of the DSLX modules explicitly given to this wrapper.
   //

--- a/xls/fuzzer/sample_generator.cc
+++ b/xls/fuzzer/sample_generator.cc
@@ -402,7 +402,8 @@ absl::StatusOr<Sample> GenerateSample(
   ImportData import_data(
       dslx::CreateImportData(/*stdlib_path=*/"",
                              /*additional_search_paths=*/{},
-                             /*enabled_warnings=*/dslx::kAllWarningsSet));
+                             /*enabled_warnings=*/dslx::kAllWarningsSet,
+                             std::make_unique<dslx::RealFilesystem>()));
   absl::StatusOr<TypecheckedModule> tm =
       ParseAndTypecheck(dslx_text, "sample.x", "sample", &import_data);
   if (!tm.ok()) {

--- a/xls/fuzzer/sample_runner.cc
+++ b/xls/fuzzer/sample_runner.cc
@@ -138,7 +138,8 @@ absl::StatusOr<std::vector<dslx::InterpValue>> InterpretDslxFunction(
     const ArgsBatch& args_batch, const std::filesystem::path& run_dir) {
   dslx::ImportData import_data = dslx::CreateImportData(
       GetDefaultDslxStdlibPath(),
-      /*additional_search_paths=*/{}, dslx::kDefaultWarningsSet);
+      /*additional_search_paths=*/{}, dslx::kDefaultWarningsSet,
+      std::make_unique<dslx::RealFilesystem>());
   XLS_ASSIGN_OR_RETURN(
       dslx::TypecheckedModule tm,
       dslx::ParseAndTypecheck(text, "sample.x", "sample", &import_data));
@@ -647,7 +648,8 @@ InterpretDslxProc(std::string_view text, std::string_view top_name,
                   const std::filesystem::path& run_dir) {
   dslx::ImportData import_data = dslx::CreateImportData(
       GetDefaultDslxStdlibPath(),
-      /*additional_search_paths=*/{}, dslx::kDefaultWarningsSet);
+      /*additional_search_paths=*/{}, dslx::kDefaultWarningsSet,
+      std::make_unique<dslx::RealFilesystem>());
   XLS_ASSIGN_OR_RETURN(
       dslx::TypecheckedModule tm,
       dslx::ParseAndTypecheck(text, "sample.x", "sample", &import_data));

--- a/xls/passes/channel_legalization_pass.cc
+++ b/xls/passes/channel_legalization_pass.cc
@@ -284,19 +284,6 @@ class AdapterBuilder {
   std::vector<ChannelReference*> adapter_instantiation_args_;
 };
 
-// Get the token operand number for a given channel op.
-absl::StatusOr<int64_t> TokenOperandNumberForChannelOp(Node* node) {
-  switch (node->op()) {
-    case Op::kSend:
-      return Send::kTokenOperand;
-    case Op::kReceive:
-      return Receive::kTokenOperand;
-    default:
-      return absl::InvalidArgumentError(
-          absl::StrFormat("Expected channel op, got %s.", node->ToString()));
-  }
-}
-
 struct ChannelSends {
   Channel* channel;
   std::vector<Send*> sends;

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -68,7 +68,8 @@ struct xls_dslx_import_data* xls_dslx_import_data_create(
   std::vector<std::filesystem::path> cpp_additional_search_paths =
       xls::ToCpp(additional_search_paths, additional_search_paths_count);
   xls::dslx::ImportData import_data = CreateImportData(
-      cpp_stdlib_path, cpp_additional_search_paths, xls::dslx::kAllWarningsSet);
+      cpp_stdlib_path, cpp_additional_search_paths, xls::dslx::kAllWarningsSet,
+      std::make_unique<xls::dslx::RealFilesystem>());
   return reinterpret_cast<xls_dslx_import_data*>(
       new xls::dslx::ImportData{std::move(import_data)});
 }

--- a/xls/public/runtime_build_actions.cc
+++ b/xls/public/runtime_build_actions.cc
@@ -55,7 +55,7 @@ absl::StatusOr<std::string> ConvertDslxToIr(
           << " stdlib_path: " << dslx_stdlib_path;
   dslx::ImportData import_data(dslx::CreateImportData(
       std::string(dslx_stdlib_path), additional_search_paths,
-      dslx::kDefaultWarningsSet));
+      dslx::kDefaultWarningsSet, std::make_unique<dslx::RealFilesystem>()));
   XLS_ASSIGN_OR_RETURN(
       dslx::TypecheckedModule typechecked,
       dslx::ParseAndTypecheck(dslx, path, module_name, &import_data));

--- a/xls/tools/eval_dslx_main.cc
+++ b/xls/tools/eval_dslx_main.cc
@@ -65,9 +65,9 @@ static absl::Status RealMain(
     const std::filesystem::path& dslx_path,
     const std::vector<std::filesystem::path>& additional_search_paths,
     std::string_view entry_fn_name, std::string_view args_text) {
-  dslx::ImportData import_data(
-      dslx::CreateImportData(kDefaultDslxStdlibPath, additional_search_paths,
-                             dslx::kDefaultWarningsSet));
+  dslx::ImportData import_data(dslx::CreateImportData(
+      kDefaultDslxStdlibPath, additional_search_paths,
+      dslx::kDefaultWarningsSet, std::make_unique<dslx::RealFilesystem>()));
 
   XLS_ASSIGN_OR_RETURN(std::vector<dslx::InterpValue> args,
                        dslx::ParseArgs(args_text));

--- a/xls/tools/eval_ir_main.cc
+++ b/xls/tools/eval_ir_main.cc
@@ -550,7 +550,8 @@ absl::StatusOr<std::unique_ptr<Package>> ConvertValidator(
     absl::Span<const std::filesystem::path> dslx_paths,
     std::string_view validator_dslx) {
   dslx::ImportData import_data(dslx::CreateImportData(
-      std::string(dslx_stdlib_path), dslx_paths, dslx::kDefaultWarningsSet));
+      std::string(dslx_stdlib_path), dslx_paths, dslx::kDefaultWarningsSet,
+      std::make_unique<dslx::RealFilesystem>()));
   XLS_ASSIGN_OR_RETURN(dslx::TypecheckedModule module,
                        dslx::ParseAndTypecheck(validator_dslx, "fake_path",
                                                kPackageName, &import_data));


### PR DESCRIPTION
"Fixes" inconsistency previously observed in the handling across files in the language server.

Previously if you made a change to `leaf.x` that unbroke a module that depended on `leaf.x`, you wouldn't naturally get an update to the "problems" pane in VSCode that indicated the problem had been resolved.

Introduces a very lightweight virtualized filesystem layer so we can see updated text in the editor (language server) workspace reflected in the language server results.

[Screencast from 10-20-2024 02:19:10 PM.webm](https://github.com/user-attachments/assets/37a3dcec-fa0d-4b9a-bfe4-81e7b605e3a8)
