### PR TITLE
[DSLX] Rename slice builtin to array_slice to match array_rev (vs rev) and array_size (vs std::sizeof)

### DIFF
--- a/docs_src/dslx_std.md
+++ b/docs_src/dslx_std.md
@@ -957,14 +957,14 @@ Counts the number of bits in `x` that are '1'.
 #### `std::extract_bits`
 
 ```dslx-snippet
-pub fn extract_bits<from_inclusive: u32, to_exclusive: u32, fixed_shift: u32,
-                    N: u32>(x : bits[N]) -> bits[std::max(0, to_exclusive - from_inclusive)] {
-    let x_extended = x as uN[max(unsigned_sizeof(x) + fixed_shift, to_exclusive)];
-    (x_extended << fixed_shift)[from_inclusive:to_exclusive]
+pub fn extract_bits<FROM_INCLUSIVE: u32, TO_EXCLUSIVE: u32, FIXED_SHIFT: u32,
+                    N: u32>(x: bits[N]) -> bits[std::max(u32:0, TO_EXCLUSIVE - FROM_INCLUSIVE)] {
+    let x_extended = x as uN[std::max(std::sizeof(x) + FIXED_SHIFT, TO_EXCLUSIVE)];
+    (x_extended << fixed_shift)[FROM_INCLUSIVE:TO_EXCLUSIVE]
 }
 ```
 
-Extracts a bit-slice from x shifted left by fixed_shift.  This function behaves as-if x as
+Extracts a bit-slice from x shifted left by `fixed_shift`.  This function behaves as-if x as
 resonably infinite precision so that the shift does not drop any bits and that the bit slice
 will be in-range.
 

--- a/xls/dslx/bytecode/builtins.cc
+++ b/xls/dslx/bytecode/builtins.cc
@@ -81,11 +81,12 @@ absl::Status RunTernaryBuiltin(
 
 }  // namespace
 
-absl::Status RunBuiltinSlice(const Bytecode& bytecode,
-                             InterpreterStack& stack) {
+absl::Status RunBuiltinArraySlice(const Bytecode& bytecode,
+                                  InterpreterStack& stack) {
   return RunTernaryBuiltin(
       [](const InterpValue& basis, const InterpValue& start,
-         const InterpValue& type_value) {
+         const InterpValue& type_value) -> absl::StatusOr<InterpValue> {
+        XLS_RET_CHECK(basis.IsArray());
         return basis.Slice(start, type_value);
       },
       stack);

--- a/xls/dslx/bytecode/builtins.h
+++ b/xls/dslx/bytecode/builtins.h
@@ -26,7 +26,8 @@
 
 namespace xls::dslx {
 
-absl::Status RunBuiltinSlice(const Bytecode& bytecode, InterpreterStack& stack);
+absl::Status RunBuiltinArraySlice(const Bytecode& bytecode,
+                                  InterpreterStack& stack);
 
 absl::Status RunBuiltinUpdate(const Bytecode& bytecode,
                               InterpreterStack& stack);

--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -1495,8 +1495,8 @@ absl::Status BytecodeInterpreter::RunBuiltinFn(const Bytecode& bytecode,
       return RunBuiltinArraySize(bytecode, stack_);
     case Builtin::kSignex:
       return RunBuiltinSignex(bytecode, stack_);
-    case Builtin::kSlice:
-      return RunBuiltinSlice(bytecode, stack_);
+    case Builtin::kArraySlice:
+      return RunBuiltinArraySlice(bytecode, stack_);
     case Builtin::kSMulp:
       return RunBuiltinSMulp(bytecode, stack_);
     case Builtin::kTrace:

--- a/xls/dslx/dslx_builtins.h
+++ b/xls/dslx/dslx_builtins.h
@@ -54,7 +54,7 @@ namespace xls::dslx {
   X("widening_cast", kWideningCast)       \
   X("signex", kSignex)                    \
   X("smulp", kSMulp)                      \
-  X("slice", kSlice)                      \
+  X("array_slice", kArraySlice)           \
   X("trace!", kTrace)                     \
   X("umulp", kUMulp)                      \
   X("update", kUpdate)                    \

--- a/xls/dslx/frontend/builtins_metadata.cc
+++ b/xls/dslx/frontend/builtins_metadata.cc
@@ -77,7 +77,7 @@ const absl::flat_hash_map<std::string, BuiltinsData>& GetParametricBuiltins() {
           // Use a dummy value to determine size.
           {"signex",
            {.signature = "(xN[M], xN[N]) -> xN[N]", .is_ast_node = false}},
-          {"slice",
+          {"array_slice",
            {.signature = "(T[M], uN[N], T[P]) -> T[P]", .is_ast_node = false}},
           {"trace!", {.signature = "(T) -> T", .is_ast_node = false}},
 

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -2152,7 +2152,7 @@ absl::Status FunctionConverter::HandleInvocation(const Invocation* node) {
           {"one_hot", &FunctionConverter::HandleBuiltinOneHot},
           {"one_hot_sel", &FunctionConverter::HandleBuiltinOneHotSel},
           {"priority_sel", &FunctionConverter::HandleBuiltinPrioritySel},
-          {"slice", &FunctionConverter::HandleBuiltinArraySlice},
+          {"array_slice", &FunctionConverter::HandleBuiltinArraySlice},
           {"bit_slice_update", &FunctionConverter::HandleBuiltinBitSliceUpdate},
           {"rev", &FunctionConverter::HandleBuiltinRev},
           {"zip", &FunctionConverter::HandleBuiltinZip},

--- a/xls/dslx/tests/array_literal_ellipsis.x
+++ b/xls/dslx/tests/array_literal_ellipsis.x
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main(x: u8[4], start: u32) -> u8[3] { slice(x, start, u8[3]:[0, ...]) }
+fn main(x: u8[4], start: u32) -> u8[3] { array_slice(x, start, u8[3]:[0, ...]) }
 
 #[test]
 fn slice_test() {

--- a/xls/dslx/tests/array_slice.x
+++ b/xls/dslx/tests/array_slice.x
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main() -> s32[3] { slice(s32[8]:[1, 2, 3, 4, 5, 6, 7, 8], u32:2, s32[3]:[0, 0, 0]) }
+fn main() -> s32[3] { array_slice(s32[8]:[1, 2, 3, 4, 5, 6, 7, 8], u32:2, s32[3]:[0, 0, 0]) }
 
 #[test]
 fn test_concat() { assert_eq(s32[3]:[3, 4, 5], main()) }

--- a/xls/dslx/tests/array_slice_str.x
+++ b/xls/dslx/tests/array_slice_str.x
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn main() -> u8[3] { slice("HelloWorld!", u32:2, u8[3]:[0, 0, 0]) }
+fn main() -> u8[3] { array_slice("HelloWorld!", u32:2, u8[3]:[0, 0, 0]) }
 
 #[test]
 fn test_slice() { assert_eq("llo", main()) }

--- a/xls/dslx/tests/constexpr_pad_via_slice.x
+++ b/xls/dslx/tests/constexpr_pad_via_slice.x
@@ -16,7 +16,7 @@
 
 // Pads an array up to "R" elements by filling with zeros in the higher indices.
 fn pad<X: u32, R: u32, DIFF: u32 = {R - X}>(xs: u32[X]) -> u32[R] {
-    if R >= X { xs ++ u32[DIFF]:[0, ...] } else { slice(xs, u32:0, u32[R]:[0, ...]) }
+    if R >= X { xs ++ u32[DIFF]:[0, ...] } else { array_slice(xs, u32:0, u32[R]:[0, ...]) }
 }
 
 fn main(x: u32[2]) -> u32[4] { pad<u32:2, u32:4>(x) }

--- a/xls/dslx/tests/slice_builtin.x
+++ b/xls/dslx/tests/slice_builtin.x
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-fn non_test_slice(x: u8[4], start: u32) -> u8[3] { slice(x, start, u8[3]:[0, 0, 0]) }
+fn non_test_slice(x: u8[4], start: u32) -> u8[3] { array_slice(x, start, u8[3]:[0, 0, 0]) }
 
 #[test]
 fn slice_test() {
     let a: u8[4] = u8[4]:[1, 2, 3, 4];
-    assert_eq(u8[2]:[1, 2], slice(a, u32:0, u8[2]:[0, 0]));
-    assert_eq(u8[2]:[3, 4], slice(a, u32:2, u8[2]:[0, 0]));
-    assert_eq(u8[3]:[2, 3, 4], slice(a, u32:1, u8[3]:[0, 0, 0]));
+    assert_eq(u8[2]:[1, 2], array_slice(a, u32:0, u8[2]:[0, 0]));
+    assert_eq(u8[2]:[3, 4], array_slice(a, u32:2, u8[2]:[0, 0]));
+    assert_eq(u8[3]:[2, 3, 4], array_slice(a, u32:1, u8[3]:[0, 0, 0]));
     assert_eq(u8[3]:[2, 3, 4], non_test_slice(a, u32:1));
 }

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -1747,7 +1747,7 @@ TEST(TypecheckTest, SliceBuiltin) {
   XLS_EXPECT_OK(Typecheck(R"(
 fn f() -> u32[3] {
   let x: u32[2] = u32[2]:[0, 1];
-  slice(x, u32:0, u32[3]:[0, 0, 0])
+  array_slice(x, u32:0, u32[3]:[0, 0, 0])
 }
 )"));
 }

--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -2300,7 +2300,7 @@ absl::StatusOr<TypedExpr> AstGenerator::GenerateArraySlice(Context* ctx) {
 
   TypedExpr width{width_expr, width_type};
   auto* invocation = module_->Make<Invocation>(
-      fake_span_, MakeBuiltinNameRef("slice"),
+      fake_span_, MakeBuiltinNameRef("array_slice"),
       std::vector<Expr*>{arg.expr, start.expr, width.expr});
   return TypedExpr{
       .expr = invocation,

--- a/xls/fuzzer/crashers/crasher_2021-06-04.x
+++ b/xls/fuzzer/crashers/crasher_2021-06-04.x
@@ -33,6 +33,6 @@
 type x3 = ();
 fn main(x0: u64) -> x3[11] {
   let x4: x3[1] = [()];
-  let x7: x3[11] = slice(x4, x0, x3[11]:[(x4)[u64:0], ...]);
+  let x7: x3[11] = array_slice(x4, x0, x3[11]:[(x4)[u64:0], ...]);
   x7
 }

--- a/xls/fuzzer/crashers/crasher_2021-06-29_6e22.x
+++ b/xls/fuzzer/crashers/crasher_2021-06-29_6e22.x
@@ -190,7 +190,7 @@ fn main(x0: u46, x1: x2[W32_V9], x3: x4[W32_V8], x5: s37, x6: s62, x7: s8, x8: u
   let x24: u46 = (x0) & (((x17) as u46));
   let x25: u21 = (x0)[25+:u21];
   let x26: u8 = (x7 as u8)[0+:u8];
-  let x27: x4[3] = slice(x23, x0, x4[3]:[(x23)[u64:0], ...]);
+  let x27: x4[3] = array_slice(x23, x0, x4[3]:[(x23)[u64:0], ...]);
   let x28: s8 = !(x7);
   let x29: u59 = bit_slice_update(x19, x11, x0);
   let x30: (s37, s8, u42) = (x5, x7, x11);

--- a/xls/fuzzer/crashers/crasher_2022-09-01_f672.x
+++ b/xls/fuzzer/crashers/crasher_2022-09-01_f672.x
@@ -177,7 +177,7 @@ fn main(x0: s7, x1: s37, x2: s57, x3: uN[745]) -> (s30, uN[796], uN[1490], x4[6]
   let x7: bool = (x5) == (x5);
   let x8: uN[1490] = ctz(x6);
   let x9: uN[796] = (x8)[:-694];
-  let x10: x4[6] = slice(x5, x6, x4[6]:[(x5)[u32:0], ...]);
+  let x10: x4[6] = array_slice(x5, x6, x4[6]:[(x5)[u32:0], ...]);
   let x11: uN[1490] = (((x2) as uN[1490])) + (x8);
   let x12: uN[1490] = -(x6);
   let x13: uN[1148] = (x11)[x9+:uN[1148]];

--- a/xls/fuzzer/crashers/crasher_2022-09-03_4d43.x
+++ b/xls/fuzzer/crashers/crasher_2022-09-03_4d43.x
@@ -174,7 +174,7 @@ fn main(x0: s58, x1: s61, x2: (u1,), x3: u10) -> (x6[1], bool, x14) {
     x
   }(x4);
   let x7: x6[1] = [x2];
-  let x8: x6[1] = slice(x7, x5, x6[1]:[(x7)[u32:0], ...]);
+  let x8: x6[1] = array_slice(x7, x5, x6[1]:[(x7)[u32:0], ...]);
   let x9: x6 = (x7)[if (x5) >= (u10:0) { u10:0 } else { x5 }];
   let x10: s10 = s10:0x2aa;
   let x11: s61 = (x1) * (((x0) as s61));

--- a/xls/fuzzer/crashers/crasher_2022-10-19_a3a3.x
+++ b/xls/fuzzer/crashers/crasher_2022-10-19_a3a3.x
@@ -191,7 +191,7 @@ fn main(x0: u1, x1: s23, x2: uN[97], x3: s29) -> (sN[97], s23, u21, u5) {
   let x22: s29 = (x3) | (((x7) as s29));
   let x23: u21 = gate!((((x17) as u5)) != (x21), x8);
   let x24: uN[97] = bit_slice_update(x7, x7, x17);
-  let x25: x14[1] = slice(x15, x7, x14[1]:[(x15)[u32:0], ...]);
+  let x25: x14[1] = array_slice(x15, x7, x14[1]:[(x15)[u32:0], ...]);
   let x26: uN[97] = !(x6);
   let x32: x31[1] = map(x15, x27);
   let x33: s45 = s45:0xfff_ffff_ffff;

--- a/xls/fuzzer/crashers/crasher_2023-04-09_1f76.x
+++ b/xls/fuzzer/crashers/crasher_2023-04-09_1f76.x
@@ -187,7 +187,7 @@ fn main(x0: s33, x1: u41, x2: u37, x3: s42, x4: s31, x5: u28) -> (u41, u20, (x6[
   let x14: u41 = !(x1);
   let x15: u2 = (x14)[x2+:u2];
   let x16: u56 = (x5) ++ (x5);
-  let x17: x8[1] = slice(x9, x14, x8[1]:[(x9)[u32:0b0], ...]);
+  let x17: x8[1] = array_slice(x9, x14, x8[1]:[(x9)[u32:0b0], ...]);
   let x18: u41 = !(x1);
   let x19: u20 = (((x11) as u31))[4:24];
   let x20: bool = (x0) <= (((x1) as s33));

--- a/xls/fuzzer/crashers/crasher_2023-06-05_c720.x
+++ b/xls/fuzzer/crashers/crasher_2023-06-05_c720.x
@@ -199,7 +199,7 @@ proc main {
       let x13: u19 = x11.1;
       let x14: bool = x11.2;
       let x16: token = send(x0, x15, x2);
-      let x17: x4[1] = slice(x5, x7, x4[1]:[x5[u32:0x0], ...]);
+      let x17: x4[1] = array_slice(x5, x7, x4[1]:[x5[u32:0x0], ...]);
       let x18: u30 = for (i, x): (u4, u30) in u4:0x0..u4:0x8 {
         x
       }(x1);

--- a/xls/fuzzer/crashers/crasher_2023-10-02_7c14.x
+++ b/xls/fuzzer/crashers/crasher_2023-10-02_7c14.x
@@ -220,7 +220,7 @@ proc main {
             let x31: x30[1] = [x29];
             let x32: bool = x29 * x10 as bool;
             let x33: x30 = x31[if x27 >= u19:0x0 { u19:0x0 } else { x27 }];
-            let x34: x6[9] = slice(x22, x16, x6[9]:[x22[u32:0x0], ...]);
+            let x34: x6[9] = array_slice(x22, x16, x6[9]:[x22[u32:0x0], ...]);
             let x35: token = for (i, x) in u4:0x0..u4:0x6 {
                 x
             }(x9);

--- a/xls/fuzzer/crashers/crasher_2023-10-06_2e1e.x
+++ b/xls/fuzzer/crashers/crasher_2023-10-06_2e1e.x
@@ -190,10 +190,10 @@ fn main(x2: s52, x3: x1[W32_V11], x4: u51) -> (x1[W32_V11], bool, u25, bool, u51
         let x15: (s52, u51, u25, u51, u51) = (x2, x4, x11, x4, x5);
         let x16: u51 = ctz(x12);
         let x17: x1[55] = x7 ++ x8;
-        let x18: x1[9] = slice(x8, x16, x1[9]:[x8[u32:0x0], ...]);
+        let x18: x1[9] = array_slice(x8, x16, x1[9]:[x8[u32:0x0], ...]);
         let x19: u51 = rev(x4);
         let x20: bool = -x10;
-        let x21: x1[1] = slice(x17, x9, x1[1]:[x17[u32:0x0], ...]);
+        let x21: x1[1] = array_slice(x17, x9, x1[1]:[x17[u32:0x0], ...]);
         let x22: bool = gate!(x6 as uN[153] != x9, x10);
         let x24: x23[1] = x4 as x23[1];
         let x25: bool = x22 - x13 as bool;

--- a/xls/fuzzer/crashers/crasher_2023-10-08_e7fc.x
+++ b/xls/fuzzer/crashers/crasher_2023-10-08_e7fc.x
@@ -183,7 +183,7 @@ fn main(x1: x0[15], x2: u7) -> (x0[15], u11, u4, x23[W32_V1], bool) {
             _ => u11:0x100,
         };
         let x5: x4[1] = [x1];
-        let x6: x0[1] = slice(x1, x3, x0[1]:[x1[u32:0x0], ...]);
+        let x6: x0[1] = array_slice(x1, x3, x0[1]:[x1[u32:0x0], ...]);
         let x7: u11 = x3 >> if x2 >= u7:0x4 { u7:0x4 } else { x2 };
         let x8: (x0[15], x0[15], u11, u7) = (x1, x1, x7, x2);
         let x9: u11 = !x3;

--- a/xls/fuzzer/crashers/crasher_2023-11-13_cf6f.x
+++ b/xls/fuzzer/crashers/crasher_2023-11-13_cf6f.x
@@ -63,7 +63,7 @@ fn main(x1: x0[7], x2: u29, x3: u43, x4: u5) -> (u11, bool, u6, u43, u43, u4) {
         let x13: bool = xor_reduce(x6);
         let x14: u43 = x12 >> if x9 >= u4:0xe { u4:0xe } else { x9 };
         let x15: u16 = x8[27+:u16];
-        let x16: x0[9] = slice(x1, x12, x0[9]:[x1[u32:0x0], ...]);
+        let x16: x0[9] = array_slice(x1, x12, x0[9]:[x1[u32:0x0], ...]);
         let x17: u7 = u7:0x8;
         let x18: u11 = match x12 {
             u43:0x3ff_ffff_ffff => u11:0x5b8,

--- a/xls/fuzzer/crashers/crasher_2023-11-19_0a23.x
+++ b/xls/fuzzer/crashers/crasher_2023-11-19_0a23.x
@@ -197,8 +197,8 @@ fn main(x0: s33, x1: u8) -> (uN[528], x9[7], uN[256]) {
         let x14: uN[528] = !x7;
         let x15: uN[528] = x14[x6+:uN[528]];
         let x16: uN[528] = bit_slice_update(x15, x5, x1);
-        let x17: x9[6] = slice(x10, x14, x9[6]:[x10[u32:0x0], ...]);
-        let x18: x9[1] = slice(x10, x12, x9[1]:[x10[u32:0x0], ...]);
+        let x17: x9[6] = array_slice(x10, x14, x9[6]:[x10[u32:0x0], ...]);
+        let x18: x9[1] = array_slice(x10, x12, x9[1]:[x10[u32:0x0], ...]);
         let x19: x9[16] = x17 ++ x10;
         let x20: x9[7] = x17 ++ x18;
         let x21: bool = x12[:];

--- a/xls/fuzzer/crashers/crasher_2023-11-19_26d5.x
+++ b/xls/fuzzer/crashers/crasher_2023-11-19_26d5.x
@@ -87,7 +87,7 @@ proc main {
             let x28: s15 = s15:0x2aaa;
             let x29: x1[13] = x19.4;
             let x30: bool = and_reduce(x22);
-            let x31: x1[10] = slice(x29, x22, x1[10]:[x29[u32:0x0], ...]);
+            let x31: x1[10] = array_slice(x29, x22, x1[10]:[x29[u32:0x0], ...]);
             let x32: (bool, bool, x1[13], x6[1]) = (x30, x23, x2, x7);
             x2
         }

--- a/xls/fuzzer/crashers/crasher_2023-12-25_3ac6.x
+++ b/xls/fuzzer/crashers/crasher_2023-12-25_3ac6.x
@@ -184,7 +184,7 @@ fn main(x0: s31, x1: s8, x2: s58, x3: u36) -> (u36, (s58, s8, u24, u2, u36), u2,
         let x13: (s58, s8, u24, u2, u36) = (x2, x1, x8, x4, x3);
         let x14: s31 = !x0;
         let x15: u49 = u49:0x1_5555_5555_5555;
-        let x16: x10[16] = slice(x11, x8, x10[16]:[x11[u32:0x0], ...]);
+        let x16: x10[16] = array_slice(x11, x8, x10[16]:[x11[u32:0x0], ...]);
         let x17: s31 = x14 / s31:0x80;
         let x18: u24 = -x8;
         let x19: u36 = signex(x5, x3);

--- a/xls/fuzzer/crashers/crasher_2024-02-23_b88e.x
+++ b/xls/fuzzer/crashers/crasher_2024-02-23_b88e.x
@@ -186,14 +186,14 @@ fn main(x1: s15, x2: u15, x3: u33, x4: u63, x5: x0[W32_V9], x6: s30, x7: s1, x8:
         let x13: x12[63] = x4 as x12[63];
         let x14: u63 = -x4;
         let x16: x15[3] = [x1, x1, x1];
-        let x17: x0[1] = slice(x5, x14, x0[1]:[x5[u32:0x0], ...]);
+        let x17: x0[1] = array_slice(x5, x14, x0[1]:[x5[u32:0x0], ...]);
         let x18: u63 = x4 >> x2;
         let x19: bool = x7 < x10 as s1;
         let x20: s23 = s23:0x7f_ffff;
         let x21: (x0[1], s15, u21, x12[63]) = (x17, x1, x10, x13);
         let x22: s15 = x1 * x10 as s15;
         let x23: bool = x21 != x21;
-        let x24: x0[1] = slice(x5, x23, x0[1]:[x5[u32:0x0], ...]);
+        let x24: x0[1] = array_slice(x5, x23, x0[1]:[x5[u32:0x0], ...]);
         let x25: bool = x18 as bool | x19;
         let x26: s41 = s41:0x1ff_ffff_ffff;
         let x27: bool = x21 != x21;

--- a/xls/fuzzer/crashers/crasher_2024-03-25_ad50.x
+++ b/xls/fuzzer/crashers/crasher_2024-03-25_ad50.x
@@ -190,7 +190,7 @@ fn main(x0: u51, x1: s46, x2: (uN[1535], (u60, u55, u30), u52), x3: u52) -> (boo
         let x8: u10 = -x5;
         let x9: u52 = x8 as u52 & x4;
         let x11: x10[W32_V13] = x9 as x10[W32_V13];
-        let x12: x10[1] = slice(x11, x0, x10[1]:[x11[u32:0b0], ...]);
+        let x12: x10[1] = array_slice(x11, x0, x10[1]:[x11[u32:0b0], ...]);
         let x13: u52 = x4 - x4;
         let x19: x18[1] = map(x12, x14);
         let x20: x18[2] = x19 ++ x19;

--- a/xls/fuzzer/crashers/crasher_2024-07-08_5973.x
+++ b/xls/fuzzer/crashers/crasher_2024-07-08_5973.x
@@ -196,7 +196,7 @@ fn x22(x23: bool, x24: s10, x25: u10) -> (bool, bool, bool, bool) {
 }
 fn x31(x32: bool, x33: x1[1], x34: (bool, bool, bool, bool)) -> (x37[W32_V10], x1[1], x1[1], x1[1]) {
     {
-        let x35: x1[1] = slice(x33, x32, x1[1]:[x33[u32:0x0], ...]);
+        let x35: x1[1] = array_slice(x33, x32, x1[1]:[x33[u32:0x0], ...]);
         let x38: x37[W32_V10] = match x34 {
             (bool:true, bool:0b1, bool:false, bool:false) | (bool:false, _, bool:0x1, bool:true) => [[s40:0x55_5555_5555, s40:0x7f_ffff_ffff, s40:0x0, s40:0x3a_9e43_35de, s40:0xaa_aaaa_aaaa, s40:0x0, s40:0x7f_ffff_ffff], [s40:0xaa_aaaa_aaaa, s40:0xae_353d_212c, s40:0x55_5555_5555, s40:0x8, s40:0x0, s40:0xff_ffff_ffff, s40:0x0], [s40:0xff_ffff_ffff, s40:0x7f_ffff_ffff, s40:0xaa_aaaa_aaaa, s40:0x4000_0000, s40:0x7f_ffff_ffff, s40:0xff_ffff_ffff, s40:68719476736], [s40:0xaa_aaaa_aaaa, s40:0x2_0000, s40:0xff_ffff_ffff, s40:0x7f_ffff_ffff, s40:0x7f_ffff_ffff, s40:0x800, s40:0xaa_aaaa_aaaa], [s40:0xaa_aaaa_aaaa, s40:0x8, s40:0x0, s40:0x8_0000, s40:0x0, s40:0x55_5555_5555, s40:0xff_ffff_ffff], [s40:0x4000, s40:0x800, s40:0xff_ffff_ffff, s40:0x0, s40:0xff_ffff_ffff, s40:0xff_ffff_ffff, s40:0x73_bfe3_6b51], [s40:0x0, s40:0x4, s40:0x0, s40:0x7f_ffff_ffff, s40:0x7f_ffff_ffff, s40:0xff_ffff_ffff, s40:0x0], [s40:0x55_5555_5555, s40:0x55_5555_5555, s40:0x200, s40:0b1_0100_1110_0001_0001_1110_1000_1001_0011_1011, s40:0x7f_ffff_ffff, s40:0x0, s40:0x0], [s40:0x55_5555_5555, s40:0x55_5555_5555, s40:0x7f_ffff_ffff, s40:0x8000_0000, s40:0xaa_aaaa_aaaa, s40:0x7f_ffff_ffff, s40:0x55_5555_5555], [s40:0xbc_283a_7f3a, s40:0xaa_aaaa_aaaa, s40:0xbd_fb0f_830d, s40:0xaa_aaaa_aaaa, s40:0x10_0000_0000, s40:0x55_5555_5555, s40:0x76_5a51_e40f]],
             _ => [[s40:0xff_ffff_ffff, s40:0x55_5555_5555, s40:0xff_ffff_ffff, s40:0x77_60c8_4f0d, s40:0xff_ffff_ffff, s40:0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111, s40:0b101_0101_0101_0101_0101_0101_0101_0101_0101_0101], [s40:0xaa_aaaa_aaaa, s40:-238053065452, s40:0x40_0000_0000, s40:0x2_0000, s40:0x55_5555_5555, s40:0xaa_aaaa_aaaa, s40:0x8_0000_0000], [s40:0xaa_aaaa_aaaa, s40:0x5_f218_541d, s40:0xaa_aaaa_aaaa, s40:0x1_0000, s40:0xff_ffff_ffff, s40:0x7f_ffff_ffff, s40:0x40], [s40:0x7f_ffff_ffff, s40:0, s40:0x13_5007_6e33, s40:0xaa_aaaa_aaaa, s40:0x0, s40:0x1000, s40:0xaa_aaaa_aaaa], [s40:0x55_5555_5555, s40:0x10, s40:0x55_5555_5555, s40:0xaa_aaaa_aaaa, s40:0x55_5555_5555, s40:0x7f_ffff_ffff, s40:0x10], [s40:0xff_ffff_ffff, s40:8589934592, s40:0x8_0000, s40:0x5dd5_0eea, s40:0xff_ffff_ffff, s40:0x3b_d3b0_4cda, s40:0b101_0101_0101_0101_0101_0101_0101_0101_0101_0101], [s40:0x55_5555_5555, s40:0x55_5555_5555, s40:0xff_ffff_ffff, s40:0x91_b13d_15d5, s40:0x0, s40:-1, s40:0x7f_ffff_ffff], [s40:0x55_5555_5555, s40:0x23_ab81_e3af, s40:0, s40:0xff_ffff_ffff, s40:0x7f_ffff_ffff, s40:0xff_ffff_ffff, s40:0xff_ffff_ffff], [s40:0x0, s40:0x9_edd3_1f4d, s40:0xaa_aaaa_aaaa, s40:0x80, s40:-1, s40:0x55_5555_5555, s40:0xff_ffff_ffff], [s40:0xff_ffff_ffff, s40:0x10_0000_0000, s40:0x800, s40:0x55_5555_5555, s40:0xff_ffff_ffff, s40:0xff_ffff_ffff, s40:0x55_5555_5555]],
@@ -215,7 +215,7 @@ proc main {
     next(x0: u58) {
         {
             let x2: x1[1] = [x0];
-            let x3: x1[1] = slice(x2, x0, x1[1]:[x2[u32:0x0], ...]);
+            let x3: x1[1] = array_slice(x2, x0, x1[1]:[x2[u32:0x0], ...]);
             let x4: s10 = s10:0x2aa;
             let x5: u58 = !x0;
             let x7: (token, u14) = recv(join(), x6);

--- a/xls/fuzzer/crashers/crasher_2024-09-20_67c5.x
+++ b/xls/fuzzer/crashers/crasher_2024-09-20_67c5.x
@@ -210,7 +210,7 @@ fn main(x1: u11, x2: x0[7], x3: (u35, u56, u35), x4: u51) -> (bool, u4, bool, x1
         let x10: x9[3] = x4 as x9[3];
         let x11: bool = x7 >> if x7 >= bool:false { bool:false } else { x7 };
         let x12: x0 = x2[x7];
-        let x13: x9[18] = slice(x10, x4, x9[18]:[x10[u32:0x0], ...]);
+        let x13: x9[18] = array_slice(x10, x4, x9[18]:[x10[u32:0x0], ...]);
         let x14: bool = x11 - x4 as bool;
         let x15: bool = x6.0;
         let x17: x16[3] = [x4, x5, x4];


### PR DESCRIPTION
Fixes #1688

Also fix a `unsigned_sizeof` straggler in the docs I saw along the way.