### PR TITLE
[DSLX:FE] Better error on `mut` usage, reserve `mut` as a keyword.

### DIFF
--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -3041,6 +3041,13 @@ absl::StatusOr<Let*> Parser::ParseLet(Bindings& bindings) {
                         start_tok.span().ToString(file_table())));
   }
 
+  XLS_ASSIGN_OR_RETURN(bool peek_is_mut, PeekTokenIs(Keyword::kMut));
+  if (peek_is_mut) {
+    return ParseErrorStatus(
+        start_tok.span(),
+        "`mut` and mutable bindings are not supported in DSLX");
+  }
+
   Bindings new_bindings(&bindings);
   NameDef* name_def = nullptr;
   NameDefTree* name_def_tree;

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -326,6 +326,22 @@ impl foo {
 })");
 }
 
+TEST(ParserErrorTest, LetMut) {
+  constexpr std::string_view kProgram = R"(fn main() -> u32 {
+    let mut x = u32:0;
+    x
+})";
+  FileTable file_table;
+  Scanner s{file_table, Fileno(0), std::string(kProgram)};
+  Parser parser{"test", &s};
+  absl::StatusOr<std::unique_ptr<Module>> module = parser.ParseModule();
+  EXPECT_THAT(
+      module.status(),
+      IsPosError(
+          "ParseError",
+          HasSubstr("`mut` and mutable bindings are not supported in DSLX")));
+}
+
 TEST(ParserErrorTest, ImplWithMisplacedSelf) {
   constexpr std::string_view kProgram = R"(struct foo {
     a: bits[9],

--- a/xls/dslx/frontend/scanner_keywords.inc
+++ b/xls/dslx/frontend/scanner_keywords.inc
@@ -41,6 +41,7 @@
   X(kType, TYPE, "type")                   \
   X(kUnrollFor, UNROLL_FOR, "unroll_for!") \
   X(kUse, USE, "use")                      \
+  X(kMut, MUT, "mut")                      \
   /* builtin types */                      \
   X(kBits, BITS, "bits")                   \
   X(kToken, TOKEN, "token")                \


### PR DESCRIPTION
It's common for new users and/or people coming from Rust knowledge to try typing `let mut` -- this gives a better error message when they try to do that, and reserves `mut` as a keyword for any potential of future usage (though that is not planned).