### PR TITLE
[DSLX:type_system] Fix for let binding with `xN` type annotation on it.

### DIFF
--- a/xls/dslx/bytecode/bytecode_emitter.cc
+++ b/xls/dslx/bytecode/bytecode_emitter.cc
@@ -138,8 +138,9 @@ std::optional<ValueFormatDescriptor> GetFormatDescriptorFromNumber(
     return std::nullopt;
   }
   return ValueFormatDescriptor::MakeLeafValue(
-      builtin_type->GetSignedness() ? FormatPreference::kSignedDecimal
-                                    : FormatPreference::kUnsignedDecimal);
+      builtin_type->GetSignedness().value()
+          ? FormatPreference::kSignedDecimal
+          : FormatPreference::kUnsignedDecimal);
 }
 
 }  // namespace

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -492,7 +492,7 @@ absl::StatusOr<bool> GetBuiltinTypeSignedness(BuiltinType type) {
       absl::StrCat("Unknown builtin type: ", static_cast<int64_t>(type)));
 }
 
-absl::StatusOr<int64_t> GetBuiltinTypeBitCount(BuiltinType type) {
+int64_t GetBuiltinTypeBitCount(BuiltinType type) {
   switch (type) {
 #define CASE(__enum, _unused1, _unused2, _unused3, __width) \
   case BuiltinType::__enum:                                 \
@@ -500,8 +500,7 @@ absl::StatusOr<int64_t> GetBuiltinTypeBitCount(BuiltinType type) {
     XLS_DSLX_BUILTIN_TYPE_EACH(CASE)
 #undef CASE
   }
-  return absl::InvalidArgumentError(
-      absl::StrCat("Unknown builtin type: ", static_cast<int64_t>(type)));
+  LOG(FATAL) << "Impossible builtin type: " << static_cast<int64_t>(type);
 }
 
 absl::StatusOr<BuiltinType> BuiltinTypeFromString(std::string_view s) {
@@ -1871,11 +1870,11 @@ std::vector<AstNode*> BuiltinTypeAnnotation::GetChildren(
 }
 
 int64_t BuiltinTypeAnnotation::GetBitCount() const {
-  return GetBuiltinTypeBitCount(builtin_type_).value();
+  return GetBuiltinTypeBitCount(builtin_type_);
 }
 
-bool BuiltinTypeAnnotation::GetSignedness() const {
-  return GetBuiltinTypeSignedness(builtin_type_).value();
+absl::StatusOr<bool> BuiltinTypeAnnotation::GetSignedness() const {
+  return GetBuiltinTypeSignedness(builtin_type_);
 }
 
 // -- class ChannelTypeAnnotation

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -312,7 +312,7 @@ absl::StatusOr<BuiltinType> BuiltinTypeFromString(std::string_view s);
 
 absl::StatusOr<BuiltinType> GetBuiltinType(bool is_signed, int64_t width);
 absl::StatusOr<bool> GetBuiltinTypeSignedness(BuiltinType type);
-absl::StatusOr<int64_t> GetBuiltinTypeBitCount(BuiltinType type);
+int64_t GetBuiltinTypeBitCount(BuiltinType type);
 
 // Represents a built-in type annotation; e.g. `u32`, `bits`, etc.
 class BuiltinTypeAnnotation : public TypeAnnotation {
@@ -335,10 +335,13 @@ class BuiltinTypeAnnotation : public TypeAnnotation {
     return BuiltinTypeToString(builtin_type_);
   }
 
+  // Note that types like `xN`/`uN`/`sN`/`bits` have a bit count of zero.
   int64_t GetBitCount() const;
 
   // Returns true if signed, false if unsigned.
-  bool GetSignedness() const;
+  //
+  // Note that a type like `xN` on its own does not have a signedness.
+  absl::StatusOr<bool> GetSignedness() const;
 
   BuiltinType builtin_type() const { return builtin_type_; }
 

--- a/xls/dslx/frontend/ast_test.cc
+++ b/xls/dslx/frontend/ast_test.cc
@@ -176,28 +176,23 @@ TEST(AstTest, GetBuiltinTypeSignedness) {
 }
 
 TEST(AstTest, GetBuiltinTypeBitCount) {
-  XLS_ASSERT_OK_AND_ASSIGN(int64_t bit_count,
-                           GetBuiltinTypeBitCount(BuiltinType::kBool));
+  int64_t bit_count = GetBuiltinTypeBitCount(BuiltinType::kBool);
   EXPECT_EQ(bit_count, 1);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count, GetBuiltinTypeBitCount(BuiltinType::kS1));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kS1);
   EXPECT_EQ(bit_count, 1);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count,
-                           GetBuiltinTypeBitCount(BuiltinType::kS64));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kS64);
   EXPECT_EQ(bit_count, 64);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count, GetBuiltinTypeBitCount(BuiltinType::kU1));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kU1);
   EXPECT_EQ(bit_count, 1);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count,
-                           GetBuiltinTypeBitCount(BuiltinType::kU64));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kU64);
   EXPECT_EQ(bit_count, 64);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count, GetBuiltinTypeBitCount(BuiltinType::kSN));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kSN);
   EXPECT_EQ(bit_count, 0);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count, GetBuiltinTypeBitCount(BuiltinType::kUN));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kUN);
   EXPECT_EQ(bit_count, 0);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count,
-                           GetBuiltinTypeBitCount(BuiltinType::kBits));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kBits);
   EXPECT_EQ(bit_count, 0);
-  XLS_ASSERT_OK_AND_ASSIGN(bit_count,
-                           GetBuiltinTypeBitCount(BuiltinType::kToken));
+  bit_count = GetBuiltinTypeBitCount(BuiltinType::kToken);
   EXPECT_EQ(bit_count, 0);
 }
 

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -324,9 +324,13 @@ std::optional<BitVectorMetadata> ExtractBitVectorMetadata(
       default:
         break;
     }
-    return BitVectorMetadata{.bit_count = builtin->GetBitCount(),
-                             .is_signed = builtin->GetSignedness(),
-                             .kind = kind};
+
+    absl::StatusOr<bool> is_signed = builtin->GetSignedness();
+    CHECK_OK(is_signed.status());
+
+    int64_t bit_count = builtin->GetBitCount();
+    return BitVectorMetadata{
+        .bit_count = bit_count, .is_signed = is_signed.value(), .kind = kind};
   }
   if (const ArrayTypeAnnotation* array_type =
           dynamic_cast<const ArrayTypeAnnotation*>(type);

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -1453,7 +1453,17 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceBuiltinTypeAnnotation(
   if (node->builtin_type() == BuiltinType::kToken) {
     t = std::make_unique<TokenType>();
   } else {
-    t = std::make_unique<BitsType>(node->GetSignedness(), node->GetBitCount());
+    absl::StatusOr<bool> signedness = node->GetSignedness();
+    if (!signedness.ok()) {
+      return TypeInferenceErrorStatus(
+          node->span(), nullptr,
+          absl::StrFormat("Could not determine signedness to turn "
+                          "`%s` into a concrete bits type.",
+                          node->ToString()),
+          ctx->file_table());
+    }
+    int64_t bit_count = node->GetBitCount();
+    t = std::make_unique<BitsType>(signedness.value(), bit_count);
   }
   VLOG(5) << "DeduceBuiltinTypeAnnotation result: " << t->ToString();
   return std::make_unique<MetaType>(std::move(t));
@@ -1600,7 +1610,9 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceArrayTypeAnnotation(
       t = std::make_unique<BitsConstructorType>(std::move(dim).value());
     } else {
       XLS_ASSIGN_OR_RETURN(dim, DimToConcreteUsize(node->dim(), ctx));
-      t = std::make_unique<BitsType>(element_type->GetSignedness(),
+      // We know we can determine signedness as the `xN` case is handled above.
+      bool is_signed = element_type->GetSignedness().value();
+      t = std::make_unique<BitsType>(is_signed,
                                      std::move(dim).value());
     }
   } else {

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -567,6 +567,14 @@ const GLOBAL: u32 = u32:4;
   XLS_EXPECT_OK(Typecheck(kProgram));
 }
 
+TEST(TypecheckErrorTest, LetTypeAnnotationIsXn) {
+  constexpr std::string_view kProgram = "fn f() { let x: xN = u32:42; }";
+  EXPECT_THAT(Typecheck(kProgram),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("Could not determine signedness to turn `xN` "
+                                 "into a concrete bits type.")));
+}
+
 TEST(TypecheckErrorTest, ParametricIdentifierLtValue) {
   constexpr std::string_view kProgram = R"(
 fn p<N: u32>(x: bits[N]) -> bits[N] { x }

--- a/xls/fuzzer/ast_generator.h
+++ b/xls/fuzzer/ast_generator.h
@@ -205,7 +205,8 @@ class AstGenerator {
   static bool IsNil(const TypeAnnotation* t);
   static bool IsBuiltinBool(const TypeAnnotation* type) {
     if (auto* builtin_type = dynamic_cast<const BuiltinTypeAnnotation*>(type)) {
-      return !builtin_type->GetSignedness() && builtin_type->GetBitCount() == 1;
+      return !builtin_type->GetSignedness().value() &&
+             builtin_type->GetBitCount() == 1;
     }
     return false;
   }

--- a/xls/fuzzer/value_generator.cc
+++ b/xls/fuzzer/value_generator.cc
@@ -194,9 +194,10 @@ absl::StatusOr<Expr*> GenerateDslxConstant(absl::BitGenRef bit_gen,
   dslx::Span fake_span = dslx::FakeSpan();
   if (auto* builtin_type = dynamic_cast<dslx::BuiltinTypeAnnotation*>(type);
       builtin_type != nullptr) {
-    XLS_ASSIGN_OR_RETURN(dslx::InterpValue num_value,
-                         GenerateBitValue(bit_gen, builtin_type->GetBitCount(),
-                                          builtin_type->GetSignedness()));
+    XLS_ASSIGN_OR_RETURN(
+        dslx::InterpValue num_value,
+        GenerateBitValue(bit_gen, builtin_type->GetBitCount(),
+                         builtin_type->GetSignedness().value()));
     return module->Make<Number>(fake_span, num_value.ToHumanString(),
                                 dslx::NumberKind::kOther, type);
   }


### PR DESCRIPTION
Previously we would access `.value()` on an error `StatusOr`