### PR TITLE
[xls][mlir] Fix XLS IR `Next` node generation in MLIR translation.

### DIFF
--- a/xls/contrib/mlir/tools/xls_translate/xls_translate.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate.cc
@@ -1287,7 +1287,7 @@ FailureOr<std::unique_ptr<Package>> mlirXlsToXls(
           auto next_value = cast<NextValueOp>(def);
           for (auto [pred, value] :
                llvm::zip(next_value.getPredicates(), next_value.getValues())) {
-            fb.Next(valueMap[arg], valueMap[yield], /*pred=*/valueMap[pred]);
+            fb.Next(valueMap[arg], valueMap[value], /*pred=*/valueMap[pred]);
           }
         } else {
           fb.Next(valueMap[arg], valueMap[yield]);


### PR DESCRIPTION
Fixes a small typo in the generation of XLS IR `Next` node in the `xls_translate` tool, which previously assigned the wrong `value`.

Also enables and fixes FileCheck in the `ops_translate.mlir` test, and adds a second `(predicate, next_value)` pair to the `xls.next_value` op. This makes it a valid `xls.next_value` op  (one and only one predicate is true) and triggers the bug.