### PR TITLE
[DSLX:FE:cleanup] Remove ConstRef node.

### DIFF
--- a/xls/dslx/bytecode/bytecode_emitter.cc
+++ b/xls/dslx/bytecode/bytecode_emitter.cc
@@ -803,10 +803,6 @@ absl::Status BytecodeEmitter::HandleConstAssert(const ConstAssert* node) {
   return absl::OkStatus();
 }
 
-absl::Status BytecodeEmitter::HandleConstRef(const ConstRef* node) {
-  return HandleNameRef(node);
-}
-
 absl::Status BytecodeEmitter::HandleFor(const For* node) {
   // Here's how a `for` loop is implemented, in some sort of pseudocode:
   //  - Initialize iterable & index

--- a/xls/dslx/bytecode/bytecode_emitter.h
+++ b/xls/dslx/bytecode/bytecode_emitter.h
@@ -91,7 +91,6 @@ class BytecodeEmitter : public ExprVisitor {
   absl::Status HandleColonRef(const ColonRef* node) override;
   absl::StatusOr<InterpValue> HandleColonRefInternal(const ColonRef* node);
   absl::Status HandleConstAssert(const ConstAssert* node) override;
-  absl::Status HandleConstRef(const ConstRef* node) override;
   absl::Status HandleFor(const For* node) override;
   absl::Status HandleFormatMacro(const FormatMacro* node) override;
   absl::Status HandleFunctionRef(const FunctionRef* node) override;

--- a/xls/dslx/bytecode/bytecode_emitter_test.cc
+++ b/xls/dslx/bytecode/bytecode_emitter_test.cc
@@ -1005,7 +1005,7 @@ fn imported_enum_ref() -> u3 {
               IsOkAndHolds(InterpValue::MakeSBits(3, 2)));
 }
 
-TEST(BytecodeEmitterTest, HandlesConstRefs) {
+TEST(BytecodeEmitterTest, HandlesConstantRefs) {
   constexpr std::string_view kProgram = R"(const kFoo = u32:100;
 
 #[test]

--- a/xls/dslx/constexpr_evaluator.cc
+++ b/xls/dslx/constexpr_evaluator.cc
@@ -347,8 +347,7 @@ absl::Status ConstexprEvaluator::HandleColonRef(const ColonRef* expr) {
             }
 
             if (!std::holds_alternative<ConstantDef*>(*maybe_member.value())) {
-              VLOG(3) << "ConstRef \"" << expr->ToString()
-                      << "\" is not constexpr evaluatable.";
+              VLOG(3) << expr->ToString() << " is not constexpr evaluatable.";
               return absl::OkStatus();
             }
 
@@ -383,10 +382,6 @@ absl::Status ConstexprEvaluator::HandleConstAssert(
   return TypeInferenceErrorStatus(const_assert->span(), nullptr,
                                   "const_assert! expression was false",
                                   file_table);
-}
-
-absl::Status ConstexprEvaluator::HandleConstRef(const ConstRef* expr) {
-  return HandleNameRef(expr);
 }
 
 absl::Status ConstexprEvaluator::HandleFor(const For* expr) {
@@ -746,20 +741,6 @@ absl::StatusOr<ConstexprEnvData> MakeConstexprEnv(
     } else {
       non_constexpr.insert(sample_ref);
     }
-  }
-
-  for (const ConstRef* const_ref : freevars.GetConstRefs()) {
-    VLOG(5) << "analyzing constant reference: " << const_ref->ToString()
-            << " def: " << const_ref->ToString();
-    Expr* const_expr = const_ref->GetValue();
-    absl::StatusOr<InterpValue> value = type_info->GetConstExpr(const_expr);
-    if (!value.ok()) {
-      continue;
-    }
-
-    VLOG(5) << "freevar env record: " << const_ref->identifier() << " => "
-            << value->ToString();
-    env.insert({const_ref->identifier(), *value});
   }
 
   return ConstexprEnvData{

--- a/xls/dslx/constexpr_evaluator.h
+++ b/xls/dslx/constexpr_evaluator.h
@@ -73,7 +73,6 @@ class ConstexprEvaluator : public xls::dslx::ExprVisitor {
   absl::Status HandleChannelDecl(const ChannelDecl* expr) override;
   absl::Status HandleColonRef(const ColonRef* expr) override;
   absl::Status HandleConstAssert(const ConstAssert* const_assert) override;
-  absl::Status HandleConstRef(const ConstRef* expr) override;
   absl::Status HandleFor(const For* expr) override;
   absl::Status HandleFunctionRef(const FunctionRef* expr) override;
   absl::Status HandleFormatMacro(const FormatMacro* expr) override {

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -225,8 +225,6 @@ std::string_view AstNodeKindToString(AstNodeKind kind) {
       return "proc member";
     case AstNodeKind::kNameRef:
       return "name reference";
-    case AstNodeKind::kConstRef:
-      return "const reference";
     case AstNodeKind::kArray:
       return "array";
     case AstNodeKind::kString:
@@ -391,18 +389,6 @@ FreeVariables::GetNameDefTuples() const {
     return lhs.first < rhs.first;
   });
   return result;
-}
-
-std::vector<const ConstRef*> FreeVariables::GetConstRefs() {
-  std::vector<const ConstRef*> const_refs;
-  for (const auto& [name, refs] : values_) {
-    for (const NameRef* name_ref : refs) {
-      if (auto* const_ref = dynamic_cast<const ConstRef*>(name_ref)) {
-        const_refs.push_back(const_ref);
-      }
-    }
-  }
-  return const_refs;
 }
 
 std::vector<AnyNameDef> FreeVariables::GetNameDefs() const {
@@ -1034,7 +1020,7 @@ SelfTypeAnnotation::~SelfTypeAnnotation() = default;
 BuiltinNameDef::~BuiltinNameDef() = default;
 
 bool IsConstant(AstNode* node) {
-  if (IsOneOf<Number, ConstRef, ColonRef>(node)) {
+  if (IsOneOf<Number, ColonRef>(node)) {
     return true;
   }
   if (IsOneOf<NameRef>(node)) {
@@ -2033,10 +2019,6 @@ Match::Match(Module* owner, Span span, Expr* matched,
 // -- class NameRef
 
 NameRef::~NameRef() = default;
-
-// -- class ConstRef
-
-ConstRef::~ConstRef() = default;
 
 // -- class Range
 

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -1534,8 +1534,8 @@ proc MyProc {
   EXPECT_EQ(kExpected, clone->ToString());
 }
 
-// A ConstRef doesn't own its underlying NameDef. So don't clone it.
-TEST(AstClonerTest, DoesntCloneConstRefNameDefs) {
+// A NameRef doesn't own its underlying NameDef. So don't clone it.
+TEST(AstClonerTest, DoesntCloneNameRefNameDefs) {
   constexpr std::string_view kProgram = R"(
 const FOO = u32:42;
 fn bar() -> u32{
@@ -1552,10 +1552,10 @@ fn bar() -> u32{
   ASSERT_EQ(body_expr->statements().size(), 1);
   ASSERT_TRUE(
       std::holds_alternative<Expr*>(body_expr->statements().at(0)->wrapped()));
-  ConstRef* orig_ref = down_cast<ConstRef*>(
+  auto* orig_ref = down_cast<NameRef*>(
       std::get<Expr*>(body_expr->statements().at(0)->wrapped()));
   XLS_ASSERT_OK_AND_ASSIGN(AstNode * clone, CloneAst(orig_ref));
-  ConstRef* new_ref = down_cast<ConstRef*>(clone);
+  NameRef* new_ref = down_cast<NameRef*>(clone);
   EXPECT_EQ(orig_ref->name_def(), new_ref->name_def());
 }
 

--- a/xls/dslx/frontend/ast_node.h
+++ b/xls/dslx/frontend/ast_node.h
@@ -43,7 +43,6 @@ enum class AstNodeKind : uint8_t {
   kColonRef,
   kConditional,
   kConstAssert,
-  kConstRef,
   kConstantDef,
   kEnumDef,
   kFor,

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -955,25 +955,9 @@ absl::StatusOr<NameRef*> Parser::ParseNameRef(Bindings& bindings,
       bindings.ResolveNodeOrError(*tok->GetValue(), tok->span(), file_table()));
   AnyNameDef name_def = BoundNodeToAnyNameDef(bn);
   if (std::holds_alternative<ConstantDef*>(bn)) {
-    return module_->Make<ConstRef>(tok->span(), *tok->GetValue(), name_def);
+    return module_->Make<NameRef>(tok->span(), *tok->GetValue(), name_def);
   }
 
-  if (std::holds_alternative<NameDef*>(bn)) {
-    // As opposed to the AnyNameDef above.
-    const AstNode* node = std::get<NameDef*>(bn);
-    while (node->parent() != nullptr &&
-           node->parent()->kind() == AstNodeKind::kNameDefTree) {
-      node = node->parent();
-    }
-
-    // Since Let construction is deferred, we can't look up the definer of this
-    // NameDef[Tree]; it doesn't exist yet. Instead, we just note that a given
-    // NDT is const (or not, by omission in the set).
-    if (dynamic_cast<const NameDefTree*>(node) != nullptr &&
-        const_ndts_.contains(dynamic_cast<const NameDefTree*>(node))) {
-      return module_->Make<ConstRef>(tok->span(), *tok->GetValue(), name_def);
-    }
-  }
   return module_->Make<NameRef>(tok->span(), *tok->GetValue(), name_def);
 }
 
@@ -1468,15 +1452,11 @@ absl::StatusOr<NameDefTree*> Parser::ParsePattern(Bindings& bindings) {
     }
 
     std::optional<BoundNode> resolved = bindings.ResolveNode(*tok.GetValue());
-    NameRef* ref;
     if (resolved) {
       AnyNameDef name_def =
           bindings.ResolveNameOrNullopt(*tok.GetValue()).value();
-      if (std::holds_alternative<ConstantDef*>(*resolved)) {
-        ref = module_->Make<ConstRef>(tok.span(), *tok.GetValue(), name_def);
-      } else {
-        ref = module_->Make<NameRef>(tok.span(), *tok.GetValue(), name_def);
-      }
+      NameRef* ref =
+          module_->Make<NameRef>(tok.span(), *tok.GetValue(), name_def);
       return module_->Make<NameDefTree>(tok.span(), ref);
     }
 
@@ -3057,8 +3037,8 @@ absl::StatusOr<Let*> Parser::ParseLet(Bindings& bindings) {
   }
 
   if (const_) {
-    // Mark this NDT as const to determine if refs to it should be ConstRefs
-    // or NameRefs. Also disallow destructuring assignment for constants.
+    // Mark this NDT as const. Also disallow destructuring assignment for
+    // constants.
     const_ndts_.insert(name_def_tree);
     if (name_def_tree->Flatten().size() != 1) {
       return ParseErrorStatus(

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -481,7 +481,6 @@ class Parser : public TokenParser {
   //            | ColonRef
   //            | NameDef
   //            | NameRef
-  //            | ConstRef
   //            | Number
   absl::StatusOr<NameDefTree*> ParsePattern(Bindings& bindings);
 
@@ -663,7 +662,7 @@ class Parser : public TokenParser {
   // `Let` nodes are created _after_ those that use their namedefs (due to the
   // chaining of the `body` member variable. We need to know, though, if a
   // reference to such an NDT (or element thereof) is to a constant or not, so
-  // we can emit either a ConstRef or NameRef. This set holds those NDTs known
+  // we can emit a NameRef. This set holds those NDTs known
   // to be constant for that purpose.
   absl::flat_hash_set<NameDefTree*> const_ndts_;
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -1596,10 +1596,10 @@ TEST_F(ParserTest, LocalConstBinding) {
   ASSERT_TRUE(const_let->is_const());
   EXPECT_EQ("u8:42", const_let->rhs()->ToString());
 
-  auto* const_ref =
-      dynamic_cast<ConstRef*>(std::get<Expr*>(stmts.at(1)->wrapped()));
-  ASSERT_NE(const_ref, nullptr);
-  const NameDef* name_def = const_ref->name_def();
+  auto* name_ref =
+      dynamic_cast<NameRef*>(std::get<Expr*>(stmts.at(1)->wrapped()));
+  ASSERT_NE(name_ref, nullptr);
+  auto* name_def = std::get<const NameDef*>(name_ref->name_def());
   EXPECT_EQ(name_def->ToString(), "FOO");
   AstNode* definer = name_def->definer();
   EXPECT_EQ(definer, const_let);
@@ -2340,14 +2340,14 @@ TEST_F(ParserTest, ConstWithTypeAnnotation) {
   RoundTrip(R"(const MOL: u32 = u32:42;)");
 }
 
-TEST_F(ParserTest, ConstArrayOfConstRefs) {
+TEST_F(ParserTest, ConstArrayOfConstantRefs) {
   RoundTrip(R"(const MOL = u32:42;
 const ZERO = u32:0;
 const ARR = u32[2]:[MOL, ZERO];)");
 }
 
 // As above, but uses a trailing ellipsis in the array definition.
-TEST_F(ParserTest, ConstArrayOfConstRefsEllipsis) {
+TEST_F(ParserTest, ConstArrayOfConstantRefsEllipsis) {
   RoundTrip(R"(const MOL = u32:42;
 const ZERO = u32:0;
 const ARR = u32[2]:[MOL, ZERO, ...];)");

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -433,11 +433,8 @@ class InvocationVisitor : public ExprVisitor {
   // No ColonRef handling (ColonRef invocations are handled in HandleInvocation;
   // all other ColonRefs are to constant values, which don't need their deriving
   // exprs converted to IR.
-  // No ConstRef handling: constants don't need their defiving exprs converted
-  // to IR.
   DEFAULT_HANDLE(ChannelDecl)
   DEFAULT_HANDLE(ColonRef)
-  DEFAULT_HANDLE(ConstRef)
   DEFAULT_HANDLE(NameRef)
   DEFAULT_HANDLE(Number)
   DEFAULT_HANDLE(String)

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -300,7 +300,6 @@ class FunctionConverterVisitor : public AstNodeVisitor {
 
   NO_TRAVERSE_DISPATCH(Param)
   NO_TRAVERSE_DISPATCH(NameRef)
-  NO_TRAVERSE_DISPATCH(ConstRef)
   NO_TRAVERSE_DISPATCH(Number)
   NO_TRAVERSE_DISPATCH(String)
 
@@ -716,10 +715,6 @@ absl::Status FunctionConverter::HandleParam(const Param* node) {
     param->set_sv_type(*sv_value);
   }
   return absl::OkStatus();
-}
-
-absl::Status FunctionConverter::HandleConstRef(const ConstRef* node) {
-  return DefAlias(node->name_def(), /*to=*/node);
 }
 
 absl::Status FunctionConverter::HandleNameRef(const NameRef* node) {

--- a/xls/dslx/ir_convert/function_converter.h
+++ b/xls/dslx/ir_convert/function_converter.h
@@ -316,7 +316,6 @@ class FunctionConverter {
 
   // AstNode handlers.
   absl::Status HandleBinop(const Binop* node);
-  absl::Status HandleConstRef(const ConstRef* node);
   absl::Status HandleNameRef(const NameRef* node);
   absl::Status HandleNumber(const Number* node);
   absl::Status HandleParam(const Param* node);

--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -65,8 +65,6 @@ AstNodeKindProto ToProto(AstNodeKind kind) {
       return AST_NODE_KIND_NAME_DEF;
     case AstNodeKind::kNameRef:
       return AST_NODE_KIND_NAME_REF;
-    case AstNodeKind::kConstRef:
-      return AST_NODE_KIND_CONST_REF;
     case AstNodeKind::kBuiltinNameDef:
       return AST_NODE_KIND_BUILTIN_NAME_DEF;
     case AstNodeKind::kConditional:
@@ -697,8 +695,6 @@ absl::StatusOr<AstNodeKind> FromProto(AstNodeKindProto p) {
       return AstNodeKind::kNameDef;
     case AST_NODE_KIND_NAME_REF:
       return AstNodeKind::kNameRef;
-    case AST_NODE_KIND_CONST_REF:
-      return AstNodeKind::kConstRef;
     case AST_NODE_KIND_BUILTIN_NAME_DEF:
       return AstNodeKind::kBuiltinNameDef;
     case AST_NODE_KIND_CONDITIONAL:
@@ -828,6 +824,7 @@ absl::StatusOr<AstNodeKind> FromProto(AstNodeKindProto p) {
     // Note: since this is a proto enum there are sentinel values defined in
     // addition to the "real" above. Return an invalid argument error.
     case AST_NODE_KIND_INVALID:
+    case AST_NODE_KIND_CONST_REF:  // Removed.
     case AstNodeKindProto_INT_MIN_SENTINEL_DO_NOT_USE_:
     case AstNodeKindProto_INT_MAX_SENTINEL_DO_NOT_USE_:
       return absl::InvalidArgumentError(

--- a/xls/dslx/type_system_v2/typecheck_module_v2.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2.cc
@@ -94,10 +94,6 @@ class PopulateInferenceTableVisitor : public AstNodeVisitorWithDefault {
     return DefaultHandler(node);
   }
 
-  absl::Status HandleConstRef(const ConstRef* node) override {
-    return PropagateDefToRef(node);
-  }
-
   absl::Status HandleNameRef(const NameRef* node) override {
     return PropagateDefToRef(node);
   }

--- a/xls/fuzzer/ast_generator.h
+++ b/xls/fuzzer/ast_generator.h
@@ -688,7 +688,7 @@ class AstGenerator {
 
   // Gets-or-creates a top level constant with the given value, using the
   // minimum number of bits required to make that constant.
-  ConstRef* GetOrCreateConstRef(
+  NameRef* GetOrCreateConstNameRef(
       int64_t value, std::optional<int64_t> want_width = std::nullopt);
 
   // Returns a recoverable status error with the given message. A recoverable


### PR DESCRIPTION
Similar to https://github.com/google/xls/pull/1753 this node is trying to reflect type-check-time information in the AST. It is better to remove the parse-time indicator and derive the information consistently in type checking.