### PR TITLE
[dev_tools] Add script to check whether header guards are style-compliant.

### DIFF
--- a/xls/codegen/vast/dslx_builder.h
+++ b/xls/codegen/vast/dslx_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_CODEGEN_VAST__DSLX_BUILDER_H_
-#define XLS_CODEGEN_VAST__DSLX_BUILDER_H_
+#ifndef XLS_CODEGEN_VAST_DSLX_BUILDER_H_
+#define XLS_CODEGEN_VAST_DSLX_BUILDER_H_
 
 #include <filesystem>  // NOLINT
 #include <optional>
@@ -231,4 +231,4 @@ class DslxBuilder {
 
 }  // namespace xls
 
-#endif  // XLS_CODEGEN_VAST__DSLX_BUILDER_H_
+#endif  // XLS_CODEGEN_VAST_DSLX_BUILDER_H_

--- a/xls/codegen/vast/fold_vast_constants.h
+++ b/xls/codegen/vast/fold_vast_constants.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_CODEGEN_FOLD_VAST_CONSTANTS_H_
-#define XLS_CODEGEN_FOLD_VAST_CONSTANTS_H_
+#ifndef XLS_CODEGEN_VAST_FOLD_VAST_CONSTANTS_H_
+#define XLS_CODEGEN_VAST_FOLD_VAST_CONSTANTS_H_
 
 #include <cstdint>
 
@@ -53,4 +53,4 @@ absl::StatusOr<DataType*> FoldVastConstants(
 }  // namespace verilog
 }  // namespace xls
 
-#endif  // XLS_CODEGEN_FOLD_VAST_CONSTANTS_H_
+#endif  // XLS_CODEGEN_VAST_FOLD_VAST_CONSTANTS_H_

--- a/xls/codegen/vast/infer_vast_types.h
+++ b/xls/codegen/vast/infer_vast_types.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_CODEGEN_INFER_VAST_TYPES_H_
-#define XLS_CODEGEN_INFER_VAST_TYPES_H_
+#ifndef XLS_CODEGEN_VAST_INFER_VAST_TYPES_H_
+#define XLS_CODEGEN_VAST_INFER_VAST_TYPES_H_
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/statusor.h"
@@ -45,4 +45,4 @@ absl::StatusOr<absl::flat_hash_map<Expression*, DataType*>> InferVastTypes(
 }  // namespace verilog
 }  // namespace xls
 
-#endif  // XLS_CODEGEN_INFER_VAST_TYPES_H_
+#endif  // XLS_CODEGEN_VAST_INFER_VAST_TYPES_H_

--- a/xls/codegen/vast/vast.h
+++ b/xls/codegen/vast/vast.h
@@ -15,8 +15,8 @@
 // Subset-of-verilog AST, suitable for combining as datastructures before
 // emission.
 
-#ifndef XLS_CODEGEN_VAST_H_
-#define XLS_CODEGEN_VAST_H_
+#ifndef XLS_CODEGEN_VAST_VAST_H_
+#define XLS_CODEGEN_VAST_VAST_H_
 
 #include <cstdint>
 #include <limits>
@@ -2787,4 +2787,4 @@ inline T* VerilogPackageSection::Add(const SourceInfo& loc, Args&&... args) {
 }  // namespace verilog
 }  // namespace xls
 
-#endif  // XLS_CODEGEN_VAST_H_
+#endif  // XLS_CODEGEN_VAST_VAST_H_

--- a/xls/dev_tools/check_header_guards.py
+++ b/xls/dev_tools/check_header_guards.py
@@ -20,9 +20,10 @@
 
 import os
 import re
-
+import sys
 def get_expected_guard(filepath, repo_root):
-    # Convert the file path relative to repo root to an uppercase header guard format
+    # Convert the file path relative to repo root to an uppercase header guard
+    # format.
     relative_path = os.path.relpath(filepath, repo_root)
     guard = relative_path.upper().replace(os.sep, '_').replace('.', '_') + '_'
     return guard
@@ -31,7 +32,7 @@ def check_header_guard(filepath, expected_guard):
     with open(filepath, 'r') as file:
         lines = file.readlines()
 
-    # Check for the presence of the expected header guard
+    # Check for the presence of the expected header guard.
     guard_pattern = re.compile(r'#ifndef\s+(\S+)')
     for line in lines:
         match = guard_pattern.match(line.strip())
@@ -42,7 +43,8 @@ def check_header_guard(filepath, expected_guard):
     return False, None
 
 def find_h_files(repo_root):
-    # Find all .h files within the repo root, excluding xls/contrib and third_party
+    # Find all `.h` files within the repo root, excluding `xls/contrib` and
+    # `third_party`.
     h_files = []
     for root, _, files in os.walk(repo_root):
         if 'xls/contrib' in root or 'third_party' in root:

--- a/xls/dev_tools/check_header_guards.py
+++ b/xls/dev_tools/check_header_guards.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=missing-function-docstring
+
+"""Script to run from XLS repo root, checks if header guards are compliant."""
+
+import os
+import re
+
+def get_expected_guard(filepath, repo_root):
+    # Convert the file path relative to repo root to an uppercase header guard format
+    relative_path = os.path.relpath(filepath, repo_root)
+    guard = relative_path.upper().replace(os.sep, '_').replace('.', '_') + '_'
+    return guard
+
+def check_header_guard(filepath, expected_guard):
+    with open(filepath, 'r') as file:
+        lines = file.readlines()
+
+    # Check for the presence of the expected header guard
+    guard_pattern = re.compile(r'#ifndef\s+(\S+)')
+    for line in lines:
+        match = guard_pattern.match(line.strip())
+        if match:
+            actual_guard = match.group(1)
+            return actual_guard == expected_guard, actual_guard
+
+    return False, None
+
+def find_h_files(repo_root):
+    # Find all .h files within the repo root, excluding xls/contrib and third_party
+    h_files = []
+    for root, _, files in os.walk(repo_root):
+        if 'xls/contrib' in root or 'third_party' in root:
+            continue
+        for file in files:
+            if file.endswith('.h'):
+                h_files.append(os.path.join(root, file))
+    return h_files
+
+def main():
+    repo_root = os.path.join(os.getcwd())
+    h_files = find_h_files(repo_root)
+
+    non_compliant_files = []
+
+    for h_file in h_files:
+        expected_guard = get_expected_guard(h_file, repo_root)
+        compliant, actual_guard = check_header_guard(h_file, expected_guard)
+        if not compliant:
+            non_compliant_files.append((h_file, expected_guard, actual_guard))
+
+    if non_compliant_files:
+        print('Non-style-compliant header files:')
+        for file, expected, actual in non_compliant_files:
+            print(file)
+            print(f'  want: {expected}')
+            print(f'  got: {actual if actual else "None"}')
+        sys.exit(-1)
+    else:
+        print('All header files are style compliant.')
+
+if __name__ == '__main__':
+    main()
+

--- a/xls/dslx/run_routines/run_comparator.h
+++ b/xls/dslx/run_routines/run_comparator.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_DSLX_RUN_COMPARATOR_H_
-#define XLS_DSLX_RUN_COMPARATOR_H_
+#ifndef XLS_DSLX_RUN_ROUTINES_RUN_COMPARATOR_H_
+#define XLS_DSLX_RUN_ROUTINES_RUN_COMPARATOR_H_
 
 #include <cstdint>
 #include <memory>
@@ -83,4 +83,4 @@ class RunComparator : public AbstractRunComparator {
 
 }  // namespace xls::dslx
 
-#endif  // XLS_DSLX_RUN_COMPARATOR_H_
+#endif  // XLS_DSLX_RUN_ROUTINES_RUN_COMPARATOR_H_

--- a/xls/dslx/run_routines/run_routines.h
+++ b/xls/dslx/run_routines/run_routines.h
@@ -15,8 +15,8 @@
 // Routines for "running" DSLX files; i.e. parsing and testing all of the tests
 // contained inside.
 
-#ifndef XLS_DSLX_RUN_ROUTINES_H_
-#define XLS_DSLX_RUN_ROUTINES_H_
+#ifndef XLS_DSLX_RUN_ROUTINES_RUN_ROUTINES_H_
+#define XLS_DSLX_RUN_ROUTINES_RUN_ROUTINES_H_
 
 #include <cstdint>
 #include <filesystem>  // NOLINT
@@ -294,4 +294,4 @@ absl::StatusOr<QuickCheckResults> DoQuickCheck(
 
 }  // namespace xls::dslx
 
-#endif  // XLS_DSLX_RUN_ROUTINES_H_
+#endif  // XLS_DSLX_RUN_ROUTINES_RUN_ROUTINES_H_

--- a/xls/dslx/run_routines/test_xml.h
+++ b/xls/dslx/run_routines/test_xml.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_DSLX_TEST_XML_H_
-#define XLS_DSLX_TEST_XML_H_
+#ifndef XLS_DSLX_RUN_ROUTINES_TEST_XML_H_
+#define XLS_DSLX_RUN_ROUTINES_TEST_XML_H_
 
 // Simple layer for building XML-serializable objects that test-reporting
 // infrastructure wants.
@@ -206,4 +206,4 @@ std::string XmlRootToString(const XmlNode& root);
 
 }  // namespace xls::dslx::test_xml
 
-#endif  // XLS_DSLX_TEST_XML_H_
+#endif  // XLS_DSLX_RUN_ROUTINES_TEST_XML_H_

--- a/xls/dslx/stdlib/tests/float32_test_utils.h
+++ b/xls/dslx/stdlib/tests/float32_test_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_DSLX_STDLIB_FLOAT32_TEST_UTILS_H_
-#define XLS_DSLX_STDLIB_FLOAT32_TEST_UTILS_H_
+#ifndef XLS_DSLX_STDLIB_TESTS_FLOAT32_TEST_UTILS_H_
+#define XLS_DSLX_STDLIB_TESTS_FLOAT32_TEST_UTILS_H_
 
 #include <cmath>
 #include <cstdint>
@@ -68,4 +68,4 @@ inline bool CompareResultsWith1PercentMargin(float a, float b) {
 
 }  // namespace xls
 
-#endif  // XLS_DSLX_STDLIB_FLOAT32_TEST_UTILS_H_
+#endif  // XLS_DSLX_STDLIB_TESTS_FLOAT32_TEST_UTILS_H_

--- a/xls/ir/topo_sort.h
+++ b/xls/ir/topo_sort.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_IR_NODE_ITERATOR_H_
-#define XLS_IR_NODE_ITERATOR_H_
+#ifndef XLS_IR_TOPO_SORT_H_
+#define XLS_IR_TOPO_SORT_H_
 
 #include <optional>
 #include <vector>
@@ -47,4 +47,4 @@ std::vector<Node*> ReverseTopoSort(
 
 }  // namespace xls
 
-#endif  // XLS_IR_NODE_ITERATOR_H_
+#endif  // XLS_IR_TOPO_SORT_H_

--- a/xls/passes/proc_state_tuple_flattening_pass.h
+++ b/xls/passes/proc_state_tuple_flattening_pass.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_PASSES_PROC_STATE_FLATTENING_PASS_H_
-#define XLS_PASSES_PROC_STATE_FLATTENING_PASS_H_
+#ifndef XLS_PASSES_PROC_STATE_TUPLE_FLATTENING_PASS_H_
+#define XLS_PASSES_PROC_STATE_TUPLE_FLATTENING_PASS_H_
 
 #include <string_view>
 
@@ -45,4 +45,4 @@ class ProcStateTupleFlatteningPass : public OptimizationProcPass {
 
 }  // namespace xls
 
-#endif  // XLS_PASSES_PROC_STATE_FLATTENING_PASS_H_
+#endif  // XLS_PASSES_PROC_STATE_TUPLE_FLATTENING_PASS_H_

--- a/xls/tests/testbench.h
+++ b/xls/tests/testbench.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_TOOLS_TESTBENCH_H_
-#define XLS_TOOLS_TESTBENCH_H_
+#ifndef XLS_TESTS_TESTBENCH_H_
+#define XLS_TESTS_TESTBENCH_H_
 
 #include <cmath>
 #include <cstdint>
@@ -352,4 +352,4 @@ class TestbenchBase {
 }  // namespace internal
 }  // namespace xls
 
-#endif  // XLS_TOOLS_TESTBENCH_H_
+#endif  // XLS_TESTS_TESTBENCH_H_

--- a/xls/tests/testbench_builder.h
+++ b/xls/tests/testbench_builder.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_TOOLS_TESTBENCH_BUILDER_H_
-#define XLS_TOOLS_TESTBENCH_BUILDER_H_
+#ifndef XLS_TESTS_TESTBENCH_BUILDER_H_
+#define XLS_TESTS_TESTBENCH_BUILDER_H_
 
 // Builder classes for XLS Testbench objects.
 // Often, much of the functionality of a Testbench doesn't need to be
@@ -277,4 +277,4 @@ Testbench<InputT, ResultT> TestbenchBuilder<
 
 }  // namespace xls
 
-#endif  // XLS_TOOLS_TESTBENCH_BUILDER_H_
+#endif  // XLS_TESTS_TESTBENCH_BUILDER_H_

--- a/xls/tests/testbench_builder_utils.h
+++ b/xls/tests/testbench_builder_utils.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_TOOLS_TESTBENCH_BUILDER_UTILS_H_
-#define XLS_TOOLS_TESTBENCH_BUILDER_UTILS_H_
+#ifndef XLS_TESTS_TESTBENCH_BUILDER_UTILS_H_
+#define XLS_TESTS_TESTBENCH_BUILDER_UTILS_H_
 
 // This file contains "helper" default implementations of the IndexToInput,
 // CompareResults, and Print* routines.
@@ -225,4 +225,4 @@ void DefaultLogError(int64_t index, InputT input, ResultT expected,
 }  // namespace internal
 }  // namespace xls
 
-#endif  // XLS_TOOLS_TESTBENCH_BUILDER_UTILS_H_
+#endif  // XLS_TESTS_TESTBENCH_BUILDER_UTILS_H_

--- a/xls/tests/testbench_thread.h
+++ b/xls/tests/testbench_thread.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef XLS_TOOLS_TESTBENCH_THREAD_H_
-#define XLS_TOOLS_TESTBENCH_THREAD_H_
+#ifndef XLS_TESTS_TESTBENCH_THREAD_H_
+#define XLS_TESTS_TESTBENCH_THREAD_H_
 
 #include <atomic>
 #include <cstdint>
@@ -280,4 +280,4 @@ class TestbenchThreadBase {
 
 }  // namespace xls
 
-#endif  // XLS_TOOLS_TESTBENCH_THREAD_H_
+#endif  // XLS_TESTS_TESTBENCH_THREAD_H_


### PR DESCRIPTION
And fix up the non-style-compliant ones.

Wrote this because I forgot one in #1827 and realized I should just write this utility to get the dividends down the road.

Simply run as a script from OSS repo root:
```
$ python xls/dev_tools/check_header_guards.py 
All header files are compliant.
```