### PR TITLE
Correctly materialize zero-width FIFOs.

### DIFF
--- a/xls/codegen/materialize_fifos_pass_test.cc
+++ b/xls/codegen/materialize_fifos_pass_test.cc
@@ -21,17 +21,17 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "xls/common/fuzzing/fuzztest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/fifo_model_test_utils.h"
+#include "xls/common/fuzzing/fuzztest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
@@ -60,17 +60,14 @@ class MaterializeFifosPassTestHelper {
       kInterpreterBlockEvaluator;
   static constexpr const BlockEvaluator& kTestEvaluator =
       kInterpreterBlockEvaluator;
-  absl::StatusOr<Block*> MakeOracleBlock(Package* p, FifoConfig config) {
-    return MakeOracleBlock(p, config, p->GetBitsType(32));
-  }
-  absl::StatusOr<Block*> MakeOracleBlock(Package* p, FifoConfig config,
-                                         Type* ty,
+  absl::StatusOr<Block*> MakeOracleBlock(Package* p, FifoTestParam params,
                                          std::string_view name = "oracle") {
     BlockBuilder bb(uniq_.GetSanitizedUniqueName(
                         absl::StrFormat("%s_%s", name, TestName())),
                     p);
-    XLS_ASSIGN_OR_RETURN(auto inst,
-                         bb.block()->AddFifoInstantiation("fifo", config, ty));
+    XLS_ASSIGN_OR_RETURN(auto inst, bb.block()->AddFifoInstantiation(
+                                        "fifo", params.config,
+                                        p->GetBitsType(params.data_bit_count)));
     XLS_ASSIGN_OR_RETURN(InstantiationType inst_ty, inst->type());
     for (const auto& [port_name, in_ty] : inst_ty.input_types()) {
       bb.InstantiationInput(inst, port_name, bb.InputPort(port_name, in_ty));
@@ -80,14 +77,9 @@ class MaterializeFifosPassTestHelper {
     }
     return bb.Build();
   }
-  absl::StatusOr<Block*> MakeFifoBlock(Package* p, FifoConfig config,
+  absl::StatusOr<Block*> MakeFifoBlock(Package* p, FifoTestParam params,
                                        std::string_view reset_name) {
-    return MakeFifoBlock(p, config, p->GetBitsType(32), reset_name);
-  }
-  absl::StatusOr<Block*> MakeFifoBlock(Package* p, FifoConfig config, Type* ty,
-                                       std::string_view reset_name) {
-    XLS_ASSIGN_OR_RETURN(Block * wrapper,
-                         MakeOracleBlock(p, config, ty, "test"));
+    XLS_ASSIGN_OR_RETURN(Block * wrapper, MakeOracleBlock(p, params, "test"));
 
     MaterializeFifosPass mfp;
     CodegenPassUnit pu(p, wrapper);
@@ -118,7 +110,7 @@ class MaterializeFifosPassTestHelper {
 
   // Compare against the interpreter as an oracle.
   void RunTestVector(
-      FifoConfig config, absl::Span<Operation const> operations,
+      FifoTestParam config, absl::Span<Operation const> operations,
       std::string_view reset_name = FifoInstantiation::kResetPortName) {
     auto p = CreatePackage();
     XLS_ASSERT_OK_AND_ASSIGN(Block * fifo_block,
@@ -131,8 +123,11 @@ class MaterializeFifosPassTestHelper {
                              MakeOracle(oracle_package.get(), config));
     testing::Test::RecordProperty("oracle", oracle_package->DumpIr());
     int64_t i = 0;
-    for (const BaseOperation& op : operations) {
-      auto input_set_inst = op.InputSet();
+    for (const BaseOperation& orig_op : operations) {
+      // Ensure applied operation has the expected type:
+      std::unique_ptr<BaseOperation> op =
+          orig_op.WithBitWidth(config.data_bit_count);
+      auto input_set_inst = op->InputSet();
 
       // Note that the name of the materialized reset port can differ from
       // the fifo instantiation reset port name, which is always
@@ -167,26 +162,11 @@ class MaterializeFifosPassTestHelper {
 
   NameUniquer uniq_ = NameUniquer("___");
 };
-struct PartialConfig {
-  bool bypass;
-  bool reg_push_outputs;
-  bool reg_pop_outputs;
 
-  FifoConfig WithDepth(int64_t depth) const {
-    return FifoConfig(depth, bypass, reg_push_outputs, reg_pop_outputs);
-  }
-};
-
-template <typename Sink>
-void AbslStringify(Sink& sink, const PartialConfig& value) {
-  absl::Format(&sink, "k%sBypass%sRegPushOutputs%sRegPopOutputs",
-               value.bypass ? "" : "No", value.reg_push_outputs ? "" : "No",
-               value.reg_pop_outputs ? "" : "No");
-}
 class MaterializeFifosPassTest
     : public MaterializeFifosPassTestHelper,
       public IrTestBase,
-      public testing::WithParamInterface<PartialConfig> {
+      public testing::WithParamInterface<FifoTestParam> {
  public:
   std::string TestName() const override { return IrTestBase::TestName(); }
   std::unique_ptr<Package> CreatePackage() const override {
@@ -195,74 +175,74 @@ class MaterializeFifosPassTest
 };
 
 TEST_P(MaterializeFifosPassTest, BasicFifo) {
-  RunTestVector(GetParam().WithDepth(3), {
-                                             Push{1},
-                                             Push{2},
-                                             Push{3},
-                                             NotReady{},
-                                             NotReady{},
-                                             NotReady{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             // Out of elements.
-                                             Pop{},
-                                             Pop{},
-                                             PushAndPop{4},
-                                             PushAndPop{5},
-                                             PushAndPop{6},
-                                             PushAndPop{7},
-                                             Pop{},
-                                             // Out of elements
-                                             Pop{},
-                                             Pop{},
-                                             Push{8},
-                                             Push{9},
-                                             Push{10},
-                                             // Full
-                                             Push{11},
-                                             Push{12},
-                                             Push{13},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             // Out of elements.
-                                             Pop{},
-                                             Pop{},
-                                         });
+  RunTestVector(GetParam(), {
+                                Push{1},
+                                Push{2},
+                                Push{3},
+                                NotReady{},
+                                NotReady{},
+                                NotReady{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                // Out of elements.
+                                Pop{},
+                                Pop{},
+                                PushAndPop{4},
+                                PushAndPop{5},
+                                PushAndPop{6},
+                                PushAndPop{7},
+                                Pop{},
+                                // Out of elements
+                                Pop{},
+                                Pop{},
+                                Push{8},
+                                Push{9},
+                                Push{10},
+                                // Full
+                                Push{11},
+                                Push{12},
+                                Push{13},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                // Out of elements.
+                                Pop{},
+                                Pop{},
+                            });
 }
 
 TEST_P(MaterializeFifosPassTest, BasicFifoFull) {
-  RunTestVector(GetParam().WithDepth(3), {
-                                             Push{1},
-                                             Push{2},
-                                             Push{3},
-                                             Push{4},
-                                             Push{5},
-                                             Push{6},
-                                             Push{7},
-                                             PushAndPop{8},
-                                             PushAndPop{9},
-                                             PushAndPop{10},
-                                             PushAndPop{11},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                         });
+  RunTestVector(GetParam(), {
+                                Push{1},
+                                Push{2},
+                                Push{3},
+                                Push{4},
+                                Push{5},
+                                Push{6},
+                                Push{7},
+                                PushAndPop{8},
+                                PushAndPop{9},
+                                PushAndPop{10},
+                                PushAndPop{11},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                            });
 }
 
 TEST_P(MaterializeFifosPassTest, FifoLengthIsSmall) {
   // If length is near the overflow point for the bit-width mistakes in mod
   // calculation are possible.
-  RunTestVector(GetParam().WithDepth(2),
+  RunTestVector(GetParam(),
                 {PushAndPop{1}, PushAndPop{2}, PushAndPop{3}, PushAndPop{4}});
 }
 
 TEST_F(MaterializeFifosPassTest, ResetFullFifo) {
-  FifoConfig cfg(3, false, false, false);
+  FifoTestParam cfg{32, {3, false, false, false}};
   RunTestVector(cfg, {
                          Push{1},
                          Push{2},
@@ -286,7 +266,7 @@ TEST_F(MaterializeFifosPassTest, ResetFullFifo) {
 }
 
 TEST_F(MaterializeFifosPassTest, ResetFullFifoWithDifferentResetName) {
-  FifoConfig cfg(3, false, false, false);
+  FifoTestParam cfg{32, {3, false, false, false}};
   RunTestVector(cfg,
                 {
                     Push{1},
@@ -312,67 +292,55 @@ TEST_F(MaterializeFifosPassTest, ResetFullFifoWithDifferentResetName) {
 }
 
 TEST_P(MaterializeFifosPassTest, BasicFifoBypass) {
-  RunTestVector(GetParam().WithDepth(3), {
-                                             PushAndPop{1},
-                                             PushAndPop{2},
-                                             PushAndPop{3},
-                                             PushAndPop{4},
-                                             PushAndPop{5},
-                                             PushAndPop{6},
-                                             PushAndPop{7},
-                                             PushAndPop{8},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                             Pop{},
-                                         });
+  RunTestVector(GetParam(), {
+                                PushAndPop{1},
+                                PushAndPop{2},
+                                PushAndPop{3},
+                                PushAndPop{4},
+                                PushAndPop{5},
+                                PushAndPop{6},
+                                PushAndPop{7},
+                                PushAndPop{8},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                                Pop{},
+                            });
+}
+
+inline std::vector<FifoTestParam> GenerateMaterializeFifoTestParams() {
+  std::vector<FifoTestParam> params;
+  for (int64_t data_bit_count : {0, 32}) {
+    for (int64_t depth : {0, 3, 5}) {
+      for (bool bypass : {true, false}) {
+        for (bool register_push_outputs : {true, false}) {
+          for (bool register_pop_outputs : {true, false}) {
+            if (depth == 0 &&
+                (!bypass || register_push_outputs || register_pop_outputs)) {
+              // Unsupported configurations of depth=0 fifos.
+              continue;
+            }
+            if (depth == 1 && register_pop_outputs) {
+              // Unsupported configuration of depth=1 fifo with
+              // register_pop_outputs.
+              continue;
+            }
+            params.push_back(FifoTestParam{
+                .data_bit_count = data_bit_count,
+                .config = FifoConfig(depth, bypass, register_push_outputs,
+                                     register_pop_outputs)});
+          }
+        }
+      }
+    }
+  }
+  return params;
 }
 
 INSTANTIATE_TEST_SUITE_P(MaterializeFifosPassTest, MaterializeFifosPassTest,
-                         testing::ValuesIn<PartialConfig>({
-                             PartialConfig{
-                                 .bypass = false,
-                                 .reg_push_outputs = false,
-                                 .reg_pop_outputs = false,
-                             },
-                             PartialConfig{
-                                 .bypass = false,
-                                 .reg_push_outputs = true,
-                                 .reg_pop_outputs = false,
-                             },
-                             PartialConfig{
-                                 .bypass = false,
-                                 .reg_push_outputs = false,
-                                 .reg_pop_outputs = true,
-                             },
-                             PartialConfig{
-                                 .bypass = false,
-                                 .reg_push_outputs = true,
-                                 .reg_pop_outputs = true,
-                             },
-                             PartialConfig{
-                                 .bypass = true,
-                                 .reg_push_outputs = false,
-                                 .reg_pop_outputs = false,
-                             },
-                             PartialConfig{
-                                 .bypass = true,
-                                 .reg_push_outputs = true,
-                                 .reg_pop_outputs = false,
-                             },
-                             PartialConfig{
-                                 .bypass = true,
-                                 .reg_push_outputs = false,
-                                 .reg_pop_outputs = true,
-                             },
-                             PartialConfig{
-                                 .bypass = true,
-                                 .reg_push_outputs = true,
-                                 .reg_pop_outputs = true,
-                             },
-                         }),
+                         testing::ValuesIn(GenerateMaterializeFifoTestParams()),
                          testing::PrintToStringParamName());
 
 class MaterializeFifosPassFuzzTest : public MaterializeFifosPassTestHelper {
@@ -382,22 +350,22 @@ class MaterializeFifosPassFuzzTest : public MaterializeFifosPassTestHelper {
   }
   std::string TestName() const override { return "FuzzTest"; }
 };
-void FuzzTestFifo(FifoConfig cfg, const std::vector<Operation>& ops) {
+void FuzzTestFifo(FifoTestParam cfg, const std::vector<Operation>& ops) {
   MaterializeFifosPassFuzzTest fixture;
   fixture.RunTestVector(cfg, ops);
 }
 
 FUZZ_TEST(MaterializeFifosPassFuzzTest, FuzzTestFifo)
-    .WithDomains(FifoConfigDomain(),
+    .WithDomains(FifoTestParamDomain(),
                  fuzztest::VectorOf(OperationDomain()).WithMaxSize(1000));
 
 TEST(FifoFuzzTest, FuzzTestJitRegression) {
-  FuzzTestFifo(xls::FifoConfig(1, false, false, false),
+  FuzzTestFifo(FifoTestParam{32, xls::FifoConfig(1, false, false, false)},
                {Operation(NotReady()), Operation(Pop())});
 }
 
 TEST(FifoFuzzTest, FuzzTestJitRegression2) {
-  FuzzTestFifo(xls::FifoConfig(10, true, false, false),
+  FuzzTestFifo(FifoTestParam{32, xls::FifoConfig(10, true, false, false)},
                {Operation(ResetOp()), Operation(ResetOp())});
 }
 

--- a/xls/interpreter/block_interpreter.cc
+++ b/xls/interpreter/block_interpreter.cc
@@ -188,6 +188,14 @@ class FifoModel {
       return absl::InvalidArgumentError(
           absl::StrFormat("Unexpected port '%s'", input->port_name()));
     }
+
+    // If this fifo does not actually carry any data, we don't require
+    // the `push_data_` input to have been provided. The presence/absence
+    // of `push_valid_` is all that is required.
+    if (type_->GetFlatBitCount() == 0) {
+      push_data_ = ZeroOfType(type_);
+    }
+
     if (!(push_valid_.has_value() && push_data_.has_value() &&
           pop_ready_.has_value() && reset_.has_value())) {
       // Not yet ready to compute next state.

--- a/xls/ir/instantiation.cc
+++ b/xls/ir/instantiation.cc
@@ -282,18 +282,24 @@ absl::StatusOr<InstantiationPort> FifoInstantiation::GetInputPort(
 
 absl::StatusOr<InstantiationType> FifoInstantiation::type() const {
   Type* u1 = package_->GetBitsType(1);
-  return InstantiationType(/*input_types=*/
-                           {
-                               {std::string{kResetPortName}, u1},
-                               {std::string(kPushValidPortName), u1},
-                               {std::string(kPopReadyPortName), u1},
-                               {std::string(kPushDataPortName), data_type()},
-                           },
-                           /*output_types=*/{
-                               {std::string(kPopValidPortName), u1},
-                               {std::string(kPushReadyPortName), u1},
-                               {std::string(kPopDataPortName), data_type()},
-                           });
+
+  absl::flat_hash_map<std::string, Type*> input_types = {
+      {std::string{kResetPortName}, u1},
+      {std::string(kPushValidPortName), u1},
+      {std::string(kPopReadyPortName), u1},
+  };
+
+  absl::flat_hash_map<std::string, Type*> output_types = {
+      {std::string(kPopValidPortName), u1},
+      {std::string(kPushReadyPortName), u1},
+  };
+
+  if (data_type()->GetFlatBitCount() > 0) {
+    input_types[std::string(kPushDataPortName)] = data_type();
+    output_types[std::string(kPopDataPortName)] = data_type();
+  }
+
+  return InstantiationType(input_types, output_types);
 }
 
 absl::StatusOr<InstantiationPort> FifoInstantiation::GetOutputPort(


### PR DESCRIPTION
Gates the generation of the FIFO "data path" behind a non-zero data width and adjusts the signature accordingly.

# Problem: 

Materializing channels with a zero-width data path fails due to mismatching signatures.

# Repro

buf.x:
```rust
proc Nop {
    input: chan<()> in;
    output: chan<()> out;

    init { () }

    config(input: chan<()> in, output: chan<()> out) {
        (input, output)
    }

    next(_: ()) {
        let (tok, v) = recv(join(), input);
        send(tok, output, v);
    }

}


proc Top {
    input: chan<()> in;
    output: chan<()> out;

    init { () }

    config(input: chan<()> in, output: chan<()> out) {
        let (s, r) = chan<(), u32:1>("between");
        spawn Nop(input, s);
        spawn Nop(r, output);

        (input, output)
    }

    next(_: ()) { }
}
```

Run: 
```bash
./bazel-bin/xls/dslx/ir_convert/ir_converter_main ./buf.x > buf.ir
./bazel-bin/xls/tools/opt_main ./buf.ir --top="__buf__Top__Nop_1_next" > buf.opt.ir
./bazel-bin/xls/tools/codegen_main ./buf.opt.ir --delay_model=unit --pipeline_stages=1 --reset="rst" --multi_proc --materialize_internal_fifos
```

Error:
```
Error: INTERNAL: Instantiation `materialized_fifo_fifo_buf__between_` of block `fifo_for_depth_1_ty____with_bypass_register_push` is missing instantation input/output node for port `push_data`; [after 'Materialize FIFO instantiations into block-instantiation if no FIFO template is specified.' pass, dynamic pass #14]; Running pass #15: Top level codegen pass pipeline [short: codegen]%
```

# Notes
This is my first time digging into the codegen codebase - I think this is the best way of fixing this but I really don't have a good overview :)

Also: This probably could do with a test for the materialization pass that double-checks the functionality of zero-width FIFOs, and maybe some sort of end-to-end test to validate the whole pipeline with zero-width channel/FIFOs: They are the type of edge-case that often gets forgotten/leads to regressions. 

I am not 100% sure what the best way of adding these tests is - so I thought I would open the PR and ask for feedback :)

Happy to rework this/add tests as desired. Let me know.

Cheers! 