### PR TITLE
[c_api] C APIs for dealing with bits values and flattening aggregates to bits.

### DIFF
--- a/xls/codegen/block_generator_test.cc
+++ b/xls/codegen/block_generator_test.cc
@@ -1399,7 +1399,8 @@ endpackage : pkg
                                            }));
     BitPushBuffer buffer;
     x_value.FlattenTo(&buffer);
-    x_bits = Bits::FromBytes(buffer.GetUint8Data(), 5 * 32);
+    x_bits = Bits::FromBytes(buffer.GetUint8DataWithMsbPadding(),
+                             buffer.size_in_bits());
   }
   Bits y_bits;
   {
@@ -1412,7 +1413,8 @@ endpackage : pkg
                                            }));
     BitPushBuffer buffer;
     y_value.FlattenTo(&buffer);
-    y_bits = Bits::FromBytes(buffer.GetUint8Data(), 5 * 32);
+    y_bits = Bits::FromBytes(buffer.GetUint8DataWithMsbPadding(),
+                             buffer.size_in_bits());
   }
   Bits out_bits;
   {
@@ -1430,7 +1432,8 @@ endpackage : pkg
                                              }));
     BitPushBuffer buffer;
     out_value.FlattenTo(&buffer);
-    out_bits = Bits::FromBytes(buffer.GetUint8Data(), 10 * 32);
+    out_bits = Bits::FromBytes(buffer.GetUint8DataWithMsbPadding(),
+                               buffer.size_in_bits());
   }
 
   seq.Set("x", x_bits).Set("y", y_bits);

--- a/xls/contrib/ice40/ice40_device_rpc_strategy.cc
+++ b/xls/contrib/ice40/ice40_device_rpc_strategy.cc
@@ -280,7 +280,7 @@ absl::StatusOr<Value> Ice40DeviceRpcStrategy::CallUnnamed(
     return absl::InvalidArgumentError("Cannot perform an empty-payload RPC.");
   }
 
-  std::vector<uint8_t> u8_data = buffer.GetUint8Data();
+  std::vector<uint8_t> u8_data = buffer.GetUint8DataWithLsbPadding();
 
   int64_t bytes_written = 0;
   while (bytes_written < buffer.size_in_bytes()) {

--- a/xls/data_structures/inline_bitmap.h
+++ b/xls/data_structures/inline_bitmap.h
@@ -76,8 +76,12 @@ class InlineBitmap {
   }
 
   // Constructs a bitmap of width `bits.size()` using the given bits,
-  // interpreting index 0 as the LSD.
-  static InlineBitmap FromBits(absl::Span<bool const> bits) {
+  // interpreting index 0 as the *least* significant bit.
+  //
+  // Note: if you find you want an overload that accepts a `std::vector<bool>`,
+  // consider using an `absl::InlinedVector<bool, N>` as storage instead, as it
+  // can be converted to span.
+  static InlineBitmap FromBitsLsbIs0(absl::Span<bool const> bits) {
     InlineBitmap result(bits.size(), /*fill=*/false);
     int64_t bit_idx = 0;
     uint64_t* word = result.data_.data();
@@ -87,6 +91,15 @@ class InlineBitmap {
         ++word;
         bit_idx = 0;
       }
+    }
+    return result;
+  }
+
+  // As above, but index 0 of the span is the most significant bit.
+  static InlineBitmap FromBitsMsbIs0(absl::Span<bool const> bits) {
+    InlineBitmap result(bits.size(), /*fill=*/false);
+    for (int64_t i = 0; i < bits.size(); ++i) {
+      result.Set(bits.size() - i - 1, bits[i]);
     }
     return result;
   }

--- a/xls/ir/BUILD
+++ b/xls/ir/BUILD
@@ -35,8 +35,10 @@ package(
 cc_library(
     name = "bit_push_buffer",
     hdrs = ["bit_push_buffer.h"],
+    srcs = ["bit_push_buffer.cc"],
     deps = [
         "//xls/common:math_util",
+        "//xls/data_structures:inline_bitmap",
     ],
 )
 

--- a/xls/ir/bit_push_buffer.cc
+++ b/xls/ir/bit_push_buffer.cc
@@ -1,0 +1,62 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/ir/bit_push_buffer.h"
+
+#include "xls/common/math_util.h"
+
+namespace xls {
+
+std::vector<uint8_t> BitPushBuffer::GetUint8DataWithLsbPadding() const {
+  // Implementation note: bitmap does not expose its underlying storage.
+  std::vector<uint8_t> result;
+  result.resize(CeilOfRatio(bitmap_.size(), 8UL), 0);
+  for (int64_t i = 0; i < static_cast<int64_t>(bitmap_.size()); ++i) {
+    result[i / 8] |= bitmap_[i] << (7 - i % 8);
+  }
+  return result;
+}
+
+std::vector<uint8_t> BitPushBuffer::GetUint8DataWithMsbPadding() const {
+  std::vector<uint8_t> result;
+  result.resize(CeilOfRatio(bitmap_.size(), 8UL), 0);
+  int64_t msbyte_padding_bits =
+      bitmap_.size() % 8 == 0 ? 0 : (8 - bitmap_.size() % 8);
+  int64_t msbyte_populated_bits = 8 - msbyte_padding_bits;
+  for (int64_t source_bit_index = 0;
+       source_bit_index < static_cast<int64_t>(bitmap_.size());
+       ++source_bit_index) {
+    bool bit_value = bitmap_[source_bit_index];
+    int64_t target_bit_index =
+        source_bit_index < msbyte_populated_bits
+            ? msbyte_populated_bits - source_bit_index - 1
+            : 7 - ((source_bit_index + msbyte_padding_bits) % 8);
+    int64_t target_byte_index =
+        source_bit_index < msbyte_populated_bits
+            ? 0
+            : (source_bit_index + msbyte_padding_bits) / 8;
+    result[target_byte_index] |= bit_value << target_bit_index;
+  }
+  return result;
+}
+
+std::string BitPushBuffer::ToString() const {
+  std::string result = "0b";
+  for (bool bit : bitmap_) {
+    result += bit ? '1' : '0';
+  }
+  return result;
+}
+
+}  // namespace xls

--- a/xls/ir/bit_push_buffer_test.cc
+++ b/xls/ir/bit_push_buffer_test.cc
@@ -30,7 +30,9 @@ TEST(BitPushBufferTest, IsEmptyAfterConstruction) {
 
   EXPECT_TRUE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 0);
-  EXPECT_THAT(buffer.GetUint8Data(), IsEmpty());
+  EXPECT_EQ(buffer.size_in_bits(), 0);
+  EXPECT_THAT(buffer.GetUint8DataWithMsbPadding(), IsEmpty());
+  EXPECT_THAT(buffer.GetUint8DataWithLsbPadding(), IsEmpty());
 }
 
 TEST(BitPushBufferTest, HasSingle0AfterPushingFalse) {
@@ -40,7 +42,9 @@ TEST(BitPushBufferTest, HasSingle0AfterPushingFalse) {
 
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 1);
-  EXPECT_EQ(buffer.GetUint8Data(), std::vector<uint8_t>{0});
+  EXPECT_EQ(buffer.GetUint8DataWithMsbPadding(), std::vector<uint8_t>{0});
+  EXPECT_EQ(buffer.GetUint8DataWithLsbPadding(), std::vector<uint8_t>{0});
+  EXPECT_EQ(buffer.size_in_bits(), 1);
 }
 
 TEST(BitPushBufferTest, HasSingle1InMsbAfterPushingTrue) {
@@ -50,7 +54,9 @@ TEST(BitPushBufferTest, HasSingle1InMsbAfterPushingTrue) {
 
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 1);
-  EXPECT_EQ(buffer.GetUint8Data(), std::vector<uint8_t>{1 << 7});
+  EXPECT_EQ(buffer.GetUint8DataWithLsbPadding(), std::vector<uint8_t>{1 << 7});
+  EXPECT_EQ(buffer.GetUint8DataWithMsbPadding(), std::vector<uint8_t>{1});
+  EXPECT_EQ(buffer.size_in_bits(), 1);
 }
 
 TEST(BitPushBufferTest, Has1InSecondMsbAfterPushingFalseTrue) {
@@ -61,7 +67,10 @@ TEST(BitPushBufferTest, Has1InSecondMsbAfterPushingFalseTrue) {
 
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 1);
-  EXPECT_EQ(buffer.GetUint8Data(), std::vector<uint8_t>{1 << 6});
+  EXPECT_EQ(buffer.GetUint8DataWithLsbPadding(),
+            std::vector<uint8_t>{0b01 << 6});
+  EXPECT_EQ(buffer.GetUint8DataWithMsbPadding(), std::vector<uint8_t>{0b01});
+  EXPECT_EQ(buffer.size_in_bits(), 2);
 }
 
 TEST(BitPushBufferTest, IsOneByteAfterPushing8Values) {
@@ -73,6 +82,7 @@ TEST(BitPushBufferTest, IsOneByteAfterPushing8Values) {
 
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 1);
+  EXPECT_EQ(buffer.size_in_bits(), 8);
 }
 
 TEST(BitPushBufferTest, Has1SecondBytesMsbAfterPushing8False1True) {
@@ -85,7 +95,17 @@ TEST(BitPushBufferTest, Has1SecondBytesMsbAfterPushing8False1True) {
 
   EXPECT_FALSE(buffer.empty());
   EXPECT_EQ(buffer.size_in_bytes(), 2);
-  EXPECT_EQ(buffer.GetUint8Data(), std::vector<uint8_t>({0, 1 << 7}));
+  EXPECT_EQ(buffer.GetUint8DataWithLsbPadding(),
+            std::vector<uint8_t>({0, 1 << 7}));
+  EXPECT_EQ(buffer.GetUint8DataWithMsbPadding(), std::vector<uint8_t>({0, 1}));
+  EXPECT_EQ(buffer.size_in_bits(), 9);
+}
+
+TEST(BitPushBufferTest, ToString) {
+  BitPushBuffer buffer;
+  buffer.PushBit(true);
+  buffer.PushBit(false);
+  EXPECT_EQ(buffer.ToString(), "0b10");
 }
 
 }  // namespace

--- a/xls/ir/bits.cc
+++ b/xls/ir/bits.cc
@@ -63,7 +63,7 @@ absl::StatusOr<Bits> SBitsWithStatus(int64_t value, int64_t bit_count) {
 }
 
 Bits::Bits(absl::Span<bool const> bits)
-    : bitmap_(InlineBitmap::FromBits(bits)) {}
+    : bitmap_(InlineBitmap::FromBitsLsbIs0(bits)) {}
 
 void Bits::SetRange(int64_t start_index, int64_t end_index, bool value) {
   bitmap_.SetRange(start_index, end_index, value);

--- a/xls/ir/bits.h
+++ b/xls/ir/bits.h
@@ -249,6 +249,9 @@ class Bits {
 
 // Helper for "stringing together" bits objects into a final result, avoiding
 // intermediate allocations.
+//
+// Note that to use this object you have to know the total bit count up front.
+// If the total bit count is unknown see `BitPushBuffer`.
 class BitsRope {
  public:
   explicit BitsRope(int64_t total_bit_count) : bitmap_(total_bit_count) {}

--- a/xls/ir/bits_test.cc
+++ b/xls/ir/bits_test.cc
@@ -533,6 +533,82 @@ TEST(BitsTest, ToBitVectorAndBack) {
   EXPECT_EQ(Bits(UBits(0b11001, 1234).ToBitVector()), UBits(0b11001, 1234));
 }
 
+static void BinFormatter(std::string* out, uint8_t value) {
+  absl::StrAppend(out, "0b");
+  for (int64_t i = 0; i < 8; ++i) {
+    bool bit = (value >> (7 - i)) & 1;
+    absl::StrAppend(out, bit ? "1" : "0");
+  }
+}
+
+TEST(BitsTest, FlattenToWithinOneByte) {
+  Bits b4 = UBits(0b100, 3);
+  BitPushBuffer buffer;
+  b4.FlattenTo(&buffer);
+  EXPECT_EQ(buffer.ToString(), "0b100");
+  EXPECT_EQ(buffer.size_in_bits(), 3);
+  {
+    const std::vector<uint8_t> expected_lsb_padded = {0b100'00000};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithLsbPadding();
+    EXPECT_EQ(actual, expected_lsb_padded)
+        << "Expected: "
+        << absl::StrJoin(expected_lsb_padded, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+  {
+    const std::vector<uint8_t> expected_msb_padded = {0b00000'100};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithMsbPadding();
+    EXPECT_EQ(actual, expected_msb_padded)
+        << "Expected: "
+        << absl::StrJoin(expected_msb_padded, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+}
+
+TEST(BitsType, FlattenTwoAcrossTwoBytes) {
+  Bits b9 = UBits(0b101'0000'0011, /*bit_count=*/11);
+  BitPushBuffer buffer;
+  b9.FlattenTo(&buffer);
+  EXPECT_EQ(buffer.ToString(), "0b10100000011");
+  // Note that the LSB padded version is always just a left shifted version
+  // of the MSB padded version.
+  {
+    const std::vector<uint8_t> expected = {0b1010'0000, 0b0110'0000};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithLsbPadding();
+    EXPECT_EQ(actual, expected)
+        << "Expected: " << absl::StrJoin(expected, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+  {
+    const std::vector<uint8_t> expected = {0b0000'0101, 0b0000'0011};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithMsbPadding();
+    EXPECT_EQ(actual, expected)
+        << "Expected: " << absl::StrJoin(expected, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+}
+
+TEST(BitsType, FlattenMultiByteExactByteAlignment) {
+  Bits b16 = UBits(0b0000'1111'1000'0000, /*bit_count=*/16);
+  BitPushBuffer buffer;
+  b16.FlattenTo(&buffer);
+  EXPECT_EQ(buffer.ToString(), "0b0000111110000000");
+  {
+    const std::vector<uint8_t> expected = {0b0000'1111, 0b1000'0000};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithLsbPadding();
+    EXPECT_EQ(actual, expected)
+        << "Expected: " << absl::StrJoin(expected, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+  {
+    const std::vector<uint8_t> expected = {0b0000'1111, 0b1000'0000};
+    std::vector<uint8_t> actual = buffer.GetUint8DataWithMsbPadding();
+    EXPECT_EQ(actual, expected)
+        << "Expected: " << absl::StrJoin(expected, ", ", BinFormatter)
+        << "\nActual: " << absl::StrJoin(actual, ", ", BinFormatter);
+  }
+}
+
 void RoundtripOneByte(uint8_t byte, int64_t bit_count) {
   EXPECT_THAT(Bits::FromBytes(std::vector<uint8_t>{byte}, bit_count).ToBytes(),
               ElementsAre(byte & Mask(bit_count)));
@@ -580,10 +656,48 @@ FUZZ_TEST(BitsFuzzTest, RoundtripNBytes)
 void RoundtripBitVectorThroughBitmap(
     const absl::InlinedVector<bool, 64>& bit_vector) {
   EXPECT_THAT(
-      Bits::FromBitmap(InlineBitmap::FromBits(bit_vector)).ToBitVector(),
+      Bits::FromBitmap(InlineBitmap::FromBitsLsbIs0(bit_vector)).ToBitVector(),
       ElementsAreArray(bit_vector));
 }
 FUZZ_TEST(BitsFuzzTest, RoundtripBitVectorThroughBitmap);
+
+void CompareBitsAndPushBufferData(
+    const absl::InlinedVector<bool, 64>& bit_vector) {
+  // Create a `Bits` object from the source `bit_vector`.
+  Bits bits = Bits::FromBitmap(InlineBitmap::FromBitsLsbIs0(bit_vector));
+
+  // Build the push buffer from those bits -- we push from the most significant
+  // bit to the least significant bit.
+  BitPushBuffer buffer;
+  for (int64_t i = 0; i < bits.bit_count(); ++i) {
+    buffer.PushBit(bits.GetFromMsb(i));
+  }
+
+  EXPECT_EQ(bits.ToDebugString(), buffer.ToString());
+
+  // Count the number of set bits in the exported bytes.
+  auto count_ones = [](const std::vector<uint8_t>& bytes) {
+    int64_t count = 0;
+    for (uint8_t byte : bytes) {
+      count += std::popcount(byte);
+    }
+    return count;
+  };
+  int64_t ones_count_lsb_padding =
+      count_ones(buffer.GetUint8DataWithLsbPadding());
+  int64_t ones_count_msb_padding =
+      count_ones(buffer.GetUint8DataWithMsbPadding());
+  int64_t ones_count_from_bits = count_ones(bits.ToBytes());
+  EXPECT_EQ(ones_count_lsb_padding, ones_count_from_bits);
+  EXPECT_EQ(ones_count_msb_padding, ones_count_from_bits);
+
+  // Check this is also the same as the direct count of the original source bit
+  // vector.
+  int64_t set_in_bit_vector = std::count_if(
+      bit_vector.begin(), bit_vector.end(), [](bool bit) { return bit; });
+  EXPECT_EQ(ones_count_from_bits, set_in_bit_vector);
+}
+FUZZ_TEST(BitsFuzzTest, CompareBitsAndPushBufferData);
 
 }  // namespace
 }  // namespace xls

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -216,6 +216,80 @@ struct xls_value* xls_value_make_false() {
   return reinterpret_cast<xls_value*>(value);
 }
 
+bool xls_bits_make_ubits(int64_t bit_count, uint64_t value, char** error_out,
+                         struct xls_bits** bits_out) {
+  CHECK(error_out != nullptr);
+  CHECK(bits_out != nullptr);
+  absl::StatusOr<xls::Bits> bits = xls::UBitsWithStatus(value, bit_count);
+  if (!bits.ok()) {
+    *error_out = xls::ToOwnedCString(bits.status().ToString());
+    return false;
+  }
+  *bits_out =
+      reinterpret_cast<xls_bits*>(new xls::Bits(std::move(bits).value()));
+  *error_out = nullptr;
+  return true;
+}
+
+bool xls_bits_make_sbits(int64_t bit_count, int64_t value, char** error_out,
+                         struct xls_bits** bits_out) {
+  CHECK(error_out != nullptr);
+  CHECK(bits_out != nullptr);
+  absl::StatusOr<xls::Bits> bits = xls::SBitsWithStatus(value, bit_count);
+  if (!bits.ok()) {
+    *error_out = xls::ToOwnedCString(bits.status().ToString());
+    return false;
+  }
+  *bits_out =
+      reinterpret_cast<xls_bits*>(new xls::Bits(std::move(bits).value()));
+  *error_out = nullptr;
+  return true;
+}
+
+bool xls_bits_get_bit(const struct xls_bits* bits, int64_t index) {
+  CHECK(bits != nullptr);
+  const auto* cpp_bits = reinterpret_cast<const xls::Bits*>(bits);
+  return cpp_bits->Get(index);
+}
+
+char* xls_bits_to_debug_string(const struct xls_bits* bits) {
+  CHECK(bits != nullptr);
+  const auto* cpp_bits = reinterpret_cast<const xls::Bits*>(bits);
+  std::string s = cpp_bits->ToDebugString();
+  return xls::ToOwnedCString(s);
+}
+
+struct xls_value* xls_value_make_tuple(size_t element_count,
+                                       struct xls_value** elements) {
+  CHECK(elements != nullptr);
+  std::vector<xls::Value> cpp_elements;
+  cpp_elements.reserve(element_count);
+  for (size_t i = 0; i < element_count; ++i) {
+    cpp_elements.push_back(*reinterpret_cast<xls::Value*>(elements[i]));
+  }
+  auto* value = new xls::Value(xls::Value::TupleOwned(std::move(cpp_elements)));
+  return reinterpret_cast<xls_value*>(value);
+}
+
+struct xls_bits* xls_value_flatten_to_bits(const struct xls_value* value) {
+  CHECK(value != nullptr);
+  const auto* cpp_value = reinterpret_cast<const xls::Value*>(value);
+  xls::BitPushBuffer push_buffer;
+  cpp_value->FlattenTo(&push_buffer);
+  LOG(INFO) << "Flattened " << cpp_value->ToString() << " to "
+            << push_buffer.size_in_bits() << " bits";
+  xls::Bits bits = xls::Bits::FromBitmap(push_buffer.ToBitmap());
+  return reinterpret_cast<xls_bits*>(new xls::Bits(std::move(bits)));
+}
+
+bool xls_bits_eq(const struct xls_bits* a, const struct xls_bits* b) {
+  CHECK(a != nullptr);
+  CHECK(b != nullptr);
+  const auto* cpp_a = reinterpret_cast<const xls::Bits*>(a);
+  const auto* cpp_b = reinterpret_cast<const xls::Bits*>(b);
+  return *cpp_a == *cpp_b;
+}
+
 int64_t xls_bits_get_bit_count(const struct xls_bits* bits) {
   CHECK(bits != nullptr);
   const auto* cpp_bits = reinterpret_cast<const xls::Bits*>(bits);

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -102,6 +102,10 @@ struct xls_value* xls_value_make_token();
 // Returns a new `bits[1]:1` XLS value which the caller must free.
 struct xls_value* xls_value_make_true();
 
+// Returns a new tuple-kind XLS value which the caller must free.
+struct xls_value* xls_value_make_tuple(size_t element_count,
+                                       struct xls_value** elements);
+
 // Attempts to extract a "bits" value from the given XLS value -- the resulting
 // `bits_out` is owned by the caller and must be freed via `xls_bits_free()` on
 // success.
@@ -110,7 +114,33 @@ bool xls_value_get_bits(const struct xls_value* value, char** error_out,
 
 int64_t xls_bits_get_bit_count(const struct xls_bits* bits);
 
+// Returns a string representation of the given bits value.
+//
+// Note: the returned string is owned by the caller and must be freed via
+// `xls_c_str_free`.
+char* xls_bits_to_debug_string(const struct xls_bits* bits);
+
+// Helper routine for making an unsigned bits value using a value that fits in a
+// 64-bit word.
+//
+// `bit_count` must be large enough to hold the value or an error is returned.
+bool xls_bits_make_ubits(int64_t bit_count, uint64_t value, char** error_out,
+                         struct xls_bits** bits_out);
+
+// As above but for a signed bit value -- `bit_count` must be large enough to
+// hold the value assuming sign extension or an error is returned.
+bool xls_bits_make_sbits(int64_t bit_count, int64_t value, char** error_out,
+                         struct xls_bits** bits_out);
+
 void xls_bits_free(struct xls_bits* bits);
+
+bool xls_bits_eq(const struct xls_bits* a, const struct xls_bits* b);
+
+// Returns the bit at the given index, where `index` is a zero-is-lsb value.
+//
+// That is, if the bits value is `0b01`, then `xls_bits_get_bit(bits, 0)`
+// returns 1, `xls_bits_get_bit(bits, 1)` returns 0.
+bool xls_bits_get_bit(const struct xls_bits* bits, int64_t index);
 
 // Returns a new `bits[1]:0` XLS value which the caller must free.
 struct xls_value* xls_value_make_false();
@@ -136,6 +166,15 @@ bool xls_value_to_string_format_preference(
 
 // Deallocates a value, e.g. one as created by `xls_parse_typed_value`.
 void xls_value_free(struct xls_value* v);
+
+// Flattens the given value to a sequence of bits in a bits "buffer" value.
+//
+// Note that in a tuple or array the earlier fields/members are stored in the
+// most significant bits of the result value.
+//
+// Note: the returned bits buffer is owned by the caller and must be freed via
+// `xls_bits_free`.
+struct xls_bits* xls_value_flatten_to_bits(const struct xls_value* v);
 
 void xls_package_free(struct xls_package* p);
 

--- a/xls/public/c_api_symbols.txt
+++ b/xls/public/c_api_symbols.txt
@@ -1,5 +1,10 @@
+xls_bits_eq
 xls_bits_free
+xls_bits_get_bit
 xls_bits_get_bit_count
+xls_bits_make_sbits
+xls_bits_make_ubits
+xls_bits_to_debug_string
 xls_c_str_free
 xls_convert_dslx_path_to_ir
 xls_convert_dslx_to_ir
@@ -91,11 +96,13 @@ xls_schedule_and_codegen_result_free
 xls_schedule_and_codegen_result_get_verilog_text
 xls_type_to_string
 xls_value_eq
+xls_value_flatten_to_bits
 xls_value_free
 xls_value_get_bits
 xls_value_make_false
 xls_value_make_token
 xls_value_make_true
+xls_value_make_tuple
 xls_value_to_string
 xls_value_to_string_format_preference
 xls_vast_concat_as_expression


### PR DESCRIPTION
Functionality for helping serialize XLS values to bit strings and C API functions for working with bits values.

Adds some functionality to BitPushBuffer so that we can piggyback on the existing Value::FlattenTo facilities.

Previously it would only allow padding in the least significant bits to get byte aligned results, but this adds a routine that can place the padding into the most significant bits of the first byte.