### PR TITLE
[DSLX] Fix handling of `xN`, e.g. in IR converter.

### DIFF
--- a/xls/dslx/bytecode/BUILD
+++ b/xls/dslx/bytecode/BUILD
@@ -277,6 +277,7 @@ cc_library(
         "//xls/dslx/type_system:parametric_env",
         "//xls/dslx/type_system:type",
         "//xls/dslx/type_system:type_info",
+        "//xls/dslx/type_system:unwrap_meta_type",
         "//xls/ir:big_int",
         "//xls/ir:bits",
         "//xls/ir:bits_ops",

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -597,7 +597,7 @@ absl::Status FunctionConverter::HandleConcat(const Binop* node, BValue lhs,
                                              BValue rhs) {
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> output_type, ResolveType(node));
   std::vector<BValue> pieces = {lhs, rhs};
-  if (dynamic_cast<BitsType*>(output_type.get()) != nullptr) {
+  if (IsBitsLike(*output_type)) {
     Def(node, [&](const SourceInfo& loc) {
       return function_builder_->Concat(pieces, loc);
     });
@@ -888,6 +888,8 @@ absl::Status FunctionConverter::HandleCast(const Cast* node) {
   }
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> input_type,
                        ResolveType(node->expr()));
+
+  // We break out the case where the input type is an array.
   if (dynamic_cast<ArrayType*>(input_type.get()) != nullptr &&
       !IsArrayOfBitsConstructor(*input_type)) {
     return CastFromArray(node, *output_type);
@@ -906,6 +908,8 @@ absl::Status FunctionConverter::HandleCast(const Cast* node) {
       std::get<InterpValue>(input_bit_count_ctd.value()).GetBitValueViaSign());
 
   if (new_bit_count < old_bit_count) {
+    // Truncating conversion -- since the bit count is going down, we just bit
+    // slice.
     auto bvalue_status = DefWithStatus(
         node,
         [this, node,
@@ -916,6 +920,8 @@ absl::Status FunctionConverter::HandleCast(const Cast* node) {
         });
     XLS_RETURN_IF_ERROR(bvalue_status.status());
   } else {
+    // Widening conversion -- since the bit count is going up, we need to sign
+    // or zero extend -- this is done based on the signedness of the input type.
     XLS_ASSIGN_OR_RETURN(bool signed_input, IsSigned(*input_type));
     auto bvalue_status = DefWithStatus(
         node,
@@ -995,8 +1001,8 @@ absl::Status FunctionConverter::HandleBuiltinWideningCast(
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> input_type,
                        ResolveType(node->args()[0]));
 
-  CHECK_NE(dynamic_cast<BitsType*>(input_type.get()), nullptr);
-  CHECK_NE(dynamic_cast<BitsType*>(output_type.get()), nullptr);
+  XLS_RET_CHECK(IsBitsLike(*input_type));
+  XLS_RET_CHECK(IsBitsLike(*output_type));
 
   XLS_ASSIGN_OR_RETURN(bool signed_input, IsSigned(*input_type));
 
@@ -1721,7 +1727,7 @@ absl::Status FunctionConverter::HandleIndex(const Index* node) {
     Def(node, [&](const SourceInfo& loc) {
       return function_builder_->TupleIndex(lhs, index, loc);
     });
-  } else if (dynamic_cast<const BitsType*>(lhs_type.value()) != nullptr) {
+  } else if (IsBitsLike(*lhs_type.value())) {
     IndexRhs rhs = node->rhs();
     if (std::holds_alternative<WidthSlice*>(rhs)) {
       auto* width_slice = std::get<WidthSlice*>(rhs);
@@ -1888,10 +1894,16 @@ absl::Status FunctionConverter::HandleAssertLtBuiltin(const Invocation* node,
   std::optional<Type*> rhs_type = current_type_info_->GetItem(node->args()[1]);
   XLS_RET_CHECK(lhs_type.has_value());
   XLS_RET_CHECK(rhs_type.has_value());
-  auto* lhs_bits_type = dynamic_cast<const BitsType*>(lhs_type.value());
-  bool is_lhs_signed = lhs_bits_type != nullptr && lhs_bits_type->is_signed();
-  auto* rhs_bits_type = dynamic_cast<const BitsType*>(rhs_type.value());
-  bool is_rhs_signed = rhs_bits_type != nullptr && rhs_bits_type->is_signed();
+  std::optional<BitsLikeProperties> lhs_bits_like =
+      GetBitsLike(*lhs_type.value());
+  std::optional<BitsLikeProperties> rhs_bits_like =
+      GetBitsLike(*rhs_type.value());
+  XLS_RET_CHECK(lhs_bits_like.has_value());
+  XLS_RET_CHECK(rhs_bits_like.has_value());
+  XLS_ASSIGN_OR_RETURN(bool is_lhs_signed,
+                       lhs_bits_like->is_signed.GetAsBool());
+  XLS_ASSIGN_OR_RETURN(bool is_rhs_signed,
+                       rhs_bits_like->is_signed.GetAsBool());
   XLS_RET_CHECK_EQ(is_lhs_signed, is_rhs_signed);
   BValue cmp;
   if (is_lhs_signed) {
@@ -2275,18 +2287,19 @@ absl::Status FunctionConverter::HandleRange(const Range* node) {
     return absl::InvalidArgumentError(
         "Range expressions must resolve to array-of-bits type.");
   }
-  auto* element_type =
-      dynamic_cast<const BitsType*>(&array_type->element_type());
-  if (element_type == nullptr) {
+  std::optional<BitsLikeProperties> bits_like =
+      GetBitsLike(array_type->element_type());
+  if (!bits_like.has_value()) {
     return absl::InvalidArgumentError(
         "Range expressions must resolve to array-of-bits type.");
   }
 
+  XLS_ASSIGN_OR_RETURN(bool is_signed, bits_like->is_signed.GetAsBool());
   XLS_ASSIGN_OR_RETURN(RangeData range_data, GetRangeData(node));
   std::vector<Value> elements;
   for (int i = 0; i < range_data.trip_count; i++) {
     Value value =
-        element_type->is_signed()
+        is_signed
             ? Value(SBits(i + range_data.start_value, range_data.bit_width))
             : Value(UBits(i + range_data.start_value, range_data.bit_width));
     elements.push_back(value);
@@ -2984,8 +2997,20 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
   std::optional<const Type*> lhs_type =
       current_type_info_->GetItem(node->lhs());
   XLS_RET_CHECK(lhs_type.has_value());
-  auto* bits_type = dynamic_cast<const BitsType*>(lhs_type.value());
-  bool signed_input = bits_type != nullptr && bits_type->is_signed();
+
+  // Helper lambda that does all the appropriate checking that we're only
+  // querying the signedness of our operand types when it's appropriate to do
+  // so.
+  auto is_signed_bits_like = [&]() -> bool {
+    std::optional<BitsLikeProperties> lhs_bits_like_properties =
+        GetBitsLike(*lhs_type.value());
+    CHECK(lhs_bits_like_properties.has_value());
+    const TypeDim& is_signed = lhs_bits_like_properties->is_signed;
+    absl::StatusOr<bool> result_or = is_signed.GetAsBool();
+    CHECK_OK(result_or.status());
+    return result_or.value();
+  };
+
   XLS_ASSIGN_OR_RETURN(BValue lhs, Use(node->lhs()));
   XLS_ASSIGN_OR_RETURN(BValue rhs, Use(node->rhs()));
   std::function<BValue(const SourceInfo&)> ir_func;
@@ -3014,7 +3039,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kMul:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SMul(lhs, rhs, loc);
         }
         return function_builder_->UMul(lhs, rhs, loc);
@@ -3022,7 +3047,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kDiv:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SDiv(lhs, rhs, loc);
         }
         return function_builder_->UDiv(lhs, rhs, loc);
@@ -3030,7 +3055,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kMod:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SMod(lhs, rhs, loc);
         }
         return function_builder_->UMod(lhs, rhs, loc);
@@ -3039,7 +3064,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
     // Non-equality comparisons.
     case BinopKind::kGe:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SGe(lhs, rhs, loc);
         }
         return function_builder_->UGe(lhs, rhs, loc);
@@ -3047,7 +3072,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kGt:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SGt(lhs, rhs, loc);
         }
         return function_builder_->UGt(lhs, rhs, loc);
@@ -3055,7 +3080,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kLe:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SLe(lhs, rhs, loc);
         }
         return function_builder_->ULe(lhs, rhs, loc);
@@ -3063,7 +3088,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
       break;
     case BinopKind::kLt:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->SLt(lhs, rhs, loc);
         }
         return function_builder_->ULt(lhs, rhs, loc);
@@ -3072,7 +3097,7 @@ absl::Status FunctionConverter::HandleBinop(const Binop* node) {
     // Shifts.
     case BinopKind::kShr:
       ir_func = [&](const SourceInfo& loc) {
-        if (signed_input) {
+        if (is_signed_bits_like()) {
           return function_builder_->Shra(lhs, rhs, loc);
         }
         return function_builder_->Shrl(lhs, rhs, loc);

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -183,6 +183,8 @@ dslx_lang_test(name = "xn_sizeof")
 
 dslx_lang_test(name = "xn_type_equivalence")
 
+dslx_lang_test(name = "xn_signedness_properties")
+
 dslx_lang_test(
     name = "parametric_shift",
     # TODO(leary): 2023-08-14 Runs into "cannot translate zero length bitvector

--- a/xls/dslx/tests/xn_signedness_properties.x
+++ b/xls/dslx/tests/xn_signedness_properties.x
@@ -1,0 +1,32 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn to_xn<S: bool, N: u32>(x: uN[N]) -> xN[S][N] { x as xN[S][N] }
+
+fn increment_signed_xn_works(x: u4) -> bool {
+    let sn = to_xn<true>(x);
+    let one = to_xn<true>(u4:1);
+    let incremented = sn + one;
+    incremented > sn || sn == s4::MAX
+}
+
+fn main() -> bool[3] {
+    [
+        increment_signed_xn_works(u4:0xf), increment_signed_xn_works(u4:0),
+        increment_signed_xn_works(u4:7),
+    ]
+}
+
+#[test]
+fn test_increment_signed_xn_works() { assert_eq(main(), [true, true, true]); }

--- a/xls/dslx/translators/dslx_to_verilog.cc
+++ b/xls/dslx/translators/dslx_to_verilog.cc
@@ -340,9 +340,9 @@ absl::StatusOr<std::pair<std::vector<int64_t>, verilog::DataType*>>
 DslxTypeToVerilogManager::GetArrayDimsAndBaseType(
     const Type* type, const ArrayTypeAnnotation* array_type_annotation) {
   // Check if this "array" is actualy a bits type.
-  if (const auto* bc = dynamic_cast<const BitsType*>(type)) {
-    XLS_ASSIGN_OR_RETURN(TypeDim dim, bc->GetTotalBitCount());
-    XLS_ASSIGN_OR_RETURN(int64_t size, dim.GetAsInt64());
+  if (std::optional<BitsLikeProperties> bits_like = GetBitsLike(*type);
+      bits_like.has_value()) {
+    XLS_ASSIGN_OR_RETURN(int64_t size, bits_like->size.GetAsInt64());
 
     verilog::DataType* base_type = nullptr;
     if (size == 1) {

--- a/xls/dslx/type_system/parametric_bind.cc
+++ b/xls/dslx/type_system/parametric_bind.cc
@@ -181,12 +181,14 @@ absl::Status ParametricBind(const Type& param_type, const Type& arg_type,
                                             nullptr, arg_type, message);
   };
 
+  // Note that we actually need to handle the distinction between
+  // BitsConstructorType and BitsType here, because array of BitsConstructorType
+  // has another dimension to bind (the signedness).
   if (auto* arg = dynamic_cast<const BitsType*>(&arg_type);
       arg != nullptr && IsArrayOfBitsConstructor(param_type)) {
     auto* param = down_cast<const ArrayType*>(&param_type);
     return ParametricBindBitsToConstructor(*param, *arg, ctx);
   }
-
   if (auto* param_bits = dynamic_cast<const BitsType*>(&param_type)) {
     auto* arg_bits = dynamic_cast<const BitsType*>(&arg_type);
     if (arg_bits == nullptr) {
@@ -194,6 +196,7 @@ absl::Status ParametricBind(const Type& param_type, const Type& arg_type,
     }
     return ParametricBindBits(*param_bits, *arg_bits, ctx);
   }
+
   if (auto* param_tuple = dynamic_cast<const TupleType*>(&param_type)) {
     auto* arg_tuple = dynamic_cast<const TupleType*>(&arg_type);
     if (arg_tuple == nullptr) {

--- a/xls/dslx/type_system/parametric_bind_test.cc
+++ b/xls/dslx/type_system/parametric_bind_test.cc
@@ -31,8 +31,10 @@ namespace xls::dslx {
 namespace {
 
 // Tests a simple sample binding like:
+// ```dslx
 //    p<X: u32>(x: uN[X]) -> ()
 //    p(u8:42)
+// ```
 // After that invocation X should be 8.
 TEST(ParametricBindTest, SampleConcreteDimBind) {
   absl::flat_hash_map<std::string, InterpValue> parametric_env;
@@ -92,6 +94,45 @@ TEST(ParametricBindTest, SampleTypeBind) {
   XLS_ASSERT_OK(ParametricBind(*param_type, *arg_type, ctx));
   ASSERT_TRUE(parametric_env.contains("X"));
   EXPECT_EQ(parametric_env.at("X"), InterpValue::MakeU32(8));
+}
+
+// Tests a sample binding of a signed value to an `xN` bits constructor type.
+// ```dslx
+//    p<S: bool, N: u32>(x: xN[S][N]) -> ()
+//    p(s32:42)
+// ```
+// After that invocation S should be true and N should be 32.
+TEST(ParametricBindTest, SampleSignedBitsBindToXn) {
+  absl::flat_hash_map<std::string, InterpValue> parametric_env;
+  const absl::flat_hash_map<std::string, Expr*> parametric_default_exprs = {
+      {"S", nullptr},
+      {"N", nullptr},
+  };
+  absl::flat_hash_map<std::string, std::unique_ptr<Type>>
+      parametric_binding_types;
+  parametric_binding_types.emplace("S", BitsType::MakeU1());
+  parametric_binding_types.emplace("N", BitsType::MakeU32());
+
+  const Span fake_span = Span::Fake();
+  auto arg_type = BitsType::MakeS32();
+  auto param_type = std::make_unique<ArrayType>(
+      /*element_type=*/std::make_unique<BitsConstructorType>(
+          TypeDim(std::make_unique<ParametricSymbol>("S", fake_span))),
+      /*size=*/TypeDim(std::make_unique<ParametricSymbol>("N", fake_span)));
+
+  DeduceCtx deduce_ctx(
+      /*type_info=*/nullptr, /*module=*/nullptr, /*deduce_function=*/nullptr,
+      /*typecheck_function=*/nullptr, /*typecheck_module=*/nullptr,
+      /*typecheck_invocation=*/nullptr, /*import_data=*/nullptr,
+      /*warnings=*/nullptr, /*parent=*/nullptr);
+  ParametricBindContext ctx{fake_span, parametric_binding_types,
+                            parametric_default_exprs, parametric_env,
+                            deduce_ctx};
+  XLS_ASSERT_OK(ParametricBind(*param_type, *arg_type, ctx));
+  ASSERT_TRUE(parametric_env.contains("S"));
+  EXPECT_EQ(parametric_env.at("S"), InterpValue::MakeBool(true));
+  ASSERT_TRUE(parametric_env.contains("N"));
+  EXPECT_EQ(parametric_env.at("N"), InterpValue::MakeU32(32));
 }
 
 }  // namespace

--- a/xls/dslx/type_system/type_test.cc
+++ b/xls/dslx/type_system/type_test.cc
@@ -184,7 +184,7 @@ TEST(TypeTest, TestU32) {
   EXPECT_EQ(false, t.HasEnum());
   EXPECT_EQ(std::vector<TypeDim>{TypeDim::CreateU32(32)}, t.GetAllDims());
   EXPECT_EQ(t, *t.ToUBits());
-  EXPECT_TRUE(IsUBits(t));
+  EXPECT_TRUE(IsBitsLikeWithNBitsAndSignedness(t, false, 32));
   EXPECT_FALSE(t.IsTuple());
 }
 
@@ -196,7 +196,7 @@ TEST(TypeTest, TestUnit) {
   EXPECT_EQ(false, t.HasEnum());
   EXPECT_TRUE(t.GetAllDims().empty());
   EXPECT_TRUE(t.IsTuple());
-  EXPECT_FALSE(IsUBits(t));
+  EXPECT_FALSE(IsBitsLikeWithNBitsAndSignedness(t, false, 0));
 
   Type* generic_type = &t;
   EXPECT_TRUE(generic_type->IsTuple());
@@ -245,7 +245,7 @@ TEST(TypeTest, TestArrayOfU32) {
   std::vector<TypeDim> want_dims = {TypeDim::CreateU32(1),
                                     TypeDim::CreateU32(32)};
   EXPECT_EQ(want_dims, t.GetAllDims());
-  EXPECT_FALSE(IsUBits(t));
+  EXPECT_FALSE(IsBitsLikeWithNBitsAndSignedness(t, false, 32));
 }
 
 TEST(TypeTest, TestEnum) {

--- a/xls/dslx/type_system/type_zero_value.cc
+++ b/xls/dslx/type_system/type_zero_value.cc
@@ -96,9 +96,11 @@ absl::StatusOr<InterpValue> ZeroOfLeafType(const Type& type,
     return InterpValue::MakeEnum(Bits(size), enum_type->is_signed(),
                                  &enum_type->nominal_type());
   }
-  if (const auto* bits_type = dynamic_cast<const BitsType*>(&type)) {
-    XLS_ASSIGN_OR_RETURN(int64_t size, bits_type->size().GetAsInt64());
-    return InterpValue::MakeBits(bits_type->is_signed(), Bits(size));
+  if (std::optional<BitsLikeProperties> bits_like = GetBitsLike(type);
+      bits_like.has_value()) {
+    XLS_ASSIGN_OR_RETURN(bool is_signed, bits_like->is_signed.GetAsBool());
+    XLS_ASSIGN_OR_RETURN(int64_t size, bits_like->size.GetAsInt64());
+    return InterpValue::MakeBits(is_signed, Bits(size));
   }
 
   return absl::InvalidArgumentError(
@@ -123,9 +125,11 @@ absl::StatusOr<InterpValue> AllOnesOfLeafType(const Type& type,
     return InterpValue::MakeEnum(Bits::AllOnes(size), enum_type->is_signed(),
                                  &enum_type->nominal_type());
   }
-  if (const auto* bits_type = dynamic_cast<const BitsType*>(&type)) {
-    XLS_ASSIGN_OR_RETURN(int64_t size, bits_type->size().GetAsInt64());
-    return InterpValue::MakeBits(bits_type->is_signed(), Bits::AllOnes(size));
+  if (std::optional<BitsLikeProperties> bits_like = GetBitsLike(type);
+      bits_like.has_value()) {
+    XLS_ASSIGN_OR_RETURN(bool is_signed, bits_like->is_signed.GetAsBool());
+    XLS_ASSIGN_OR_RETURN(int64_t size, bits_like->size.GetAsInt64());
+    return InterpValue::MakeBits(is_signed, Bits::AllOnes(size));
   }
 
   return absl::InvalidArgumentError(

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -1881,9 +1881,16 @@ TEST(TypecheckTest, Index) {
   EXPECT_THAT(
       Typecheck("fn f(x: u32, i: u8) -> u32 { x[i] }"),
       StatusIs(absl::StatusCode::kInvalidArgument, HasSubstr("not an array")));
+
+  // Use an array as an index.
   EXPECT_THAT(Typecheck("fn f(x: u32[5], i: u8[5]) -> u32 { x[i] }"),
               StatusIs(absl::StatusCode::kInvalidArgument,
-                       HasSubstr("not unsigned-bits type")));
+                       HasSubstr("Index is not bits typed")));
+
+  // Use a signed number as an index.
+  EXPECT_THAT(Typecheck("fn f(x: u32[5], i: s8) -> u32 { x[i] }"),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("Index is not unsigned-bits typed")));
 }
 
 TEST(TypecheckTest, OutOfRangeNumber) {


### PR DESCRIPTION
`xN` was primarily created so we could write polymorphic metaprogramming on
sign like `sizeof` in the standard library. Since `xN` is not fuzzed beyond
that simple use there were opportunities for mishandling it in IR conversion,
and the DSLX language tests I believe don't run `--compare=jit` anymore. We
should figure out how to fix that and add `xN` to the fuzzer, even though it's
a fairly new feature it is now documented, see https://github.com/google/xls/issues/1572.

I noticed that quickchecks on a function with `xN` was giving odd results,
which was because quickchecks *only* work in the JIT, via IR conversion.
Debugged the discrepancy to `dynamic_cast<BitsType*>` and so knocked out nearly
all of the `dynamic_cast<BitsType*>` and `dynamic_cast<const BitsType*>` in the
code base.  We should also make DSLX concrete type visitor use more pervasive
and consolidate on recommended (vs deprecated, with pointer at what's
recommended) routines as we can.

In that vein this change removes `IsUBits` and `IsSBits` -- less identity
testing and more polymorphic-property-testing the better.