### PR TITLE
[DSLX:BC] Remove logic from bytecode emitter, consolidate on type information

### DIFF
--- a/xls/dslx/bytecode/bytecode.h
+++ b/xls/dslx/bytecode/bytecode.h
@@ -161,7 +161,8 @@ class Bytecode {
     // otherwise it'll be logical.
     kShr,
     // Slices out a subset of the bits-typed value on TOS2,
-    // starting at index TOS1 and ending at index TOS0.
+    // starting at index TOS1 with bitwidth at TOS0.
+    // Note: the start index and the bitwidth should both be non-negative.
     kSlice,
     // Creates a new proc interpreter using the data in the optional data member
     // (as a `SpawnData`).

--- a/xls/dslx/bytecode/bytecode_emitter.h
+++ b/xls/dslx/bytecode/bytecode_emitter.h
@@ -113,7 +113,11 @@ class BytecodeEmitter : public ExprVisitor {
   absl::Status HandleFunctionRef(const FunctionRef* node) override;
   absl::Status HandleZeroMacro(const ZeroMacro* node) override;
   absl::Status HandleAllOnesMacro(const AllOnesMacro* node) override;
+
   absl::Status HandleIndex(const Index* node) override;
+  absl::Status HandleSlice(const Index* node, Slice* slice);
+  absl::Status HandleWidthSlice(const Index* node, WidthSlice* width_slice);
+
   absl::Status HandleInvocation(const Invocation* node) override;
   absl::Status HandleLet(const Let* node) override;
   absl::Status HandleMatch(const Match* node) override;

--- a/xls/dslx/interp_value.cc
+++ b/xls/dslx/interp_value.cc
@@ -451,9 +451,11 @@ bool InterpValue::operator==(const InterpValue& rhs) const { return Eq(rhs); }
     const InterpValue& lhs, const InterpValue& rhs, CompareF ucmp,
     CompareF scmp) {
   if (lhs.tag_ != rhs.tag_) {
-    return absl::InvalidArgumentError(absl::StrFormat(
-        "Same tag is required for a comparison operation: lhs %s rhs %s",
-        TagToString(lhs.tag_), TagToString(rhs.tag_)));
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Same tag is required for a comparison operation: lhs "
+                        "tag: %s, rhs tag: %s, lhs value: %s, rhs value: %s",
+                        TagToString(lhs.tag_), TagToString(rhs.tag_),
+                        lhs.ToString(), rhs.ToString()));
   }
   switch (lhs.tag_) {
     case InterpValueTag::kUBits:
@@ -692,7 +694,8 @@ absl::StatusOr<Bits> InterpValue::GetBits() const {
     return std::get<EnumData>(payload_).value;
   }
 
-  return absl::InvalidArgumentError("Value does not contain bits.");
+  return absl::InvalidArgumentError(
+      absl::StrFormat("Value %s does not contain bits.", ToString()));
 }
 
 const Bits& InterpValue::GetBitsOrDie() const {


### PR DESCRIPTION
We already note in the type information what we deduced for the slice start/size as they must be constexpr. This change prevents duplication of logic which can be subtly off/different by keying off the type information data as much as possible.

Fixes google/xls#1784