### PR TITLE
[DSLX] Add support for use statement in TI/interp.

### DIFF
--- a/xls/dslx/BUILD
+++ b/xls/dslx/BUILD
@@ -39,6 +39,8 @@ cc_library(
     hdrs = ["virtualizable_file_system.h"],
     deps = [
         "//xls/common/file:filesystem",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/log",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",

--- a/xls/dslx/bytecode/bytecode.h
+++ b/xls/dslx/bytecode/bytecode.h
@@ -51,7 +51,8 @@ class Bytecode {
     kAnd,
     // Invokes the function given in the Bytecode's data argument. Arguments are
     // given on the stack with deeper elements being earlier in the arg list
-    // (rightmost arg is TOS0 because we evaluate args left-to-right).
+    // (rightmost arg is TOS1 because we evaluate args left-to-right, TOS0 is
+    // the callee).
     kCall,
     // Casts the element on top of the stack to the type given in the optional
     // arg.

--- a/xls/dslx/bytecode/bytecode_emitter.h
+++ b/xls/dslx/bytecode/bytecode_emitter.h
@@ -122,8 +122,14 @@ class BytecodeEmitter : public ExprVisitor {
   absl::Status HandleLet(const Let* node) override;
   absl::Status HandleMatch(const Match* node) override;
   absl::Status HandleNameRef(const NameRef* node) override;
+
   absl::StatusOr<std::variant<InterpValue, Bytecode::SlotIndex>>
   HandleNameRefInternal(const NameRef* node);
+
+  absl::StatusOr<InterpValue> HandleExternRef(const NameRef& name_ref,
+                                              const NameDef& name_def,
+                                              UseTreeEntry& use_tree_entry);
+
   absl::Status HandleNumber(const Number* node) override;
   struct FormattedInterpValue {
     InterpValue value;

--- a/xls/dslx/constexpr_evaluator.h
+++ b/xls/dslx/constexpr_evaluator.h
@@ -102,6 +102,9 @@ class ConstexprEvaluator : public xls::dslx::ExprVisitor {
   absl::Status HandleXlsTuple(const XlsTuple* expr) override;
 
  private:
+  absl::Status HandleExternRef(const NameRef* name_ref, const NameDef* name_def,
+                               UseTreeEntry* use_tree_entry);
+
   ConstexprEvaluator(ImportData* import_data, TypeInfo* type_info,
                      WarningCollector* warning_collector,
                      ParametricEnv bindings, const Type* type)

--- a/xls/dslx/create_import_data.cc
+++ b/xls/dslx/create_import_data.cc
@@ -38,10 +38,14 @@ ImportData CreateImportData(
   return import_data;
 }
 
-ImportData CreateImportDataForTest() {
-  ImportData import_data(xls::kDefaultDslxStdlibPath,
-                         /*additional_search_paths=*/{}, kDefaultWarningsSet,
-                         std::make_unique<RealFilesystem>());
+ImportData CreateImportDataForTest(
+    std::unique_ptr<VirtualizableFilesystem> vfs) {
+  if (vfs == nullptr) {
+    vfs = std::make_unique<RealFilesystem>();
+  }
+  absl::Span<const std::filesystem::path> additional_search_paths = {};
+  ImportData import_data(xls::kDefaultDslxStdlibPath, additional_search_paths,
+                         kDefaultWarningsSet, std::move(vfs));
   import_data.SetBytecodeCache(std::make_unique<BytecodeCache>(&import_data));
   return import_data;
 }

--- a/xls/dslx/create_import_data.h
+++ b/xls/dslx/create_import_data.h
@@ -36,7 +36,8 @@ ImportData CreateImportData(
 
 // Creates an ImportData with reasonable defaults (standard path to the stdlib
 // and no additional search paths).
-ImportData CreateImportDataForTest();
+ImportData CreateImportDataForTest(
+    std::unique_ptr<VirtualizableFilesystem> vfs = nullptr);
 
 std::unique_ptr<ImportData> CreateImportDataPtrForTest();
 

--- a/xls/dslx/frontend/ast_test.cc
+++ b/xls/dslx/frontend/ast_test.cc
@@ -362,5 +362,6 @@ TEST(AstTest, IsConstantEmptyArray) {
 
   EXPECT_TRUE(IsConstant(array));
 }
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -281,6 +281,18 @@ absl::StatusOr<InterpValue> GetArrayTypeColonAttr(
                                 [&] { return array_type->ToString(); });
 }
 
+std::optional<const UseTreeEntry*> IsExternNameRef(const NameRef& name_ref) {
+  const AstNode* definer = name_ref.GetDefiner();
+  if (definer == nullptr) {
+    return std::nullopt;
+  }
+  auto* use_tree_entry = dynamic_cast<const UseTreeEntry*>(definer);
+  if (use_tree_entry == nullptr) {
+    return std::nullopt;
+  }
+  return use_tree_entry;
+}
+
 // Attempts to evaluate an expression as a literal boolean.
 //
 // This has a few simple forms:

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -84,6 +84,9 @@ absl::StatusOr<InterpValue> GetArrayTypeColonAttr(
     const ArrayTypeAnnotation* type, uint64_t constexpr_dim,
     std::string_view attr);
 
+// Returns a non-nullopt value if `name_ref` is bound by a `use` statement.
+std::optional<const UseTreeEntry*> IsExternNameRef(const NameRef& name_ref);
+
 // -- Template Metaprogramming helpers for dealing with AST node variants
 
 // TMP helper that gets the Nth type from a parameter pack.

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -172,7 +172,7 @@ class Module : public AstNode {
     }
 
     return absl::NotFoundError(
-        absl::StrFormat("No %s in module %s with name \"%s\"",
+        absl::StrFormat("No %s in module `%s` with name `%s`",
                         T::GetDebugTypeName(), name_, target_name));
   }
 

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -1564,7 +1564,9 @@ absl::StatusOr<UseTreeEntry*> Parser::ParseUseTreeEntry(Bindings& bindings) {
     // subsequent level.
     XLS_ASSIGN_OR_RETURN(NameDef * name_def, TokenToNameDef(tok));
     bindings.Add(name_def->identifier(), name_def);
-    return module_->Make<UseTreeEntry>(name_def, tok.span());
+    auto* use_tree_entry = module_->Make<UseTreeEntry>(name_def, tok.span());
+    name_def->set_definer(use_tree_entry);
+    return use_tree_entry;
   }
 
   // If we've gotten here we know there's a next level, we're just looking to

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -1666,12 +1666,22 @@ fn foo() -> bar::T<2>[3] {
 }
 
 TEST_F(ParserTest, UseOneItemFromModule) {
-  RoundTrip(R"(#![feature(use_syntax)]
+  std::unique_ptr<Module> m = RoundTrip(R"(#![feature(use_syntax)]
 
 use foo::BAR;
 fn main() -> u32 {
     BAR
 })");
+  std::optional<ModuleMember*> member = m->FindMemberWithName("BAR");
+  ASSERT_TRUE(member.has_value());
+  ASSERT_TRUE(std::holds_alternative<Use*>(*member.value()));
+  Use* use = std::get<Use*>(*member.value());
+  std::vector<UseSubject> subjects = use->LinearizeToSubjects();
+  ASSERT_EQ(subjects.size(), 1);
+  EXPECT_EQ(subjects.at(0).identifiers(),
+            std::vector<std::string>({"foo", "BAR"}));
+  EXPECT_EQ(subjects.at(0).name_def().identifier(), "BAR");
+  EXPECT_EQ(subjects.at(0).ToErrorString(), "`foo::BAR`");
 }
 
 TEST_F(ParserTest, UseTwoItemsFromModule) {

--- a/xls/dslx/import_data.h
+++ b/xls/dslx/import_data.h
@@ -70,6 +70,10 @@ class ModuleInfo {
 // Hashable (usable in a flat hash map).
 class ImportTokens {
  public:
+  static ImportTokens FromSpan(absl::Span<const std::string> identifiers) {
+    return ImportTokens(
+        std::vector<std::string>(identifiers.begin(), identifiers.end()));
+  }
   static absl::StatusOr<ImportTokens> FromString(std::string_view module_name);
 
   explicit ImportTokens(std::vector<std::string> pieces)
@@ -230,7 +234,8 @@ class ImportData {
       const std::filesystem::path&, absl::Span<const std::filesystem::path>,
       WarningKindSet);
 
-  friend ImportData CreateImportDataForTest();
+  friend ImportData CreateImportDataForTest(
+      std::unique_ptr<VirtualizableFilesystem> vfs);
   friend std::unique_ptr<ImportData> CreateImportDataPtrForTest();
 
   ImportData(std::filesystem::path stdlib_path,

--- a/xls/dslx/import_routines.h
+++ b/xls/dslx/import_routines.h
@@ -54,6 +54,27 @@ absl::StatusOr<ModuleInfo*> DoImport(const TypecheckModuleFn& ftypecheck,
                                      const Span& import_span,
                                      VirtualizableFilesystem& vfs);
 
+struct UseImportResult {
+  // The `ModuleInfo`s that were imported as we traversed. Note that there can
+  // be more that one if there is a chain of `pub use` statements.
+  ModuleInfo* imported_module;
+
+  // If the `use` statement was referring to an entity inside of the enclosing
+  // module, it is given here.
+  //
+  // If this is nullptr, then it is implied that the module was the entity being
+  // referred to.
+  ModuleMember* imported_member;
+};
+
+// Imports a subject of a `use` statement -- note that this imports a single
+// `subject` -- generally we linearize a `use` tree into elements and import
+// each one via this routine in sequence.
+absl::StatusOr<UseImportResult> DoImportViaUse(
+    const TypecheckModuleFn& ftypecheck, const UseSubject& subject,
+    ImportData* import_data, const Span& name_def_span, FileTable& file_table,
+    VirtualizableFilesystem& vfs);
+
 }  // namespace xls::dslx
 
 #endif  // XLS_DSLX_IMPORT_ROUTINES_H_

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -518,6 +518,22 @@ class InvocationVisitor : public ExprVisitor {
       return std::nullopt;
     }
 
+    if (std::optional<const UseTreeEntry*> tree_entry =
+            IsExternNameRef(*name_ref);
+        tree_entry.has_value()) {
+      XLS_RET_CHECK(tree_entry.value() != nullptr);
+      XLS_ASSIGN_OR_RETURN(const ImportedInfo* imported_info,
+                           type_info_->GetImportedOrError(tree_entry.value()));
+      XLS_RET_CHECK(imported_info != nullptr);
+      XLS_ASSIGN_OR_RETURN(Function * f,
+                           imported_info->module->GetMemberOrError<Function>(
+                               name_ref->identifier()));
+      XLS_RET_CHECK(f != nullptr);
+      return CalleeInfo{.module = imported_info->module,
+                        .callee = f,
+                        .type_info = imported_info->type_info};
+    }
+
     Module* this_m = name_ref->owner();
     XLS_ASSIGN_OR_RETURN(Function * f, this_m->GetMemberOrError<Function>(
                                            name_ref->identifier()));

--- a/xls/dslx/ir_convert/function_converter.h
+++ b/xls/dslx/ir_convert/function_converter.h
@@ -62,7 +62,11 @@ absl::StatusOr<Value> InterpValueToValue(const InterpValue& v);
 
 // For all free variables of "node", adds them transitively for any required
 // constant dependencies to the converter.
-absl::StatusOr<std::vector<ConstantDef*>> GetConstantDepFreevars(AstNode* node);
+//
+// Warning: the `ConstantDef`s may be owned by different modules, e.g. if we had
+// to traverse a name that was `use`d into the current module.
+absl::StatusOr<std::vector<ConstantDef*>> GetConstantDepFreevars(
+    AstNode* node, TypeInfo& type_info);
 
 // Wrapper around the type information query for whether DSL function "f"
 // requires an implicit token calling convention.
@@ -317,6 +321,10 @@ class FunctionConverter {
   // AstNode handlers.
   absl::Status HandleBinop(const Binop* node);
   absl::Status HandleNameRef(const NameRef* node);
+
+  absl::Status HandleExternNameRef(const NameRef* node,
+                                   const UseTreeEntry* use_tree_entry);
+
   absl::Status HandleNumber(const Number* node);
   absl::Status HandleParam(const Param* node);
   absl::Status HandleString(const String* node);

--- a/xls/dslx/ir_convert/ir_converter.cc
+++ b/xls/dslx/ir_convert/ir_converter.cc
@@ -172,8 +172,9 @@ absl::Status ConvertOneFunctionInternal(PackageData& package_data,
   FunctionConverter converter(package_data, record.module(), import_data,
                               options, proc_data, channel_scope,
                               record.IsTop());
-  XLS_ASSIGN_OR_RETURN(auto constant_deps,
-                       GetConstantDepFreevars(record.f()->body()));
+  XLS_ASSIGN_OR_RETURN(
+      auto constant_deps,
+      GetConstantDepFreevars(record.f()->body(), *record.type_info()));
   for (const auto& dep : constant_deps) {
     converter.AddConstantDep(dep);
   }

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -958,6 +958,25 @@ fn test() -> Foo<u32:5> {
   ExpectIr(converted, TestName());
 }
 
+// This is an example where we use an externally-defined parametric function
+// into module scope and invoke it at module scope.
+TEST(IrConverterTest, UseOfClog2InModuleScopedConstantDefinition) {
+  const char* kProgram = R"(#![feature(use_syntax)]
+use std::clog2;
+
+const MAX_BITS: u32 = clog2(u32:256);
+
+fn main() -> u32 {
+    MAX_BITS
+}
+)";
+
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::string converted,
+      ConvertModuleForTest(kProgram, ConvertOptions{.emit_positions = false}));
+  ExpectIr(converted, TestName());
+}
+
 TEST(IrConverterTest, UnrollForSimple) {
   const char* kProgram = R"(
 fn test() -> u32 {

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_UseOfClog2InModuleScopedConstantDefinition.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_UseOfClog2InModuleScopedConstantDefinition.ir
@@ -1,0 +1,24 @@
+package test_module
+
+file_number 0 "xls/dslx/stdlib/std.x"
+file_number 1 "test_module.x"
+
+fn __std__clog2__32(x: bits[32] id=1) -> bits[32] {
+  literal.6: bits[32] = literal(value=1, id=6)
+  sub.7: bits[32] = sub(x, literal.6, id=7)
+  reverse.8: bits[32] = reverse(sub.7, id=8)
+  one_hot.9: bits[33] = one_hot(reverse.8, lsb_prio=true, id=9)
+  N: bits[32] = literal(value=32, id=2)
+  encode.10: bits[6] = encode(one_hot.9, id=10)
+  literal.3: bits[32] = literal(value=1, id=3)
+  zero_ext.5: bits[32] = zero_ext(N, new_bit_count=32, id=5)
+  zero_ext.11: bits[32] = zero_ext(encode.10, new_bit_count=32, id=11)
+  uge.4: bits[1] = uge(x, literal.3, id=4)
+  literal.13: bits[32] = literal(value=0, id=13)
+  sub.12: bits[32] = sub(zero_ext.5, zero_ext.11, id=12)
+  ret sel.14: bits[32] = sel(uge.4, cases=[literal.13, sub.12], id=14)
+}
+
+fn __test_module__main() -> bits[32] {
+  ret MAX_BITS: bits[32] = literal(value=8, id=15)
+}

--- a/xls/dslx/lsp/BUILD
+++ b/xls/dslx/lsp/BUILD
@@ -169,6 +169,22 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "document_symbols_test",
+    srcs = ["document_symbols_test.cc"],
+    deps = [
+        ":document_symbols",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/dslx:create_import_data",
+        "//xls/dslx:import_data",
+        "//xls/dslx:parse_and_typecheck",
+        "@com_google_googletest//:gtest",
+        "@verible//verible/common/lsp:lsp-protocol",
+        "@verible//verible/common/lsp:lsp-protocol-enums",
+    ],
+)
+
 cc_library(
     name = "import_sensitivity",
     srcs = ["import_sensitivity.cc"],

--- a/xls/dslx/lsp/document_symbols.cc
+++ b/xls/dslx/lsp/document_symbols.cc
@@ -72,6 +72,19 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(
   return {std::move(ds)};
 }
 
+std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(Use& u) {
+  std::vector<verible::lsp::DocumentSymbol> result;
+  for (const UseSubject& subject : u.LinearizeToSubjects()) {
+    result.push_back(verible::lsp::DocumentSymbol{
+        .name = subject.name_def().identifier(),
+        .kind = verible::lsp::SymbolKind::kModule,
+        .range = ConvertSpanToLspRange(subject.name_def().span()),
+        .selectionRange = ConvertSpanToLspRange(subject.name_def().span()),
+    });
+  }
+  return result;
+}
+
 }  // namespace
 
 std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
@@ -81,7 +94,7 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
   for (const ModuleMember& member : m.top()) {
     std::vector<verible::lsp::DocumentSymbol> symbols =
         absl::visit(Visitor{
-                        [](Function* f) { return ToDocumentSymbols(*f); },
+                        [](auto* n) { return ToDocumentSymbols(*n); },
                         [](Proc*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
@@ -102,19 +115,11 @@ std::vector<verible::lsp::DocumentSymbol> ToDocumentSymbols(const Module& m) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },
-                        [](StructDef* s) { return ToDocumentSymbols(*s); },
-                        [](ProcDef* p) { return ToDocumentSymbols(*p); },
                         [](Impl*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },
-                        [](ConstantDef* c) { return ToDocumentSymbols(*c); },
-                        [](EnumDef* e) { return ToDocumentSymbols(*e); },
                         [](Import*) {
-                          // TODO(google/xls#1080): Complete the set of symbols.
-                          return std::vector<verible::lsp::DocumentSymbol>{};
-                        },
-                        [](Use*) {
                           // TODO(google/xls#1080): Complete the set of symbols.
                           return std::vector<verible::lsp::DocumentSymbol>{};
                         },

--- a/xls/dslx/lsp/document_symbols_test.cc
+++ b/xls/dslx/lsp/document_symbols_test.cc
@@ -1,0 +1,49 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/dslx/lsp/document_symbols.h"
+
+#include <string_view>
+
+#include "gtest/gtest.h"
+#include "verible/common/lsp/lsp-protocol-enums.h"
+#include "verible/common/lsp/lsp-protocol.h"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/parse_and_typecheck.h"
+
+namespace xls {
+
+TEST(DocumentSymbolsTest, TestUseConstruct) {
+  const std::string_view kModule = R"(#![feature(use_syntax)]
+use foo::{bar, baz::{qux, quux}};
+)";
+  dslx::FileTable file_table;
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<dslx::Module> module,
+      dslx::ParseModule(kModule, "/path/to/sample.x", /*module_name=*/"sample",
+                        file_table));
+  std::vector<verible::lsp::DocumentSymbol> symbols =
+      dslx::ToDocumentSymbols(*module);
+  EXPECT_EQ(symbols.size(), 3);
+  EXPECT_EQ(symbols[0].name, "bar");
+  EXPECT_EQ(symbols[1].name, "qux");
+  EXPECT_EQ(symbols[2].name, "quux");
+
+  for (const auto& symbol : symbols) {
+    EXPECT_EQ(symbol.kind, verible::lsp::SymbolKind::kModule);
+  }
+}
+
+}  // namespace xls

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -694,6 +694,22 @@ xls_dslx_library(
     srcs = ["mod_imported.x"],
 )
 
+xls_dslx_library(
+    name = "mod_imported_multi_const_dslx",
+    srcs = ["mod_imported_multi_const.x"],
+)
+
+xls_dslx_library(
+    name = "mod_use_multi_lib",
+    srcs = ["mod_use_multi.x"],
+    deps = [":mod_imported_multi_const_dslx"],
+)
+
+dslx_lang_test(
+    name = "mod_use_multi",
+    dslx_deps = [":mod_use_multi_lib"],
+)
+
 dslx_lang_test(
     name = "mod_importer",
     dslx_deps = [":mod_imported_dslx"],

--- a/xls/dslx/tests/mod_imported_multi_const.x
+++ b/xls/dslx/tests/mod_imported_multi_const.x
@@ -1,0 +1,16 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const MOL = u32:42;
+pub const ONE = u32:1;

--- a/xls/dslx/tests/mod_use_multi.x
+++ b/xls/dslx/tests/mod_use_multi.x
@@ -1,0 +1,22 @@
+#![feature(use_syntax)]
+
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use xls::dslx::tests::mod_imported_multi_const::{MOL, ONE};
+
+fn main() -> u32 { MOL + ONE }
+
+#[test]
+fn test_main() { assert_eq(main(), u32:43); }

--- a/xls/dslx/type_system/deduce_ctx.cc
+++ b/xls/dslx/type_system/deduce_ctx.cc
@@ -138,9 +138,9 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceCtx::Deduce(const AstNode* node) {
   XLS_RET_CHECK(!fn_stack().empty());
   XLS_RET_CHECK(deduce_function_ != nullptr);
   XLS_RET_CHECK_EQ(node->owner(), type_info()->module())
-      << "node: `" << node->ToString() << "` from module "
+      << "node: `" << node->ToString() << "` is from module "
       << node->owner()->name()
-      << " vs type info module: " << type_info()->module()->name();
+      << " vs type info is for module: " << type_info()->module()->name();
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> result,
                        deduce_function_(node, this));
 

--- a/xls/dslx/type_system/deduce_utils.cc
+++ b/xls/dslx/type_system/deduce_utils.cc
@@ -471,6 +471,20 @@ ResolveColonRefSubjectAfterTypeChecking(ImportData* import_data,
 absl::StatusOr<Function*> ResolveFunction(Expr* callee,
                                           const TypeInfo* type_info) {
   if (NameRef* name_ref = dynamic_cast<NameRef*>(callee); name_ref != nullptr) {
+    // If the definer is a UseTreeEntry, we need to resolve the function from
+    // the module that the UseTreeEntry is in.
+    if (std::holds_alternative<const NameDef*>(name_ref->name_def())) {
+      const NameDef* name_def = std::get<const NameDef*>(name_ref->name_def());
+      if (auto* use_tree_entry =
+              dynamic_cast<UseTreeEntry*>(name_def->definer());
+          use_tree_entry != nullptr) {
+        XLS_ASSIGN_OR_RETURN(const ImportedInfo* imported_info,
+                             type_info->GetImportedOrError(use_tree_entry));
+        return imported_info->module->GetMemberOrError<Function>(
+            name_ref->identifier());
+      }
+    }
+
     return name_ref->owner()->GetMemberOrError<Function>(
         name_ref->identifier());
   }

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -561,6 +561,29 @@ proc Bar {
       ParseAndTypecheck(kProgram, "fake_main_path.x", "main", &import_data));
 }
 
+TEST(TypecheckTest, UseOfConstant) {
+  constexpr std::string_view kImported = R"(
+pub const MY_CONSTANT: u32 = u32:42;
+)";
+  constexpr std::string_view kProgram = R"(#![feature(use_syntax)]
+use imported::MY_CONSTANT;
+
+fn f() -> u32 {
+  MY_CONSTANT
+}
+)";
+  absl::flat_hash_map<std::filesystem::path, std::string> files = {
+      {std::filesystem::path("/imported.x"), std::string(kImported)},
+      {std::filesystem::path("/fake_main_path.x"), std::string(kProgram)},
+  };
+  auto vfs = std::make_unique<FakeFilesystem>(
+      files, /*cwd=*/std::filesystem::path("/"));
+  ImportData import_data = CreateImportDataForTest(std::move(vfs));
+  absl::StatusOr<TypecheckedModule> main_module =
+      ParseAndTypecheck(kProgram, "fake_main_path.x", "main", &import_data);
+  XLS_EXPECT_OK(main_module.status()) << main_module.status();
+}
+
 TEST(TypecheckTest, FailsOnProcWithImplAsImportedStructMember) {
   constexpr std::string_view kImported = R"(
 pub proc Foo {
@@ -984,6 +1007,18 @@ fn f() -> u32 {
   for (_, accum) in range(u32:0, std::clog2(MOL)) {
     accum
   }(u32:0)
+}
+)"));
+}
+
+TEST(TypecheckTest, UseOfClog2InModuleScopedConstantDefinition) {
+  XLS_EXPECT_OK(Typecheck(R"(#![feature(use_syntax)]
+use std::clog2;
+
+const MAX_BITS: u32 = clog2(u32:256);
+
+fn main() -> u32 {
+    MAX_BITS
 }
 )"));
 }
@@ -4021,7 +4056,7 @@ proc t {
       IsPosError(
           "TypeInferenceError",
           HasSubstr("Cannot resolve callee `result_in` to a function; No "
-                    "function in module fake with name \"result_in\"")));
+                    "function in module `fake` with name `result_in`")));
 }
 
 TEST(TypecheckErrorTest, ReferenceToBuiltinFunctionInNext) {


### PR DESCRIPTION
Use statement introduce the notion of "extern refs" -- i.e. NameRefs that actually indicate things whose definitions live in other modules. Previously we knew more directly when we were referring to an extern definition because it would go through a ColonRef.

This introduces first handling of extern refs and support for imports via the `use` construct. You still cannot use a module directly, just entities defined inside of it -- we'll maybe want something like a "Module" type to keep in the TypeInfo when we introduce the ability to use a module directly, but I also didn't want to mess with anything that could affect type inference v2 work, so this focuses on direct use of definitions into the module scope.

Still also no support for "use *", I don't feel compelled to add support for that in any short order since it's also not usually a good practice and the mitigation of "type more" is not bad.

Summary of changes:
- Handle extern refs in the bytecode interpreter and constexpr evaluator
- Ability to linearize a use tree to definitions inside the module that should be imported
- Refactoring of routines for handling import statements to similarly handle use statements
- IR conversion FunctionConverter support for handling extern refs
- Some better invariants for ScopedTypeInfoSwap guard in the IR converter
- Typecheck support for traversing use statements at module scope
- FakeFilesystem that just takes a map for multi-module scenarios (vs UniformContentFilesystem which only supported one file)
- LSP test that the `use`-bound symbols are shown in the results