### PR TITLE
[xls][mlir] Update YieldOp description

### DIFF
--- a/xls/contrib/mlir/IR/xls_ops.td
+++ b/xls/contrib/mlir/IR/xls_ops.td
@@ -1051,7 +1051,7 @@ def Xls_MapOp : Xls_Op<"map", []> {
 def Xls_YieldOp : Xls_Op<"yield", [Pure, ReturnLike, Terminator]> {
   let summary = "for return op";
   let description = [{
-    Yields an SSA value from the enclosing ForOp region.
+    Yields an SSA value from the enclosing ForOp, EprocOp, or SprocOp region.
   }];
 
   let arguments = (ins Variadic<AnyType>:$results);


### PR DESCRIPTION
Updates the `xls.yield` documentation in the MLIR dialect, noting that it is also used to terminate procs, not just for-loops.