### PR TITLE
[DSLX:TIv2] Implement cast operation.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
-        exclude: '^(xls/contrib/.*|.*\.(sh|ir|txt|patch|csv))$'
+        exclude: '^(xls/contrib/.*|docs_src/bazel_rules_macros.md|.*\.(sh|ir|txt|patch|csv))$'

--- a/xls/dslx/interp_value.cc
+++ b/xls/dslx/interp_value.cc
@@ -562,8 +562,9 @@ absl::StatusOr<InterpValue> InterpValue::Mul(const InterpValue& other) const {
   XLS_ASSIGN_OR_RETURN(Bits rhs, other.GetBits());
   if (lhs.bit_count() != rhs.bit_count()) {
     return absl::InvalidArgumentError(absl::StrFormat(
-        "Cannot mul different width values: lhs %d bits, rhs %d bits",
-        lhs.bit_count(), rhs.bit_count()));
+        "Cannot mul different width values: lhs `%s` vs rhs `%s`",
+        BitsToString(lhs, FormatPreference::kDefault, true),
+        BitsToString(rhs, FormatPreference::kDefault, true)));
   }
   return InterpValue(tag_, bits_ops::UMul(lhs, rhs).Slice(0, lhs.bit_count()));
 }

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -681,35 +681,6 @@ absl::StatusOr<std::unique_ptr<Type>> DeduceUnrollFor(const UnrollFor* node,
   return std::move(loop_types.accumulator_type);
 }
 
-// Returns true if the cast-conversion from "from" to "to" is acceptable (i.e.
-// should not cause a type error to occur).
-static bool IsAcceptableCast(const Type& from, const Type& to) {
-  auto is_enum = [](const Type& ct) -> bool {
-    return dynamic_cast<const EnumType*>(&ct) != nullptr;
-  };
-  auto is_bits_array = [&](const Type& ct) -> bool {
-    const ArrayType* at = dynamic_cast<const ArrayType*>(&ct);
-    if (at == nullptr) {
-      return false;
-    }
-    if (IsBitsLike(at->element_type())) {
-      return true;
-    }
-    return false;
-  };
-  if ((is_bits_array(from) && IsBitsLike(to)) ||
-      (IsBitsLike(from) && is_bits_array(to))) {
-    return from.GetTotalBitCount() == to.GetTotalBitCount();
-  }
-  if ((IsBitsLike(from) || is_enum(from)) && IsBitsLike(to)) {
-    return true;
-  }
-  if (IsBitsLike(from) && is_enum(to)) {
-    return true;
-  }
-  return false;
-}
-
 absl::StatusOr<std::unique_ptr<Type>> DeduceCast(const Cast* node,
                                                  DeduceCtx* ctx) {
   VLOG(5) << "DeduceCast: " << node->ToString();

--- a/xls/dslx/type_system/deduce_utils.h
+++ b/xls/dslx/type_system/deduce_utils.h
@@ -204,6 +204,10 @@ absl::StatusOr<std::unique_ptr<Type>> ConcretizeBuiltinTypeAnnotation(
 absl::StatusOr<std::optional<Function*>> ImplFnFromCallee(
     const Attr* attr, const TypeInfo* type_info);
 
+// Returns true if the cast-conversion from "from" to "to" is acceptable (i.e.
+// should not cause a type error to occur).
+bool IsAcceptableCast(const Type& from, const Type& to);
+
 }  // namespace xls::dslx
 
 #endif  // XLS_DSLX_TYPE_SYSTEM_DEDUCE_UTILS_H_

--- a/xls/dslx/type_system_v2/solve_for_parametrics.cc
+++ b/xls/dslx/type_system_v2/solve_for_parametrics.cc
@@ -184,7 +184,7 @@ class Resolver {
                  signedness_and_bit_count.signedness));
     XLS_ASSIGN_OR_RETURN(
         int64_t bit_count,
-        Evaluate(CreateS64Annotation(*variable->owner(), variable->span()),
+        Evaluate(CreateU32Annotation(*variable->owner(), variable->span()),
                  signedness_and_bit_count.bit_count));
     return NoteValue(it->second,
                      is_signed ? InterpValue::MakeSBits(bit_count, value)

--- a/xls/dslx/type_system_v2/type_annotation_utils.cc
+++ b/xls/dslx/type_system_v2/type_annotation_utils.cc
@@ -87,11 +87,6 @@ TypeAnnotation* CreateBoolAnnotation(Module& module, const Span& span) {
       span, BuiltinType::kBool, module.GetOrCreateBuiltinNameDef("bool"));
 }
 
-TypeAnnotation* CreateS64Annotation(Module& module, const Span& span) {
-  return module.Make<BuiltinTypeAnnotation>(
-      span, BuiltinType::kS64, module.GetOrCreateBuiltinNameDef("s64"));
-}
-
 TypeAnnotation* CreateU32Annotation(Module& module, const Span& span) {
   return module.Make<BuiltinTypeAnnotation>(
       span, BuiltinType::kU32, module.GetOrCreateBuiltinNameDef("u32"));

--- a/xls/dslx/type_system_v2/type_annotation_utils.h
+++ b/xls/dslx/type_system_v2/type_annotation_utils.h
@@ -51,10 +51,12 @@ TypeAnnotation* CreateUnOrSnAnnotation(Module& module, const Span& span,
 // Creates a `bool` type annotation.
 TypeAnnotation* CreateBoolAnnotation(Module& module, const Span& span);
 
-// Creates a `s64` type annotation.
-TypeAnnotation* CreateS64Annotation(Module& module, const Span& span);
-
 // Creates a `u32` type annotation.
+//
+// TODO(https://github.com/google/xls/issues/450): 2025-01-23 In the future we
+// should perhaps be using "usize" instead to characterize the places we need
+// this, e.g. a type that we evaluate array dimensions and similar undecorated
+// values to.
 TypeAnnotation* CreateU32Annotation(Module& module, const Span& span);
 
 // Creates an annotation referring to the given struct definition with the given

--- a/xls/dslx/type_system_v2/typecheck_module_v2.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2.cc
@@ -166,6 +166,16 @@ class PopulateInferenceTableVisitor : public AstNodeVisitorWithDefault {
     return DefaultHandler(node);
   }
 
+  absl::Status HandleCast(const Cast* node) override {
+    VLOG(5) << "HandleCast: " << node->ToString();
+
+    // The cast node has the target type annotation (assuming it is valid, which
+    // will be checked at conversion time).
+    const TypeAnnotation* target_type = node->type_annotation();
+    XLS_RETURN_IF_ERROR(table_.SetTypeAnnotation(node, target_type));
+    return DefaultHandler(node);
+  }
+
   absl::Status HandleConditional(const Conditional* node) override {
     VLOG(5) << "HandleConditional: " << node->ToString();
     // In the example `const D = if (a) {b} else {c};`, the `ConstantDef`

--- a/xls/dslx/type_system_v2/typecheck_module_v2.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2.cc
@@ -169,6 +169,13 @@ class PopulateInferenceTableVisitor : public AstNodeVisitorWithDefault {
   absl::Status HandleCast(const Cast* node) override {
     VLOG(5) << "HandleCast: " << node->ToString();
 
+    // Create a new type variable for the casted expression.
+    XLS_ASSIGN_OR_RETURN(const NameRef* casted_variable,
+                         table_.DefineInternalVariable(
+                             InferenceVariableKind::kType, node->expr(),
+                             GenerateInternalTypeVariableName(node->expr())));
+    XLS_RETURN_IF_ERROR(table_.SetTypeVariable(node->expr(), casted_variable));
+
     // The cast node has the target type annotation (assuming it is valid, which
     // will be checked at conversion time).
     const TypeAnnotation* target_type = node->type_annotation();

--- a/xls/dslx/type_system_v2/typecheck_module_v2_test.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2_test.cc
@@ -2190,35 +2190,42 @@ fn foo(x: u32, y: u32) -> bool {
 
 TEST(TypecheckV2Test, CastU32ToU32) {
   EXPECT_THAT(R"(const X = u32:1;
-const Y: u32 = X as u32;)",
+const Y = X as u32;)",
+              TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[32]"),
+                                      HasNodeWithType("Y", "uN[32]"))));
+}
+
+TEST(TypecheckV2Test, CastXPlus1AsU32) {
+  EXPECT_THAT(R"(const X = u32:1;
+const Y = (X + 1) as u32;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[32]"),
                                       HasNodeWithType("Y", "uN[32]"))));
 }
 
 TEST(TypecheckV2Test, CastU32ToU16) {
   EXPECT_THAT(R"(const X = u32:1;
-const Y: u16 = X as u16;)",
+const Y = X as u16;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[32]"),
                                       HasNodeWithType("Y", "uN[16]"))));
 }
 
 TEST(TypecheckV2Test, CastU16ToU32) {
   EXPECT_THAT(R"(const X = u16:1;
-const Y: u32 = X as u32;)",
+const Y = X as u32;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[16]"),
                                       HasNodeWithType("Y", "uN[32]"))));
 }
 
 TEST(TypecheckV2Test, CastS16ToU32) {
   EXPECT_THAT(R"(const X = s16:1;
-const Y: u32 = X as u32;)",
+const Y = X as u32;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "sN[16]"),
                                       HasNodeWithType("Y", "uN[32]"))));
 }
 
 TEST(TypecheckV2Test, CastU16ToS32) {
   EXPECT_THAT(R"(const X = u16:1;
-const Y: s32 = X as s32;)",
+const Y = X as s32;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[16]"),
                                       HasNodeWithType("Y", "sN[32]"))));
 }
@@ -2231,13 +2238,13 @@ const X = f(u10:256);)",
 
 TEST(TypecheckV2Test, CastTupleToU32) {
   EXPECT_THAT(R"(const X = (u32:1, u32:2);
-const Y: u32 = X as u32;)",
+const Y = X as u32;)",
               TypecheckFails(HasCastError("(uN[32], uN[32])", "uN[32]")));
 }
 
 TEST(TypecheckV2Test, CastBitsArray2xU16ToU32) {
   EXPECT_THAT(R"(const X = [u16:1, u16:2];
-const Y: u32 = X as u32;)",
+const Y = X as u32;)",
               TypecheckSucceeds(AllOf(HasNodeWithType("X", "uN[16][2]"),
                                       HasNodeWithType("Y", "uN[32]"))));
 }


### PR DESCRIPTION
The type annotation the user provides is the type annotation that results from the cast expression.

It is validated when we go to finalize the inference table into type information, where we have concrete types that can check whether it is an acceptable cast.

Note that I also switched from S64 to U32s for default "usize like" usage and put a link to the relevant github issue where it explains why it'd be nice to have a usize type for this purpose similar to Rust.