### PR TITLE
[DSLX:FE] Rest-of-tuple pattern can only appear within a tuple (match Rust)

### DIFF
--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -515,7 +515,8 @@ class Parser : public TokenParser {
   //            | NameDef
   //            | NameRef
   //            | Number
-  absl::StatusOr<NameDefTree*> ParsePattern(Bindings& bindings);
+  absl::StatusOr<NameDefTree*> ParsePattern(Bindings& bindings,
+                                            bool within_tuple_pattern);
 
   // Parses a match expression.
   absl::StatusOr<Match*> ParseMatch(Bindings& bindings);

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -2162,9 +2162,9 @@ fn f(x: u32) {
         _ => u32:42,
     }
 })";
-  EXPECT_NONFATAL_FAILURE(RoundTrip(kProgram),
-                          "Cannot use both wildcard (`_`) and rest-of-tuple "
-                          "(`..`) as match arms");
+  EXPECT_NONFATAL_FAILURE(
+      RoundTrip(kProgram),
+      "`..` patterns are not allowed outside of a tuple pattern");
 }
 
 TEST_F(ParserTest, ArrayTypeAnnotation) {

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -386,7 +386,7 @@ TEST(IrConverterTest, MatchRestOfTupleAsArmFails) {
   let t = (u32:1, u32:2);
   match t {
     (u32:1, .., a) => a,
-    .. => u32:1
+    (..) => u32:1
   }
 })";
   auto import_data = CreateImportDataForTest();


### PR DESCRIPTION
Came across that this was acting like another kind of wildcard when rebasing the exhaustiveness-checking change.

Per https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=67b999ff70ddc15c57a9c2c3437616e1 the .. can only appear within a tuple pattern (we don't support the other forms Rust mentions there yet).