### PR TITLE
[xls][mlir] Allow non-bits values as array update operand

### DIFF
--- a/xls/contrib/mlir/IR/xls_ops.td
+++ b/xls/contrib/mlir/IR/xls_ops.td
@@ -658,7 +658,7 @@ def Xls_ArrayUpdateOp : Xls_Op<"array_update", [Pure, ShapesAreConsistent<["arra
   }];
   let arguments = (ins
     Xls_ArrayType:$array,
-    Xls_Bits:$value,
+    Xls_BitsOrTuple:$value,
     Xls_Bits:$index
   );
   let results = (outs

--- a/xls/contrib/mlir/testdata/ops_translate.mlir
+++ b/xls/contrib/mlir/testdata/ops_translate.mlir
@@ -248,9 +248,9 @@ func.func @array_slice(%arg0: !xls.array<4 x i8>, %arg1: i32) -> !xls.array<1 x 
   return %0 : !xls.array<1 x i8>
 }
 
-func.func @array_update(%arg0: !xls.array<4 x i8>, %arg1: i8, %arg2: i32) -> !xls.array<4 x i8> {
-  %0 = "xls.array_update"(%arg0, %arg1, %arg2) : (!xls.array<4 x i8>, i8, i32) -> !xls.array<4 x i8>
-  return %0 : !xls.array<4 x i8>
+func.func @array_update(%arg0: !xls.array<4 x tuple<i1, i2>>, %arg1: tuple<i1, i2>, %arg2: i32) -> !xls.array<4 x tuple<i1, i2>> {
+  %0 = "xls.array_update"(%arg0, %arg1, %arg2) : (!xls.array<4 x tuple<i1, i2>>, tuple<i1, i2>, i32) -> !xls.array<4 x tuple<i1, i2>>
+  return %0 : !xls.array<4 x tuple<i1, i2>>
 }
 
 func.func @trace(%arg0: i32, %tkn: !xls.token) -> !xls.token {


### PR DESCRIPTION
Mirrors XLS IR behavior. XLS Arrays can contain non-bits values, and the update op needs to support that.

@jpienaar @jmolloy