### PR TITLE
[cleanup] Get rid of need for external/ on z3 library includes

### DIFF
--- a/dependency_support/z3/bundled.BUILD.bazel
+++ b/dependency_support/z3/bundled.BUILD.bazel
@@ -56,6 +56,7 @@ common_linkopts = [
 
 cc_library(
     name = "z3lib",
+    include_prefix = "z3",
     srcs = GEN_SRCS + glob([
         "src/ackermannization/*.cpp",
         "src/api/*.cpp",
@@ -283,6 +284,7 @@ cc_library(
 
 cc_library(
     name = "api",
+    include_prefix = "z3",
     hdrs = glob(
         [
             "src/api/z3*.h",
@@ -404,6 +406,7 @@ cc_binary(
 
 cc_library(
     name = "z3main",
+    include_prefix = "z3",
     srcs = glob(
         [
             "src/shell/*.cpp",

--- a/xls/contrib/xlscc/translator.h
+++ b/xls/contrib/xlscc/translator.h
@@ -68,7 +68,7 @@
 #include "xls/ir/type.h"
 #include "xls/ir/value.h"
 #include "xls/solvers/z3_ir_translator.h"
-#include "external/z3/src/api/z3_api.h"
+#include "z3/src/api/z3_api.h"
 
 namespace xlscc {
 

--- a/xls/data_structures/graph_coloring.h
+++ b/xls/data_structures/graph_coloring.h
@@ -29,7 +29,7 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/check.h"
 #include "absl/strings/str_format.h"
-#include "external/z3/src/api/c++/z3++.h"
+#include "z3/src/api/c++/z3++.h"
 
 namespace xls {
 

--- a/xls/dslx/frontend/BUILD
+++ b/xls/dslx/frontend/BUILD
@@ -438,8 +438,6 @@ cc_library(
         ":ast_node",
         ":module",
         ":proc",
-        "//xls/ir:foreign_function_data_cc_proto",
-        "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
     ],
 )

--- a/xls/dslx/type_system_v2/BUILD
+++ b/xls/dslx/type_system_v2/BUILD
@@ -46,7 +46,6 @@ cc_library(
     deps = [
         ":inference_table",
         "//xls/common/status:status_macros",
-        "//xls/dslx:errors",
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:module",
         "//xls/dslx/frontend:pos",

--- a/xls/solvers/z3_ir_translator.h
+++ b/xls/solvers/z3_ir_translator.h
@@ -42,8 +42,8 @@
 #include "xls/ir/nodes.h"
 #include "xls/ir/type.h"
 #include "xls/ir/value.h"
-#include "external/z3/src/api/z3.h"  // IWYU pragma: keep
-#include "external/z3/src/api/z3_api.h"
+#include "z3/src/api/z3.h"  // IWYU pragma: keep
+#include "z3/src/api/z3_api.h"
 
 namespace xls {
 namespace solvers {


### PR DESCRIPTION
Towards #1736

For verible we can probably patch the cc_library targets we depend on to add the include_prefix attribute similarly.