### PR TITLE
[codegen] Support genvars & generate loop, use in simple array updates.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,6 +36,10 @@ jobs:
         run: |
           bazel build -c opt --noshow_progress --test_output=errors -- //xls/dslx:interpreter_main //xls/dslx/ir_convert:ir_converter_main //xls/tools:opt_main //xls/tools:codegen_main
 
-      - name: Bazel Test All (opt)
+      - name: Bazel Test xls/... (opt)
+        run: |
+          bazel test -c opt --noshow_progress --test_output=errors -- //xls/... -//xls/contrib/... -//xls/dev_tools/...
+
+      - name: Bazel Test Including Contrib & DevTools (opt)
         run: |
           bazel test -c opt --noshow_progress --test_output=errors -- //...

--- a/xls/codegen/module_builder.h
+++ b/xls/codegen/module_builder.h
@@ -297,6 +297,15 @@ class ModuleBuilder {
                                       absl::Span<const IndexType> indices,
                                       IndexMatch index_match, Type* xls_type);
 
+  // Emits a copy-and-update of an array using a generate loop, which avoids
+  // unnecessary bloat in the output code size.
+  absl::Status EmitArrayCopyAndUpdateViaGenerate1D(std::string_view op_name,
+                                                   IndexableExpression* lhs,
+                                                   IndexableExpression* rhs,
+                                                   Expression* update_value,
+                                                   IndexType index_type,
+                                                   Type* xls_type);
+
   // Assigns the arbitrarily-typed Value 'value' to 'lhs'. Depending upon the
   // type this may require multiple assignment statements. The function
   // add_assignment should add a single assignment statement.

--- a/xls/codegen/testdata/combinational_generator_test_ArrayUpdateLiteralIndex.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_ArrayUpdateLiteralIndex.vtxt
@@ -8,8 +8,11 @@ module ArrayUpdateLiteralIndex(
   assign a_unflattened[1] = a[15:8];
   assign a_unflattened[2] = a[23:16];
   wire [7:0] array_update_8[0:2];
-  assign array_update_8[0] = a_unflattened[0];
-  assign array_update_8[1] = value;
-  assign array_update_8[2] = a_unflattened[2];
   assign out = {array_update_8[2], array_update_8[1], array_update_8[0]};
+  genvar array_update_8__index;
+  generate
+    for (array_update_8__index = 0; array_update_8__index < 3; array_update_8__index = array_update_8__index + 1) begin : array_update_8__gen
+      assign array_update_8[array_update_8__index] = 16'h0001 == array_update_8__index ? value : a_unflattened[array_update_8__index];
+    end
+  endgenerate
 endmodule

--- a/xls/codegen/testdata/combinational_generator_test_ArrayUpdateVariableIndex.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_ArrayUpdateVariableIndex.vtxt
@@ -9,8 +9,11 @@ module ArrayUpdateVariableIndex(
   assign a_unflattened[1] = a[15:8];
   assign a_unflattened[2] = a[23:16];
   wire [7:0] array_update_8[0:2];
-  assign array_update_8[0] = idx == 32'h0000_0000 ? value : a_unflattened[0];
-  assign array_update_8[1] = idx == 32'h0000_0001 ? value : a_unflattened[1];
-  assign array_update_8[2] = idx == 32'h0000_0002 ? value : a_unflattened[2];
   assign out = {array_update_8[2], array_update_8[1], array_update_8[0]};
+  genvar array_update_8__index;
+  generate
+    for (array_update_8__index = 0; array_update_8__index < 3; array_update_8__index = array_update_8__index + 1) begin : array_update_8__gen
+      assign array_update_8[array_update_8__index] = idx == array_update_8__index ? value : a_unflattened[array_update_8__index];
+    end
+  endgenerate
 endmodule

--- a/xls/codegen/testdata/combinational_generator_test_ArrayUpdateWithNarrowIndex.vtxt
+++ b/xls/codegen/testdata/combinational_generator_test_ArrayUpdateWithNarrowIndex.vtxt
@@ -16,15 +16,11 @@ module ArrayUpdateWithNarrowIndex(
   assign a_unflattened[8] = a[287:256];
   assign a_unflattened[9] = a[319:288];
   wire [31:0] array_update_8[0:9];
-  assign array_update_8[0] = idx == 2'h0 ? v : a_unflattened[0];
-  assign array_update_8[1] = idx == 2'h1 ? v : a_unflattened[1];
-  assign array_update_8[2] = idx == 2'h2 ? v : a_unflattened[2];
-  assign array_update_8[3] = idx == 2'h3 ? v : a_unflattened[3];
-  assign array_update_8[4] = a_unflattened[4];
-  assign array_update_8[5] = a_unflattened[5];
-  assign array_update_8[6] = a_unflattened[6];
-  assign array_update_8[7] = a_unflattened[7];
-  assign array_update_8[8] = a_unflattened[8];
-  assign array_update_8[9] = a_unflattened[9];
   assign out = {array_update_8[9], array_update_8[8], array_update_8[7], array_update_8[6], array_update_8[5], array_update_8[4], array_update_8[3], array_update_8[2], array_update_8[1], array_update_8[0]};
+  genvar array_update_8__index;
+  generate
+    for (array_update_8__index = 0; array_update_8__index < 10; array_update_8__index = array_update_8__index + 1) begin : array_update_8__gen
+      assign array_update_8[array_update_8__index] = idx == array_update_8__index ? v : a_unflattened[array_update_8__index];
+    end
+  endgenerate
 endmodule

--- a/xls/codegen/testdata/module_builder_test_ArrayUpdate1D.vtxt
+++ b/xls/codegen/testdata/module_builder_test_ArrayUpdate1D.vtxt
@@ -1,0 +1,18 @@
+module ArrayUpdate1D(
+  input wire [127:0] array,
+  input wire [1:0] index,
+  input wire [31:0] value
+);
+  wire [31:0] array_unflattened[0:3];
+  assign array_unflattened[0] = array[31:0];
+  assign array_unflattened[1] = array[63:32];
+  assign array_unflattened[2] = array[95:64];
+  assign array_unflattened[3] = array[127:96];
+  wire [31:0] updated_array[0:3];
+  genvar array_update_4__index;
+  generate
+    for (array_update_4__index = 0; array_update_4__index < 4; array_update_4__index = array_update_4__index + 1) begin : array_update_4__gen
+      assign updated_array[array_update_4__index] = value == array_update_4__index ? index : array_unflattened[array_update_4__index];
+    end
+  endgenerate
+endmodule


### PR DESCRIPTION
Previously we would create a lot of Verilog output spew (even for simple cases), which can choke downstream tools that are not accustomed to generated files.

This PR sets its sights a bit low and only handles a simple case (1D array of bits typed objects) to keep things a bit more manageable for review. We can extend this technique to nested generate loops in the future from this basis.

VAST note: generate loops are interesting in that they are not statement blocks in a sense, they are “AST construct yielding”, i.e. they yield AST constructs at elaboration time that are appropriate for the enclosing scope. Which is to say, it could be creating ModuleMembers even though the generate loop’s body block is seemingly “within” the direct module scope. As a result, we have the body for a generate loop be a sequence of VastNodes to avoid artificially limiting what can be placed inside of them; i.e. a StatementBlock is not usable in this context.