### PR TITLE
[DSLX:ir_conv] IR convert for-loop over array items.

### DIFF
--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -294,6 +294,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
 
   // Causes node "n" to accept this visitor (basic double-dispatch).
   absl::Status Visit(const AstNode* n) {
+    XLS_RET_CHECK(n != nullptr);
     VLOG(6) << this << " visiting: `" << n->ToString() << "` ("
             << n->GetNodeTypeName() << ")" << " @ "
             << SpanToString(n->GetSpan(), converter_->file_table());
@@ -703,6 +704,8 @@ absl::Status FunctionConverter::HandleString(const String* node) {
 absl::Status FunctionConverter::HandleTupleIndex(const TupleIndex* node) {
   XLS_RETURN_IF_ERROR(Visit(ToAstNode(node->lhs())));
   XLS_ASSIGN_OR_RETURN(BValue v, Use(node->lhs()));
+  XLS_RET_CHECK(v.GetType()->IsTuple());
+
   XLS_RETURN_IF_ERROR(Visit(ToAstNode(node->index())));
   XLS_ASSIGN_OR_RETURN(Bits rhs, GetConstBits(ToAstNode(node->index())));
   XLS_ASSIGN_OR_RETURN(uint64_t index, rhs.ToUint64());
@@ -943,6 +946,7 @@ absl::Status FunctionConverter::HandleLet(const Let* node) {
                                  : name_def_tree->GetSpan());
         }
 
+        CHECK(tuple.GetType()->IsTuple());
         BValue tuple_index = function_builder_->TupleIndex(tuple, index, loc);
         CHECK_OK(function_builder_->GetError());
 
@@ -1321,47 +1325,10 @@ absl::StatusOr<FunctionConverter::RangeData> FunctionConverter::GetRangeData(
   return RangeData{start_int, trip_count_int, bit_width};
 }
 
-absl::Status FunctionConverter::HandleFor(const For* node) {
-  XLS_RETURN_IF_ERROR(Visit(node->init()));
-
-  XLS_ASSIGN_OR_RETURN(RangeData range_data, GetRangeData(node->iterable()));
-
-  VLOG(5) << "Converting for-loop @ " << node->span().ToString(file_table());
-  FunctionConverter body_converter(package_data_, module_, import_data_,
-                                   options_, proc_data_, channel_scope_,
-                                   /*is_top=*/false);
-  body_converter.set_parametric_env_map(parametric_env_map_);
-
-  // The body conversion uses the same types that we use in the caller.
-  body_converter.current_type_info_ = current_type_info_;
-
-  // Note: there should be no name collisions (i.e. this name is unique)
-  // because:
-  //
-  // a) Double underscore symbols are reserved for the compiler.
-  //    TODO(leary): document this in the DSL reference.
-  // b) The function name being built must be unique in the module.
-  // c) The loop number bumps for each loop in that function.
-  std::string body_fn_name =
-      absl::StrFormat("__%s_counted_for_%d_body", function_builder_->name(),
-                      GetAndBumpCountedForCount());
-  auto body_builder =
-      std::make_unique<FunctionBuilder>(body_fn_name, package());
-  auto* body_builder_ptr = body_builder.get();
-  body_converter.SetFunctionBuilder(std::move(body_builder));
-
-  // Grab the two tuple of `(ivar, accum)`.
-  std::vector<std::variant<NameDefTree::Leaf, NameDefTree*>> flat =
-      node->names()->Flatten1();
-  if (flat.size() != 2) {
-    return absl::UnimplementedError(
-        "Expect for loop to have counter (induction variable) and carry data "
-        "for IR conversion.");
-  }
-
-  // Add the induction value (the "ranged" counter).
-  auto ivar = std::get<NameDefTree::Leaf>(flat[0]);
-  absl::StatusOr<BValue> loop_index = absl::visit(
+absl::StatusOr<BValue> FunctionConverter::HandleRangedForInductionVariable(
+    const For* node, FunctionConverter& body_converter,
+    NameDefTree::Leaf ivar_node) {
+  return absl::visit(
       Visitor{
           [&](NameDef* name_def) -> absl::StatusOr<BValue> {
             XLS_RET_CHECK(name_def != nullptr);
@@ -1392,24 +1359,31 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
                 "Induction variable cannot be a \"rest of tuple\"");
           },
       },
-      ivar);
-  XLS_RETURN_IF_ERROR(loop_index.status());
+      ivar_node);
+}
 
+absl::Status FunctionConverter::HandleForLoopCarry(
+    const For* node, FunctionConverter& body_converter,
+    const std::optional<RangeData>& range_data, BValue ivar_value,
+    NameDefTree::Leaf ivar, AstNode* carry_node) {
   // IR `counted_for` ops only support a trip count, not a set of iterables, so
   // we need to add an offset to that trip count/index to support nonzero loop
-  // start indices.
-  // Pulling values out of the iterable invocation is safe, as it was all
-  // checked in QueryConstRangeCall.
-  Value index_offset =
-      Value(UBits(range_data.start_value, range_data.bit_width));
-  BValue offset_literal =
-      body_converter.function_builder_->Literal(index_offset);
-  BValue offset_sum =
-      body_converter.function_builder_->Add(*loop_index, offset_literal);
-  body_converter.SetNodeToIr(ToAstNode(ivar), offset_sum);
+  // start indices; e.g. `for (i, accum) in 1..10` we actually iterate from 0 to
+  // 9 and add the offset of 1 to the index.
+  if (range_data.has_value()) {
+    Value index_offset =
+        Value(UBits(range_data->start_value, range_data->bit_width));
+    BValue offset_literal =
+        body_converter.function_builder_->Literal(index_offset);
+    BValue offset_sum =
+        body_converter.function_builder_->Add(ivar_value, offset_literal);
+
+    body_converter.SetNodeToIr(ToAstNode(ivar), offset_sum);
+  } else {
+    body_converter.SetNodeToIr(ToAstNode(ivar), ivar_value);
+  }
 
   // Add the loop carry value.
-  AstNode* carry_node = ToAstNode(flat[1]);
   if (auto* carry_name_def = dynamic_cast<NameDef*>(carry_node)) {
     // When the loop carry value is just a name; e.g. the `x` in `for (i, x)` we
     // can simply bind it.
@@ -1456,14 +1430,17 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
              "WildcardPattern";
     }
   }
+  return absl::OkStatus();
+}
 
-  // We need to capture the lexical scope and pass it to his loop body function.
-  //
-  // So we suffix free variables for the function body onto the function
-  // parameters.
+absl::StatusOr<std::vector<const NameDef*>>
+FunctionConverter::HandleForLexicalScope(const For* node,
+                                         FunctionConverter& body_converter) {
+  // Get all of the lexical free variables that are not builtin names.
   FreeVariables freevars =
       GetFreeVariablesByPos(node->body(), &node->span().start());
   freevars = freevars.DropBuiltinDefs();
+
   std::vector<const NameDef*> relevant_name_defs;
   for (const auto& any_name_def : freevars.GetNameDefs()) {
     const auto* freevar_name_def = std::get<const NameDef*>(any_name_def);
@@ -1472,6 +1449,7 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
     if (!type.has_value()) {
       continue;
     }
+    // Functions will be available to call at package scope.
     if (dynamic_cast<const FunctionType*>(type.value()) != nullptr) {
       continue;
     }
@@ -1511,7 +1489,11 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
   if (implicit_token_data_.has_value()) {
     XLS_RET_CHECK(body_converter.implicit_token_data_.has_value());
   }
+  return relevant_name_defs;
+}
 
+absl::StatusOr<BValue> FunctionConverter::HandleForBody(
+    const For* node, FunctionConverter& body_converter, int64_t trip_count) {
   FunctionConverterVisitor visitor(&body_converter);
   XLS_RETURN_IF_ERROR(visitor.Visit(node->body()));
 
@@ -1547,29 +1529,135 @@ absl::Status FunctionConverter::HandleFor(const For* node) {
          retval});
   }
 
-  XLS_ASSIGN_OR_RETURN(xls::Function * body_function,
-                       body_builder_ptr->Build());
-  VLOG(5) << "Converted body function: " << body_function->name();
+  XLS_ASSIGN_OR_RETURN(BValue init, Use(node->init()));
+  if (implicit_token_data_.has_value()) {
+    BValue activated = trip_count == 0 ? function_builder_->Literal(UBits(0, 1))
+                                       : implicit_token_data_->activated;
+    init = function_builder_->Tuple(
+        {implicit_token_data_->entry_token, activated, init});
+  }
+  return init;
+}
+
+// Returns whether `node` is a range expression, which is either a `Range` node
+// or an `Invocation` node with a callee of the builtin `range`.
+static bool IsRangeExpr(AstNode* node) {
+  if (auto* range = dynamic_cast<Range*>(node)) {
+    return true;
+  }
+  if (auto* invocation = dynamic_cast<Invocation*>(node)) {
+    // If the callee is builtin name ref to `range` then we also consider it a
+    // range expression.
+    if (auto* callee_name_ref = dynamic_cast<NameRef*>(invocation->callee())) {
+      return std::holds_alternative<BuiltinNameDef*>(
+                 callee_name_ref->name_def()) &&
+             std::get<BuiltinNameDef*>(callee_name_ref->name_def())
+                     ->identifier() == "range";
+    }
+  }
+  return false;
+}
+
+absl::Status FunctionConverter::HandleFor(const For* node) {
+  XLS_RETURN_IF_ERROR(Visit(node->init()));
+
+  std::optional<BValue> indexable;
+  std::optional<RangeData> range_data;
+  int64_t trip_count;
+  if (IsRangeExpr(node->iterable())) {
+    XLS_ASSIGN_OR_RETURN(range_data, GetRangeData(node->iterable()));
+    trip_count = range_data->trip_count;
+  } else {
+    XLS_RETURN_IF_ERROR(Visit(node->iterable()));
+    XLS_ASSIGN_OR_RETURN(indexable, Use(node->iterable()));
+    int64_t array_size = indexable->GetType()->AsArrayOrDie()->size();
+    XLS_RET_CHECK_GE(array_size, 0);
+    trip_count = array_size;
+  }
+
+  // Grab the two tuple of `(ivar, accum)`.
+  std::vector<std::variant<NameDefTree::Leaf, NameDefTree*>> flat =
+      node->names()->Flatten1();
+  if (flat.size() != 2) {
+    return absl::UnimplementedError(
+        "Expect for loop to have counter (induction variable) and carry data "
+        "for IR conversion.");
+  }
+
+  // Add the induction value (the "ranged" counter).
+  NameDefTree::Leaf ivar_node = std::get<NameDefTree::Leaf>(flat[0]);
+  AstNode* carry_node = ToAstNode(flat[1]);
+
+  VLOG(5) << "Converting for-loop @ " << node->span().ToString(file_table());
+  FunctionConverter body_converter(package_data_, module_, import_data_,
+                                   options_, proc_data_, channel_scope_,
+                                   /*is_top=*/false);
+  body_converter.set_parametric_env_map(parametric_env_map_);
+
+  // The body conversion uses the same types that we use in the caller.
+  body_converter.current_type_info_ = current_type_info_;
+
+  // Note: there should be no name collisions (i.e. this name is unique)
+  // because:
+  //
+  // a) Double underscore symbols are reserved for the compiler.
+  //    TODO(leary): document this in the DSL reference.
+  // b) The function name being built must be unique in the module.
+  // c) The loop number bumps for each loop in that function.
+  std::string body_fn_name =
+      absl::StrFormat("__%s_counted_for_%d_body", function_builder_->name(),
+                      GetAndBumpCountedForCount());
+  auto ir_body_builder =
+      std::make_unique<FunctionBuilder>(body_fn_name, package());
+  auto* ir_body_builder_ptr = ir_body_builder.get();
+  body_converter.SetFunctionBuilder(std::move(ir_body_builder));
 
   std::vector<BValue> invariant_args;
+
+  // Get the induction variable value -- this is handled differently for range
+  // expression vs iterating elements of an array because we need to add the
+  // iterable as an extra invariant arg in the latter case.
+  BValue ivar_value;
+  if (range_data.has_value()) {
+    XLS_ASSIGN_OR_RETURN(ivar_value, HandleRangedForInductionVariable(
+                                         node, body_converter, ivar_node));
+    XLS_RETURN_IF_ERROR(HandleForLoopCarry(node, body_converter, range_data,
+                                           ivar_value, ivar_node, carry_node));
+  } else {
+    BValue index =
+        body_converter.AddParam("__index", package()->GetBitsType(32));
+    XLS_RETURN_IF_ERROR(HandleForLoopCarry(node, body_converter, range_data,
+                                           ivar_value, ivar_node, carry_node));
+    BValue iterable =
+        body_converter.AddParam("__indexable", indexable->GetType());
+    ivar_value =
+        body_converter.function_builder_->ArrayIndex(iterable, {index});
+    body_converter.SetNodeToIr(ToAstNode(ivar_node), ivar_value);
+    invariant_args.push_back(indexable.value());
+  }
+
+  // Get any arguments we need lexically as invariant arguments -- this also
+  // prepares them to be available for discovery when we convert in
+  // `HandleForBody`.
+  XLS_ASSIGN_OR_RETURN(std::vector<const NameDef*> relevant_name_defs,
+                       HandleForLexicalScope(node, body_converter));
+
+  // Convert the for-loop body block into its IR (function) form.
+  XLS_ASSIGN_OR_RETURN(BValue init,
+                       HandleForBody(node, body_converter, trip_count));
+
+  // Now the body has been built up, we can get the IR function for it.
+  XLS_ASSIGN_OR_RETURN(xls::Function * ir_body_function,
+                       ir_body_builder_ptr->Build());
+
   for (const NameDef* nd : relevant_name_defs) {
     XLS_ASSIGN_OR_RETURN(BValue value, Use(nd));
     invariant_args.push_back(value);
   }
 
-  XLS_ASSIGN_OR_RETURN(BValue init, Use(node->init()));
-  if (implicit_token_data_.has_value()) {
-    BValue activated = range_data.trip_count == 0
-                           ? function_builder_->Literal(UBits(0, 1))
-                           : implicit_token_data_->activated;
-    init = function_builder_->Tuple(
-        {implicit_token_data_->entry_token, activated, init});
-  }
-
   Def(node, [&](const SourceInfo& loc) {
-    BValue result =
-        function_builder_->CountedFor(init, range_data.trip_count, /*stride=*/1,
-                                      body_function, invariant_args);
+    BValue result = function_builder_->CountedFor(
+        init, trip_count, /*stride=*/1, ir_body_function, invariant_args);
     // If a token was threaded through, we grab it and note it's an assertion
     // token.
     if (implicit_token_data_.has_value()) {

--- a/xls/dslx/ir_convert/function_converter.h
+++ b/xls/dslx/ir_convert/function_converter.h
@@ -163,6 +163,14 @@ class FunctionConverter {
   // Helper class used for chaining on/off control predicates.
   friend class ScopedControlPredicate;
 
+  // Contains/returns the pertinent information about a range expression (either
+  // a Range node or the range() builtin).
+  struct RangeData {
+    int64_t start_value;
+    int64_t trip_count;
+    int64_t bit_width;
+  };
+
   const FileTable& file_table() const { return import_data_->file_table(); }
 
   // Wraps up a type so it is (token, u1, type).
@@ -341,7 +349,45 @@ class FunctionConverter {
   absl::Status HandleCast(const Cast* node);
   absl::Status HandleColonRef(const ColonRef* node);
   absl::Status HandleConstantDef(const ConstantDef* node);
+
   absl::Status HandleFor(const For* node);
+
+  // Helper that adds a parameter for the induction variable node for a ranged
+  // for loop, e.g. when we have a pattern like: `for (i, accum) in 1..10` this
+  // handles the `ivar` named `i`.
+  absl::StatusOr<BValue> HandleRangedForInductionVariable(
+      const For* node, FunctionConverter& body_converter,
+      NameDefTree::Leaf ivar);
+
+  // Helpers that adds a parameter for the loop carried accumulator value.
+  // Handles the fact that we may need to destructure a pattern for
+  // `carry_node`.
+  absl::Status HandleForLoopCarry(const For* node,
+                                  FunctionConverter& body_converter,
+                                  const std::optional<RangeData>& range_data,
+                                  BValue loop_index, NameDefTree::Leaf ivar,
+                                  AstNode* carry_node);
+
+  // Returns the relevant name definitions for the lexical scope of the for
+  // loop.
+  //
+  // This lets us convert the body of the for loop into a function and pass all
+  // of the lexically required bindings as invariant arguments.
+  absl::StatusOr<std::vector<const NameDef*>> HandleForLexicalScope(
+      const For* node, FunctionConverter& body_converter);
+
+  // Runs conversion on the body block of `node`, placing the built IR into
+  // `body_converter`.
+  //
+  // This encapsulates any token threading that has to happen if the body is
+  // implicit-token calling convention.
+  //
+  // Returns the `init` BValue (which is also appropriately adapted for the
+  // calling convention).
+  absl::StatusOr<BValue> HandleForBody(const For* node,
+                                       FunctionConverter& body_converter,
+                                       int64_t trip_count);
+
   absl::Status HandleFormatMacro(const FormatMacro* node);
   absl::Status HandleIndex(const Index* node);
   absl::Status HandleInvocation(const Invocation* node);
@@ -435,13 +481,6 @@ class FunctionConverter {
   // with parametric values mangled in appropriately.
   absl::StatusOr<std::string> GetCalleeIdentifier(const Invocation* node);
 
-  // Contains/returns the pertinent information about a range expression (either
-  // a Range node or the range() builtin).
-  struct RangeData {
-    int64_t start_value;
-    int64_t trip_count;
-    int64_t bit_width;
-  };
   absl::StatusOr<RangeData> GetRangeData(const Expr* iterable);
 
   struct AssertionLabelData {

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -463,6 +463,32 @@ TEST(IrConverterTest, CountedFor) {
   ExpectIr(converted, TestName());
 }
 
+TEST(IrConverterTest, ForOverArrayOfItems) {
+  const std::string_view kProgram = R"(
+fn main(a: (u7, u7)[3]) -> u7 {
+  for (t, accum): ((u7, u7), u7) in a {
+    accum + t.0 + t.1
+  }(u7:0)
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertOneFunctionForTest(kProgram, "main"));
+  ExpectIr(converted, TestName());
+}
+
+TEST(IrConverterTest, ForOverArrayLiteral) {
+  const std::string_view kProgram = R"(
+fn main() -> u7 {
+  for (t, accum): ((u7, u7), u7) in (u7, u7)[2]:[(u7:0, u7:1), (u7:2, u7:3)] {
+    accum + t.0 + t.1
+  }(u7:0)
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertOneFunctionForTest(kProgram, "main"));
+  ExpectIr(converted, TestName());
+}
+
 TEST(IrConverterTest, CountedForDestructuring) {
   const char* program =
       R"(fn f() -> u32 {
@@ -684,6 +710,19 @@ fn main(input: u8[2]) -> u8[2] {
   XLS_ASSERT_OK_AND_ASSIGN(
       std::string converted,
       ConvertModuleForTest(program, ConvertOptions{.emit_positions = false}));
+  ExpectIr(converted, TestName());
+}
+
+// TODO(https://github.com/google/xls/issues/1289): Need to be able to convert
+// enumerate builtin.
+TEST(IrConverterTest, DISABLED_ArrayEnumerate) {
+  const std::string_view kProgram = R"(
+fn main(array: u8[4]) -> (u32, u8)[4]) {
+  enumerate(array)
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertOneFunctionForTest(kProgram, "main"));
   ExpectIr(converted, TestName());
 }
 

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_ForOverArrayLiteral.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_ForOverArrayLiteral.ir
@@ -1,0 +1,25 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn ____test_module__main_counted_for_0_body(__index: bits[32] id=9, accum: bits[7] id=10, __indexable: (bits[7], bits[7])[2] id=11) -> bits[7] {
+  array_index.12: (bits[7], bits[7]) = array_index(__indexable, indices=[__index], id=12)
+  tuple_index.14: bits[7] = tuple_index(array_index.12, index=0, id=14, pos=[(0,3,13)])
+  add.15: bits[7] = add(accum, tuple_index.14, id=15, pos=[(0,3,4)])
+  tuple_index.17: bits[7] = tuple_index(array_index.12, index=1, id=17, pos=[(0,3,19)])
+  literal.13: bits[32] = literal(value=0, id=13, pos=[(0,3,14)])
+  literal.16: bits[32] = literal(value=1, id=16, pos=[(0,3,20)])
+  ret add.18: bits[7] = add(add.15, tuple_index.17, id=18, pos=[(0,3,4)])
+}
+
+top fn __test_module__main() -> bits[7] {
+  literal.2: bits[7] = literal(value=0, id=2, pos=[(0,2,50)])
+  literal.3: bits[7] = literal(value=1, id=3, pos=[(0,2,56)])
+  literal.5: bits[7] = literal(value=2, id=5, pos=[(0,2,64)])
+  literal.6: bits[7] = literal(value=3, id=6, pos=[(0,2,70)])
+  tuple.4: (bits[7], bits[7]) = tuple(literal.2, literal.3, id=4, pos=[(0,2,49)])
+  tuple.7: (bits[7], bits[7]) = tuple(literal.5, literal.6, id=7, pos=[(0,2,63)])
+  literal.1: bits[7] = literal(value=0, id=1, pos=[(0,4,4)])
+  array.8: (bits[7], bits[7])[2] = array(tuple.4, tuple.7, id=8, pos=[(0,2,48)])
+  ret counted_for.19: bits[7] = counted_for(literal.1, trip_count=2, stride=1, body=____test_module__main_counted_for_0_body, invariant_args=[array.8], id=19)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_ForOverArrayOfItems.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_ForOverArrayOfItems.ir
@@ -1,0 +1,18 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn ____test_module__main_counted_for_0_body(__index: bits[32] id=3, accum: bits[7] id=4, __indexable: (bits[7], bits[7])[3] id=5) -> bits[7] {
+  array_index.6: (bits[7], bits[7]) = array_index(__indexable, indices=[__index], id=6)
+  tuple_index.8: bits[7] = tuple_index(array_index.6, index=0, id=8, pos=[(0,3,13)])
+  add.9: bits[7] = add(accum, tuple_index.8, id=9, pos=[(0,3,4)])
+  tuple_index.11: bits[7] = tuple_index(array_index.6, index=1, id=11, pos=[(0,3,19)])
+  literal.7: bits[32] = literal(value=0, id=7, pos=[(0,3,14)])
+  literal.10: bits[32] = literal(value=1, id=10, pos=[(0,3,20)])
+  ret add.12: bits[7] = add(add.9, tuple_index.11, id=12, pos=[(0,3,4)])
+}
+
+top fn __test_module__main(a: (bits[7], bits[7])[3] id=1) -> bits[7] {
+  literal.2: bits[7] = literal(value=0, id=2, pos=[(0,4,4)])
+  ret counted_for.13: bits[7] = counted_for(literal.2, trip_count=3, stride=1, body=____test_module__main_counted_for_0_body, invariant_args=[a], id=13)
+}

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -196,10 +196,7 @@ dslx_lang_test(
     test_ir_equivalence = False,
 )
 
-dslx_lang_test(
-    name = "for_over_range_u8",
-    convert_to_ir = False,
-)
+dslx_lang_test(name = "for_over_range_u8")
 
 dslx_lang_test(
     name = "parametric_binding",
@@ -221,10 +218,7 @@ dslx_lang_test(
     convert_to_ir = False,
 )
 
-dslx_lang_test(
-    name = "for_over_array",
-    convert_to_ir = False,
-)
+dslx_lang_test(name = "for_over_array")
 
 dslx_lang_test(name = "zero_macro")
 
@@ -337,16 +331,13 @@ dslx_lang_test(
     convert_to_ir = False,
 )
 
-dslx_lang_test(
-    name = "for_over_range",
-    # No meaningful entry point to convert.
-    convert_to_ir = False,
-)
+dslx_lang_test(name = "for_over_range")
 
 dslx_lang_test(
     name = "enumerate",
-    # No meaningful entry point to convert.
+    # TODO(https://github.com/google/xls/issues/1289): Need to be able to convert enumerate builtin.
     convert_to_ir = False,
+    compare = "none",
 )
 
 dslx_lang_test(

--- a/xls/dslx/tests/enumerate.x
+++ b/xls/dslx/tests/enumerate.x
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+fn main(array: u8[4]) -> (u32, u8)[4] { enumerate(array) }
+
 #[test]
 fn enumerate_test() {
-    let my_array = u32[4]:[u32:1, u32:2, u32:4, u32:8];
-    let enumerated = enumerate(my_array);
-    assert_eq(enumerated[u32:0], (u32:0, u32:1));
-    assert_eq(enumerated[u32:1], (u32:1, u32:2));
-    assert_eq(enumerated[u32:2], (u32:2, u32:4));
-    assert_eq(enumerated[u32:3], (u32:3, u32:8));
+    let my_array = u8[4]:[1, 2, 4, 8];
+    let enumerated = main(my_array);
+    assert_eq(enumerated[u32:0], (u32:0, u8:1));
+    assert_eq(enumerated[u32:1], (u32:1, u8:2));
+    assert_eq(enumerated[u32:2], (u32:2, u8:4));
+    assert_eq(enumerated[u32:3], (u32:3, u8:8));
 }

--- a/xls/dslx/tests/for_over_array.x
+++ b/xls/dslx/tests/for_over_array.x
@@ -12,11 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[test]
-fn for_over_array_test() {
-    let a: u32[3] = u32[3]:[1, 2, 3];
+fn main(a: u32[3]) -> u32 {
     let result: u32 = for (value, accum): (u32, u32) in a {
         accum + value
     }(u32:0);
-    assert_eq(u32:6, result)
+    result
+}
+
+#[test]
+fn for_over_array_test() {
+    let a: u32[3] = u32[3]:[1, 2, 3];
+    assert_eq(u32:6, main(a))
 }

--- a/xls/dslx/tests/for_over_range.x
+++ b/xls/dslx/tests/for_over_range.x
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[test]
-fn for_over_array_test() {
-    let result: u32 = for (value, accum): (u32, u32) in range(u32:1, u32:4) {
+fn main() -> u32 {
+    for (value, accum): (u32, u32) in u32:1..u32:4 {
         accum + value
-    }(u32:0);
-    assert_eq(u32:6, result)
+    }(u32:0)
 }
+
+#[test]
+fn for_over_range_expr_test() { assert_eq(u32:6, main()) }

--- a/xls/dslx/tests/for_over_range_u8.x
+++ b/xls/dslx/tests/for_over_range_u8.x
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[test]
-fn for_over_array_test() {
-    let result: u8 = for (value, accum): (u8, u8) in range(u8:1, u8:4) {
+fn main() -> u8 {
+    for (value, accum): (u8, u8) in range(u8:1, u8:4) {
         accum + value
-    }(u8:0);
-    assert_eq(u8:6, result)
+    }(u8:0)
 }
+
+#[test]
+fn for_over_builtin_range_invocation_test() { assert_eq(u8:6, main()) }

--- a/xls/ir/function_builder.cc
+++ b/xls/ir/function_builder.cc
@@ -62,7 +62,10 @@ namespace xls {
 std::ostream& operator<<(std::ostream& os, const BValue& bv) {
   return os << bv.ToString();
 }
-Type* BValue::GetType() const { return node()->GetType(); }
+Type* BValue::GetType() const {
+  CHECK(node_ != nullptr);
+  return node_->GetType();
+}
 
 int64_t BValue::BitCountOrDie() const { return node()->BitCountOrDie(); }
 


### PR DESCRIPTION
This also factors the for-loop handling into a few more decomposed functions so the new functionality didn't grow the large method even larger.

Makes some of the language tests have main() functions so we can observe whether IR conversion was successful.