### PR TITLE
[VAST] `ExternPackageType` & tighten space invariants.

### DIFF
--- a/xls/codegen/vast/vast.cc
+++ b/xls/codegen/vast/vast.cc
@@ -102,6 +102,21 @@ std::string EmitNothing(const VastNode* node, LineInfo* line_info) {
   return "";
 }
 
+// Helper for validating that there is not leading/trailing whitespace that can
+// be stripped from string view `s` -- this helps us maintain our invariants
+// that our Emit() calls generally do not return things with leading or
+// trailing whitespace, so callers uniformly know what to expect in terms of
+// spacing.
+//
+// This routine is made without performing string copies or performing a strcmp
+// so should be usable in CHECKs instead of resorting to DCHECKs everywhere.
+//
+// i.e. callers are expected to call `CHECK(CannotStripWhitespace(s));`
+bool CannotStripWhitespace(std::string_view s) {
+  std::string_view stripped = absl::StripAsciiWhitespace(s);
+  return stripped.size() == s.size();
+}
+
 }  // namespace
 
 int Precedence(OperatorKind kind) {
@@ -301,6 +316,16 @@ std::string ToString(Direction direction) {
   }
 }
 
+std::string DataType::EmitWithIdentifier(LineInfo* line_info,
+                                         std::string_view identifier) const {
+  std::string base = Emit(line_info);
+  if (base.empty()) {
+    return std::string{identifier};
+  }
+  CHECK(CannotStripWhitespace(base));
+  return absl::StrCat(base, " ", identifier);
+}
+
 std::string ScalarType::Emit(LineInfo* line_info) const {
   // The `DataKind` preceding the type is enough.
   if (!is_signed_) {
@@ -308,7 +333,7 @@ std::string ScalarType::Emit(LineInfo* line_info) const {
   }
   LineInfoStart(line_info, this);
   LineInfoEnd(line_info, this);
-  return " signed";
+  return "signed";
 }
 
 std::string IntegerType::Emit(LineInfo* line_info) const {
@@ -319,7 +344,7 @@ std::string IntegerType::Emit(LineInfo* line_info) const {
   }
   LineInfoStart(line_info, this);
   LineInfoEnd(line_info, this);
-  return " unsigned";
+  return "unsigned";
 }
 
 std::string MacroRef::Emit(LineInfo* line_info) const {
@@ -500,17 +525,21 @@ LogicRef* VerilogFunction::return_value_ref() {
 
 std::string VerilogFunction::Emit(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
+
+  // Construct the return type for the function, sometimes we want to put
+  // "logic" in front when in SV mode.
   std::string return_type =
       return_value_def_->data_type()->EmitWithIdentifier(line_info, name());
-  if (!absl::StartsWith(return_type, " ")) {
-    return_type = absl::StrCat(" ", return_type);
-  }
   if (return_value_def_->data_type()->IsScalar() &&
       file()->use_system_verilog()) {
     // Preface the return type with "logic", so there's always a type provided.
     return_type =
-        absl::StrCat(" ", DataKindToString(DataKind::kLogic), return_type);
+        absl::StrCat(DataKindToString(DataKind::kLogic), " ", return_type);
   }
+  if (!return_type.empty()) {
+    return_type = absl::StrCat(" ", return_type);
+  }
+
   std::string parameters =
       absl::StrJoin(argument_defs_, ", ", [=](std::string* out, Def* d) {
         absl::StrAppend(out, "input ", d->EmitNoSemi(line_info));
@@ -757,10 +786,11 @@ absl::StatusOr<int64_t> BitVectorType::FlatBitCountAsInt64() const {
 
 std::string BitVectorType::Emit(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
-  std::string result =
-      absl::StrFormat("%s [%s:0]", is_signed_ ? " signed" : "",
-                      size_expr_is_max_ ? size_expr_->Emit(line_info)
-                                        : WidthToLimit(line_info, size_expr_));
+  std::string result = is_signed_ ? "signed " : "";
+  absl::StrAppendFormat(&result, "[%s:0]",
+                        size_expr_is_max_
+                            ? size_expr_->Emit(line_info)
+                            : WidthToLimit(line_info, size_expr_));
   LineInfoEnd(line_info, this);
   return result;
 }
@@ -891,8 +921,20 @@ std::string Def::Emit(LineInfo* line_info) const {
 std::string Def::EmitNoSemi(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
   std::string kind_str = DataKindToString(data_kind());
-  std::string result = absl::StrCat(
-      kind_str, data_type()->EmitWithIdentifier(line_info, GetName()));
+  std::string data_type_str =
+      data_type()->EmitWithIdentifier(line_info, GetName());
+
+  CHECK(CannotStripWhitespace(kind_str));
+  CHECK(CannotStripWhitespace(data_type_str));
+
+  std::string result;
+  if (kind_str.empty()) {
+    result = data_type_str;
+  } else if (data_type_str.empty()) {
+    result = kind_str;
+  } else {
+    result = absl::StrCat(kind_str, " ", data_type_str);
+  }
   LineInfoEnd(line_info, this);
   return result;
 }
@@ -1106,8 +1148,10 @@ std::string Module::Emit(LineInfo* line_info) const {
     absl::StrAppend(
         &result,
         absl::StrJoin(ports_, ",\n  ", [=](std::string* out, const Port& port) {
+          std::string wire_str = port.wire->EmitNoSemi(line_info);
+          CHECK(CannotStripWhitespace(wire_str));
           absl::StrAppendFormat(out, "%s %s", ToString(port.direction),
-                                port.wire->EmitNoSemi(line_info));
+                                wire_str);
           LineInfoIncrease(line_info, 1);
         }));
     absl::StrAppend(&result, "\n);\n");
@@ -1302,7 +1346,14 @@ std::string TypedefType::Emit(LineInfo* line_info) const {
 
 std::string ExternType::Emit(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
-  std::string result = absl::StrCat(" ", name_);
+  std::string result = name_;
+  LineInfoEnd(line_info, this);
+  return result;
+}
+
+std::string ExternPackageType::Emit(LineInfo* line_info) const {
+  LineInfoStart(line_info, this);
+  std::string result = absl::StrCat(package_name_, "::", type_name_);
   LineInfoEnd(line_info, this);
   return result;
 }
@@ -1311,8 +1362,13 @@ std::string Enum::Emit(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
   std::string result = "enum {\n";
   if (kind_ != DataKind::kUntypedEnum) {
-    result = absl::StrFormat("enum %s%s {\n", DataKindToString(kind_),
-                             BaseType()->Emit(line_info));
+    std::string underlying_type_string = DataKindToString(kind_);
+    if (!underlying_type_string.empty()) {
+      absl::StrAppend(&underlying_type_string, " ");
+    }
+    absl::StrAppend(&underlying_type_string, BaseType()->Emit(line_info));
+
+    result = absl::StrFormat("enum %s {\n", underlying_type_string);
   }
   LineInfoIncrease(line_info, 1);
   for (int i = 0; i < members_.size(); i++) {

--- a/xls/codegen/vast/vast_test.cc
+++ b/xls/codegen/vast/vast_test.cc
@@ -80,6 +80,40 @@ TEST_P(VastTest, EmitBitVectorLogicDef) {
   EXPECT_EQ(logic_def->Emit(&line_info), "logic [41:0] foo;");
 }
 
+// Tests we can build and emit a construct of the following form:
+// ```
+// typedef enum integer {
+//   kElem0 = 0,
+//   kElem1 = 1,
+//   kElem2 = 2,
+//   kElem3 = 3,
+// } enum_t;
+// ```
+TEST_P(VastTest, EmitTypedefOfEnumWithUnderlyingInteger) {
+  VerilogFile f(GetFileType());
+  const SourceInfo si;
+  DataType* data_type = f.IntegerType(si);
+  Enum* enum_def = f.Make<Enum>(si, DataKind::kInteger, data_type);
+  EnumMemberRef* elem0 =
+      enum_def->AddMember("kElem0", f.PlainLiteral(0, si), si);
+  EnumMemberRef* elem1 =
+      enum_def->AddMember("kElem1", f.PlainLiteral(1, si), si);
+  EnumMemberRef* elem2 =
+      enum_def->AddMember("kElem2", f.PlainLiteral(2, si), si);
+  EnumMemberRef* elem3 =
+      enum_def->AddMember("kElem3", f.PlainLiteral(3, si), si);
+  Typedef* enum_typedef =
+      f.Make<Typedef>(si, f.Make<Def>(si, "enum_t", DataKind::kUser, enum_def));
+  LineInfo line_info;
+  EXPECT_EQ(enum_typedef->Emit(&line_info),
+            R"(typedef enum integer {
+  kElem0 = 0,
+  kElem1 = 1,
+  kElem2 = 2,
+  kElem3 = 3
+} enum_t;)");
+}
+
 TEST_P(VastTest, DataTypes) {
   VerilogFile f(GetFileType());
 


### PR DESCRIPTION
Adds an `ExternPackageType` to refer to types defined in other packages (that we do not know the underlying bit width for or have a definition to refer to in the current `VerilogFile`).

In the process found it was hard to reason about the invariants of `Emit()` giving back associated spaces for types and `EmitWithIdentifier()` and similar -- reworked that so all Emit functionality gives back a value with no whitespace to strip so the caller knows what to expect. Previously it was confusing/confused because DataKind could be empty string and DataType could also be empty string in various cases. Case in point this fixed an error in the test where there were two spaces after the `output` keyword.

Also adds a bunch of tests for constructs we're about to use in stitching just to ensure they were all possible.