### PR TITLE
[DSLX:FE] Progress on `use` construct #352

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2548,6 +2548,12 @@ DocRef Formatter::Format(const Import& n) {
   return ConcatNGroup(arena_, pieces);
 }
 
+DocRef Formatter::Format(const Use& n) {
+  // TODO(cdleary): 2024-12-07 This is just a stopgap, we should add reflow
+  // capability.
+  return arena_.MakeText(n.ToString());
+}
+
 DocRef Formatter::Format(const Let& n, bool trailing_semi) {
   std::vector<DocRef> leader_pieces = {
       arena_.Make(n.is_const() ? Keyword::kConst : Keyword::kLet),
@@ -2655,6 +2661,7 @@ DocRef Formatter::Format(const ModuleMember& n) {
                          [&](const ConstantDef* n) { return Format(*n); },
                          [&](const EnumDef* n) { return Format(*n); },
                          [&](const Import* n) { return Format(*n); },
+                         [&](const Use* n) { return Format(*n); },
                          [&](const ConstAssert* n) {
                            return arena_.MakeConcat(Format(*n), arena_.semi());
                          },

--- a/xls/dslx/fmt/ast_fmt.h
+++ b/xls/dslx/fmt/ast_fmt.h
@@ -59,6 +59,7 @@ class Formatter {
   DocRef Format(const Impl& n);
   DocRef Format(const ImplMember& n);
   DocRef Format(const Import& n);
+  DocRef Format(const Use& n);
   DocRef Format(const ModuleMember& n);
   DocRef Format(const ParametricBinding& n);
   DocRef Format(const ParametricBinding* n);

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -313,6 +313,8 @@ std::string_view AstNodeKindToString(AstNodeKind kind) {
       return "tuple index";
     case AstNodeKind::kUnrollFor:
       return "unroll-for";
+    case AstNodeKind::kUse:
+      return "use";
     case AstNodeKind::kVerbatimNode:
       return "verbatim-node";
   }
@@ -767,6 +769,102 @@ std::string Import::ToString() const {
                            *alias_);
   }
   return absl::StrFormat("import %s;", absl::StrJoin(subject_, "."));
+}
+
+// -- class Use
+
+UseInteriorEntry::UseInteriorEntry(
+    std::string identifier, std::vector<std::unique_ptr<UseTreeEntry>> subtrees)
+    : identifier_(std::move(identifier)), subtrees_(std::move(subtrees)) {
+  CHECK(!subtrees_.empty());
+  for (const auto& subtree : subtrees_) {
+    DCHECK(subtree != nullptr);
+  }
+}
+
+std::vector<NameDef*> UseInteriorEntry::GetLeafNameDefs() const {
+  std::vector<NameDef*> result;
+  for (const auto& subtree : subtrees_) {
+    std::vector<NameDef*> subtree_leaf_name_defs = subtree->GetLeafNameDefs();
+    result.insert(result.end(), subtree_leaf_name_defs.begin(),
+                  subtree_leaf_name_defs.end());
+  }
+  return result;
+}
+
+std::string UseInteriorEntry::ToString() const {
+  std::string subtrees_str;
+  if (subtrees_.size() == 1) {
+    subtrees_str = subtrees_.front()->ToString();
+  } else {
+    subtrees_str =
+        absl::StrCat("{",
+                     absl::StrJoin(subtrees_, ", ",
+                                   [](std::string* out, const auto& subtree) {
+                                     absl::StrAppend(out, subtree->ToString());
+                                   }),
+                     "}");
+  }
+  return absl::StrCat(identifier_, "::", subtrees_str);
+}
+
+/* static */ std::unique_ptr<UseTreeEntry> UseTreeEntry::MakeLeaf(
+    NameDef* name_def, Span span) {
+  return std::make_unique<UseTreeEntry>(UseLeafEntry{name_def}, span);
+}
+
+/* static */ std::unique_ptr<UseTreeEntry> UseTreeEntry::MakeInterior(
+    std::string identifier, std::vector<std::unique_ptr<UseTreeEntry>> subtrees,
+    Span span) {
+  return std::make_unique<UseTreeEntry>(
+      UseInteriorEntry{std::move(identifier), std::move(subtrees)}, span);
+}
+
+std::string UseTreeEntry::ToString() const {
+  return absl::visit(
+      Visitor{
+          [](const UseLeafEntry& leaf) { return leaf.name_def->identifier(); },
+          [](const UseInteriorEntry& interior) { return interior.ToString(); }},
+      entry_);
+}
+
+std::vector<NameDef*> UseTreeEntry::GetLeafNameDefs() const {
+  return absl::visit(Visitor{[](const UseLeafEntry& leaf) {
+                               return std::vector<NameDef*>{leaf.name_def};
+                             },
+                             [](const UseInteriorEntry& interior) {
+                               return interior.GetLeafNameDefs();
+                             }},
+                     entry_);
+}
+
+std::vector<std::string> UseTreeEntry::GetLeafIdentifiers() const {
+  std::vector<NameDef*> leaf_name_defs = GetLeafNameDefs();
+  std::vector<std::string> result;
+  result.reserve(leaf_name_defs.size());
+  for (const NameDef* name_def : leaf_name_defs) {
+    result.push_back(name_def->identifier());
+  }
+  return result;
+}
+
+Use::Use(Module* owner, Span span, std::unique_ptr<UseTreeEntry> root)
+    : AstNode(owner), span_(std::move(span)), root_(std::move(root)) {}
+
+Use::~Use() = default;
+
+std::string Use::ToString() const {
+  return absl::StrCat("use ", root_->ToString(), ";");
+}
+
+std::vector<AstNode*> Use::GetChildren(bool want_types) const {
+  std::vector<NameDef*> name_defs = root_->GetLeafNameDefs();
+  std::vector<AstNode*> results;
+  results.reserve(name_defs.size());
+  for (NameDef* name_def : name_defs) {
+    results.push_back(name_def);
+  }
+  return results;
 }
 
 // -- class ColonRef

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -107,6 +107,7 @@
   X(TestProc)                     \
   X(TypeAlias)                    \
   X(TypeRef)                      \
+  X(Use)                          \
   X(WidthSlice)                   \
   X(WildcardPattern)              \
   /* type annotations */          \
@@ -1302,6 +1303,115 @@ class Import : public AstNode {
   std::vector<std::string> subject_;
   NameDef& name_def_;
   std::optional<std::string> alias_;
+};
+
+// -- Use
+
+class UseTreeEntry;  // forward decl
+
+// Interior node in the `use` construct tree.
+//
+//              v--v identifier
+// e.g. in `use foo::{bar, baz}`
+//                   ^--------^ subtrees
+//
+// For a node to be considered "interior" there must be subtrees.
+class UseInteriorEntry {
+ public:
+  UseInteriorEntry(std::string identifier,
+                   std::vector<std::unique_ptr<UseTreeEntry>> subtrees);
+
+  // Move-only.
+  UseInteriorEntry(UseInteriorEntry&&) = default;
+  UseInteriorEntry& operator=(UseInteriorEntry&&) = default;
+
+  std::vector<NameDef*> GetLeafNameDefs() const;
+
+  absl::Span<const std::unique_ptr<UseTreeEntry>> subtrees() const {
+    return subtrees_;
+  }
+
+  std::string ToString() const;
+
+ private:
+  std::string identifier_;
+  std::vector<std::unique_ptr<UseTreeEntry>> subtrees_;
+};
+
+// Leaf node in the `use` construct tree.
+struct UseLeafEntry {
+  NameDef* name_def;
+};
+
+// Arbitrary entry (interior or leaf) in the `use` construct tree.
+class UseTreeEntry {
+ public:
+  static std::unique_ptr<UseTreeEntry> MakeInterior(
+      std::string identifier,
+      std::vector<std::unique_ptr<UseTreeEntry>> subtrees, Span span);
+  static std::unique_ptr<UseTreeEntry> MakeLeaf(NameDef* name_def, Span span);
+
+  UseTreeEntry(std::variant<UseInteriorEntry, UseLeafEntry> entry, Span span)
+      : entry_(std::move(entry)), span_(std::move(span)) {}
+
+  std::string ToString() const;
+
+  std::vector<std::string> GetLeafIdentifiers() const;
+  std::vector<NameDef*> GetLeafNameDefs() const;
+
+ private:
+  std::variant<UseInteriorEntry, UseLeafEntry> entry_;
+  Span span_;
+};
+
+// Represents a use statement; e.g.
+//  use foo::bar::{baz::{bat, qux}, ipsum};
+//
+// In that case there are 3 leafs that create name definitions for the module:
+// `bat`, `qux`, and `ipsum`.
+//
+// You can also use a module directly instead of an item within it; e.g.
+//  use foo;
+//
+// And then subsequently refer to `foo::STUFF`.
+//
+// Note we DO NOT support multiple use at the "root" level; e.g.
+// ```
+//  use {bar, baz};
+// ```
+// is invalid.
+//
+// Attributes:
+//  span: Span of the overall `use` statement in the text.
+class Use : public AstNode {
+ public:
+  Use(Module* owner, Span span, std::unique_ptr<UseTreeEntry> root);
+
+  ~Use() override;
+
+  AstNodeKind kind() const override { return AstNodeKind::kUse; }
+
+  absl::Status Accept(AstNodeVisitor* v) const override {
+    return v->HandleUse(this);
+  }
+  std::string_view GetNodeTypeName() const override { return "Use"; }
+  std::string ToString() const override;
+  std::optional<Span> GetSpan() const override { return span_; }
+
+  std::vector<AstNode*> GetChildren(bool want_types) const override;
+
+  std::vector<std::string> GetLeafIdentifiers() const {
+    return root_->GetLeafIdentifiers();
+  }
+  std::vector<NameDef*> GetLeafNameDefs() const {
+    return root_->GetLeafNameDefs();
+  }
+
+  const Span& span() const { return span_; }
+
+ private:
+  Span span_;
+  std::unique_ptr<UseTreeEntry> root_;
 };
 
 // Represents a module-value or enum-value style reference when the LHS

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -399,6 +399,10 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
+  absl::Status HandleUse(const Use* n) override {
+    return absl::UnimplementedError("Not implemented: clone use");
+  }
+
   absl::Status HandleIndex(const Index* n) override {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 

--- a/xls/dslx/frontend/ast_node.h
+++ b/xls/dslx/frontend/ast_node.h
@@ -94,6 +94,7 @@ enum class AstNodeKind : uint8_t {
   kTypeRef,
   kUnop,
   kUnrollFor,
+  kUse,
   kVerbatimNode,
   kWidthSlice,
   kWildcardPattern,

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -43,11 +43,16 @@ namespace xls::dslx {
 using ModuleMember =
     std::variant<Function*, Proc*, TestFunction*, TestProc*, QuickCheck*,
                  TypeAlias*, StructDef*, ProcDef*, ConstantDef*, EnumDef*,
-                 Import*, ConstAssert*, Impl*, VerbatimNode*>;
+                 Import*, Use*, ConstAssert*, Impl*, VerbatimNode*>;
 
+// Returns all the NameDefs defined by the given module member.
+//
+// Note that generally there is either zero or one, but for `Use` in particular
+// there may be many.
+//
 // Note: this returns nullptr for constructs that do not define a name, e.g.
 // `ConstAssert`.
-NameDef* ModuleMemberGetNameDef(const ModuleMember& mm);
+std::vector<NameDef*> ModuleMemberGetNameDefs(const ModuleMember& mm);
 
 // Returns the starting position of the given module member.
 //

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -556,8 +556,16 @@ class Parser : public TokenParser {
                                                   bool is_public,
                                                   Bindings& outer_bindings);
 
-  // Parses an import statement into an Import AST node.
+  // Parses an import statement into an `Import` AST node.
   absl::StatusOr<Import*> ParseImport(Bindings& bindings);
+
+  // Parses a single entry in a `use` tree -- this can be a leaf or an interior
+  // entry.
+  absl::StatusOr<std::unique_ptr<UseTreeEntry>> ParseUseTreeEntry(
+      Bindings& bindings);
+
+  // Parses a use statement into a `Use` AST node.
+  absl::StatusOr<Use*> ParseUse(Bindings& bindings);
 
   // Returns TestFunction AST node by parsing new-style unit test construct.
   absl::StatusOr<TestFunction*> ParseTestFunction(Bindings& bindings,

--- a/xls/dslx/frontend/scanner_keywords.inc
+++ b/xls/dslx/frontend/scanner_keywords.inc
@@ -40,6 +40,7 @@
   X(kTrue, TRUE, "true")                   \
   X(kType, TYPE, "type")                   \
   X(kUnrollFor, UNROLL_FOR, "unroll_for!") \
+  X(kUse, USE, "use")                      \
   /* builtin types */                      \
   X(kBits, BITS, "bits")                   \
   X(kToken, TOKEN, "token")                \

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -825,6 +825,7 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrder(Module* module,
             [](Impl*) { return absl::OkStatus(); },
             [](EnumDef*) { return absl::OkStatus(); },
             [](Import*) { return absl::OkStatus(); },
+            [](Use*) { return absl::OkStatus(); },
             [](ConstAssert*) { return absl::OkStatus(); },
             [](VerbatimNode*) {
               return absl::UnimplementedError(

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -372,6 +372,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   INVALID(Function)
   INVALID(Impl)
   INVALID(Import)
+  INVALID(Use)
   INVALID(Module)
   INVALID(Proc)
   INVALID(ProcMember)

--- a/xls/dslx/lsp/document_symbols.cc
+++ b/xls/dslx/lsp/document_symbols.cc
@@ -114,6 +114,10 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },
+                        [](Use*) {
+                          // TODO(google/xls#1080): Complete the set of symbols.
+                          return std::vector<verible::lsp::DocumentSymbol>{};
+                        },
                         [](ConstAssert*) {
                           // Note: no symbols are bound by a const assert.
                           return std::vector<verible::lsp::DocumentSymbol>{};

--- a/xls/dslx/stdlib/tests/float32_test.cc
+++ b/xls/dslx/stdlib/tests/float32_test.cc
@@ -47,9 +47,10 @@ TEST(Float32Test, ToInt32) {
   for (uint64_t i = 0; i < num_iters; i++) {
     float input = absl::bit_cast<float>(static_cast<uint32_t>(i));
     if (!exhaustive) {
-      input = absl::Uniform<float>(absl::IntervalClosedClosed, bitgen,
-                                   std::numeric_limits<int32_t>::min(),
-                                   std::numeric_limits<int32_t>::max());
+      input = absl::Uniform<float>(
+          absl::IntervalClosedClosed, bitgen,
+          static_cast<float>(std::numeric_limits<int32_t>::min()),
+          static_cast<float>(std::numeric_limits<int32_t>::max()));
     }
 
     // Frustratingly, float-to-int casts are undefined behavior if the source
@@ -57,9 +58,9 @@ TEST(Float32Test, ToInt32) {
     // knobs to tell UBSan to ignore this, we just have to limit our test range.
     // We need >= and <= to handle precision loss when converting max\min into
     // float.
-    if (input >= std::numeric_limits<int32_t>::max() ||
-        input <= std::numeric_limits<int32_t>::min() || std::isnan(input) ||
-        std::isinf(input)) {
+    if (input >= static_cast<float>(std::numeric_limits<int32_t>::max()) ||
+        input <= static_cast<float>(std::numeric_limits<int32_t>::min()) ||
+        std::isnan(input) || std::isinf(input)) {
       continue;
     }
 

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -2077,6 +2077,7 @@ class DeduceVisitor : public AstNodeVisitor {
   absl::Status HandleProc(const Proc* n) override { return Fatal(n); }
   absl::Status HandleSlice(const Slice* n) override { return Fatal(n); }
   absl::Status HandleImport(const Import* n) override { return Fatal(n); }
+  absl::Status HandleUse(const Use* n) override { return Fatal(n); }
   absl::Status HandleFunction(const Function* n) override { return Fatal(n); }
   absl::Status HandleQuickCheck(const QuickCheck* n) override {
     return Fatal(n);

--- a/xls/dslx/type_system/type_info.proto
+++ b/xls/dslx/type_system/type_info.proto
@@ -98,6 +98,7 @@ enum AstNodeKindProto {
   AST_NODE_KIND_VERBATIM_NODE = 64;
   AST_NODE_KIND_FUNCTION_REF = 65;
   AST_NODE_KIND_PROC_DEF = 66;
+  AST_NODE_KIND_USE = 67;
 }
 
 message BitsValueProto {

--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -185,6 +185,8 @@ AstNodeKindProto ToProto(AstNodeKind kind) {
       return AST_NODE_KIND_IMPL;
     case AstNodeKind::kVerbatimNode:
       return AST_NODE_KIND_VERBATIM_NODE;
+    case AstNodeKind::kUse:
+      return AST_NODE_KIND_USE;
   }
   // Fatal since enum class values should not be out of range.
   LOG(FATAL) << "Out of range AstNodeKind: " << static_cast<int64_t>(kind);
@@ -813,6 +815,8 @@ absl::StatusOr<AstNodeKind> FromProto(AstNodeKindProto p) {
       return AstNodeKind::kImpl;
     case AST_NODE_KIND_VERBATIM_NODE:
       return AstNodeKind::kVerbatimNode;
+    case AST_NODE_KIND_USE:
+      return AstNodeKind::kUse;
     // Note: since this is a proto enum there are sentinel values defined in
     // addition to the "real" above. Return an invalid argument error.
     case AST_NODE_KIND_INVALID:

--- a/xls/dslx/type_system/typecheck_module.cc
+++ b/xls/dslx/type_system/typecheck_module.cc
@@ -226,6 +226,10 @@ absl::Status TypecheckModuleMember(const ModuleMember& member, Module* module,
                                         imported->type_info());
             return absl::OkStatus();
           },
+          [](Use* use) -> absl::Status {
+            return absl::UnimplementedError(
+                "`use` statements are not yet supported for typechecking");
+          },
           [ctx](ConstantDef* member) -> absl::Status {
             return ctx->Deduce(ToAstNode(member)).status();
           },


### PR DESCRIPTION
- Adds parsing support for `use` tree and makes `use` a keyword.
- One-line-only formatting support as a stub for the time being.
- Type inference support returns unimplemented for the moment.

Note that `use` introduces the first AST node at module scope that defines multiple NameDefs simultaneously, so small amount of rework in this PR to handle that new development.

Clang was also complaining about the lossy conversion of int32 limits to floats so I fixed that here too.

No documentation yet as it's a WIP construct.