### PR TITLE
[DSLX] Fix `use` of a type instantiated in a alias.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v5.0.0
     hooks:
       - id: end-of-file-fixer
-        exclude: '^(xls/contrib/.*|.*\.(sh|ir|txt|patch|csv))$'
+        exclude: '^(xls/contrib/.*|docs_src/bazel_rules_macros.md|.*\.(sh|ir|txt|patch|csv))$'

--- a/xls/codegen/vast/dslx_builder.cc
+++ b/xls/codegen/vast/dslx_builder.cc
@@ -86,6 +86,9 @@ absl::StatusOr<bool> IsNegative(const dslx::InterpValue& value) {
 std::string GetTypeDefName(const dslx::TypeDefinition& type_def) {
   return absl::visit(Visitor{
                          [&](const dslx::ColonRef* n) { return n->ToString(); },
+                         [&](const dslx::UseTreeEntry* n) {
+                           return n->GetLeafNameDef().value()->identifier();
+                         },
                          [&](const auto* n) { return n->identifier(); },
                      },
                      type_def);

--- a/xls/dslx/cpp_transpiler/cpp_type_generator.cc
+++ b/xls/dslx/cpp_transpiler/cpp_type_generator.cc
@@ -665,31 +665,38 @@ class StructCppTypeGenerator : public CppTypeGenerator {
 CppTypeGenerator::Create(const TypeDefinition& type_definition,
                          TypeInfo* type_info, ImportData* import_data) {
   return absl::visit(
-      Visitor{[&](const TypeAlias* type_alias)
-                  -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
-                return TypeAliasCppTypeGenerator::Create(type_alias, type_info,
-                                                         import_data);
-              },
-              [&](const StructDef* struct_def)
-                  -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
-                return StructCppTypeGenerator::Create(struct_def, type_info,
-                                                      import_data);
-              },
-              [&](const EnumDef* enum_def)
-                  -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
-                return EnumCppTypeGenerator::Create(enum_def, type_info,
-                                                    import_data);
-              },
-              [&](const ColonRef* colon_ref)
-                  -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
-                return absl::UnimplementedError(absl::StrFormat(
-                    "Unsupported type: %s", colon_ref->ToString()));
-              },
-              [&](const ProcDef* proc_def)
-                  -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
-                return absl::UnimplementedError(absl::StrFormat(
-                    "Unsupported type: %s", proc_def->ToString()));
-              }},
+      Visitor{
+          [&](const TypeAlias* type_alias)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return TypeAliasCppTypeGenerator::Create(type_alias, type_info,
+                                                     import_data);
+          },
+          [&](const StructDef* struct_def)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return StructCppTypeGenerator::Create(struct_def, type_info,
+                                                  import_data);
+          },
+          [&](const EnumDef* enum_def)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return EnumCppTypeGenerator::Create(enum_def, type_info,
+                                                import_data);
+          },
+          [&](const ColonRef* colon_ref)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return absl::UnimplementedError(
+                absl::StrFormat("Unsupported type: %s", colon_ref->ToString()));
+          },
+          [&](const ProcDef* proc_def)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return absl::UnimplementedError(
+                absl::StrFormat("Unsupported type: %s", proc_def->ToString()));
+          },
+          [](const UseTreeEntry* use_tree_entry)
+              -> absl::StatusOr<std::unique_ptr<CppTypeGenerator>> {
+            return absl::UnimplementedError(absl::StrFormat(
+                "Unsupported type: %s", use_tree_entry->ToString()));
+          },
+      },
       type_definition);
 }
 

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -337,6 +337,11 @@ DocRef Fmt(const TypeRef& n, Comments& comments, DocArena& arena) {
   return absl::visit(
       Visitor{
           [&](const ColonRef* n) { return Fmt(*n, comments, arena); },
+          [&](const UseTreeEntry* n) {
+            std::string_view identifier =
+                n->GetLeafNameDef().value()->identifier();
+            return arena.MakeText(std::string(identifier));
+          },
           [&](const auto* n) { return arena.MakeText(n->identifier()); },
       },
       n.type_definition());

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -336,6 +336,9 @@ AnyNameDef TypeDefinitionGetNameDef(const TypeDefinition& td) {
           [](ColonRef* n) -> AnyNameDef {
             return GetSubjectNameDef(n->subject());
           },
+          [](UseTreeEntry* n) -> AnyNameDef {
+            return n->GetLeafNameDef().value();
+          },
       },
       td);
 }
@@ -761,11 +764,13 @@ TypeRef::TypeRef(Module* owner, Span span, TypeDefinition type_definition)
       type_definition_(type_definition) {}
 
 std::string TypeRef::ToString() const {
-  return absl::visit(Visitor{[&](TypeAlias* n) { return n->identifier(); },
-                             [&](StructDef* n) { return n->identifier(); },
-                             [&](ProcDef* n) { return n->identifier(); },
-                             [&](EnumDef* n) { return n->identifier(); },
-                             [&](ColonRef* n) { return n->ToString(); }},
+  return absl::visit(Visitor{
+                         [&](ColonRef* n) { return n->ToString(); },
+                         [&](UseTreeEntry* n) {
+                           return n->GetLeafNameDef().value()->identifier();
+                         },
+                         [&](auto* n) { return n->identifier(); },
+                     },
                      type_definition_);
 }
 

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -1314,8 +1314,8 @@ class Array final : public Expr {
 
 // Several different AST nodes define types that can be referred to by a
 // TypeRef.
-using TypeDefinition =
-    std::variant<TypeAlias*, StructDef*, ProcDef*, EnumDef*, ColonRef*>;
+using TypeDefinition = std::variant<TypeAlias*, StructDef*, ProcDef*, EnumDef*,
+                                    ColonRef*, UseTreeEntry*>;
 
 // Returns the name definition that (most locally) defined this type definition
 // AST node.
@@ -1506,6 +1506,13 @@ class UseTreeEntry : public AstNode {
     return payload_;
   }
   const Span& span() const { return span_; }
+
+  std::optional<NameDef*> GetLeafNameDef() const {
+    if (std::holds_alternative<NameDef*>(payload_)) {
+      return std::get<NameDef*>(payload_);
+    }
+    return std::nullopt;
+  }
 
   // Note: this is non-const because we capture a mutable AST node pointer in
   // the results.

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -138,6 +138,9 @@ absl::StatusOr<StructDef*> ResolveLocalStructDef(TypeDefinition td) {
           [&](ProcDef* n) -> absl::StatusOr<StructDef*> { return error(n); },
           [&](EnumDef* n) -> absl::StatusOr<StructDef*> { return error(n); },
           [&](ColonRef* n) -> absl::StatusOr<StructDef*> { return error(n); },
+          [&](UseTreeEntry* n) -> absl::StatusOr<StructDef*> {
+            return error(n);
+          },
       },
       td);
 }

--- a/xls/dslx/frontend/bindings.cc
+++ b/xls/dslx/frontend/bindings.cc
@@ -84,6 +84,9 @@ AnyNameDef BoundNodeToAnyNameDef(BoundNode bn) {
               [](BuiltinNameDef* node) -> AnyNameDef { return node; },
               [](TypeAlias* node) -> AnyNameDef { return &node->name_def(); },
               [](Import* node) -> AnyNameDef { return &node->name_def(); },
+              [](UseTreeEntry* node) -> AnyNameDef {
+                return node->GetLeafNameDef().value();
+              },
               [](auto* node) -> AnyNameDef { return node->name_def(); }},
       bn);
 }

--- a/xls/dslx/frontend/bindings.h
+++ b/xls/dslx/frontend/bindings.h
@@ -40,8 +40,9 @@ namespace xls::dslx {
 // Bindings (name references in the environment that map back to definition
 // points in the AST) resolve to this BoundNode variant, which are all kinds of
 // definitions.
-using BoundNode = std::variant<EnumDef*, TypeAlias*, ConstantDef*, NameDef*,
-                               BuiltinNameDef*, StructDef*, ProcDef*, Import*>;
+using BoundNode =
+    std::variant<EnumDef*, TypeAlias*, ConstantDef*, NameDef*, BuiltinNameDef*,
+                 StructDef*, ProcDef*, Import*, UseTreeEntry*>;
 
 // Returns a string, useful for reporting in error messages, for the type of the
 // AST node contained inside of the given BoundNode variant; e.g. "Import".

--- a/xls/dslx/frontend/module.cc
+++ b/xls/dslx/frontend/module.cc
@@ -253,6 +253,11 @@ std::optional<ModuleMember*> Module::FindMemberWithName(
   return std::nullopt;
 }
 
+std::optional<const ModuleMember*> Module::FindMemberWithName(
+    std::string_view target) const {
+  return const_cast<Module*>(this)->FindMemberWithName(target);
+}
+
 absl::StatusOr<ConstantDef*> Module::GetConstantDef(std::string_view target) {
   std::optional<ModuleMember*> member = FindMemberWithName(target);
   if (!member.has_value()) {

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -189,6 +189,8 @@ class Module : public AstNode {
   // Finds the first top-level member in top() with the given "target" name as
   // an identifier.
   std::optional<ModuleMember*> FindMemberWithName(std::string_view target);
+  std::optional<const ModuleMember*> FindMemberWithName(
+      std::string_view target) const;
 
   // Returns whether the given node is a public member of this module.
   bool IsPublicMember(const AstNode& node) const;

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -700,6 +700,11 @@ xls_dslx_library(
 )
 
 xls_dslx_library(
+    name = "mod_imported_parameterized_type_alias_dslx",
+    srcs = ["mod_imported_parameterized_type_alias.x"],
+)
+
+xls_dslx_library(
     name = "mod_use_multi_lib",
     srcs = ["mod_use_multi.x"],
     deps = [":mod_imported_multi_const_dslx"],
@@ -723,6 +728,11 @@ xls_dslx_library(
 dslx_lang_test(
     name = "mod_importer_typedef",
     dslx_deps = [":mod_imported_typedef_dslx"],
+)
+
+dslx_lang_test(
+    name = "mod_use_parameterized_type_alias",
+    dslx_deps = [":mod_imported_parameterized_type_alias_dslx"],
 )
 
 # Library defined to be imported.

--- a/xls/dslx/tests/mod_imported_parameterized_type_alias.x
+++ b/xls/dslx/tests/mod_imported_parameterized_type_alias.x
@@ -1,0 +1,15 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+struct Point<X: u32, Y: u32> { x: bits[X], y: bits[Y] }

--- a/xls/dslx/tests/mod_use_parameterized_type_alias.x
+++ b/xls/dslx/tests/mod_use_parameterized_type_alias.x
@@ -1,0 +1,24 @@
+#![feature(use_syntax)]
+
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use xls::dslx::tests::mod_imported_parameterized_type_alias::Point;
+
+type MyPoint = Point<u32:4, u32:8>;
+
+fn main(p: MyPoint) -> (u4, u8) { (p.x, p.y) }
+
+#[test]
+fn test_main() { assert_eq(main(MyPoint { x: u4:4, y: u8:8 }), (u4:4, u8:8)); }

--- a/xls/dslx/translators/dslx_to_verilog.cc
+++ b/xls/dslx/translators/dslx_to_verilog.cc
@@ -327,6 +327,13 @@ DslxTypeToVerilogManager::TypeAnnotationToVastType(
                                   "DslxTypeToVerilogManager",
                                   type_annotation->ToString()));
             },
+            [&](UseTreeEntry* use_tree_entry)
+                -> absl::StatusOr<verilog::DataType*> {
+              return absl::UnimplementedError(absl::StrFormat(
+                  "TypeAnnotation UseTreeEntry %s not supported by "
+                  "DslxTypeToVerilogManager",
+                  type_annotation->ToString()));
+            },
         },
         ta->type_ref()->type_definition());
   }

--- a/xls/dslx/type_system/type_info.h
+++ b/xls/dslx/type_system/type_info.h
@@ -238,6 +238,7 @@ class TypeInfo {
   // its name.
   absl::StatusOr<TypeSource> ResolveTypeDefinition(TypeDefinition source);
   absl::StatusOr<TypeSource> ResolveTypeDefinition(ColonRef* source);
+  absl::StatusOr<TypeSource> ResolveTypeDefinition(UseTreeEntry* source);
 
   // Find the first annotated sv_type for the given type reference, assuming one
   // exists

--- a/xls/dslx/type_system_v2/type_annotation_utils.cc
+++ b/xls/dslx/type_system_v2/type_annotation_utils.cc
@@ -65,6 +65,12 @@ std::optional<StructOrProcDef> GetStructOrProcDef(
               },
               [](EnumDef*) -> std::optional<StructOrProcDef> {
                 return std::nullopt;
+              },
+              [](UseTreeEntry*) -> std::optional<StructOrProcDef> {
+                // TODO(https://github.com/google/xls/issues/352): 2025-01-23
+                // Resolve possible Struct or Proc definition through the extern
+                // UseTreeEntry.
+                return std::nullopt;
               }},
       def);
 }

--- a/xls/fuzzer/value_generator.cc
+++ b/xls/fuzzer/value_generator.cc
@@ -314,6 +314,11 @@ absl::StatusOr<Expr*> GenerateDslxConstant(absl::BitGenRef bit_gen,
             return absl::UnimplementedError(
                 "Generating constants of ColonRef types isn't yet supported.");
           },
+          [&](dslx::UseTreeEntry* use_tree_entry) -> absl::StatusOr<Expr*> {
+            return absl::UnimplementedError(
+                "Generating constants of UseTreeEntry types isn't yet "
+                "supported.");
+          },
       },
       typeref->type_definition());
 }

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -242,6 +242,9 @@ xls_dslx_type_definition_kind xls_dslx_module_get_type_definition_kind(
                          [](const xls::dslx::ColonRef*) {
                            return xls_dslx_type_definition_kind_colon_ref;
                          },
+                         [](const xls::dslx::UseTreeEntry*) {
+                           return xls_dslx_type_definition_kind_use_tree_entry;
+                         },
                      },
                      cpp_type_definition);
 }

--- a/xls/public/c_api_dslx.h
+++ b/xls/public/c_api_dslx.h
@@ -38,6 +38,7 @@ enum {
   xls_dslx_type_definition_kind_enum_def,
   xls_dslx_type_definition_kind_colon_ref,
   xls_dslx_type_definition_kind_proc_def,
+  xls_dslx_type_definition_kind_use_tree_entry,
 };
 
 typedef int32_t xls_dslx_module_member_kind;


### PR DESCRIPTION
Fix for the scenario where we use a type definition into the module scope and then instantiate it in a type alias. Add a `dslx_lang_test` for this.

Note that this adds `UseTreeEntry` as a node that can be a `TypeDefinition`.

Progress towards #352 