### PR TITLE
[DSLX:RR][cleanup] Rename failures to GetFailureMessages

### DIFF
--- a/xls/dslx/run_routines/run_routines.h
+++ b/xls/dslx/run_routines/run_routines.h
@@ -169,7 +169,7 @@ class TestResultData {
     test_cases_.push_back(std::move(test_case));
   }
 
-  std::vector<std::string> failures() {
+  std::vector<std::string> GetFailureMessages() const {
     std::vector<std::string> failures;
     for (const auto& test_case : test_cases_) {
       if (test_case.status == test_xml::RunStatus::kRun &&

--- a/xls/dslx/run_routines/run_routines_test.cc
+++ b/xls/dslx/run_routines/run_routines_test.cc
@@ -529,7 +529,7 @@ proc tester_proc {
       TestResultData result,
       ParseAndTest(kProgram, "test_module", "test.x", options));
 
-  auto failures = result.failures();
+  std::vector<std::string> failures = result.GetFailureMessages();
   EXPECT_EQ(failures.size(), 1);
   if (GetParam() == RunnerType::kDslxInterpreter) {
     EXPECT_THAT(failures[0],


### PR DESCRIPTION
 per cpp style (lowercase should be simple accessors that do no work)