### PR TITLE
[DSLX:cleanup] Remove ConstantArray node from AST, it is misleading / not useful.

### DIFF
--- a/xls/dslx/bytecode/bytecode_emitter.cc
+++ b/xls/dslx/bytecode/bytecode_emitter.cc
@@ -881,10 +881,6 @@ absl::Status BytecodeEmitter::HandleConstAssert(const ConstAssert* node) {
   return absl::OkStatus();
 }
 
-absl::Status BytecodeEmitter::HandleConstantArray(const ConstantArray* node) {
-  return HandleArray(node);
-}
-
 absl::Status BytecodeEmitter::HandleConstRef(const ConstRef* node) {
   return HandleNameRef(node);
 }

--- a/xls/dslx/bytecode/bytecode_emitter.h
+++ b/xls/dslx/bytecode/bytecode_emitter.h
@@ -91,7 +91,6 @@ class BytecodeEmitter : public ExprVisitor {
   absl::Status HandleColonRef(const ColonRef* node) override;
   absl::StatusOr<InterpValue> HandleColonRefInternal(const ColonRef* node);
   absl::Status HandleConstAssert(const ConstAssert* node) override;
-  absl::Status HandleConstantArray(const ConstantArray* node) override;
   absl::Status HandleConstRef(const ConstRef* node) override;
   absl::Status HandleFor(const For* node) override;
   absl::Status HandleFormatMacro(const FormatMacro* node) override;

--- a/xls/dslx/constexpr_evaluator.cc
+++ b/xls/dslx/constexpr_evaluator.cc
@@ -397,11 +397,6 @@ absl::Status ConstexprEvaluator::HandleColonRef(const ColonRef* expr) {
       subject);
 }
 
-absl::Status ConstexprEvaluator::HandleConstantArray(
-    const ConstantArray* expr) {
-  return HandleArray(expr);
-}
-
 absl::Status ConstexprEvaluator::HandleConstAssert(
     const ConstAssert* const_assert) {
   const FileTable& file_table = *const_assert->owner()->file_table();

--- a/xls/dslx/constexpr_evaluator.h
+++ b/xls/dslx/constexpr_evaluator.h
@@ -73,7 +73,6 @@ class ConstexprEvaluator : public xls::dslx::ExprVisitor {
   absl::Status HandleChannelDecl(const ChannelDecl* expr) override;
   absl::Status HandleColonRef(const ColonRef* expr) override;
   absl::Status HandleConstAssert(const ConstAssert* const_assert) override;
-  absl::Status HandleConstantArray(const ConstantArray* expr) override;
   absl::Status HandleConstRef(const ConstRef* expr) override;
   absl::Status HandleFor(const For* expr) override;
   absl::Status HandleFunctionRef(const FunctionRef* expr) override;

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -728,19 +728,6 @@ Array::Array(Module* owner, Span span, std::vector<Expr*> members,
       members_(std::move(members)),
       has_ellipsis_(has_ellipsis) {}
 
-ConstantArray::ConstantArray(Module* owner, Span span,
-                             std::vector<Expr*> members, bool has_ellipsis,
-                             bool in_parens)
-    : Array(owner, std::move(span), std::move(members), has_ellipsis,
-            in_parens) {
-  for (Expr* expr : this->members()) {
-    CHECK(IsConstant(expr))
-        << "non-constant in constant array: " << expr->ToString();
-  }
-}
-
-ConstantArray::~ConstantArray() = default;
-
 // -- class TypeRef
 
 TypeRef::TypeRef(Module* owner, Span span, TypeDefinition type_definition)
@@ -913,7 +900,7 @@ SelfTypeAnnotation::~SelfTypeAnnotation() = default;
 BuiltinNameDef::~BuiltinNameDef() = default;
 
 bool IsConstant(AstNode* node) {
-  if (IsOneOf<ConstantArray, Number, ConstRef, ColonRef>(node)) {
+  if (IsOneOf<Number, ConstRef, ColonRef>(node)) {
     return true;
   }
   if (IsOneOf<NameRef>(node)) {

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -54,7 +54,6 @@
   X(Cast)                          \
   X(ChannelDecl)                   \
   X(ColonRef)                      \
-  X(ConstantArray)                 \
   X(ConstRef)                      \
   X(For)                           \
   X(FormatMacro)                   \
@@ -1116,7 +1115,7 @@ class TypeAlias : public AstNode {
 };
 
 // Represents an array expression; e.g. `[a, b, c]`.
-class Array : public Expr {
+class Array final : public Expr {
  public:
   Array(Module* owner, Span span, std::vector<Expr*> members, bool has_ellipsis,
         bool in_parens = false);
@@ -1166,22 +1165,6 @@ class Array : public Expr {
   TypeAnnotation* type_annotation_ = nullptr;
   std::vector<Expr*> members_;
   bool has_ellipsis_;
-};
-
-// A constant array expression is an array expression where all of the
-// expressions contained within it are constant.
-class ConstantArray : public Array {
- public:
-  // Adds checking for constant-expression-ness of the members beyond
-  // Array::Array.
-  ConstantArray(Module* owner, Span span, std::vector<Expr*> members,
-                bool has_ellipsis, bool in_parens = false);
-
-  ~ConstantArray() override;
-
-  absl::Status Accept(AstNodeVisitor* v) const override {
-    return v->HandleConstantArray(this);
-  }
 };
 
 // Several different AST nodes define types that can be referred to by a
@@ -3406,10 +3389,8 @@ class VerbatimNode : public Expr {
   std::string text_;
 };
 
-// Helper for determining whether an AST node is constant (e.g., can be
-// considered a constant value in a ConstantArray). In general a node
-// with no children is considered constant, but there are some exceptions
-// (e.g., NameRef).
+// Helper for determining whether an AST node is constant (e.g., clearly can be
+// considered a constant value before type checking).
 bool IsConstant(AstNode* n);
 
 }  // namespace xls::dslx

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -241,23 +241,6 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstantArray(const ConstantArray* n) override {
-    XLS_RETURN_IF_ERROR(VisitChildren(n));
-
-    std::vector<Expr*> new_members;
-    for (const Expr* old_member : n->members()) {
-      new_members.push_back(down_cast<Expr*>(old_to_new_.at(old_member)));
-    }
-    ConstantArray* new_array = module_->Make<ConstantArray>(
-        n->span(), new_members, n->has_ellipsis(), n->in_parens());
-    if (n->type_annotation() != nullptr) {
-      new_array->set_type_annotation(
-          down_cast<TypeAnnotation*>(old_to_new_.at(n->type_annotation())));
-    }
-    old_to_new_[n] = new_array;
-    return absl::OkStatus();
-  }
-
   absl::Status HandleConstantDef(const ConstantDef* n) override {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     TypeAnnotation* new_type_annotation = nullptr;

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -655,7 +655,7 @@ fn main() -> foo::BAR {
   EXPECT_EQ(kProgram, clone->ToString());
 }
 
-TEST(AstClonerTest, ConstantArray) {
+TEST(AstClonerTest, IotaArray) {
   constexpr std::string_view kProgram = R"(const ARRAY_SIZE = uN[32]:5;
 fn main() -> u32[ARRAY_SIZE] {
     ([u32:0, u32:1, u32:2, u32:3, u32:4])

--- a/xls/dslx/frontend/ast_test.cc
+++ b/xls/dslx/frontend/ast_test.cc
@@ -319,6 +319,9 @@ TEST(AstTest, IsConstantNumber) {
   EXPECT_TRUE(IsConstant(number));
 }
 
+// Tests the IsConstant predicate on an array with a single `name` reference.
+//
+// Since the name reference is not constant, the array is not constant.
 TEST(AstTest, IsConstantArrayOfNameRefs) {
   FileTable file_table;
   const Span fake_span;
@@ -332,6 +335,8 @@ TEST(AstTest, IsConstantArrayOfNameRefs) {
   EXPECT_FALSE(IsConstant(array));
 }
 
+// Tests the IsConstant predicate on an array with a single `number` literal.
+// Since the number literal is constant, the array is constant.
 TEST(AstTest, IsConstantArrayOfNumbers) {
   FileTable file_table;
   const Span fake_span;
@@ -344,6 +349,8 @@ TEST(AstTest, IsConstantArrayOfNumbers) {
   EXPECT_TRUE(IsConstant(array));
 }
 
+// Tests the IsConstant predicate on an empty array.
+// Since there are no members, the array is constant.
 TEST(AstTest, IsConstantEmptyArray) {
   FileTable file_table;
   const Span fake_span;

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -1217,10 +1217,6 @@ absl::StatusOr<Array*> Parser::ParseArray(Bindings& bindings) {
   }
 
   Span span(start_tok.span().start(), cbrack_pos);
-  if (std::all_of(exprs.begin(), exprs.end(), IsConstant)) {
-    return module_->Make<ConstantArray>(span, std::move(exprs),
-                                        has_trailing_ellipsis);
-  }
   return module_->Make<Array>(span, std::move(exprs), has_trailing_ellipsis);
 }
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -2060,7 +2060,7 @@ TEST_F(ParserTest, TupleArrayAndInt) {
   auto* tuple = dynamic_cast<XlsTuple*>(e);
   EXPECT_EQ(2, tuple->members().size());
   auto* array = tuple->members()[0];
-  EXPECT_NE(dynamic_cast<ConstantArray*>(array), nullptr);
+  EXPECT_NE(dynamic_cast<Array*>(array), nullptr);
 }
 
 TEST_F(ParserTest, Cast) { RoundTripExpr("foo() as u32", {"foo"}); }
@@ -2424,9 +2424,9 @@ fn f(a: MyStruct) -> u32 {
 })");
 }
 
-TEST_F(ParserTest, ConstantArray) {
+TEST_F(ParserTest, ArrayOfConstantNumberLiterals) {
   Expr* e = RoundTripExpr("u32[2]:[0, 1]", {}, false, std::nullopt);
-  ASSERT_TRUE(dynamic_cast<ConstantArray*>(e) != nullptr);
+  ASSERT_TRUE(dynamic_cast<Array*>(e) != nullptr);
 }
 
 TEST_F(ParserTest, MixedArrayIsNotConstantArray) {
@@ -2447,9 +2447,9 @@ const b = u32[2]:[a, a];)");
   ASSERT_TRUE(dynamic_cast<Array*>(array) != nullptr);
 }
 
-TEST_F(ParserTest, EmptyArrayIsConstant) {
+TEST_F(ParserTest, EmptyArray) {
   Expr* e = RoundTripExpr("u32[2]:[]", {}, false, std::nullopt);
-  ASSERT_TRUE(dynamic_cast<ConstantArray*>(e) != nullptr);
+  ASSERT_TRUE(dynamic_cast<Array*>(e) != nullptr);
 }
 
 TEST_F(ParserTest, DoubleNegation) { RoundTripExpr("!!x", {"x"}, false); }

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -236,10 +236,6 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstantArray(const ConstantArray* expr) override {
-    return HandleArray(expr);
-  }
-
   absl::Status HandleFor(const For* expr) override {
     XLS_RETURN_IF_ERROR(expr->init()->AcceptExpr(this));
     XLS_RETURN_IF_ERROR(expr->iterable()->AcceptExpr(this));

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -314,7 +314,6 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   NO_TRAVERSE_DISPATCH_VISIT(Attr)
   NO_TRAVERSE_DISPATCH_VISIT(Array)
   NO_TRAVERSE_DISPATCH_VISIT(StatementBlock)
-  NO_TRAVERSE_DISPATCH_VISIT(ConstantArray)
   NO_TRAVERSE_DISPATCH_VISIT(Cast)
   NO_TRAVERSE_DISPATCH_VISIT(ColonRef)
   NO_TRAVERSE_DISPATCH_VISIT(ConstantDef)
@@ -3697,14 +3696,6 @@ absl::StatusOr<Bits> FunctionConverter::GetConstBits(
     const AstNode* node) const {
   XLS_ASSIGN_OR_RETURN(Value value, GetConstValue(node));
   return value.GetBitsWithStatus();
-}
-
-absl::Status FunctionConverter::HandleConstantArray(const ConstantArray* node) {
-  // Note: previously we would force constant evaluation here, but because all
-  // constexprs should be evaluated during typechecking, we shouldn't need to
-  // forcibly do constant evaluation at IR conversion time; therefore, we just
-  // build BValues and let XLS opt constant fold them.
-  return HandleArray(node);
 }
 
 absl::StatusOr<xls::Type*> FunctionConverter::ResolveTypeToIr(

--- a/xls/dslx/ir_convert/function_converter.h
+++ b/xls/dslx/ir_convert/function_converter.h
@@ -333,7 +333,6 @@ class FunctionConverter {
   absl::Status HandleStatementBlock(const StatementBlock* node);
   absl::Status HandleCast(const Cast* node);
   absl::Status HandleColonRef(const ColonRef* node);
-  absl::Status HandleConstantArray(const ConstantArray* node);
   absl::Status HandleConstantDef(const ConstantDef* node);
   absl::Status HandleFor(const For* node);
   absl::Status HandleFormatMacro(const FormatMacro* node);

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -2030,7 +2030,6 @@ class DeduceVisitor : public AstNodeVisitor {
   DEDUCE_DISPATCH(Attr, DeduceAttr)
   DEDUCE_DISPATCH(StatementBlock, DeduceStatementBlock)
   DEDUCE_DISPATCH(ChannelDecl, DeduceChannelDecl)
-  DEDUCE_DISPATCH(ConstantArray, DeduceConstantArray)
   DEDUCE_DISPATCH(ColonRef, DeduceColonRef)
   DEDUCE_DISPATCH(Index, DeduceIndex)
   DEDUCE_DISPATCH(Match, DeduceMatch)

--- a/xls/dslx/type_system/deduce_expr.h
+++ b/xls/dslx/type_system/deduce_expr.h
@@ -31,9 +31,6 @@ namespace xls::dslx {
 absl::StatusOr<std::unique_ptr<Type>> DeduceArray(const Array* node,
                                                   DeduceCtx* ctx);
 
-absl::StatusOr<std::unique_ptr<Type>> DeduceConstantArray(
-    const ConstantArray* node, DeduceCtx* ctx);
-
 absl::StatusOr<std::unique_ptr<Type>> DeduceNumber(const Number* node,
                                                    DeduceCtx* ctx);
 

--- a/xls/dslx/type_system/deduce_utils.cc
+++ b/xls/dslx/type_system/deduce_utils.cc
@@ -205,6 +205,18 @@ absl::Status TryEnsureFitsInType(const Number& number,
   return absl::OkStatus();
 }
 
+absl::Status TryEnsureFitsInType(const Number& number, const Type& type) {
+  if (std::optional<BitsLikeProperties> bits_like = GetBitsLike(type);
+      bits_like.has_value()) {
+    return TryEnsureFitsInType(number, bits_like.value(), type);
+  }
+  return TypeInferenceErrorStatus(
+      number.span(), &type,
+      absl::StrFormat("Non-bits type (%s) used to define a numeric literal.",
+                      type.GetDebugTypeName()),
+      *number.owner()->file_table());
+}
+
 absl::Status TryEnsureFitsInBitsType(const Number& number,
                                      const BitsType& type) {
   std::optional<BitsLikeProperties> bits_like = GetBitsLike(type);

--- a/xls/dslx/type_system/deduce_utils.h
+++ b/xls/dslx/type_system/deduce_utils.h
@@ -42,10 +42,16 @@ using ColonRefSubjectT =
     std::variant<Module*, EnumDef*, BuiltinNameDef*, ArrayTypeAnnotation*,
                  StructDef*, TypeRefTypeAnnotation*, ColonRef*>;
 
-// If the width is known for "type", checks that "number" fits in that type.
+// Validates that "number" fits in `bits_like` if the size is known. `bits_like`
+// should have been derived from `type` -- this routine uses `type` for error
+// reporting.
 absl::Status TryEnsureFitsInType(const Number& number,
                                  const BitsLikeProperties& bits_like,
                                  const Type& type);
+
+// Validates whether the given `type` is bits-like and, if so, delegates to
+// `TryEnsureFitsInType(number, bits_like, type)`.
+absl::Status TryEnsureFitsInType(const Number& number, const Type& type);
 
 // Shorthand for the above where we know a prori the type is a `BitsType` (note
 // that there are types that are bits-like that are not exactly `BitsType`, see

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -1910,10 +1910,11 @@ TEST(TypecheckTest, OutOfRangeNumberInConstantArray) {
 }
 
 TEST(TypecheckErrorTest, BadTypeForConstantArrayOfNumbers) {
-  EXPECT_THAT(Typecheck("const A = u8[3][4]:[1, 2, 3, 4];"),
-              StatusIs(absl::StatusCode::kInvalidArgument,
-                       HasSubstr("Annotated element type for array cannot be "
-                                 "applied to a literal number")));
+  EXPECT_THAT(
+      Typecheck("const A = u8[3][4]:[1, 2, 3, 4];"),
+      StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          HasSubstr("Non-bits type (array) used to define a numeric literal")));
 }
 
 TEST(TypecheckErrorTest, ConstantArrayEmptyMembersWrongCountVsDecl) {
@@ -2263,14 +2264,14 @@ fn main() -> () {
 }
 
 TEST(TypecheckTest, BadArrayLiteralType) {
-  EXPECT_THAT(Typecheck(R"(
+  EXPECT_THAT(
+      Typecheck(R"(
 fn main() -> s32[2] {
   s32:[1, 2]
 }
 )"),
-              StatusIs(absl::StatusCode::kInvalidArgument,
-                       HasSubstr("Annotated type for array literal must be an "
-                                 "array type; got sbits s32")));
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("Array was not annotated with an array type")));
 }
 
 TEST(TypecheckTest, CharLiteralArray) {

--- a/xls/tools/proto_to_dslx.cc
+++ b/xls/tools/proto_to_dslx.cc
@@ -342,7 +342,7 @@ absl::StatusOr<dslx::Expr*> MakeZeroValuedElement(
     const dslx::FileTable& file_table = *module->file_table();
     XLS_ASSIGN_OR_RETURN(uint64_t real_size,
                          array_size->GetAsUint64(file_table));
-    return module->Make<dslx::ConstantArray>(
+    return module->Make<dslx::Array>(
         span, std::vector<dslx::Expr*>(real_size, member),
         /*has_ellipsis=*/false);
   }
@@ -708,8 +708,7 @@ absl::Status EmitArray(
     }
   }
 
-  auto* array =
-      module->Make<dslx::ConstantArray>(span, *array_elements, has_ellipsis);
+  auto* array = module->Make<dslx::Array>(span, *array_elements, has_ellipsis);
   elements->push_back(std::make_pair(std::string(field_name), array));
 
   auto* u32_type = module->Make<dslx::BuiltinTypeAnnotation>(


### PR DESCRIPTION
Previously `ConstantArray` was trying to convey some type-system-level properties as imbued in an AST node, but it was not fully accurate, and generally only served to confuse things. This gets us back to where the AST just represents the parsed syntax and the typechecker figures out constexpr properties and annotates them in the type information. This also allows us to seal up the Array AST node as final  — subclassing of AST nodes can be awkward, we generally use hierarchy in the AST very sparingly.

This reworks the deduce routine a bit to consolidate on the main discrepancy that was there between Arrays and ConstArrays, which was that we would, for user convenience, annotate the element type on any un-annotated numerical literals contained within the array. This will become better and more general will type inference 2.0 but until that comes we want to make sure we don’t have to change code in a sprawling way.

Just trying to tighten up invariants in advance of somebody investigating google/xls#1748