### PR TITLE
[DSLX:TS] Give an error if there is an ellipsis without a type annotation.

### DIFF
--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -139,6 +139,15 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceArray(const Array* node,
       member_types[0]->CloneToUnique(), member_types_dim);
 
   if (node->type_annotation() == nullptr) {
+    if (node->has_ellipsis()) {
+      const Span array_obrack_span(node->span().start(), node->span().start());
+      return TypeInferenceErrorStatus(
+        array_obrack_span, inferred.get(),
+        "Array has ellipsis (`...`) but does not have a type annotation; "
+        "please add a type annotation to indicate how many elements to expand to.",
+        ctx->file_table());
+    }
+
     return inferred;
   }
 

--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -142,10 +142,13 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceArray(const Array* node,
     if (node->has_ellipsis()) {
       const Span array_obrack_span(node->span().start(), node->span().start());
       return TypeInferenceErrorStatus(
-        array_obrack_span, inferred.get(),
-        "Array has ellipsis (`...`) but does not have a type annotation; "
-        "please add a type annotation to indicate how many elements to expand to.",
-        ctx->file_table());
+          array_obrack_span, inferred.get(),
+          absl::StrFormat(
+              "Array has ellipsis (`...`) but does not have a type annotation; "
+              "please add a type annotation to indicate how many elements to "
+              "expand to; for example: `%s[N]:%s`",
+              inferred->element_type().ToString(), node->ToString()),
+          ctx->file_table());
     }
 
     return inferred;

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2019,6 +2019,16 @@ TEST(TypecheckErrorTest, ArrayEllipsisNoTrailingElement) {
                          "repeat; please add at least one element")));
 }
 
+TEST(TypecheckErrorTest, ArrayEllipsisNoLeadingTypeAnnotation) {
+  EXPECT_THAT(
+      Typecheck(R"(fn main() -> u8[2] {
+    let x: u8[2] = [u8:0, ...];
+    x
+})"),
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("does not have a type annotation; please add a type annotation to indicate how many elements")));
+}
+
 TEST(TypecheckTest, BadArrayAddition) {
   EXPECT_THAT(Typecheck(R"(
 fn f(a: bits[32][4], b: bits[32][4]) -> bits[32][4] {

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2026,7 +2026,9 @@ TEST(TypecheckErrorTest, ArrayEllipsisNoLeadingTypeAnnotation) {
     x
 })"),
       StatusIs(absl::StatusCode::kInvalidArgument,
-               HasSubstr("does not have a type annotation; please add a type annotation to indicate how many elements")));
+               HasSubstr("does not have a type annotation; please add a type "
+                         "annotation to indicate how many elements to expand "
+                         "to; for example: `uN[8][N]:[u8:0, ...]`")));
 }
 
 TEST(TypecheckTest, BadArrayAddition) {


### PR DESCRIPTION
Previously we would assume we do not need to extend beyond the provided (literal) element count, which led to errors when users did:

```
fn f() -> u32[4] {
    let x: u32[4] = [u32:42, ...];  // RHS is actually 1 element here, the u32[4] from the type annotation does /not/ propagate into the array expression as context!
}
```

This also relates to our recent unifying type inference discussions -- in unifying TI we'd make the right hand side type "at least a u32[1] if not more" and then it would unify with `u32[4]` to say "ok it's a u32[4] filled with the value 42". cc @richmckeever @meheff 