### PR TITLE
[DSLX:TS] Don't crash on "member[0] of array is a type ref" scenario.

### DIFF
--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -856,6 +856,14 @@ absl::StatusOr<TypeDim> TupleType::GetTotalBitCount() const {
 
 // -- ArrayType
 
+ArrayType::ArrayType(std::unique_ptr<Type> element_type, const TypeDim& size)
+    : element_type_(std::move(element_type)), size_(size) {
+  CHECK(!element_type_->IsMeta())
+      << "Array element cannot be a metatype because arrays cannot hold types; "
+         "got: "
+      << element_type_->ToStringInternal(FullyQualify::kNo, nullptr);
+}
+
 absl::StatusOr<std::unique_ptr<Type>> ArrayType::MapSize(
     const std::function<absl::StatusOr<TypeDim>(TypeDim)>& f) const {
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> new_element_type,

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -751,11 +751,7 @@ class TupleType : public Type {
 // These will nest in the case of multidimensional arrays.
 class ArrayType : public Type {
  public:
-  ArrayType(std::unique_ptr<Type> element_type, const TypeDim& size)
-      : element_type_(std::move(element_type)), size_(size) {
-    CHECK(!element_type_->IsMeta())
-        << element_type_->ToStringInternal(FullyQualify::kNo, nullptr);
-  }
+  ArrayType(std::unique_ptr<Type> element_type, const TypeDim& size);
 
   absl::Status Accept(TypeVisitor& v) const override {
     return v.HandleArray(*this);


### PR DESCRIPTION
Previously this would cause a crash.