### PR TITLE
[DSLX:TS] Fix array type annotation that would create internal error.

### DIFF
--- a/xls/dslx/type_system/proc_typecheck_test.cc
+++ b/xls/dslx/type_system/proc_typecheck_test.cc
@@ -25,6 +25,13 @@
 namespace xls::dslx {
 namespace {
 
+// Previously this would cause an internal error due to token not having a
+// signedness.
+TEST(TypecheckTest, TokenArrayTypeAnnotation) {
+  constexpr std::string_view kProgram = R"(proc t{e:token[0]})";
+  XLS_EXPECT_OK(Typecheck(kProgram));
+}
+
 // Scenario where entry proc has a config with a "spawn" statement and a
 // trailing semicolon, with no members to configure for itself.
 TEST(TypecheckTest, ConfigSpawnTerminatingSemicolonNoMembers) {


### PR DESCRIPTION
Previously this caused:

```
C++ exception with description "Bad StatusOr access: INVALID_ARGUMENT: Type "token" has no defined signedness." thrown in the test body.

[  FAILED  ] TypecheckErrorTest.TokenHasNoSignedness (3 ms)
```