### PR TITLE
[DSLX:FE] Better error message if you try to use "unsized" array types.

### DIFF
--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -2965,6 +2965,14 @@ absl::StatusOr<ChannelDecl*> Parser::ParseChannelDecl(Bindings& bindings) {
 absl::StatusOr<std::vector<Expr*>> Parser::ParseDims(Bindings& bindings,
                                                      Pos* limit_pos) {
   XLS_ASSIGN_OR_RETURN(Token obrack, PopTokenOrError(TokenKind::kOBrack));
+
+  XLS_ASSIGN_OR_RETURN(bool peek_is_cbrack, PeekTokenIs(TokenKind::kCBrack));
+  if (peek_is_cbrack) {
+    return ParseErrorStatus(
+        obrack.span(),
+        "Unsized arrays are not supported, a (constant) size is required.");
+  }
+
   XLS_ASSIGN_OR_RETURN(Expr * first_dim,
                        ParseConditionalExpression(bindings, kNoRestrictions));
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -2158,6 +2158,19 @@ TEST_F(ParserTest, ArrayTypeAnnotation) {
   EXPECT_EQ(array_type->element_type()->ToString(), "u8");
 }
 
+TEST_F(ParserTest, UnsizedArrayTypeAnnotation) {
+  const std::string kProgram = "u8[]";
+  scanner_.emplace(file_table_, Fileno(0), kProgram);
+  parser_.emplace("test", &*scanner_);
+  Bindings bindings;
+  absl::StatusOr<TypeAnnotation*> ta =
+      ParseTypeAnnotation(parser_.value(), bindings);
+  ASSERT_FALSE(ta.ok());
+  EXPECT_THAT(ta.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("Unsized arrays are not supported")));
+}
+
 // Tests parsing of a type annotation made from the `xN` bits constructor.
 TEST_F(ParserTest, xNTypeAnnotation) {
   std::string s = "xN[false][128]";

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1277,6 +1277,13 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
     self.assertIn(
         "Want argument 0 to 'update' to be an array; got uN[32]", stderr
     )
+  
+  def test_unsized_array_type(self):
+    stderr = self._run('xls/dslx/tests/errors/unsized_array_type.x')
+    self.assertIn('ParseError:', stderr)
+    self.assertIn(
+        "Unsized arrays are not supported, a (constant) size is required.", stderr
+    )
 
 
 if __name__ == '__main__':

--- a/xls/dslx/tests/errors/unsized_array_type.x
+++ b/xls/dslx/tests/errors/unsized_array_type.x
@@ -1,0 +1,17 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn f(x: u32[]) -> u32[] { x }
+
+fn main() { f(u32[3]:[1, 2, 3] }


### PR DESCRIPTION
Helps to guide if folks assume they can make an array with no constant size as a way of representing an arbitrary-sized slice.