### PR TITLE
[DSLX:TS] Add flag to fatal on internal error for typecheck_main.

### DIFF
--- a/xls/dslx/type_system/BUILD
+++ b/xls/dslx/type_system/BUILD
@@ -738,6 +738,7 @@ cc_binary(
         "//xls/dslx:parse_and_typecheck",
         "//xls/dslx:virtualizable_file_system",
         "//xls/dslx:warning_kind",
+        "//xls/dslx/frontend:bindings",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",


### PR DESCRIPTION
This is the most easily fuzzed binary as it doesn't depend on JIT components. Adding a flag to let it turn internal errors into fatals avoids the need to make a wrapper layer or a custom fuzz target to identify places where we (undesirably) flag internal errors.