### PR TITLE
[DSLX] Language test for a simple module with a multi-`use` binding

### DIFF
--- a/xls/dslx/BUILD
+++ b/xls/dslx/BUILD
@@ -39,6 +39,8 @@ cc_library(
     hdrs = ["virtualizable_file_system.h"],
     deps = [
         "//xls/common/file:filesystem",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",

--- a/xls/dslx/create_import_data.cc
+++ b/xls/dslx/create_import_data.cc
@@ -38,10 +38,14 @@ ImportData CreateImportData(
   return import_data;
 }
 
-ImportData CreateImportDataForTest() {
-  ImportData import_data(xls::kDefaultDslxStdlibPath,
-                         /*additional_search_paths=*/{}, kDefaultWarningsSet,
-                         std::make_unique<RealFilesystem>());
+ImportData CreateImportDataForTest(
+    std::unique_ptr<VirtualizableFilesystem> vfs) {
+  if (vfs == nullptr) {
+    vfs = std::make_unique<RealFilesystem>();
+  }
+  absl::Span<const std::filesystem::path> additional_search_paths = {};
+  ImportData import_data(xls::kDefaultDslxStdlibPath, additional_search_paths,
+                         kDefaultWarningsSet, std::move(vfs));
   import_data.SetBytecodeCache(std::make_unique<BytecodeCache>(&import_data));
   return import_data;
 }

--- a/xls/dslx/create_import_data.h
+++ b/xls/dslx/create_import_data.h
@@ -36,7 +36,8 @@ ImportData CreateImportData(
 
 // Creates an ImportData with reasonable defaults (standard path to the stdlib
 // and no additional search paths).
-ImportData CreateImportDataForTest();
+ImportData CreateImportDataForTest(
+    std::unique_ptr<VirtualizableFilesystem> vfs = nullptr);
 
 std::unique_ptr<ImportData> CreateImportDataPtrForTest();
 

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -828,6 +828,25 @@ std::string UseInteriorEntry::ToString() const {
   return absl::StrCat(identifier_, "::", subtrees_str);
 }
 
+void UseTreeEntry::LinearizeToSubjects(std::vector<std::string>& prefix,
+                                       std::vector<UseSubject>& results) const {
+  return absl::visit(Visitor{
+                         [&](const UseInteriorEntry& interior) {
+                           prefix.push_back(std::string{interior.identifier()});
+                           for (UseTreeEntry* subtree : interior.subtrees()) {
+                             subtree->LinearizeToSubjects(prefix, results);
+                           }
+                           prefix.pop_back();
+                         },
+                         [&](const NameDef* name_def) {
+                           UseSubject result = {prefix, name_def};
+                           result.identifiers.push_back(name_def->identifier());
+                           results.push_back(std::move(result));
+                         },
+                     },
+                     payload_);
+}
+
 std::string UseTreeEntry::ToString() const {
   return absl::visit(
       Visitor{
@@ -867,6 +886,10 @@ std::vector<std::string> UseTreeEntry::GetLeafIdentifiers() const {
     result.push_back(name_def->identifier());
   }
   return result;
+}
+
+std::string UseSubject::ToErrorString() const {
+  return absl::StrCat("`", absl::StrJoin(identifiers, "::"), "`");
 }
 
 absl::Status UseTreeEntry::Accept(AstNodeVisitor* v) const {

--- a/xls/dslx/frontend/ast_test.cc
+++ b/xls/dslx/frontend/ast_test.cc
@@ -362,5 +362,6 @@ TEST(AstTest, IsConstantEmptyArray) {
 
   EXPECT_TRUE(IsConstant(array));
 }
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/import_data.h
+++ b/xls/dslx/import_data.h
@@ -70,6 +70,10 @@ class ModuleInfo {
 // Hashable (usable in a flat hash map).
 class ImportTokens {
  public:
+  static ImportTokens FromSpan(absl::Span<const std::string> identifiers) {
+    return ImportTokens(
+        std::vector<std::string>(identifiers.begin(), identifiers.end()));
+  }
   static absl::StatusOr<ImportTokens> FromString(std::string_view module_name);
 
   explicit ImportTokens(std::vector<std::string> pieces)
@@ -230,7 +234,8 @@ class ImportData {
       const std::filesystem::path&, absl::Span<const std::filesystem::path>,
       WarningKindSet);
 
-  friend ImportData CreateImportDataForTest();
+  friend ImportData CreateImportDataForTest(
+      std::unique_ptr<VirtualizableFilesystem> vfs);
   friend std::unique_ptr<ImportData> CreateImportDataPtrForTest();
 
   ImportData(std::filesystem::path stdlib_path,

--- a/xls/dslx/import_routines.cc
+++ b/xls/dslx/import_routines.cc
@@ -171,36 +171,19 @@ static absl::StatusOr<DslxPath> FindExistingPath(
       vfs.GetCurrentDirectory().value(), stdlib_path));
 }
 
-absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
-                                     const ImportTokens& subject,
-                                     ImportData* import_data,
-                                     const Span& import_span,
-                                     VirtualizableFilesystem& vfs) {
-  XLS_RET_CHECK(import_data != nullptr);
-  if (import_data->Contains(subject)) {
-    VLOG(3) << "DoImport (cached) subject: " << subject.ToString();
-    return import_data->Get(subject);
-  }
-
-  VLOG(3) << "DoImport (uncached) subject: " << subject.ToString();
-
-  FileTable& file_table = import_data->file_table();
-  XLS_ASSIGN_OR_RETURN(DslxPath dslx_path,
-                       FindExistingPath(subject, import_data->stdlib_path(),
-                                        import_data->additional_search_paths(),
-                                        import_span, file_table, vfs));
-
-  VLOG(3) << "Found DSLX path: " << dslx_path.ToString();
-
+static absl::StatusOr<std::unique_ptr<ModuleInfo>> DslxPathToModuleInfo(
+    const TypecheckModuleFn& ftypecheck, ImportData* import_data,
+    const ImportTokens& subject, const DslxPath& dslx_path, const Span& span,
+    FileTable& file_table, VirtualizableFilesystem& vfs) {
   // We make a note about the import that's about to happen:
   // - so we can detect circular imports
   // - so that external entities can observe what's happening in the import
   // process, e.g. if they
   //   wanted to understand the dependency DAG
   XLS_RETURN_IF_ERROR(
-      import_data->AddToImporterStack(import_span, dslx_path.source_path));
+      import_data->AddToImporterStack(span, dslx_path.source_path));
   absl::Cleanup cleanup = absl::MakeCleanup(
-      [&] { CHECK_OK(import_data->PopFromImporterStack(import_span)); });
+      [&] { CHECK_OK(import_data->PopFromImporterStack(span)); });
 
   // Use the "filesystem_path" for reading the contents but the "source_path"
   // for other uses. This avoids decorated paths like
@@ -225,9 +208,148 @@ absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
 
   VLOG(3) << "Parsing and typechecking " << fully_qualified_name << ": done";
 
-  return import_data->Put(
-      subject, std::make_unique<ModuleInfo>(std::move(module), type_info,
-                                            std::move(dslx_path.source_path)));
+  return std::make_unique<ModuleInfo>(
+      /*module=*/std::move(module),
+      /*type_info=*/type_info,
+      /*path=*/std::move(dslx_path.source_path));
+}
+
+absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
+                                     const ImportTokens& subject,
+                                     ImportData* import_data,
+                                     const Span& import_span,
+                                     VirtualizableFilesystem& vfs) {
+  XLS_RET_CHECK(import_data != nullptr);
+  if (import_data->Contains(subject)) {
+    VLOG(3) << "DoImport (cached) subject: " << subject.ToString();
+    return import_data->Get(subject);
+  }
+
+  VLOG(3) << "DoImport (uncached) subject: " << subject.ToString();
+
+  FileTable& file_table = import_data->file_table();
+  XLS_ASSIGN_OR_RETURN(DslxPath dslx_path,
+                       FindExistingPath(subject, import_data->stdlib_path(),
+                                        import_data->additional_search_paths(),
+                                        import_span, file_table, vfs));
+
+  VLOG(3) << "Found DSLX path: " << dslx_path.ToString();
+
+  XLS_ASSIGN_OR_RETURN(std::unique_ptr<ModuleInfo> module_info,
+                       DslxPathToModuleInfo(
+                           /*ftypecheck=*/ftypecheck,
+                           /*import_data=*/import_data,
+                           /*subject=*/subject,
+                           /*dslx_path=*/dslx_path,
+                           /*import_span=*/import_span,
+                           /*file_table=*/file_table,
+                           /*vfs=*/vfs));
+
+  return import_data->Put(subject, std::move(module_info));
+}
+
+absl::StatusOr<UseImportResult> DoImportViaUse(
+    const TypecheckModuleFn& ftypecheck, const UseSubject& subject,
+    ImportData* import_data, const Span& name_def_span, FileTable& file_table,
+    VirtualizableFilesystem& vfs) {
+  // Keep track of what we attempted to import.
+  std::vector<ImportTokens> attempted;
+
+  // 1. Try to import the leaf `NameDef` as a module path.
+  //
+  //    For example in `use foo::bar::baz;` if `foo/bar/baz.x` is present, that
+  //    is the result of the use statement.
+  attempted.push_back(ImportTokens(subject.identifiers));
+  absl::StatusOr<DslxPath> dslx_path =
+      FindExistingPath(attempted.back(), import_data->stdlib_path(),
+                       import_data->additional_search_paths(), name_def_span,
+                       import_data->file_table(), vfs);
+  if (dslx_path.ok()) {
+    const ImportTokens& import_tokens = attempted.back();
+    if (absl::StatusOr<ModuleInfo*> module_info =
+            import_data->Get(import_tokens);
+        module_info.ok()) {
+      return UseImportResult{.imported_module = module_info.value(),
+                             .imported_member = nullptr};
+    }
+    XLS_ASSIGN_OR_RETURN(std::unique_ptr<ModuleInfo> module_info,
+                         DslxPathToModuleInfo(
+                             /*ftypecheck=*/ftypecheck,
+                             /*import_data=*/import_data,
+                             /*subject=*/import_tokens,
+                             /*dslx_path=*/*dslx_path,
+                             /*import_span=*/name_def_span,
+                             /*file_table=*/import_data->file_table(),
+                             /*vfs=*/vfs));
+    XLS_ASSIGN_OR_RETURN(
+        ModuleInfo * module_info_ptr,
+        import_data->Put(import_tokens, std::move(module_info)));
+    return UseImportResult{.imported_module = module_info_ptr,
+                           .imported_member = nullptr};
+  }
+
+  // 2. If that is not present, check whether the NameDef refers to an entity
+  // inside of the enclosing module.
+  //
+  //    For example in `use foo::bar::baz;` if `baz.x` is not present, we are
+  //    requesting an attribute access of the top level entity `baz` within the
+  //    module `foo/bar.x`.
+  attempted.push_back(
+      ImportTokens::FromSpan(absl::MakeConstSpan(subject.identifiers)
+                                 .subspan(0, subject.identifiers.size() - 1)));
+  dslx_path = FindExistingPath(
+      /*subject=*/attempted.back(),
+      /*stdlib_path=*/import_data->stdlib_path(),
+      /*additional_search_paths=*/import_data->additional_search_paths(),
+      /*import_span=*/name_def_span,
+      /*file_table=*/import_data->file_table(),
+      /*vfs=*/vfs);
+  if (dslx_path.ok()) {
+    const ImportTokens& import_tokens = attempted.back();
+    auto process =
+        [&](ModuleInfo* module_info,
+            std::string_view name) -> absl::StatusOr<UseImportResult> {
+      std::optional<ModuleMember*> member =
+          module_info->module().FindMemberWithName(name);
+      if (!member.has_value()) {
+        return absl::NotFoundError(
+            absl::StrFormat("ImportError: %s Could not find member %s within "
+                            "(successfully imported) module %s",
+                            name_def_span.ToString(file_table), name,
+                            import_tokens.ToString()));
+      }
+      return UseImportResult{.imported_module = module_info,
+                             .imported_member = member.value()};
+    };
+
+    if (absl::StatusOr<ModuleInfo*> module_info =
+            import_data->Get(import_tokens);
+        module_info.ok()) {
+      return process(module_info.value(), subject.name_def->identifier());
+    }
+    XLS_ASSIGN_OR_RETURN(std::unique_ptr<ModuleInfo> module_info,
+                         DslxPathToModuleInfo(
+                             /*ftypecheck=*/ftypecheck,
+                             /*import_data=*/import_data,
+                             /*subject=*/import_tokens,
+                             /*dslx_path=*/*dslx_path,
+                             /*import_span=*/name_def_span,
+                             /*file_table=*/import_data->file_table(),
+                             /*vfs=*/vfs));
+    XLS_ASSIGN_OR_RETURN(
+        ModuleInfo * module_info_ptr,
+        import_data->Put(import_tokens, std::move(module_info)));
+    return process(module_info_ptr, subject.name_def->identifier());
+  }
+
+  return absl::NotFoundError(absl::StrFormat(
+      "ImportError: %s Could not find import for use of `%s`; attempted: [ %s "
+      "]",
+      name_def_span.ToString(file_table), subject.ToErrorString(),
+      absl::StrJoin(attempted,
+                    " :: ", [](std::string* out, const ImportTokens& tokens) {
+                      absl::StrAppend(out, tokens.ToString());
+                    })));
 }
 
 }  // namespace xls::dslx

--- a/xls/dslx/import_routines.h
+++ b/xls/dslx/import_routines.h
@@ -54,6 +54,27 @@ absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
                                      const Span& import_span,
                                      VirtualizableFilesystem& vfs);
 
+struct UseImportResult {
+  // The `ModuleInfo`s that were imported as we traversed. Note that there can
+  // be more that one if there is a chain of `pub use` statements.
+  ModuleInfo* imported_module;
+
+  // If the `use` statement was referring to an entity inside of the enclosing
+  // module, it is given here.
+  //
+  // If this is nullptr, then it is implied that the module was the entity being
+  // referred to.
+  ModuleMember* imported_member;
+};
+
+// Imports a subject of a `use` statement -- note that this imports a single
+// `subject` -- generally we linearize a `use` tree into elements and import
+// each one via this routine in sequence.
+absl::StatusOr<UseImportResult> DoImportViaUse(
+    const TypecheckModuleFn& ftypecheck, const UseSubject& subject,
+    ImportData* import_data, const Span& name_def_span, FileTable& file_table,
+    VirtualizableFilesystem& vfs);
+
 }  // namespace xls::dslx
 
 #endif  // XLS_DSLX_IMPORT_ROUTINES_H_

--- a/xls/dslx/lsp/BUILD
+++ b/xls/dslx/lsp/BUILD
@@ -169,6 +169,22 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "document_symbols_test",
+    srcs = ["document_symbols_test.cc"],
+    deps = [
+        ":document_symbols",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/dslx:create_import_data",
+        "//xls/dslx:import_data",
+        "//xls/dslx:parse_and_typecheck",
+        "@com_google_googletest//:gtest",
+        "@verible//verible/common/lsp:lsp-protocol",
+        "@verible//verible/common/lsp:lsp-protocol-enums",
+    ],
+)
+
 cc_library(
     name = "import_sensitivity",
     srcs = ["import_sensitivity.cc"],

--- a/xls/dslx/lsp/document_symbols.cc
+++ b/xls/dslx/lsp/document_symbols.cc
@@ -72,6 +72,19 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(
   return {std::move(ds)};
 }
 
+std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Use& u) {
+  std::vector<verible::lsp::DocumentSymbol> result;
+  for (const UseSubject& subject : u.LinearizeToSubjects()) {
+    result.push_back(verible::lsp::DocumentSymbol{
+        .name = subject.name_def->identifier(),
+        .kind = verible::lsp::SymbolKind::kModule,
+        .range = ConvertSpanToLspRange(subject.name_def->span()),
+        .selectionRange = ConvertSpanToLspRange(subject.name_def->span()),
+    });
+  }
+  return result;
+}
+
 }  // namespace
 
 std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
@@ -81,7 +94,7 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
   for (const ModuleMember& member : m.top()) {
     std::vector<verible::lsp::DocumentSymbol> symbols =
         absl::visit(Visitor{
-                        [](Function* f) { return ToDocumentSymbols(*f); },
+                        [](auto* n) { return ToDocumentSymbols(*n); },
                         [](Proc*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
@@ -102,19 +115,11 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },
-                        [](StructDef* s) { return ToDocumentSymbols(*s); },
-                        [](ProcDef* p) { return ToDocumentSymbols(*p); },
                         [](Impl*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },
-                        [](ConstantDef* c) { return ToDocumentSymbols(*c); },
-                        [](EnumDef* e) { return ToDocumentSymbols(*e); },
                         [](Import*) {
-                          // TODO(google/xls#1080): Complete the set of symbols.
-                          return std::vector<verible::lsp::DocumentSymbol>{};
-                        },
-                        [](Use*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },

--- a/xls/dslx/lsp/document_symbols_test.cc
+++ b/xls/dslx/lsp/document_symbols_test.cc
@@ -1,0 +1,47 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/dslx/lsp/document_symbols.h"
+
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "verible/common/lsp/lsp-protocol-enums.h"
+#include "verible/common/lsp/lsp-protocol.h"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/parse_and_typecheck.h"
+
+namespace xls {
+
+TEST(DocumentSymbolsTest, TestUseConstruct) {
+  const std::string_view kModule = "use foo::{bar, baz::{qux, quux}};";
+  dslx::FileTable file_table;
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<dslx::Module> module,
+      dslx::ParseModule(kModule, "/path/to/sample.x", /*module_name=*/"sample",
+                        file_table));
+  std::vector<verible::lsp::DocumentSymbol> symbols =
+      dslx::ToDocumentSymbols(*module);
+  EXPECT_EQ(symbols.size(), 3);
+  EXPECT_EQ(symbols[0].name, "bar");
+  EXPECT_EQ(symbols[1].name, "qux");
+  EXPECT_EQ(symbols[2].name, "quux");
+
+  for (const auto& symbol : symbols) {
+    EXPECT_EQ(symbol.kind, verible::lsp::SymbolKind::kModule);
+  }
+}
+
+}  // namespace xls

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -690,6 +690,22 @@ xls_dslx_library(
     srcs = ["mod_imported.x"],
 )
 
+xls_dslx_library(
+    name = "mod_imported_multi_const_dslx",
+    srcs = ["mod_imported_multi_const.x"],
+)
+
+xls_dslx_library(
+    name = "mod_use_multi_lib",
+    srcs = ["mod_use_multi.x"],
+    deps = [":mod_imported_multi_const_dslx"],
+)
+
+dslx_lang_test(
+    name = "mod_use_multi",
+    dslx_deps = [":mod_use_multi_lib"],
+)
+
 dslx_lang_test(
     name = "mod_importer",
     dslx_deps = [":mod_imported_dslx"],

--- a/xls/dslx/tests/mod_imported_multi_const.x
+++ b/xls/dslx/tests/mod_imported_multi_const.x
@@ -1,0 +1,16 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const MOL = u32:42;
+pub const ONE = u32:1;

--- a/xls/dslx/tests/mod_use_multi.x
+++ b/xls/dslx/tests/mod_use_multi.x
@@ -1,0 +1,20 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use xls::dslx::tests::mod_imported_multi_const::{MOL, ONE};
+
+fn main() -> u32 { MOL + ONE }
+
+#[test]
+fn test_main() { assert_eq(main(), u32:43); }

--- a/xls/dslx/type_system/type_info.cc
+++ b/xls/dslx/type_system/type_info.cc
@@ -582,8 +582,9 @@ std::optional<StartAndWidth> TypeInfo::GetSliceStartAndWidth(
   return it2->second;
 }
 
-void TypeInfo::AddImport(Import* import, Module* module, TypeInfo* type_info) {
-  CHECK_EQ(import->owner(), module_);
+void TypeInfo::AddImport(std::variant<Use*, Import*> import, Module* module,
+                         TypeInfo* type_info) {
+  CHECK_EQ(ToAstNode(import)->owner(), module_);
   GetRoot()->imports_[import] = ImportedInfo{module, type_info};
 }
 

--- a/xls/dslx/type_system/type_info.h
+++ b/xls/dslx/type_system/type_info.h
@@ -246,13 +246,15 @@ class TypeInfo {
   //
   // Note that added type information and such will generally be owned by the
   // import cache.
-  void AddImport(Import* import, Module* module, TypeInfo* type_info);
+  void AddImport(std::variant<Use*, Import*> import, Module* module,
+                 TypeInfo* type_info);
 
   // Returns information on the imported module (its module AST node and
   // top-level type information).
   std::optional<const ImportedInfo*> GetImported(Import* import) const;
   absl::StatusOr<const ImportedInfo*> GetImportedOrError(Import* import) const;
-  const absl::flat_hash_map<Import*, ImportedInfo>& imports() const {
+  const absl::flat_hash_map<std::variant<Use*, Import*>, ImportedInfo>&
+  imports() const {
     return imports_;
   }
 
@@ -388,7 +390,7 @@ class TypeInfo {
       unrolled_loops_;
 
   // The following are only present on the root type info.
-  absl::flat_hash_map<Import*, ImportedInfo> imports_;
+  absl::flat_hash_map<std::variant<Use*, Import*>, ImportedInfo> imports_;
   absl::flat_hash_map<const Invocation*, InvocationData> invocations_;
   absl::flat_hash_map<Slice*, SliceData> slices_;
   absl::flat_hash_map<const Function*, bool> requires_implicit_token_;


### PR DESCRIPTION
- Create a helper for linearizing the subjects in a use tree
- Generalize import routines to accommodate both `import` and `use` via common helpers
- Language test with multiple use bindings from a single imported module
- Fake filesystem helper so we can pass a map contents for use as a filesystem

Towards #352 