### PR TITLE
[DSLX:TS] Fix issues with type compatibility for parametric signedness params

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: bazel-cache-nightly-${{ runner.os }}-
 
       - name: Install dependencies via apt
-        run: sudo apt-get install python3-distutils python3-dev python-is-python3 libtinfo5  build-essential liblapack-dev libblas-dev gfortran
+        run: sudo apt-get install python3-dev python-is-python3 build-essential liblapack-dev libblas-dev gfortran
 
       - name: Bazel Build Tools (opt)
         run: |

--- a/xls/dslx/type_system/deduce.h
+++ b/xls/dslx/type_system/deduce.h
@@ -47,6 +47,12 @@ absl::StatusOr<std::unique_ptr<Type>> Deduce(const AstNode* node,
 absl::StatusOr<TypeDim> DimToConcreteUsize(const Expr* dim_expr,
                                            DeduceCtx* ctx);
 
+// Evaluates a dimension expression to a `TypeDim` value of the given `type`.
+//
+// Note that right now this is limited to evaluating only `bool` and `u32` values.
+absl::StatusOr<TypeDim> DimToConcrete(const Expr* dim_expr, const Type& type,
+                                      DeduceCtx* ctx);
+
 }  // namespace xls::dslx
 
 #endif  // XLS_DSLX_TYPE_SYSTEM_DEDUCE_H_

--- a/xls/dslx/type_system/deduce_ctx.cc
+++ b/xls/dslx/type_system/deduce_ctx.cc
@@ -46,6 +46,8 @@ namespace {
 
 absl::StatusOr<std::unique_ptr<Type>> ResolveViaEnv(
     const Type& type, const ParametricEnv& parametric_env) {
+  VLOG(10) << "ResolveViaEnv; type: " << type.ToString()
+           << " parametric_env: " << parametric_env.ToString();
   ParametricExpression::Env env;
   for (const auto& [k, v] : parametric_env.bindings()) {
     env[k] = v;
@@ -197,6 +199,7 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceCtx::Resolve(
 
 absl::StatusOr<std::unique_ptr<Type>> DeduceCtx::DeduceAndResolve(
     const AstNode* node) {
+  VLOG(10) << "DeduceAndResolve; node: `" << node->ToString() << "`";
   XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> deduced, Deduce(node));
   return Resolve(*deduced);
 }

--- a/xls/dslx/type_system/type.cc
+++ b/xls/dslx/type_system/type.cc
@@ -206,6 +206,14 @@ absl::StatusOr<std::unique_ptr<Type>> Type::FromInterpValue(
 TypeDim::TypeDim(const TypeDim& other)
     : value_(std::move(other.Clone().value_)) {}
 
+TypeDim::TypeDim(std::variant<InterpValue, OwnedParametric> value)
+    : value_(std::move(value)) {
+  if (std::holds_alternative<OwnedParametric>(value_)) {
+    const OwnedParametric& parametric = std::get<OwnedParametric>(value_);
+    CHECK(!parametric->const_value().has_value());
+  }
+}
+
 TypeDim TypeDim::Clone() const {
   if (std::holds_alternative<InterpValue>(value_)) {
     return TypeDim(std::get<InterpValue>(value_));
@@ -234,8 +242,38 @@ std::string TypeDim::ToString() const {
   return BitsToString(std::get<InterpValue>(value_).GetBitsOrDie());
 }
 
+static std::string VariantToString(
+    const std::variant<InterpValue, const ParametricExpression*>& variant) {
+  return absl::visit(Visitor{[](const InterpValue& value) {
+                               return absl::StrFormat("InterpValue{%s}",
+                                                      value.ToString());
+                             },
+                             [](const ParametricExpression* pe) {
+                               return absl::StrFormat(
+                                   "ParametricExpression{%s}", pe->ToString());
+                             }},
+                     variant);
+}
+
+static std::string VariantToString(
+    const std::variant<InterpValue, TypeDim::OwnedParametric>& variant) {
+  return absl::visit(Visitor{[](const InterpValue& value) {
+                               return absl::StrFormat("InterpValue{%s}",
+                                                      value.ToString());
+                             },
+                             [](const TypeDim::OwnedParametric& pe) {
+                               return absl::StrFormat(
+                                   "ParametricExpression{%s}", pe->ToString());
+                             }},
+                     variant);
+}
+
+std::string TypeDim::ToDebugString() const { return VariantToString(value_); }
+
 bool TypeDim::operator==(
     const std::variant<InterpValue, const ParametricExpression*>& other) const {
+  VLOG(10) << "TypeDim::operator==; this: " << VariantToString(value_)
+           << " other variant: " << VariantToString(other);
   return absl::visit(
       Visitor{
           [this](const InterpValue& other_value) {
@@ -255,13 +293,16 @@ bool TypeDim::operator==(
 }
 
 bool TypeDim::operator==(const TypeDim& other) const {
-  if (std::holds_alternative<std::unique_ptr<ParametricExpression>>(value_) &&
-      std::holds_alternative<std::unique_ptr<ParametricExpression>>(
-          other.value_)) {
-    return *std::get<std::unique_ptr<ParametricExpression>>(value_) ==
-           *std::get<std::unique_ptr<ParametricExpression>>(other.value_);
-  }
-  return value_ == other.value_;
+  // Extracts the variant from "other" and delegates to the variant-based
+  // equality comparison.
+  using VariantT = std::variant<InterpValue, const ParametricExpression*>;
+  VariantT other_variant = absl::visit(Visitor{
+      [](const InterpValue& v) -> VariantT { return v; },
+      [](const std::unique_ptr<ParametricExpression>& p) -> VariantT {
+        return p.get();
+      },
+  }, other.value_);
+  return *this == other_variant;
 }
 
 absl::StatusOr<TypeDim> TypeDim::Mul(const TypeDim& rhs) const {
@@ -482,7 +523,21 @@ MetaType::~MetaType() = default;
 // -- BitsConstructorType
 
 BitsConstructorType::BitsConstructorType(TypeDim is_signed)
-    : is_signed_(std::move(is_signed)) {}
+    : is_signed_(std::move(is_signed)) {
+  VLOG(10) << "BitsConstructorType constructor; is_signed: "
+           << is_signed_.ToDebugString();
+
+  // Validate that if we hold a parametric it is not just wrapping a concrete
+  // value -- that should always be represented with just the concrete value
+  // directly.
+  if (!is_signed_.IsParametric()) {
+    // Check that the InterpValue is a boolean.
+    const InterpValue& value = std::get<InterpValue>(is_signed_.value());
+    CHECK(value.IsBool())
+        << "BitsConstructorType is_signed must be a boolean; got: "
+        << value.ToString();
+  }
+}
 
 BitsConstructorType::~BitsConstructorType() = default;
 
@@ -493,6 +548,11 @@ absl::Status BitsConstructorType::Accept(TypeVisitor& v) const {
 absl::StatusOr<std::unique_ptr<Type>> BitsConstructorType::MapSize(
     const MapFn& f) const {
   XLS_ASSIGN_OR_RETURN(TypeDim new_is_signed, f(is_signed_));
+  if (!new_is_signed.IsParametric()) {
+    // Check that the concrete value that we got for signedness is a boolean.
+    const InterpValue& value = std::get<InterpValue>(new_is_signed.value());
+    XLS_RET_CHECK(value.IsBool()) << "Bits constructor `is_signed` value must be a boolean; got: " << value.ToString();
+  }
   return std::make_unique<BitsConstructorType>(std::move(new_is_signed));
 }
 
@@ -500,7 +560,9 @@ bool BitsConstructorType::operator==(const Type& other) const {
   VLOG(10) << "BitsConstructorType::operator==; this: " << *this
            << " other: " << other;
   if (auto* t = dynamic_cast<const BitsConstructorType*>(&other)) {
-    return t->is_signed_ == is_signed_;
+    bool result = t->is_signed_ == is_signed_;
+    VLOG(10) << "BitsConstructorType::operator==; result: " << result;
+    return result;
   }
   if (auto* b = dynamic_cast<const BitsType*>(&other)) {
     return TypeDim::CreateBool(b->is_signed()) == is_signed_ &&
@@ -1141,6 +1203,37 @@ std::optional<BitsLikeProperties> GetBitsLike(const Type& t) {
                               .size = array->size()};
   }
   return std::nullopt;
+}
+
+static std::optional<bool> GetKnownSignedness(
+    const BitsLikeProperties& properties) {
+  const TypeDim& is_signed = properties.is_signed;
+  if (is_signed.IsParametric()) {
+    return std::nullopt;
+  }
+  CHECK(std::get<InterpValue>(is_signed.value()).IsBool());
+  return is_signed.GetAsBool().value();
+}
+
+static std::optional<int64_t> GetKnownBitCount(
+    const BitsLikeProperties& properties) {
+  const TypeDim& size = properties.size;
+  if (size.IsParametric()) {
+    return std::nullopt;
+  }
+  return size.GetAsInt64().value();
+}
+
+bool IsKnownU1(const BitsLikeProperties& properties) {
+  std::optional<bool> signedness = GetKnownSignedness(properties);
+  std::optional<int64_t> bit_count = GetKnownBitCount(properties);
+  return signedness == false && bit_count == 1;
+}
+
+bool IsKnownU32(const BitsLikeProperties& properties) {
+  std::optional<bool> signedness = GetKnownSignedness(properties);
+  std::optional<int64_t> bit_count = GetKnownBitCount(properties);
+  return signedness == false && bit_count == 32;
 }
 
 }  // namespace xls::dslx

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -83,8 +83,7 @@ class TypeDim {
     return TypeDim(InterpValue::MakeBool(value));
   }
 
-  explicit TypeDim(std::variant<InterpValue, OwnedParametric> value)
-      : value_(std::move(value)) {}
+  explicit TypeDim(std::variant<InterpValue, OwnedParametric> value);
 
   TypeDim(const TypeDim& other);
   TypeDim(TypeDim&& other) = default;
@@ -100,6 +99,10 @@ class TypeDim {
   // Returns a string representation of this dimension, which is either the
   // integral string or the parametric expression string conversion.
   std::string ToString() const;
+
+  // Returns a string representation of this dimension with more internal
+  // details, suitable for debugging.
+  std::string ToDebugString() const;
 
   bool operator==(const TypeDim& other) const;
   bool operator==(const std::variant<InterpValue, const ParametricExpression*>&
@@ -1113,6 +1116,14 @@ struct BitsLikeProperties {
   TypeDim is_signed;
   TypeDim size;
 };
+
+// Returns true iff both the signedness and size of the `properties` are known
+// constants and they indicate that the type is a `u1` AKA `bool`.
+bool IsKnownU1(const BitsLikeProperties& properties);
+
+// Returns true iff both the signedness and size of the `properties` are known
+// constants and they indicate that the type is a `u32`.
+bool IsKnownU32(const BitsLikeProperties& properties);
 
 // Returns a string representation of the BitsLikeProperties that looks similar
 // to a corresponding BitsType.

--- a/xls/dslx/type_system/type_test.cc
+++ b/xls/dslx/type_system/type_test.cc
@@ -482,5 +482,35 @@ TEST(TypeDimTest, TestGetAs64BitsParametricSymbol) {
                        HasSubstr("Can't evaluate a ParametricExpression")));
 }
 
+TEST(TypeTest, TestEqualityOfBitsConstructorType) {
+  BitsConstructorType bct_unsigned0(TypeDim::CreateBool(false));
+  BitsConstructorType bct_unsigned1(TypeDim::CreateBool(false));
+  BitsConstructorType bct_signed0(TypeDim::CreateBool(true));
+  BitsConstructorType bct_signed1(TypeDim::CreateBool(true));
+  EXPECT_EQ(bct_unsigned0, bct_unsigned1);
+  EXPECT_EQ(bct_signed0, bct_signed1);
+  EXPECT_NE(bct_unsigned0, bct_signed0);
+  EXPECT_NE(bct_unsigned1, bct_signed1);
+}
+
+TEST(TypeTest, TestEqualityOfBitsConstructorTypeArrays) {
+  BitsConstructorType bct_unsigned0(TypeDim::CreateBool(false));
+  BitsConstructorType bct_unsigned1(TypeDim::CreateBool(false));
+
+  BitsConstructorType bct_signed0(TypeDim::CreateBool(true));
+  BitsConstructorType bct_signed1(TypeDim::CreateBool(true));
+
+  ArrayType array_u8_0(bct_unsigned0.CloneToUnique(), TypeDim::CreateU32(8));
+  ArrayType array_s8_0(bct_signed0.CloneToUnique(), TypeDim::CreateU32(8));
+
+  ArrayType array_u8_1(bct_unsigned1.CloneToUnique(), TypeDim::CreateU32(8));
+  ArrayType array_s8_1(bct_signed1.CloneToUnique(), TypeDim::CreateU32(8));
+
+  EXPECT_EQ(array_u8_0, array_u8_1);
+  EXPECT_EQ(array_s8_0, array_s8_1);
+  EXPECT_NE(array_u8_0, array_s8_0);
+  EXPECT_NE(array_u8_1, array_s8_1);
+}
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -302,6 +302,21 @@ fn main() -> bool[44] {
   XLS_EXPECT_OK(Typecheck(kProgram));
 }
 
+// Various samples of actual-argument compatibility with an `xN` field within a
+// struct via a struct instantiation expression.
+TEST(TypecheckTest, StructInstantiateParametricXnField) {
+  constexpr std::string_view kProgram = R"(
+struct XnWrapper<S: bool, N: u32> {
+  field: xN[S][N]
+}
+fn f() -> XnWrapper<false, u32:8> { XnWrapper<false, u32:8> { field: u8:0 } }
+fn g() -> XnWrapper<true, u32:8> { XnWrapper<true, u32:8> { field: s8:1 } }
+fn h() -> XnWrapper<false, u32:8> { XnWrapper<false, u32:8> { field: xN[false][8]:2 } }
+fn i() -> XnWrapper<true, u32:8> { XnWrapper<true, u32:8> { field: xN[true][8]:3 } }
+)";
+  XLS_EXPECT_OK(Typecheck(kProgram));
+}
+
 TEST(TypecheckTest, ParametricPlusGlobal) {
   constexpr std::string_view kProgram = R"(
 const GLOBAL = u32:4;


### PR DESCRIPTION
There were incompatibilities reported confusingly because the bit widths of the signedness were different; e.g. `u1:0` vs `u32:0` (note the difference in type bitwidth) where we don't visually show the width of the signedness when we print in `xN[is_signed=0][8]` sort of form.

Note: not sure why but I'm seeing package installation issues with the CI action, e.g. https://github.com/google/xls/actions/runs/12818961097/job/35745586502 around python3-distutils and libtinfo5.

Fixes #1861