### PR TITLE
[DSLX][cleanup] Clean up uses of IsNameParametricBuiltin, stringy comparisons …

### DIFF
--- a/xls/dslx/frontend/builtins_metadata.h
+++ b/xls/dslx/frontend/builtins_metadata.h
@@ -32,8 +32,14 @@ struct BuiltinsData {
 // and 2) whether the builtin is represented as an AST node.
 const absl::flat_hash_map<std::string, BuiltinsData>& GetParametricBuiltins();
 
-// Returns whether the identifier is a builtin parameter not implemented as an
-// AST node
+// Returns whether the identifier is a builtin parameetric function (i.e. a key
+// in the `GetParametricBuiltins` map)
+// -- built-in functions are always available at the DSLX top level scope, but
+// are not implemented as AST nodes.
+//
+// Warning: prefer to use `IsBuiltinParametricNameRef()` over this function
+// wherever possible -- it's easy to forget to check that the name definition is
+// a `BuiltinNameDef` before testing the identifier.
 bool IsNameParametricBuiltin(std::string_view identifier);
 
 }  // namespace xls::dslx

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -1666,7 +1666,7 @@ absl::StatusOr<BValue> FunctionConverter::HandleMap(const Invocation* node) {
   Module* lookup_module = nullptr;
   if (auto* name_ref = dynamic_cast<NameRef*>(fn_node)) {
     map_fn_name = name_ref->identifier();
-    if (IsNameParametricBuiltin(map_fn_name)) {
+    if (IsBuiltinParametricNameRef(name_ref)) {
       VLOG(5) << "Map of parametric builtin: " << map_fn_name;
       return DefMapWithBuiltin(node, name_ref, node->args()[0],
                                *node_parametric_env.value());

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -3089,6 +3089,20 @@ proc Counter {
   ExpectIr(converted, TestName());
 }
 
+TEST(IrConverterTest, MapInvocationWithBuiltinFunction) {
+  constexpr std::string_view program =
+      R"(
+fn main(x: u32[4]) -> u32[4] {
+  map(x, clz)
+}
+)";
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::string converted,
+      ConvertModuleForTest(program, ConvertOptions{.emit_positions = false}));
+  ExpectIr(converted, TestName());
+}
+
 TEST(IrConverterTest, MapInvocationWithParametricFunction) {
   constexpr std::string_view program =
       R"(

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_MapInvocationWithBuiltinFunction.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_MapInvocationWithBuiltinFunction.ir
@@ -1,0 +1,14 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__clz(arg: bits[32] id=2) -> bits[32] {
+  reverse.3: bits[32] = reverse(arg, id=3)
+  one_hot.4: bits[33] = one_hot(reverse.3, lsb_prio=true, id=4)
+  encode.5: bits[6] = encode(one_hot.4, id=5)
+  ret zero_ext.6: bits[32] = zero_ext(encode.5, new_bit_count=32, id=6)
+}
+
+fn __test_module__main(x: bits[32][4] id=1) -> bits[32][4] {
+  ret map.7: bits[32][4] = map(x, to_apply=__test_module__clz, id=7)
+}

--- a/xls/dslx/type_system/BUILD
+++ b/xls/dslx/type_system/BUILD
@@ -348,6 +348,7 @@ cc_library(
         "//xls/dslx/bytecode:bytecode_emitter",
         "//xls/dslx/bytecode:bytecode_interpreter",
         "//xls/dslx/frontend:ast",
+        "//xls/dslx/frontend:ast_utils",
         "//xls/dslx/frontend:builtins_metadata",
         "//xls/dslx/frontend:pos",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xls/dslx/type_system/typecheck_invocation.cc
+++ b/xls/dslx/type_system/typecheck_invocation.cc
@@ -31,6 +31,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
+#include "re2/re2.h"
 #include "xls/common/casts.h"
 #include "xls/common/logging/log_lines.h"
 #include "xls/common/status/ret_check.h"
@@ -42,7 +43,7 @@
 #include "xls/dslx/dslx_builtins_signatures.h"
 #include "xls/dslx/errors.h"
 #include "xls/dslx/frontend/ast.h"
-#include "xls/dslx/frontend/builtins_metadata.h"
+#include "xls/dslx/frontend/ast_utils.h"
 #include "xls/dslx/frontend/pos.h"
 #include "xls/dslx/import_data.h"
 #include "xls/dslx/interp_value.h"
@@ -57,7 +58,6 @@
 #include "xls/dslx/type_system/type_and_parametric_env.h"
 #include "xls/dslx/type_system/type_info.h"
 #include "xls/dslx/type_system/unwrap_meta_type.h"
-#include "re2/re2.h"
 
 namespace xls::dslx {
 
@@ -341,7 +341,8 @@ absl::StatusOr<TypeAndParametricEnv> TypecheckInvocation(
   Expr* callee = invocation->callee();
 
   Function* caller = ctx->fn_stack().back().f();
-  if (IsNameParametricBuiltin(callee->ToString())) {
+  if (auto* name_ref = dynamic_cast<const NameRef*>(callee);
+      name_ref != nullptr && IsBuiltinParametricNameRef(name_ref)) {
     return TypecheckParametricBuiltinInvocation(ctx, invocation, caller);
   }
 
@@ -377,9 +378,9 @@ absl::StatusOr<TypeAndParametricEnv> TypecheckInvocation(
   DeduceCtx* parent_ctx = ctx;
   std::unique_ptr<DeduceCtx> imported_ctx_holder;
   if (dynamic_cast<ColonRef*>(invocation->callee()) != nullptr) {
-    auto placeholder = GetImportedDeduceCtx;
-    XLS_ASSIGN_OR_RETURN(imported_ctx_holder,
-                         placeholder(ctx, invocation, caller_parametric_env));
+    XLS_ASSIGN_OR_RETURN(
+        imported_ctx_holder,
+        GetImportedDeduceCtx(ctx, invocation, caller_parametric_env));
     ctx = imported_ctx_holder.get();
   }
 


### PR DESCRIPTION
…are more dangerous than node-based ones!

In particular it's based to have places that turn AST nodes to strings to see if they look like a BuiltinNameDef is being invoked, better to use AST-node-inspecting utilities to check that a NameRef is indeed referring to a BuiltinNameDef (instead of a user defined NameDef) so that we don't have bugs when users shadow builtin names with their own user defined functions.

This is pre-factoring for introduction of more `use` syntax support so towards #352 