### PR TITLE
[DSLX] Switch UseTreeEntry to an AstNode, make a cloner implementation.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,6 +23,9 @@ build --copt "-D_HAS_AUTO_PTR_ETC=0"   --host_copt "-D_HAS_AUTO_PTR_ETC=0"
 build --copt "-Wall"                   --host_copt "-Wall"
 build --copt "-Wextra"                 --host_copt "-Wextra"
 
+# Turn some specific warnings into errors.
+build --copt "-Werror=switch" --host_copt "-Werror=switch"
+
 # ... and disable the warnings we're not interested in.
 build --copt "-Wno-sign-compare"       --host_copt "-Wno-sign-compare"
 build --copt "-Wno-comment"            --host_copt "-Wno-comment"

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -1714,5 +1714,17 @@ fn divmod() {})*";
   EXPECT_EQ(kProgram, clone->ToString());
 }
 
+TEST(AstClonerTest, Use) {
+  constexpr std::string_view kProgram =
+      R"(use foo::bar::{baz::{bat, qux}, ipsum};)";
+
+  FileTable file_table;
+  XLS_ASSERT_OK_AND_ASSIGN(auto module, ParseModule(kProgram, "fake_path.x",
+                                                    "the_module", file_table));
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Module> clone,
+                           CloneModule(*module.get()));
+  EXPECT_EQ(kProgram, clone->ToString());
+}
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/frontend/ast_node.h
+++ b/xls/dslx/frontend/ast_node.h
@@ -95,6 +95,7 @@ enum class AstNodeKind : uint8_t {
   kUnop,
   kUnrollFor,
   kUse,
+  kUseTreeEntry,
   kVerbatimNode,
   kWidthSlice,
   kWildcardPattern,

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -561,8 +561,7 @@ class Parser : public TokenParser {
 
   // Parses a single entry in a `use` tree -- this can be a leaf or an interior
   // entry.
-  absl::StatusOr<std::unique_ptr<UseTreeEntry>> ParseUseTreeEntry(
-      Bindings& bindings);
+  absl::StatusOr<UseTreeEntry*> ParseUseTreeEntry(Bindings& bindings);
 
   // Parses a use statement into a `Use` AST node.
   absl::StatusOr<Use*> ParseUse(Bindings& bindings);

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -373,6 +373,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   INVALID(Impl)
   INVALID(Import)
   INVALID(Use)
+  INVALID(UseTreeEntry)
   INVALID(Module)
   INVALID(Proc)
   INVALID(ProcMember)

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -2108,6 +2108,9 @@ class DeduceVisitor : public AstNodeVisitor {
   absl::Status HandleSlice(const Slice* n) override { return Fatal(n); }
   absl::Status HandleImport(const Import* n) override { return Fatal(n); }
   absl::Status HandleUse(const Use* n) override { return Fatal(n); }
+  absl::Status HandleUseTreeEntry(const UseTreeEntry* n) override {
+    return Fatal(n);
+  }
   absl::Status HandleFunction(const Function* n) override { return Fatal(n); }
   absl::Status HandleQuickCheck(const QuickCheck* n) override {
     return Fatal(n);

--- a/xls/dslx/type_system/type_info.proto
+++ b/xls/dslx/type_system/type_info.proto
@@ -99,6 +99,7 @@ enum AstNodeKindProto {
   AST_NODE_KIND_FUNCTION_REF = 65;
   AST_NODE_KIND_PROC_DEF = 66;
   AST_NODE_KIND_USE = 67;
+  AST_NODE_KIND_USE_TREE_ENTRY = 68;
 }
 
 message BitsValueProto {

--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -187,6 +187,8 @@ AstNodeKindProto ToProto(AstNodeKind kind) {
       return AST_NODE_KIND_VERBATIM_NODE;
     case AstNodeKind::kUse:
       return AST_NODE_KIND_USE;
+    case AstNodeKind::kUseTreeEntry:
+      return AST_NODE_KIND_USE_TREE_ENTRY;
   }
   // Fatal since enum class values should not be out of range.
   LOG(FATAL) << "Out of range AstNodeKind: " << static_cast<int64_t>(kind);
@@ -817,6 +819,8 @@ absl::StatusOr<AstNodeKind> FromProto(AstNodeKindProto p) {
       return AstNodeKind::kVerbatimNode;
     case AST_NODE_KIND_USE:
       return AstNodeKind::kUse;
+    case AST_NODE_KIND_USE_TREE_ENTRY:
+      return AstNodeKind::kUseTreeEntry;
     // Note: since this is a proto enum there are sentinel values defined in
     // addition to the "real" above. Return an invalid argument error.
     case AST_NODE_KIND_INVALID:


### PR DESCRIPTION
Switch to AstNode for UseTreeEntry is per discussion with @richmckeever -- the rationale is, though we don't quite have it at the moment, in the future we may want to make an arbitrary matcher or replacer that was polymorphic on AstNode types, which makes it useful here to opt to reflect more structure of the AST in the node class form.