### PR TITLE
[MLIR] XLS -> MLIR Translation

### DIFF
--- a/xls/contrib/mlir/BUILD
+++ b/xls/contrib/mlir/BUILD
@@ -524,10 +524,12 @@ cc_library(
     name = "xls_translate_lib",
     srcs = [
         "tools/xls_translate/xls_stitch.cc",
+        "tools/xls_translate/xls_translate_to_mlir.cc",
         "tools/xls_translate/xls_translate_from_mlir.cc",
     ],
     hdrs = [
         "tools/xls_translate/xls_stitch.h",
+        "tools/xls_translate/xls_translate_to_mlir.h",
         "tools/xls_translate/xls_translate_from_mlir.h",
     ],
     data = [

--- a/xls/contrib/mlir/BUILD
+++ b/xls/contrib/mlir/BUILD
@@ -524,11 +524,11 @@ cc_library(
     name = "xls_translate_lib",
     srcs = [
         "tools/xls_translate/xls_stitch.cc",
-        "tools/xls_translate/xls_translate.cc",
+        "tools/xls_translate/xls_translate_from_mlir.cc",
     ],
     hdrs = [
         "tools/xls_translate/xls_stitch.h",
-        "tools/xls_translate/xls_translate.h",
+        "tools/xls_translate/xls_translate_from_mlir.h",
     ],
     data = [
         "stdlib/fp_ext_trunc.x",

--- a/xls/contrib/mlir/IR/xls_ops.td
+++ b/xls/contrib/mlir/IR/xls_ops.td
@@ -357,8 +357,10 @@ def Xls_NegOp : Xls_UnaryOp<"neg", [Pure, SameOperandsAndResultType]> {
 // Arithmetic binary operations
 //===----------------------------------------------------------------------===//
 
-class Xls_ArithBinaryOp<string name, string desc>
-    : Xls_BinaryOp<name, [Pure, SameOperandsAndResultType]> {
+class Xls_ArithBinaryOp<string name, string desc, list<Trait> traits = []>
+    : Xls_BinaryOp<name, !listconcat(traits, [
+        Pure,
+      ]) > {
   let summary = !strconcat(desc, " operation");
   let description = summary;
   let arguments = (ins
@@ -368,7 +370,7 @@ class Xls_ArithBinaryOp<string name, string desc>
   let builders = [
     OpBuilder<(ins "::mlir::Value":$lhs, "int":$rhs), [{
       ::mlir::Value rhs_val = $_builder.create<ConstantScalarOp>(lhs.getLoc(), lhs.getType(), $_builder.getI32IntegerAttr(rhs));
-      build($_builder, $_state, lhs, rhs_val);
+      build($_builder, $_state, lhs.getType(), lhs, rhs_val);
     }]>
   ];
   let results = (outs
@@ -403,7 +405,7 @@ class Xls_PartialProdOp<string name, string desc> :  Xls_Op<name, [
   ];
 }
 
-def Xls_AddOp : Xls_ArithBinaryOp<"add", "addition"> {
+def Xls_AddOp : Xls_ArithBinaryOp<"add", "addition", [SameOperandsAndResultType]> {
   let hasFolder = 1;
 }
 def Xls_SmulOp : Xls_ArithBinaryOp<"smul", "signed multiplication">;
@@ -435,11 +437,11 @@ def Xls_UmulpOp : Xls_PartialProdOp<"umulp", [{
   The two results must have the same (scalar) bitwidth, but there are no other
   constraints: The two operands can be of arbitrary (scalar) bitwidths.
 }]>;
-def Xls_SdivOp : Xls_ArithBinaryOp<"sdiv", "signed division">;
-def Xls_SmodOp : Xls_ArithBinaryOp<"smod", "signed modulo">;
-def Xls_SubOp : Xls_ArithBinaryOp<"sub", "subtraction">;
-def Xls_UdivOp : Xls_ArithBinaryOp<"udiv", "unsigned division">;
-def Xls_UmodOp : Xls_ArithBinaryOp<"umod", "unsigned modulo">;
+def Xls_SdivOp : Xls_ArithBinaryOp<"sdiv", "signed division", [SameOperandsAndResultType]>;
+def Xls_SmodOp : Xls_ArithBinaryOp<"smod", "signed modulo", [SameOperandsAndResultType]>;
+def Xls_SubOp : Xls_ArithBinaryOp<"sub", "subtraction", [SameOperandsAndResultType]>;
+def Xls_UdivOp : Xls_ArithBinaryOp<"udiv", "unsigned division", [SameOperandsAndResultType]>;
+def Xls_UmodOp : Xls_ArithBinaryOp<"umod", "unsigned modulo", [SameOperandsAndResultType]>;
 
 //===----------------------------------------------------------------------===//
 // Comparison operations

--- a/xls/contrib/mlir/IR/xls_ops.td
+++ b/xls/contrib/mlir/IR/xls_ops.td
@@ -989,7 +989,7 @@ def Xls_DecodeOp : Xls_UnaryOp<"decode", [Pure, ShapesAreConsistent<["operand", 
   }];
   let arguments = (ins
     Xls_Bits:$operand,
-    OptionalAttr<I64Attr>:$width
+    I64Attr:$width
   );
   let results = (outs
     Xls_Bits:$result

--- a/xls/contrib/mlir/testdata/BUILD.bazel
+++ b/xls/contrib/mlir/testdata/BUILD.bazel
@@ -60,7 +60,7 @@ RUNFILES_DIR = LITE_CFG_PY.parents[3].absolute().as_posix()''',
         deps = ["@rules_python//python/runfiles"],
     )
     for src in glob(
-        ["**/*.mlir"],
+        ["**/*.mlir", "**/*.ir"],
         # TODO(jpienaar): The lookup in RUNFILES does not seem to work for these files with the
         # current lit setup.
         exclude = [

--- a/xls/contrib/mlir/testdata/lit.cfg.py
+++ b/xls/contrib/mlir/testdata/lit.cfg.py
@@ -26,7 +26,7 @@ from lit.llvm import llvm_config
 # Some metadata is populated in lit.site.cfg.py.in.
 config.name = 'MLIR_TESTS_SUITE'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
-config.suffixes = ['.mlir']
+config.suffixes = ['.mlir', '.ir']
 config.test_source_root = os.path.dirname(__file__)
 
 # Disallow reusing variables across CHECK-LABEL matches.

--- a/xls/contrib/mlir/testdata/ops.mlir
+++ b/xls/contrib/mlir/testdata/ops.mlir
@@ -257,7 +257,7 @@ func.func @reverse(%arg0: i32) -> i32 {
 // CHECK-LABEL: decode
 func.func @decode(%arg0: i4) -> i16 {
   // CHECK: xls.decode
-  %0 = xls.decode %arg0 : (i4) -> i16
+  %0 = xls.decode %arg0 { width = 16 : i64 } : (i4) -> i16
   return %0 : i16
 }
 

--- a/xls/contrib/mlir/testdata/ops_translate.mlir
+++ b/xls/contrib/mlir/testdata/ops_translate.mlir
@@ -62,9 +62,9 @@ func.func @add(%arg0: i8, %arg1: i8) -> i8 {
   return %0 : i8
 }
 
-func.func @smul(%arg0: i8, %arg1: i8) -> i8 {
-  %0 = xls.smul %arg0, %arg1 : i8
-  return %0 : i8
+func.func @smul(%arg0: i8, %arg1: i8) -> i16 {
+  %0 = xls.smul %arg0, %arg1 : (i8, i8) -> i16
+  return %0 : i16
 }
 
 func.func @smulp(%arg0: i8, %arg1: i7) -> i9 {

--- a/xls/contrib/mlir/testdata/ops_translate.mlir
+++ b/xls/contrib/mlir/testdata/ops_translate.mlir
@@ -219,7 +219,7 @@ func.func @reverse(%arg0: i32) -> i32 {
 }
 
 func.func @decode(%arg0: i4) -> i16 {
-  %0 = xls.decode %arg0 : (i4) -> i16
+  %0 = xls.decode %arg0 { width = 16 : i64 } : (i4) -> i16
   return %0 : i16
 }
 

--- a/xls/contrib/mlir/testdata/ops_translate.mlir
+++ b/xls/contrib/mlir/testdata/ops_translate.mlir
@@ -320,6 +320,25 @@ func.func @constant_scalar() -> i7 {
   return %0 : i7
 }
 
+// XLS-LABEL: complex_literal
+func.func @complex_literal() -> tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>> {
+  // XLS: ret {{.*}}: ((bits[1], bits[2], (bits[32], bits[32])), bits[3][2]) = literal(value=((1, 2, (10, 0)), [4, 5]),
+  %lit = xls.literal : tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>> {
+    %0 = "xls.constant_scalar"() <{value = true}> : () -> i1
+    %1 = "xls.constant_scalar"() <{value = -2 : i2}> : () -> i2
+    %2 = "xls.constant_scalar"() <{value = 10 : i32}> : () -> i32
+    %3 = "xls.constant_scalar"() <{value = 0 : i32}> : () -> i32
+    %4 = "xls.tuple"(%2, %3) : (i32, i32) -> tuple<i32, i32>
+    %5 = "xls.tuple"(%0, %1, %4) : (i1, i2, tuple<i32, i32>) -> tuple<i1, i2, tuple<i32, i32>>
+    %6 = "xls.constant_scalar"() <{value = -4 : i3}> : () -> i3
+    %7 = "xls.constant_scalar"() <{value = -3 : i3}> : () -> i3
+    %8 = xls.array %6, %7 : (i3, i3) -> !xls.array<2 x i3>
+    %final = "xls.tuple"(%5, %8) : (tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>) -> tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>>
+    xls.yield %final : tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>>
+  }
+  return %lit : tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>>
+}
+
 xls.chan @mychan : i32
 
 // XLS-LABEL: proc eproc({{.*}}: bits[32], {{.*}}: (bits[32], bits[1]), {{.*}}: bits[1], {{.*}}: (bits[1], bits[8], bits[7]), init={

--- a/xls/contrib/mlir/testdata/translate_from_xls/arithop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/arithop.ir
@@ -1,0 +1,13 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./arithop.ir.x"
+
+// CHECK: func @test_arithop([[ARG1:%.*]]: i32, [[ARG2:%.*]]: i32) -> i32 {
+fn test_arithop(a: bits[32] id=1, b: bits[32] id=2) -> bits[32] {
+  // CHECK: %{{.*}} = xls.umul [[ARG1]], [[ARG2]] : i32
+  umul.3: bits[32] = umul(a, b, id=3)
+  // CHECK: %{{.*}} = xls.smul [[ARG1]], [[ARG2]] : i32
+  ret smul.4: bits[32] = smul(a, b, id=4)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/array.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/array.ir
@@ -1,0 +1,37 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./array.x"
+
+fn is_zero(a: bits[32] id=100) -> bits[1] {
+  literal.102: bits[32] = literal(value=0, id=102)
+  ret eq.103: bits[1] = eq(a, literal.102, id=103)
+}
+
+// CHECK: func @test_array([[ARG1:%.*]]: !xls.array<2 x i32>, [[ARG2:%.*]]: !xls.array<4 x i32>) -> !xls.array<2 x i32> {
+fn test_array(a: bits[32][2] id=1, b: bits[32][4] id=2) -> bits[32][2] {
+  // CHECK: [[LIT1:%.*]] = "xls.constant_scalar"() <{value = 10 : i32}> : () -> i32
+  literal.3: bits[32] = literal(value=10, id=3)
+
+  // CHECK: [[LIT2:%.*]] = "xls.constant_scalar"() <{value = 20 : i32}> : () -> i32
+  literal.4: bits[32] = literal(value=20, id=4)
+
+  // CHECK: {{.*}} = xls.array [[LIT1]], [[LIT2]] : (i32, i32) -> !xls.array<2 x i32>
+  array.5: bits[32][2] = array(literal.3, literal.4, id=5)
+
+  // CHECK: {{.*}} = xls.array_concat [[ARG1]], [[ARG2]] : (!xls.array<2 x i32>, !xls.array<4 x i32>) -> !xls.array<6 x i32>
+  array_concat.6: bits[32][6] = array_concat(a, b, id=6)
+
+  // CHECK: {{.*}} = "xls.array_index"([[ARG1]], [[LIT1]]) : (!xls.array<2 x i32>, i32) -> i32
+  array_index.7: bits[32] = array_index(a, indices=[literal.3], id=7)
+
+  // CHECK: {{.*}} = "xls.array_slice"([[ARG2]], [[LIT1]]) <{width = 2 : i64}> : (!xls.array<4 x i32>, i32) -> !xls.array<2 x i32>
+  array_slice.8: bits[32][2] = array_slice(b, literal.3, width=2, id=8)
+
+  // CHECK: {{.*}} = "xls.map"([[ARG1]]) <{to_apply = @is_zero}> : (!xls.array<2 x i32>) -> !xls.array<2 x i1>
+  map.9: bits[1][2] = map(a, to_apply=is_zero, id=9)
+
+  // CHECK: {{.*}} = "xls.array_update"([[ARG1]], [[LIT2]], [[LIT1]]) : (!xls.array<2 x i32>, i32, i32) -> !xls.array<2 x i32>
+  ret array_update.10: bits[32][2] = array_update(a, literal.4, indices=[literal.3], id=10)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/binop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/binop.ir
@@ -1,0 +1,36 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./binop.x"
+
+// CHECK: func @test_binop([[ARG1:%.*]]: i32, [[ARG2:%.*]]: i32) -> i32 {
+fn test_binop(a: bits[32] id=1, b: bits[32] id=2) -> bits[32] {
+
+  // CHECK: %{{.*}} = xls.add [[ARG1]], [[ARG2]] : i32
+  add.3: bits[32] = add(a, b, id=3)
+
+  // CHECK: %{{.*}} = xls.sdiv [[ARG1]], [[ARG2]] : i32
+  sdiv.4: bits[32] = sdiv(a, b, id=4)
+
+  // CHECK: %{{.*}} = xls.smod [[ARG1]], [[ARG2]] : i32
+  smod.5: bits[32] = smod(a, b, id=5)
+
+  // CHECK: %{{.*}} = xls.shll [[ARG1]], [[ARG2]] : i32
+  shll.6: bits[32] = shll(a, b, id=6)
+
+  // CHECK: %{{.*}} = xls.shrl [[ARG1]], [[ARG2]] : i32
+  shrl.7: bits[32] = shrl(a, b, id=7)
+
+  // CHECK: %{{.*}} = xls.shra [[ARG1]], [[ARG2]] : i32
+  shra.8: bits[32] = shra(a, b, id=8)
+
+  // CHECK: %{{.*}} = xls.sub [[ARG1]], [[ARG2]] : i32
+  sub.9: bits[32] = sub(a, b, id=9)
+
+  // CHECK: %{{.*}} = xls.udiv [[ARG1]], [[ARG2]] : i32
+  udiv.10: bits[32] = udiv(a, b, id=10)
+
+  // CHECK: %{{.*}} = xls.umod [[ARG1]], [[ARG2]] : i32
+  ret umod.11: bits[32] = umod(a, b, id=11)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/bitslice.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/bitslice.ir
@@ -1,0 +1,18 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./binop.x"
+
+// CHECK: func @test_binop([[ARG1:%.*]]: i32, [[ARG2:%.*]]: i6,  [[ARG3:%.*]]: i32) -> i70 {
+fn test_binop(a: bits[32] id=1, b: bits[6] id=2, c: bits[32] id=3) -> bits[70] {
+
+  // CHECK: %{{.*}} = xls.bit_slice [[ARG1]] {start = 3 : i64, width = 10 : i64} : (i32) -> i10
+  bit_slice.5: bits[10] = bit_slice(a, start=3, width=10, id=5)
+
+  // CHECK: %{{.*}} = "xls.bit_slice_update"([[ARG1]], [[ARG3]], [[ARG2]]) : (i32, i32, i6) -> i32
+  bit_slice_update.6: bits[32] = bit_slice_update(a, c, b, id=6)
+
+  // CHECK: %{{.*}} = xls.concat [[ARG1]], [[ARG3]], [[ARG2]] : (i32, i32, i6) -> i70
+  ret concat.7: bits[70] = concat(a, c, b, id=7)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/compareop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/compareop.ir
@@ -1,0 +1,39 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./compareop.x"
+
+// CHECK: func @test_compareop([[ARG1:%.*]]: i32, [[ARG2:%.*]]: i32) -> i1 {
+fn test_compareop(a: bits[32] id=1, b: bits[32] id=2) -> bits[1] {
+
+  // CHECK: %{{.*}} = xls.eq [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  eq.3: bits[1] = eq(a, b, id=3)
+
+  // CHECK: %{{.*}} = xls.ne [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  ne.4: bits[1] = ne(a, b, id=4)
+
+  // CHECK: %{{.*}} = xls.sle [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  sle.5: bits[1] = sle(a, b, id=5)
+
+  // CHECK: %{{.*}} = xls.sge [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  sge.6: bits[1] = sge(a, b, id=6)
+
+  // CHECK: %{{.*}} = xls.slt [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  slt.7: bits[1] = slt(a, b, id=7)
+
+  // CHECK: %{{.*}} = xls.sgt [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  sgt.8: bits[1] = sgt(a, b, id=8)
+
+  // CHECK: %{{.*}} = xls.ule [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  ule.9: bits[1] = ule(a, b, id=9)
+
+  // CHECK: %{{.*}} = xls.uge [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  uge.10: bits[1] = uge(a, b, id=10)
+
+  // CHECK: %{{.*}} = xls.ult [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  ult.11: bits[1] = ult(a, b, id=11)
+
+  // CHECK: %{{.*}} = xls.ugt [[ARG1]], [[ARG2]] : (i32, i32) -> i1
+  ret ugt.12: bits[1] = ugt(a, b, id=12)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/extendop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/extendop.ir
@@ -1,0 +1,15 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./extendop.x"
+
+// CHECK: func @test_extendop([[ARG1:%.*]]: i5) -> i32 {
+fn test_extendop(a: bits[5] id=1) -> bits[32] {
+
+  // CHECK: %{{.*}} = xls.zero_ext [[ARG1]] : (i5) -> i32
+  zero_ext.2: bits[32] = zero_ext(a, new_bit_count=32, id=2)
+
+  // CHECK: %{{.*}} = xls.sign_ext [[ARG1]] : (i5) -> i32
+  ret sign_ext.3: bits[32] = sign_ext(a, new_bit_count=32, id=3)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/invoke.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/invoke.ir
@@ -1,0 +1,25 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./invoke.x"
+
+// CHECK: func @__invoke__bar([[ARG1:%.*]]: i32) -> i32 {
+fn __invoke__bar(a: bits[32] id=1) -> bits[32] {
+
+  // CHECK: [[LITERAL1:%.*]] = "xls.constant_scalar"() <{value = 42 : i32}> : () -> i32
+  literal.2: bits[32] = literal(value=42, id=2)
+
+  // CHECK: %{{.*}} = xls.add [[LITERAL1]], [[ARG1]] : i32
+  ret add.3: bits[32] = add(literal.2, a, id=3)
+}
+
+// CHECK: func.func @__invoke__foo() -> i32 {
+fn __invoke__foo() -> bits[32] {
+
+  // CHECK: [[LITERAL2:%.*]] = "xls.constant_scalar"() <{value = 10 : i32}> : () -> i32
+  a: bits[32] = literal(value=10, id=4)
+
+  // CHECK: %{{.*}} = call @__invoke__bar([[LITERAL2]]) : (i32) -> i32
+  ret invoke.5: bits[32] = invoke(a, to_apply=__invoke__bar, id=5)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/literal.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/literal.ir
@@ -1,0 +1,30 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./literal.x"
+
+// CHECK: func @test_literal() -> i32 {
+fn test_literal() -> bits[32] {
+
+  // CHECK: %{{.*}} = "xls.constant_scalar"() <{value = 0 : i0}> : () -> i0
+  zero: bits[0] = literal(value=0, id=1, pos=[(0,1,6)])
+
+  // CHECK:      %{{.*}} = xls.literal : tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>> {
+  // CHECK-NEXT:   %[[TMP0:.*]] = "xls.constant_scalar"() <{value = true}> : () -> i1
+  // CHECK-NEXT:   %[[TMP1:.*]] = "xls.constant_scalar"() <{value = -2 : i2}> : () -> i2
+  // CHECK-NEXT:   %[[TMP2:.*]] = "xls.constant_scalar"() <{value = 10 : i32}> : () -> i32
+  // CHECK-NEXT:   %[[TMP3:.*]] = "xls.constant_scalar"() <{value = 0 : i32}> : () -> i32
+  // CHECK-NEXT:   %[[TMP4:.*]] = "xls.tuple"(%[[TMP2]], %[[TMP3]]) : (i32, i32) -> tuple<i32, i32>
+  // CHECK-NEXT:   %[[TMP5:.*]] = "xls.tuple"(%[[TMP0]], %[[TMP1]], %[[TMP4]]) : (i1, i2, tuple<i32, i32>) -> tuple<i1, i2, tuple<i32, i32>>
+  // CHECK-NEXT:   %[[TMP6:.*]] = "xls.constant_scalar"() <{value = -4 : i3}> : () -> i3
+  // CHECK-NEXT:   %[[TMP7:.*]] = "xls.constant_scalar"() <{value = -3 : i3}> : () -> i3
+  // CHECK-NEXT:   %[[TMP8:.*]] = xls.array %[[TMP6]], %[[TMP7]] : (i3, i3) -> !xls.array<2 x i3>
+  // CHECK-NEXT:   %[[FINL:.*]] = "xls.tuple"(%[[TMP5]], %[[TMP8]]) : (tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>) -> tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>>
+  // CHECK-NEXT:   xls.yield %[[FINL]] : tuple<tuple<i1, i2, tuple<i32, i32>>, !xls.array<2 x i3>>
+  // CHECK-NEXT: }
+  my_tuple : ((bits[1], bits[2], (bits[32], bits[32])), bits[3][2]) = literal(value=((1, 2, (10, 0)), [4, 5]), id=2)
+
+  // CHECK: %{{.*}} = "xls.constant_scalar"() <{value = 42 : i32}> : () -> i32
+  ret literal.3: bits[32] = literal(value=42, id=3, pos=[(0,1,6)])
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/naryop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/naryop.ir
@@ -1,0 +1,18 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./naryop.x"
+
+// CHECK: func @test_naryop([[ARG1:%.*]]: i32, [[ARG2:%.*]]: i32, [[ARG3:%.*]]: i32) -> i32 {
+fn test_naryop(a: bits[32] id=1, b: bits[32] id=2, c: bits[32] id=3) -> bits[32] {
+
+  // CHECK: %{{.*}} = xls.and [[ARG1]], [[ARG2]], [[ARG3]] : i32
+  and.4: bits[32] = and(a, b, c, id=4)
+
+  // CHECK: %{{.*}} = xls.or [[ARG1]], [[ARG2]], [[ARG3]] : i32
+  or.5: bits[32] = or(a, b, c, id=5)
+
+  // CHECK: %{{.*}} = xls.xor [[ARG1]], [[ARG2]], [[ARG3]] : i32
+  ret xor.6: bits[32] = xor(a, b, c, id=6)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/onehot.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/onehot.ir
@@ -1,0 +1,27 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./onehot.x"
+
+// CHECK: func @test_onehot([[ARG1:%.*]]: i4) -> i4 {
+fn test_onehot(a: bits[4] id=1) -> bits[4] {
+
+  // CHECK: [[VAL1:%.*]] = xls.decode [[ARG1]] {width = 16 : i64} : (i4) -> i16
+  decode.2: bits[16] = decode(a, width=16, id=2, pos=[(0,1,6)])
+
+  // CHECK: %{{.*}} = xls.encode [[VAL1]] : (i16) -> i4
+  encode.3: bits[4] = encode(decode.2, id=3, pos=[(0,1,6)])
+
+  // CHECK: %{{.*}} = xls.one_hot [[VAL1]] {lsb_prio = true} : (i16) -> i17
+  one_hot.4: bits[17] = one_hot(decode.2, lsb_prio=true, id=4, pos=[(0,1,6)])
+
+  // CHECK: [[VAL2:%.*]] = "xls.constant_scalar"
+  literal.5: bits[2] = literal(value=1, id=5, pos=[(0,1,6)])
+
+  // CHECK: [[VAL3:%.*]] = "xls.constant_scalar"
+  literal.6: bits[4] = literal(value=1, id=6, pos=[(0,1,6)])
+
+  // CHECK: %{{.*}} = "xls.one_hot_sel"([[VAL2]], [[ARG1]], [[VAL3]]) : (i2, i4, i4) -> i4
+  ret one_hot_sel.7: bits[4] = one_hot_sel(literal.5, cases=[a, literal.6], id=7, pos=[(0,1,6)])
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/proc.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/proc.ir
@@ -1,0 +1,22 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package simple_proc
+
+file_number 0 "./simple_proc.x"
+
+// CHECK-LABEL: xls.chan @ch_inp {send_supported = false} : i32
+chan ch_inp(bits[32], id=0, kind=streaming, ops=receive_only, metadata="")
+
+// CHECK-LABEL: xls.chan @ch_out {recv_supported = false} : i32
+chan ch_out(bits[32], id=1, kind=streaming, ops=send_only, metadata="")
+
+// CHECK-LABEL: xls.eproc @ident() zeroinitializer {
+// CHECK:         xls.yield
+// CHECK:       }
+top proc ident() {
+  after_all.4: token = after_all(id=4)
+  receive.15: (token, bits[32]) = receive(after_all.4, channel=ch_inp, id=15)
+  tok: token = tuple_index(receive.15, index=0, id=7)
+  val: bits[32] = tuple_index(receive.15, index=1, id=8)
+  send.16: token = send(tok, val, channel=ch_out, id=16)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/sel.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/sel.ir
@@ -1,0 +1,27 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./sel.x"
+
+// CHECK: func @test_sel() -> i4 {
+fn test_sel() -> bits[4] {
+
+  // CHECK: %[[LIT1:.*]] = "xls.constant_scalar"
+  literal.1: bits[2] = literal(value=1, id=1)
+
+  // CHECK: %[[LIT2:.*]] = "xls.constant_scalar"
+  literal.2: bits[4] = literal(value=1, id=2)
+
+  // CHECK: %[[LIT3:.*]] = "xls.constant_scalar"
+  literal.3: bits[4] = literal(value=1, id=3)
+
+  // CHECK: %[[LIT4:.*]] = "xls.constant_scalar"
+  literal.4: bits[4] = literal(value=1, id=4)
+
+  // CHECK: %{{.*}} = xls.sel %[[LIT1]] in [%[[LIT2]], %[[LIT3]]] else %[[LIT4]] : (i2, [i4, i4], i4) -> i4
+  sel.5 : bits[4] = sel(literal.1, cases=[literal.2, literal.3], default=literal.4, id=5)
+
+  // CHECK: %{{.*}} = xls.priority_sel %[[LIT1]] in [%[[LIT2]], %[[LIT3]]] else %[[LIT4]] : (i2, [i4, i4], i4) -> i4
+  ret priority_sel.6 : bits[4] = priority_sel(literal.1, cases=[literal.2, literal.3], default=literal.4, id=6)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/tuple.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/tuple.ir
@@ -1,0 +1,20 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./tuple.x"
+
+// CHECK: func @test_tuple() -> i32 {
+fn test_tuple() ->  bits[32] {
+  // CHECK: [[LIT1:%.*]] = "xls.constant_scalar"() <{value = 10 : i32}> : () -> i32
+  literal.1: bits[32] = literal(value=10, id=1)
+
+  // CHECK: [[LIT2:%.*]] = "xls.constant_scalar"() <{value = 20 : i32}> : () -> i32
+  literal.2: bits[32] = literal(value=20, id=2)
+
+  // CHECK: [[TUPLE1:%.*]] = "xls.tuple"([[LIT1]], [[LIT2]]) : (i32, i32) -> tuple<i32, i32>
+  tuple.3: (bits[32], bits[32]) = tuple(literal.1, literal.2, id=3)
+
+  // CHECK: {{.*}} = "xls.tuple_index"([[TUPLE1:%.*]]) <{index = 1 : i64}> : (tuple<i32, i32>) -> i32
+  ret tuple_index.4: bits[32] = tuple_index(tuple.3, index=1, id=4)
+}

--- a/xls/contrib/mlir/testdata/translate_from_xls/unop.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/unop.ir
@@ -1,0 +1,20 @@
+// RUN: xls_translate --xls-to-mlir-xls %s 2>&1 | FileCheck %s
+
+package translate_ops
+
+file_number 0 "./unop.x"
+
+// CHECK: func @test_unop([[ARG1:%.*]]: i32) -> i32 {
+fn test_unop(a: bits[32] id=1) -> bits[32] {
+  // CHECK: %{{.*}} = xls.identity [[ARG1]] : i32
+  identity.2: bits[32] = identity(a, id=2)
+
+  // CHECK: %{{.*}} = xls.neg [[ARG1]] : i32
+  neg.3: bits[32] = neg(a, id=3)
+
+  // CHECK: %{{.*}} = xls.not [[ARG1]] : i32
+  not.4: bits[32] = not(a, id=4)
+
+  // CHECK: %{{.*}} = xls.reverse [[ARG1]] : i32
+  ret reverse.5: bits[32] = reverse(a, id=5)
+}

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate.cc
@@ -332,11 +332,20 @@ XLS_UNARY_OP(NegOp, Negate);
 XLS_BINARY_OP(AddOp, Add);
 XLS_BINARY_OP(SdivOp, SDiv);
 XLS_BINARY_OP(SmodOp, SMod);
-XLS_BINARY_OP(SmulOp, SMul);
 XLS_BINARY_OP(SubOp, Subtract);
 XLS_BINARY_OP(UdivOp, UDiv);
 XLS_BINARY_OP(UmodOp, UMod);
-XLS_BINARY_OP(UmulOp, UMul);
+
+#define XLS_MUL_OP(TYPE, BUILDER)                                             \
+  BValue convertOp(TYPE op, const TranslationState& state, BuilderBase& fb) { \
+    auto result_type =                                                        \
+        cast<IntegerType>(mlir::getElementTypeOrSelf(op.getResult()));        \
+    return fb.BUILDER(state.getXlsValue(op.getLhs()),                         \
+                      state.getXlsValue(op.getRhs()), result_type.getWidth(), \
+                      state.getLoc(op));                                      \
+  }
+XLS_MUL_OP(SmulOp, SMul);
+XLS_MUL_OP(UmulOp, UMul);
 
 // Partial Products
 #define XLS_PARTIAL_PROD_OP(TYPE, BUILDER)                                \

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "xls/contrib/mlir/tools/xls_translate/xls_translate.h"
+#include "xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.h"
 
 #include <cassert>
 #include <cstdint>

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.h
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_H_
-#define GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_H_
+#ifndef GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_FROM_MLIR_H_
+#define GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_FROM_MLIR_H_
 
 #include <memory>
 #include <string>
@@ -23,6 +23,8 @@
 #include "absl/status/statusor.h"
 #include "llvm/include/llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/include/llvm/ADT/StringRef.h"
+#include "mlir/include/mlir/IR/MLIRContext.h"
+#include "mlir/include/mlir/IR/OwningOpRef.h"
 #include "mlir/include/mlir/Support/LLVM.h"
 #include "xls/codegen/xls_metrics.pb.h"
 #include "xls/tools/codegen_flags.h"
@@ -102,4 +104,4 @@ LogicalResult MlirXlsToXlsTranslate(Operation* op, llvm::raw_ostream& output,
 
 }  // namespace mlir::xls
 
-#endif  // GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_H_
+#endif  // GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_FROM_MLIR_H_

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_main.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_main.cc
@@ -36,7 +36,7 @@
 #include "xls/codegen/xls_metrics.pb.h"
 #include "xls/contrib/mlir/IR/register.h"
 #include "xls/contrib/mlir/tools/xls_translate/xls_stitch.h"
-#include "xls/contrib/mlir/tools/xls_translate/xls_translate.h"
+#include "xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.h"
 #include "xls/public/c_api.h"
 
 namespace mlir::xls {

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_main.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_main.cc
@@ -14,6 +14,7 @@
 
 #include <string>
 
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/include/llvm/ADT/APFloat.h"
 #include "llvm/include/llvm/ADT/StringExtras.h"
 #include "llvm/include/llvm/ADT/StringRef.h"
@@ -37,6 +38,7 @@
 #include "xls/contrib/mlir/IR/register.h"
 #include "xls/contrib/mlir/tools/xls_translate/xls_stitch.h"
 #include "xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.h"
+#include "xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.h"
 #include "xls/public/c_api.h"
 
 namespace mlir::xls {
@@ -102,6 +104,11 @@ LogicalResult mlirXlsToXlsTranslate(Operation* op, llvm::raw_ostream& output) {
   return MlirXlsToXlsTranslate(op, output, options);
 }
 
+OwningOpRef<Operation*> xlsToMlirXlsTranslate(llvm::SourceMgr& mgr,
+                                              MLIRContext* ctx) {
+  return XlsToMlirXlsTranslate(mgr, ctx);
+}
+
 LogicalResult mlirXlsToVerilogTranslate(Operation* op,
                                         llvm::raw_ostream& output) {
   MlirXlsToXlsTranslateOptions options;
@@ -124,6 +131,10 @@ LogicalResult mlirXlsStitch(Operation* op, llvm::raw_ostream& output) {
 TranslateFromMLIRRegistration mlirXlsToXlsTranslateRegistration(
     "mlir-xls-to-xls", "convert from MLIR XLS dialect to XLS",
     mlirXlsToXlsTranslate, registerInputDialects);
+
+TranslateToMLIRRegistration XlsToMlirXlsTranslateRegistration(
+    "xls-to-mlir-xls", "convert from XLS to MLIR XLS dialect",
+    xlsToMlirXlsTranslate, registerInputDialects);
 
 TranslateFromMLIRRegistration mlirXlsToVerilogTranslateRegistration(
     "mlir-xls-to-verilog", "convert from MLIR XLS dialect to Verilog",

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.cc
@@ -1,0 +1,1488 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.h"
+
+#include <cassert>
+#include <cstdint>
+
+#include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "llvm/include/llvm/Support/SourceMgr.h"
+#include "llvm/include/llvm/Support/raw_ostream.h"
+#include "mlir/include/mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/include/mlir/IR/BuiltinOps.h"
+#include "mlir/include/mlir/IR/Location.h"
+#include "xls/contrib/mlir/IR/xls_ops.h"
+#include "xls/ir/function.h"
+#include "xls/ir/nodes.h"
+#include "xls/public/ir_parser.h"
+
+namespace mlir::xls {
+
+//===----------------------------------------------------------------------===//
+// Translation State
+//===----------------------------------------------------------------------===//
+
+class TranslationState {
+ public:
+  TranslationState() = default;
+
+  absl::Status setFileName(::xls::Fileno num, StringAttr name) {
+    if (!fileno_map_.insert({num, name}).second) {
+      return absl::InternalError(
+          absl::StrCat("Duplicate file number ", num.value()));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<StringAttr> getFileName(::xls::Fileno no) {
+    if (auto name = fileno_map_.find(no); name == fileno_map_.end()) {
+      return absl::InternalError(
+          absl::StrCat("Unknown file number  ", no.value()));
+    } else {
+      return name->second;
+    }
+  }
+
+  absl::Status setFunction(const std::string& name, FlatSymbolRefAttr fn) {
+    if (!function_map_.insert({name, fn}).second) {
+      return absl::InternalError(
+          absl::StrCat("Duplicate function name ", name));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<FlatSymbolRefAttr> getFunction(const std::string& name) {
+    if (auto fn = function_map_.find(name); fn == function_map_.end()) {
+      return absl::InternalError(absl::StrCat("Unknown function name  ", name));
+    } else {
+      return fn->second;
+    }
+  }
+
+  absl::Status setChannel(const std::string& name, FlatSymbolRefAttr chn) {
+    if (!channel_map_.insert({name, chn}).second) {
+      return absl::InternalError(absl::StrCat("Duplicate channel name ", name));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<SymbolRefAttr> getChannel(const std::string& name) {
+    if (auto chn = channel_map_.find(name); chn == channel_map_.end()) {
+      return absl::InternalError(absl::StrCat("Unknown channel name  ", name));
+    } else {
+      return chn->second;
+    }
+  }
+
+  absl::Status setMlirValue(int64_t id, Value op) {
+    if (!ssa_map_.insert({id, op}).second) {
+      return absl::InternalError(
+          absl::StrCat("Duplicate assignment to value id ", id));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::StatusOr<Value> getMlirValue(int64_t id) {
+    if (auto val = ssa_map_.find(id); val == ssa_map_.end()) {
+      return absl::InternalError(absl::StrCat("Unknown value id ", id));
+    } else {
+      return val->second;
+    }
+  }
+
+  void newFunctionBaseContext() { this->ssa_map_ = {}; }
+
+ private:
+  // --- package/module state ----
+  // Maps name -> MLIR ref for all functions in current
+  // package/module.
+  absl::flat_hash_map<std::string, FlatSymbolRefAttr> function_map_;
+  // Maps name -> MLIR ref for all channels in current
+  // package/module.
+  absl::flat_hash_map<std::string, FlatSymbolRefAttr> channel_map_;
+  // Maps XLS source file ID -> pathsourcefile_map_.
+  absl::flat_hash_map<::xls::Fileno, StringAttr> fileno_map_;
+
+  // --- function base (func/proc) state ----
+  // Maps id -> MLIR value for all SSA values inside the current
+  // function base (function or proc body).
+  absl::flat_hash_map<int64_t, Value> ssa_map_;
+};
+
+//===----------------------------------------------------------------------===//
+// Type Translation
+//===----------------------------------------------------------------------===//
+
+Type translateType(::xls::Type* xls_type, OpBuilder& builder,
+                   MLIRContext* ctx) {
+  switch (xls_type->kind()) {
+    case ::xls::TypeKind::kTuple: {
+      SmallVector<Type> types;
+      for (auto* type : xls_type->AsTupleOrDie()->element_types()) {
+        types.push_back(translateType(type, builder, ctx));
+      }
+      return TupleType::get(ctx, types);
+    }
+    case ::xls::TypeKind::kBits: {
+      return builder.getIntegerType(xls_type->AsBitsOrDie()->bit_count());
+    }
+    case ::xls::TypeKind::kArray: {
+      return ArrayType::get(
+          xls_type->AsArrayOrDie()->size(),
+          translateType(xls_type->AsArrayOrDie()->element_type(), builder,
+                        ctx));
+    }
+    case ::xls::TypeKind::kToken: {
+      return TokenType::get(ctx);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Literal Translation
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<Operation*> translateBitsLiteral(const ::xls::Bits& b,
+                                                Location loc,
+                                                OpBuilder& builder,
+                                                MLIRContext* ctx,
+                                                TranslationState& state) {
+  APInt converted_value;
+
+  if (b.bit_count() == 0) {
+    converted_value = APInt(/*numBits=*/0, /*val=*/0, /*isSigned=*/false,
+                            /*implicitTrunc=*/false);
+  } else {
+    uint64_t num_words = b.bitmap().word_count();
+    SmallVector<uint64_t> words;
+    words.reserve(num_words);
+    for (uint64_t i = 0; i < num_words; i++) {
+      words.push_back(b.bitmap().GetWord(i));
+    }
+    converted_value = APInt(b.bit_count(), words);
+  }
+
+  auto type = builder.getIntegerType(b.bit_count());
+  return builder
+      .create<ConstantScalarOp>(loc, type,
+                                builder.getIntegerAttr(type, converted_value))
+      .getOperation();
+}
+
+absl::StatusOr<Operation*> translateLiteral(const ::xls::Value& b,
+                                            OpBuilder& builder,
+                                            MLIRContext* ctx,
+                                            TranslationState& state) {
+  switch (b.kind()) {
+    case ::xls::ValueKind::kBits:
+      return translateBitsLiteral(b.bits(), builder.getUnknownLoc(), builder,
+                                  ctx, state);
+
+    case ::xls::ValueKind::kToken: {
+      return builder.create<xls::AfterAllOp>(builder.getUnknownLoc(),
+                                             ValueRange{});
+    }
+
+    case ::xls::ValueKind::kTuple:
+    case ::xls::ValueKind::kArray: {
+      SmallVector<Value> members;
+      SmallVector<Type> types;
+
+      for (auto& xls_member : b.elements()) {
+        auto member = translateLiteral(xls_member, builder, ctx, state);
+        if (!member.ok()) {
+          return member.status();
+        }
+        members.push_back(member.value()->getResult(0));
+        types.push_back(member.value()->getResult(0).getType());
+      }
+
+      if (b.IsArray()) {
+        if (members.empty()) {
+          return absl::InternalError("Empty arrays are not supported.");
+        }
+        Type result_type = ArrayType::get(types.size(), types[0]);
+        return builder.create<xls::ArrayOp>(builder.getUnknownLoc(),
+                                            result_type, ValueRange(members));
+      } else {
+        auto result_type = TupleType::get(ctx, types);
+        return builder.create<xls::TupleOp>(builder.getUnknownLoc(),
+                                            result_type, ValueRange(members));
+      }
+
+      break;
+    }
+
+    case ::xls::ValueKind::kInvalid:
+    default: {
+      return absl::InternalError(absl::StrCat(
+          "Cannot construct literal. Unknown kind: ", b.ToHumanString()));
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Source Location Translation
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<Location> translateLoc(const ::xls::SourceInfo& xls_loc,
+                                      mlir::Builder& builder,
+                                      TranslationState& state) {
+  SmallVector<Location> locs;
+  for (auto loc : xls_loc.locations) {
+    auto filename = state.getFileName(loc.fileno());
+    if (!filename.ok()) {
+      return filename.status();
+    }
+    locs.push_back(FileLineColLoc::get(*filename, loc.fileno().value(),
+                                       loc.colno().value()));
+  }
+
+  if (locs.empty()) {
+    return builder.getUnknownLoc();
+  } else if (locs.size() == 1) {
+    return locs[0];
+  } else {
+    return builder.getFusedLoc(locs);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Operation Translation
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<Operation*> translateOp(::xls::ArithOp& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto opr_lhs =
+      state.getMlirValue(node.operands()[::xls::ArithOp::kLhsOperand]->id());
+  if (!opr_lhs.ok()) {
+    return opr_lhs.status();
+  }
+
+  auto opr_rhs =
+      state.getMlirValue(node.operands()[::xls::ArithOp::kRhsOperand]->id());
+  if (!opr_rhs.ok()) {
+    return opr_rhs.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kUMul:
+      return builder.create<xls::UmulOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSMul:
+      return builder.create<xls::SmulOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    default:
+      return absl::InternalError(absl::StrCat(
+          "Expected ArithOp operation, not ", ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::PartialProductOp& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto opr_lhs = state.getMlirValue(
+      node.operands()[::xls::PartialProductOp::kLhsOperand]->id());
+  if (!opr_lhs.ok()) {
+    return opr_lhs.status();
+  }
+
+  auto opr_rhs = state.getMlirValue(
+      node.operands()[::xls::PartialProductOp::kRhsOperand]->id());
+  if (!opr_rhs.ok()) {
+    return opr_rhs.status();
+  }
+
+  auto result_type = translateType(
+      node.GetType()->AsTupleOrDie()->element_type(0), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  Operation* op = nullptr;
+  switch (node.op()) {
+    case ::xls::Op::kSMulp:
+      op = builder.create<xls::SmulpOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+      break;
+    case ::xls::Op::kUMulp:
+      op = builder.create<xls::UmulpOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+      break;
+    default:
+      return absl::InternalError(
+          absl::StrCat("Expected PartialProductOp operation, not ",
+                       ::xls::OpToString(node.op())));
+  }
+
+  SmallVector<Value> result_tuple_elems;
+  result_tuple_elems.push_back(op->getResult(0));
+  result_tuple_elems.push_back(op->getResult(1));
+  ValueRange result_tuple(result_tuple_elems);
+  return builder.create<xls::TupleOp>(*loc, result_tuple);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::CompareOp& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto opr_lhs =
+      state.getMlirValue(node.operands()[::xls::CompareOp::kLhsOperand]->id());
+  if (!opr_lhs.ok()) {
+    return opr_lhs.status();
+  }
+
+  auto opr_rhs =
+      state.getMlirValue(node.operands()[::xls::CompareOp::kRhsOperand]->id());
+  if (!opr_rhs.ok()) {
+    return opr_rhs.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kEq:
+      return builder.create<xls::EqOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kNe:
+      return builder.create<xls::NeOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSLe:
+      return builder.create<xls::SleOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSGe:
+      return builder.create<xls::SgeOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSLt:
+      return builder.create<xls::SltOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSGt:
+      return builder.create<xls::SgtOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kULe:
+      return builder.create<xls::UleOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kUGe:
+      return builder.create<xls::UgeOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kULt:
+      return builder.create<xls::UltOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kUGt:
+      return builder.create<xls::UgtOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    default:
+      return absl::InternalError(absl::StrCat(
+          "Expected CompareOp operation, not ", ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::BinOp& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto opr_lhs =
+      state.getMlirValue(node.operands()[::xls::BinOp::kLhsOperand]->id());
+  if (!opr_lhs.ok()) {
+    return opr_lhs.status();
+  }
+  auto opr_rhs =
+      state.getMlirValue(node.operands()[::xls::BinOp::kRhsOperand]->id());
+  if (!opr_rhs.ok()) {
+    return opr_rhs.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kAdd:
+      return builder.create<xls::AddOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSDiv:
+      return builder.create<xls::SdivOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSMod:
+      return builder.create<xls::SmodOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kShll:
+      return builder.create<xls::ShllOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kShrl:
+      return builder.create<xls::ShrlOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kShra:
+      return builder.create<xls::ShraOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kSub:
+      return builder.create<xls::SubOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kUDiv:
+      return builder.create<xls::UdivOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    case ::xls::Op::kUMod:
+      return builder.create<xls::UmodOp>(*loc, result_type, *opr_lhs, *opr_rhs);
+    default:
+      return absl::InternalError(absl::StrCat("Expected BinOp operation, not ",
+                                              ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::UnOp& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto operand =
+      state.getMlirValue(node.operands()[::xls::UnOp::kArgOperand]->id());
+  if (!operand.ok()) {
+    return operand.status();
+  }
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kIdentity:
+      return builder.create<xls::IdentityOp>(*loc, *operand);
+    case ::xls::Op::kNeg:
+      return builder.create<xls::NegOp>(*loc, *operand);
+    case ::xls::Op::kNot:
+      return builder.create<xls::NotOp>(*loc, *operand);
+    case ::xls::Op::kReverse:
+      return builder.create<xls::ReverseOp>(*loc, *operand);
+    default:
+      return absl::InternalError(absl::StrCat("Expected UnOp operation, not ",
+                                              ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ExtendOp& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto operand =
+      state.getMlirValue(node.operands()[::xls::ExtendOp::kArgOperand]->id());
+  if (!operand.ok()) {
+    return operand.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kZeroExt:
+      return builder.create<xls::ZeroExtOp>(*loc, result_type, *operand);
+    case ::xls::Op::kSignExt:
+      return builder.create<xls::SignExtOp>(*loc, result_type, *operand);
+    default:
+      return absl::InternalError(absl::StrCat(
+          "Expected ExtendOp operation, not ", ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::TupleIndex& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto operand =
+      state.getMlirValue(node.operands()[::xls::TupleIndex::kArgOperand]->id());
+  if (!operand.ok()) {
+    return operand.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+  auto index = builder.getI64IntegerAttr(node.index());
+
+  return builder.create<xls::TupleIndexOp>(*loc, result_type, *operand, index);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Array& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ArrayOp>(*loc, result_type, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ArrayIndex& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto xls_arg =
+      state.getMlirValue(node.operands()[::xls::ArrayIndex::kArgOperand]->id());
+  if (!xls_arg.ok()) {
+    return xls_arg.status();
+  }
+
+  if (node.indices().length() != 1) {
+    return absl::InternalError(
+        "MLIR currently only supports ArrayIndex with a single index!");
+  }
+  auto xls_index = state.getMlirValue(
+      node.operands()[::xls::ArrayIndex::kIndexOperandStart]->id());
+  if (!xls_arg.ok()) {
+    return xls_arg.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ArrayIndexOp>(*loc, result_type, *xls_arg,
+                                           *xls_index);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ArrayConcat& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ArrayConcatOp>(*loc, result_type, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ArraySlice& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto array = state.getMlirValue(
+      node.operands()[::xls::ArraySlice::kArrayOperand]->id());
+  if (!array.ok()) {
+    return array.status();
+  }
+  auto start = state.getMlirValue(
+      node.operands()[::xls::ArraySlice::kStartOperand]->id());
+  if (!start.ok()) {
+    return start.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ArraySliceOp>(*loc, result_type, *array, *start,
+                                           node.width());
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ArrayUpdate& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto array_to_update = state.getMlirValue(node.array_to_update()->id());
+  if (!array_to_update.ok()) {
+    return array_to_update.status();
+  }
+
+  if (node.indices().length() != 1) {
+    return absl::InternalError(
+        "MLIR currently only supports ArrayUpdate with a single index!");
+  }
+  auto index = state.getMlirValue(node.indices()[0]->id());
+  if (!index.ok()) {
+    return index.status();
+  }
+
+  auto value = state.getMlirValue(node.update_value()->id());
+  if (!value.ok()) {
+    return value.status();
+  }
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ArrayUpdateOp>(*loc, *array_to_update, *value,
+                                            *index);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::BitSlice& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto arg =
+      state.getMlirValue(node.operands()[::xls::BitSlice::kArgOperand]->id());
+  if (!arg.ok()) {
+    return arg.status();
+  }
+
+  auto result_type = builder.getIntegerType(node.width());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::BitSliceOp>(*loc, result_type, *arg, node.start(),
+                                         node.width());
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::BitSliceUpdate& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto to_update = state.getMlirValue(node.to_update()->id());
+  if (!to_update.ok()) {
+    return to_update.status();
+  }
+
+  auto start = state.getMlirValue(node.start()->id());
+  if (!start.ok()) {
+    return start.status();
+  }
+
+  auto update_value = state.getMlirValue(node.update_value()->id());
+  if (!update_value.ok()) {
+    return update_value.status();
+  }
+
+  auto result_type =
+      builder.getIntegerType(node.to_update()->GetType()->GetFlatBitCount());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::BitSliceUpdateOp>(*loc, result_type, *to_update,
+                                               *start, *update_value);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::DynamicBitSlice& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto arg = state.getMlirValue(
+      node.operands()[::xls::DynamicBitSlice::kArgOperand]->id());
+  if (!arg.ok()) {
+    return arg.status();
+  }
+
+  auto start = state.getMlirValue(node.start()->id());
+  if (!start.ok()) {
+    return start.status();
+  }
+
+  auto result_type = builder.getIntegerType(node.width());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::DynamicBitSliceOp>(
+      *loc, result_type, *arg, *start, builder.getI64IntegerAttr(node.width()));
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Concat& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  uint64_t result_width = 0;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+    result_width += xls_operand->GetType()->GetFlatBitCount();
+  }
+  ValueRange operands(operands_vec);
+
+  auto result_type = builder.getIntegerType(result_width);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::ConcatOp>(*loc, result_type, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Tuple& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::TupleOp>(*loc, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Literal& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.GetType()->kind()) {
+    case ::xls::TypeKind::kBits:
+      return translateBitsLiteral(node.value().bits(), *loc, builder, ctx,
+                                  state);
+    default: {
+      auto result_type = translateType(node.GetType(), builder, ctx);
+
+      // Create literal with region:
+      auto literal_op = builder.create<xls::LiteralOp>(*loc, result_type);
+      builder.setInsertionPointToStart(&literal_op.getRegion().emplaceBlock());
+
+      // Construct value using ops:
+      auto final_op = translateLiteral(node.value(), builder, ctx, state);
+      if (!final_op.ok()) {
+        return final_op.status();
+      }
+
+      // Add yield:
+      builder.create<YieldOp>(builder.getUnknownLoc(),
+                              final_op.value()->getResults());
+
+      return literal_op;
+    }
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::NaryOp& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kAnd:
+      return builder.create<xls::AndOp>(*loc, operands);
+    case ::xls::Op::kNand:
+      return builder.create<xls::NandOp>(*loc, operands);
+    case ::xls::Op::kOr:
+      return builder.create<xls::OrOp>(*loc, operands);
+    case ::xls::Op::kNor:
+      return builder.create<xls::NorOp>(*loc, operands);
+    case ::xls::Op::kXor:
+      return builder.create<xls::XorOp>(*loc, operands);
+    default:
+      return absl::InternalError(absl::StrCat("Expected BinOp operation, not ",
+                                              ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::BitwiseReductionOp& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto operand = state.getMlirValue(
+      node.operands()[::xls::BitwiseReductionOp::kOperandOperand]->id());
+  if (!operand.ok()) {
+    return operand.status();
+  }
+
+  auto result_type = builder.getIntegerType(1);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  switch (node.op()) {
+    case ::xls::Op::kAndReduce:
+      return builder.create<xls::AndReductionOp>(*loc, result_type, *operand);
+    case ::xls::Op::kOrReduce:
+      return builder.create<xls::OrReductionOp>(*loc, result_type, *operand);
+    case ::xls::Op::kXorReduce:
+      return builder.create<xls::XorReductionOp>(*loc, result_type, *operand);
+    default:
+      return absl::InternalError(
+          absl::StrCat("Expected BitwiseReductionOp operation, not ",
+                       ::xls::OpToString(node.op())));
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Encode& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto arg =
+      state.getMlirValue(node.operands()[::xls::Encode::kArgOperand]->id());
+  if (!arg.ok()) {
+    return arg.status();
+  }
+
+  auto result_type = builder.getIntegerType(node.GetType()->GetFlatBitCount());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::EncodeOp>(*loc, result_type, *arg);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Decode& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto arg =
+      state.getMlirValue(node.operands()[::xls::Decode::kArgOperand]->id());
+  if (!arg.ok()) {
+    return arg.status();
+  }
+
+  auto width = builder.getI64IntegerAttr(node.GetType()->GetFlatBitCount());
+
+  auto result_type = builder.getIntegerType(node.GetType()->GetFlatBitCount());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::DecodeOp>(*loc, result_type, *arg, width);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::OneHot& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto arg =
+      state.getMlirValue(node.operands()[::xls::OneHot::kInputOperand]->id());
+  if (!arg.ok()) {
+    return arg.status();
+  }
+
+  auto lsb_prio = builder.getBoolAttr(node.priority() == ::xls::LsbOrMsb::kLsb);
+
+  auto result_type = builder.getIntegerType(node.GetType()->GetFlatBitCount());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::OneHotOp>(*loc, result_type, *arg, lsb_prio);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::OneHotSelect& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto selector = state.getMlirValue(
+      node.operands()[::xls::OneHotSelect::kSelectorOperand]->id());
+  if (!selector.ok()) {
+    return selector.status();
+  }
+
+  SmallVector<Value> cases_vec;
+  for (auto* xls_case : node.cases()) {
+    auto operand = state.getMlirValue(xls_case->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    cases_vec.push_back(*operand);
+  }
+  ValueRange cases(cases_vec);
+
+  auto result_type = builder.getIntegerType(node.GetType()->GetFlatBitCount());
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::OneHotSelOp>(*loc, result_type, *selector, cases);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Invoke& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto fn = state.getFunction(node.to_apply()->name());
+  if (!fn.ok()) {
+    return fn.status();
+  }
+
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<func::CallOp>(*loc, *fn, result_type, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Map& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto fn = state.getFunction(node.to_apply()->name());
+  if (!fn.ok()) {
+    return fn.status();
+  }
+
+  auto array =
+      state.getMlirValue(node.operands()[::xls::Map::kArgOperand]->id());
+  if (!array.ok()) {
+    return array.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::MapOp>(*loc, result_type, *array, *fn);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Select& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto selector = state.getMlirValue(node.selector()->id());
+  if (!selector.ok()) {
+    return selector.status();
+  }
+
+  SmallVector<Value> cases_vec;
+  for (auto* xls_case : node.cases()) {
+    auto operand = state.getMlirValue(xls_case->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    cases_vec.push_back(*operand);
+  }
+  ValueRange cases(cases_vec);
+
+  Value default_value;
+
+  if (auto xls_default_val = node.default_value();
+      xls_default_val.has_value()) {
+    auto maybe_default_val =
+        state.getMlirValue(node.default_value().value()->id());
+    if (!maybe_default_val.ok()) {
+      return maybe_default_val.status();
+    }
+    default_value = maybe_default_val.value();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::SelOp>(*loc, result_type, *selector, default_value,
+                                    cases);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::PrioritySelect& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto selector = state.getMlirValue(
+      node.operands()[::xls::PrioritySelect::kSelectorOperand]->id());
+  if (!selector.ok()) {
+    return selector.status();
+  }
+
+  SmallVector<Value> cases_vec;
+  for (auto* xls_case : node.cases()) {
+    auto operand = state.getMlirValue(xls_case->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    cases_vec.push_back(*operand);
+  }
+  ValueRange cases(cases_vec);
+
+  auto default_value = state.getMlirValue(node.default_value()->id());
+  if (!default_value.ok()) {
+    return default_value.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::PrioritySelOp>(*loc, result_type, *selector, cases,
+                                            *default_value);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::AfterAll& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  SmallVector<Value> operands_vec;
+  for (auto* xls_operand : node.operands()) {
+    auto operand = state.getMlirValue(xls_operand->id());
+    if (!operand.ok()) {
+      return operand.status();
+    }
+    operands_vec.push_back(*operand);
+  }
+  ValueRange operands(operands_vec);
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::AfterAllOp>(*loc, operands);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::ChannelNode& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto chn = state.getChannel(node.channel_name());
+  if (!chn.ok()) {
+    return chn.status();
+  }
+
+  auto inp_token = state.getMlirValue(node.token()->id());
+  if (!inp_token.ok()) {
+    return inp_token.status();
+  }
+
+  Value predicate;
+  if (auto xls_predicate = node.predicate(); xls_predicate.has_value()) {
+    auto maybe_predicate = state.getMlirValue(xls_predicate.value()->id());
+    if (!maybe_predicate.ok()) {
+      return maybe_predicate.status();
+    }
+    predicate = *maybe_predicate;
+  }
+
+  auto token_type = TokenType::get(ctx);
+  auto data_type = translateType(node.GetPayloadType(), builder, ctx);
+  auto valid_type = builder.getIntegerType(1);
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  if (node.Is<::xls::Receive>()) {
+    auto recv = node.As<::xls::Receive>();
+
+    SmallVector<Value> result_tuple_elems;
+
+    if (recv->is_blocking()) {
+      auto receive_op = builder.create<xls::BlockingReceiveOp>(
+          *loc, token_type, data_type, *inp_token, predicate, *chn);
+
+      result_tuple_elems.push_back(receive_op.getTknOut());
+      result_tuple_elems.push_back(receive_op.getResult());
+
+    } else {
+      auto receive_op = builder.create<xls::NonblockingReceiveOp>(
+          *loc, token_type, data_type, valid_type, *inp_token, predicate, *chn);
+
+      result_tuple_elems.push_back(receive_op.getTknOut());
+      result_tuple_elems.push_back(receive_op.getResult());
+      result_tuple_elems.push_back(receive_op.getValid());
+    }
+
+    ValueRange operands(result_tuple_elems);
+    return builder.create<xls::TupleOp>(*loc, operands);
+
+  } else {
+    auto send = node.As<::xls::Send>();
+
+    auto data = state.getMlirValue(send->data()->id());
+    if (!data.ok()) {
+      return data.status();
+    }
+
+    return builder.create<xls::SendOp>(*loc, token_type, *inp_token, *data,
+                                       predicate, *chn);
+  }
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::Gate& node, OpBuilder& builder,
+                                       MLIRContext* ctx,
+                                       TranslationState& state) {
+  auto data = state.getMlirValue(node.data()->id());
+  if (!data.ok()) {
+    return data.status();
+  }
+
+  auto condition = state.getMlirValue(node.condition()->id());
+  if (!condition.ok()) {
+    return condition.status();
+  }
+
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::GateOp>(*loc, *condition, *data);
+}
+
+absl::StatusOr<Operation*> translateOp(::xls::CountedFor& node,
+                                       OpBuilder& builder, MLIRContext* ctx,
+
+                                       TranslationState& state) {
+  auto initial_value = state.getMlirValue(node.initial_value()->id());
+  if (!initial_value.ok()) {
+    return initial_value.status();
+  }
+
+  auto trip_count = builder.getI64IntegerAttr(node.trip_count());
+
+  auto stride = builder.getI64IntegerAttr(node.stride());
+
+  SmallVector<Value> invar_args_vec;
+  for (auto* xls_operand : node.invariant_args()) {
+    auto invar_arg = state.getMlirValue(xls_operand->id());
+    if (!invar_arg.ok()) {
+      return invar_arg.status();
+    }
+    invar_args_vec.push_back(*invar_arg);
+  }
+  ValueRange invar_args(invar_args_vec);
+
+  auto body = state.getFunction(node.body()->name());
+  if (!body.ok()) {
+    return body.status();
+  }
+
+  auto result_type = translateType(node.GetType(), builder, ctx);
+  auto loc = translateLoc(node.loc(), builder, state);
+  if (!loc.ok()) {
+    return loc.status();
+  }
+
+  return builder.create<xls::CountedForOp>(
+      *loc, result_type, *initial_value, invar_args, trip_count, *body, stride);
+}
+
+absl::StatusOr<Operation*> translateAnyOp(::xls::Node& xls_node,
+                                          OpBuilder& builder, MLIRContext* ctx,
+                                          TranslationState& state) {
+  absl::StatusOr<Operation*> op;
+
+  if (auto* xls_op = dynamic_cast<::xls::Literal*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::BinOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ArithOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::PartialProductOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::UnOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::CompareOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::NaryOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op =
+                 dynamic_cast<::xls::BitwiseReductionOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ExtendOp*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Tuple*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::TupleIndex*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Array*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ArrayIndex*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ArrayConcat*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ArraySlice*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ArrayUpdate*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::BitSlice*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::BitSliceUpdate*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::DynamicBitSlice*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Concat*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Encode*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Decode*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::OneHot*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::OneHotSelect*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Invoke*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Select*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::PrioritySelect*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Map*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::AfterAll*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::ChannelNode*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::Gate*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (auto* xls_op = dynamic_cast<::xls::CountedFor*>(&xls_node)) {
+    op = translateOp(*xls_op, builder, ctx, state);
+  } else if (dynamic_cast<::xls::Param*>(&xls_node)) {
+    return absl::InternalError(
+        "Param not handeled during function translation.");
+  } else if (dynamic_cast<::xls::StateRead*>(&xls_node)) {
+    return absl::InternalError(
+        "StateRead not handeled during proc translation.");
+  } else if (dynamic_cast<::xls::Next*>(&xls_node)) {
+    return absl::InternalError("Next not handeled during proc translation.");
+  } else if (dynamic_cast<::xls::Cover*>(&xls_node) ||
+             dynamic_cast<::xls::Assert*>(&xls_node) ||
+             dynamic_cast<::xls::MinDelay*>(&xls_node) ||
+             dynamic_cast<::xls::RegisterRead*>(&xls_node) ||
+             dynamic_cast<::xls::RegisterWrite*>(&xls_node)) {
+    return absl::InternalError(
+        absl::StrCat("Unsuported operation: ", ::xls::OpToString(xls_node.op()),
+                     " - Not yet available in XLS MLIR!"));
+  } else {
+    return absl::InternalError(absl::StrCat("Unsuported operation: ",
+                                            ::xls::OpToString(xls_node.op())));
+  }
+
+  if (!op.ok()) {
+    return op.status();
+  }
+
+  if (auto err = state.setMlirValue(xls_node.id(), (*op)->getResult(0));
+      !err.ok()) {
+    return err;
+  }
+
+  return *op;
+}
+
+//===----------------------------------------------------------------------===//
+// Function Translation
+//===----------------------------------------------------------------------===//
+
+absl::StatusOr<Operation*> translateFunction(::xls::Function& xls_func,
+                                             OpBuilder& builder,
+                                             MLIRContext* ctx,
+                                             TranslationState& state) {
+  // Argument types:
+  SmallVector<Type> mlir_arg_types;
+  for (auto* arg : xls_func.GetType()->parameters()) {
+    mlir_arg_types.push_back(translateType(arg, builder, ctx));
+  }
+
+  // Return type:
+  auto return_type =
+      translateType(xls_func.GetType()->return_type(), builder, ctx);
+
+  // Create Function:
+  auto funcType =
+      FunctionType::get(ctx, TypeRange(mlir_arg_types), {return_type});
+  auto func =
+      func::FuncOp::create(builder.getUnknownLoc(), xls_func.name(), funcType);
+
+  builder.insert(func);
+
+  // Add function to package context:
+  if (auto err = state.setFunction(xls_func.name(),
+                                   SymbolRefAttr::get(func.getNameAttr()));
+      !err.ok()) {
+    return err;
+  }
+
+  // Create function body:
+  auto* body = func.addEntryBlock();
+
+  // New function base scope
+  state.newFunctionBaseContext();
+
+  // Add parameters to function context:
+  for (uint64_t arg_idx = 0; arg_idx < xls_func.params().length(); arg_idx++) {
+    auto xls_param = xls_func.params()[arg_idx];
+    auto mlir_arg = body->getArgument(arg_idx);
+    if (auto err = state.setMlirValue(xls_param->id(), mlir_arg); !err.ok()) {
+      return err;
+    }
+  }
+
+  // Function body:
+  Value return_value;
+  for (auto* n : xls_func.nodes()) {
+    builder.setInsertionPointToEnd(body);
+    if (n->Is<::xls::Param>()) {
+      // Params have already been converted and added to func context.
+      if (xls_func.return_value() == n) {
+        auto maybe_return_value =
+            state.getMlirValue(n->As<::xls::Param>()->id());
+        if (!maybe_return_value.ok()) {
+          return maybe_return_value.status();
+        }
+        return_value = *maybe_return_value;
+      }
+
+      continue;
+    }
+
+    auto op = translateAnyOp(*n, builder, ctx, state);
+    if (!op.ok()) {
+      return op;
+    }
+
+    if (xls_func.return_value() == n) {
+      assert(op.value()->getResults().size() == 1 &&
+             "Returning op with multiple result.");
+      return_value = op.value()->getResult(0);
+    }
+  }
+
+  if (return_value == Value()) {
+    assert(return_value != Value() && "Function return op not translated.");
+  }
+
+  // Function body terminator (return):
+  builder.setInsertionPointToEnd(body);
+  builder.create<func::ReturnOp>(builder.getUnknownLoc(),
+                                 ValueRange(return_value));
+
+  return func;
+}
+
+//===----------------------------------------------------------------------===//
+// Channel Translation
+//===----------------------------------------------------------------------===//
+
+absl::Status translateChannel(::xls::Channel& xls_chn, OpBuilder& builder,
+                              MLIRContext* ctx, TranslationState& state) {
+  auto chn = builder.create<xls::ChanOp>(
+      builder.getUnknownLoc(),
+      /*name=*/builder.getStringAttr(xls_chn.name()),
+      /*type=*/TypeAttr::get(translateType(xls_chn.type(), builder, ctx)),
+      /*send_supported=*/builder.getBoolAttr(xls_chn.CanSend()),
+      /*recv_supported=*/builder.getBoolAttr(xls_chn.CanReceive()));
+
+  return state.setChannel(std::string(xls_chn.name()),
+                          SymbolRefAttr::get(chn.getNameAttr()));
+}
+
+//===----------------------------------------------------------------------===//
+// Package Translation
+//===----------------------------------------------------------------------===//
+
+absl::Status translatePackage(::xls::Package& xls_pkg, OpBuilder& builder,
+                              MLIRContext* ctx, ModuleOp& module) {
+  TranslationState state;
+
+  // Translate file numbers:
+  auto xls_fileno_map = xls_pkg.fileno_to_name();
+  for (auto& [fileno, name] : xls_fileno_map) {
+    auto name_attr = builder.getStringAttr(name);
+    if (auto err = state.setFileName(fileno, name_attr); !err.ok()) {
+      return err;
+    }
+  }
+
+  // Translate all channels:
+  for (auto* c : xls_pkg.channels()) {
+    builder.setInsertionPointToEnd(module.getBody());
+    if (auto err = translateChannel(*c, builder, ctx, state); !err.ok()) {
+      return err;
+    }
+  }
+
+  // Translate all functions:
+  for (const auto& f : xls_pkg.functions()) {
+    builder.setInsertionPointToEnd(module.getBody());
+    auto func = translateFunction(*f, builder, ctx, state);
+    if (!func.ok()) {
+      return func.status();
+    }
+  }
+
+  return absl::OkStatus();
+}
+
+OwningOpRef<Operation*> XlsToMlirXlsTranslate(llvm::SourceMgr& mgr,
+                                              MLIRContext* ctx) {
+  OpBuilder builder(ctx);
+
+  // Load XLS dialect we will be emitting:
+  ctx->loadDialect<XlsDialect>();
+
+  // New top module to hold generated MLIR:
+  const llvm::MemoryBuffer* buf = mgr.getMemoryBuffer(mgr.getMainFileID());
+  auto loc = FileLineColLoc::get(
+      StringAttr::get(ctx, buf->getBufferIdentifier()), /*line=*/0,
+      /*column=*/0);
+  ModuleOp module = ModuleOp::create(loc);
+
+  // Parse XLS IR:
+  absl::StatusOr<std::unique_ptr<::xls::Package>> package =
+      ::xls::ParsePackage(buf->getBuffer().str(), std::nullopt);
+  if (!package.ok()) {
+    llvm::errs() << "Failed to parse: " << package.status().message() << "\n";
+    return {};
+  }
+
+  // Translate package from XLS IR to MLIR:
+  if (auto err = translatePackage(**package, builder, ctx, module); !err.ok()) {
+    llvm::errs() << err.message() << "\n";
+    return {};
+  }
+
+  return OwningOpRef(module);
+}
+
+}  // namespace mlir::xls

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.h
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_to_mlir.h
@@ -1,0 +1,29 @@
+// Copyright 2024 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_TO_MLIR_H_
+#define GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_TO_MLIR_H_
+
+#include "llvm/Support/SourceMgr.h"
+#include "mlir/include/mlir/IR/MLIRContext.h"
+#include "mlir/include/mlir/IR/OwningOpRef.h"
+
+namespace mlir::xls {
+
+OwningOpRef<Operation*> XlsToMlirXlsTranslate(llvm::SourceMgr& mgr,
+                                              MLIRContext* ctx);
+
+}  // namespace mlir::xls
+
+#endif  // GDM_HW_MLIR_XLS_TOOLS_XLS_TRANSLATE_XLS_TRANSLATE_TO_MLIR_H_


### PR DESCRIPTION

As requested, here is a combined PR that implements the XLS IR -> MLIR translation.

# STATE 

A few notes up front about the state of this:

- This relies on two PRs that are not yet merged - I have kept them in this PR branch so it is functional and will drop them + rebase once #1866 and #1843 are in.

- This currently implements full-fidelity round trip conversion for XLS functions. 

- Procs are mostly supported with the main limitation that non-zero initializers are not yet representable. This is WIP because it requires reworking of the yield OPs which is fairly invasive and I did not want commit to it until the "LiteralRegion" mechanism had been reviewed + merged.

- The notion of "top proc/func" is not yet translated/represented in MLIR.

- I have setup fuzzing of XLS->MLIR->XLS conversion that ties in interpretation of this round-tripped IR into the multi-way comparison:

  With this and the added unit tests I have a non-zero level of confidence that the translation for functions is correct :)

  Because proc initializers are not ready, I have not yet fuzzed those and expect there to be edge cases/bugs left.

  You can find the fuzzer for this branch here:

  https://github.com/schilkp/xls/tree/schilkp/xls_translate_func_fuzz

  To run it:
  ```bash
  bazel run -c opt //xls/fuzzer:run_fuzz_multiprocess -- --duration=500s --worker_count=32 --alsologtostderr --translate_ir_to_mlir=true --translate_opt_ir_to_mlir=true --translate_mlir_to_ir=true --crash_path=/tmp/fuzz_crasher --generate_proc=false
  ```

  I did not include the fuzzer in this commit because it still has some hacky workarounds. It touches core XLS infra so I assume it would be better to hold off there until it is ready.

  ![image](https://github.com/user-attachments/assets/91c82da5-24b8-4484-9590-0f5a6774e3d2)

# WIDTH ATTRIBUTE

There is one MLIR Dialect design decision/bike-shedding discussion left related to this :)

There are now quite a few operations where the output width is not constraint
but relevant for the semantics of the operation. For example:

- Multiplication result can be any width, irregardless of operand types. The result is truncated or zero-padded if it does not fit. (This is also fixed in MLIR in this PR)
- Decode, where the result can be any size up less than or equal to `2**N` where `N` is the operand width.

XLS IR is not consistent in how operations with non-inferable return type are handle. For multiplication, the width of the output is simply taken from the result type:

```
literal.1: bits[8] = literal(value=7)
literal.2: bits[8] = literal(value=2)
ret result: bits[10] = umul(literal.1, literal.2)
```

For decode, the width is included as an "attribute":

```
onehot.10: bits[16] = decode(y, width=16, id=10)
```

Currently I updated the MLIR to behave exactly the same as XLS IR (required width for decode, no attr for multiplication etc).

In my eyes, it makes sense to unify this behavior at least in MLIR: Either all operations with unconstrained return type should have this information as an attribute, or all should simply use the actual return type.

Let me know what you think.