### PR TITLE
Log to stderr to match expected output shown in the "Hello, XLS!" tutorial

### DIFF
--- a/docs_src/tutorials/hello_xls.md
+++ b/docs_src/tutorials/hello_xls.md
@@ -107,7 +107,7 @@ up! Open a terminal and execute the following in the XLS checkout root
 directory:
 
 ```
-$ ./bazel-bin/xls/dslx/interpreter_main hello_xls.x
+$ ./bazel-bin/xls/dslx/interpreter_main --logtostderr hello_xls.x
 ```
 
 You should see the following output:

--- a/docs_src/tutorials/hello_xls.md
+++ b/docs_src/tutorials/hello_xls.md
@@ -114,7 +114,7 @@ You should see the following output:
 
 ```
 [ RUN UNITTEST  ] hello_test
-trace of hello_string @ hello.x:4:17-4:31: [72, 101, 108, 108, 111, 44, 32, 88, 76, 83, 33]
+... trace of hello_string: [72, 101, 108, 108, 111, 44, 32, 88, 76, 83, 33]
 [            OK ]
 [===============] 1 test(s) ran; 0 failed; 0 skipped.
 ```

--- a/docs_src/tutorials/hello_xls.md
+++ b/docs_src/tutorials/hello_xls.md
@@ -107,7 +107,7 @@ up! Open a terminal and execute the following in the XLS checkout root
 directory:
 
 ```
-$ ./bazel-bin/xls/dslx/interpreter_main --logtostderr hello_xls.x
+$ ./bazel-bin/xls/dslx/interpreter_main --alsologtostderr hello_xls.x
 ```
 
 You should see the following output:


### PR DESCRIPTION
When following the "Hello, XLS!" tutorial, I didn't see the expected output from running the hello_xls.x test. It looks like we need --logtostderr (or --alsologtostderr) for the output to match what is shown in the tutorial.