### PR TITLE
[DSLX:FE] Add feature flag to gate `use` syntax.

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2897,6 +2897,10 @@ absl::StatusOr<DocRef> Formatter::Format(const Module& n) {
           pieces.push_back(arena_.MakeText("#![type_inference_version = 2]"));
           pieces.push_back(arena_.hard_line());
           break;
+        case ModuleAnnotation::kAllowUseSyntax:
+          pieces.push_back(arena_.MakeText("#![feature(use_syntax)]"));
+          pieces.push_back(arena_.hard_line());
+          break;
       }
     }
     pieces.push_back(arena_.hard_line());

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -1738,7 +1738,9 @@ fn divmod() {})*";
 
 TEST(AstClonerTest, Use) {
   constexpr std::string_view kProgram =
-      R"(use foo::bar::{baz::{bat, qux}, ipsum};)";
+      R"(#![feature(use_syntax)]
+
+use foo::bar::{baz::{bat, qux}, ipsum};)";
 
   FileTable file_table;
   XLS_ASSERT_OK_AND_ASSIGN(auto module, ParseModule(kProgram, "fake_path.x",

--- a/xls/dslx/frontend/module.cc
+++ b/xls/dslx/frontend/module.cc
@@ -85,6 +85,9 @@ std::string Module::ToString() const {
             case ModuleAnnotation::kTypeInferenceVersion2:
               absl::StrAppend(out, "#![type_inference_version = 2]");
               break;
+            case ModuleAnnotation::kAllowUseSyntax:
+              absl::StrAppend(out, "#![feature(use_syntax)]");
+              break;
           }
         });
     return absl::StrCat(header, "\n\n", body);

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -69,6 +69,9 @@ enum class ModuleAnnotation : uint8_t {
   kAllowNonstandardMemberNaming,
 
   kTypeInferenceVersion2,
+
+  // Enable "use" syntax instead of "import" for this module.
+  kAllowUseSyntax,
 };
 
 // Represents a syntactic module in the AST.


### PR DESCRIPTION
Feature flag to gate the `use` syntax until support is more complete.

There are some distributed challenges in enabling it comprehensively because, e.g. for IR conversion, before we could assume that all "external references" were via a ColonRef AST construct, but now they are NameDefs in the local module scope that happen to have their definition externally.

Towards #352 