### PR TITLE
[DSLX:TS] Unit tests for defined-but-unused scenarios.

### DIFF
--- a/xls/dslx/diagnostics/BUILD
+++ b/xls/dslx/diagnostics/BUILD
@@ -29,15 +29,34 @@ cc_library(
     deps = [
         "//xls/common/status:ret_check",
         "//xls/common/status:status_macros",
+        "//xls/dslx:warning_collector",
         "//xls/dslx:warning_kind",
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:ast_utils",
-        "//xls/dslx/type_system:deduce_ctx",
         "//xls/dslx/type_system:type",
+        "//xls/dslx/type_system:type_info",
         "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+cc_test(
+    name = "warn_on_defined_but_unused_test",
+    srcs = ["warn_on_defined_but_unused_test.cc"],
+    deps = [
+        ":warn_on_defined_but_unused",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/common/status:status_macros",
+        "//xls/dslx:create_import_data",
+        "//xls/dslx:import_data",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/dslx:warning_collector",
+        "//xls/dslx/type_system:type_info",
+        "@com_google_absl//absl/status",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/xls/dslx/diagnostics/warn_on_defined_but_unused.h
+++ b/xls/dslx/diagnostics/warn_on_defined_but_unused.h
@@ -17,13 +17,15 @@
 
 #include "absl/status/status.h"
 #include "xls/dslx/frontend/ast.h"
-#include "xls/dslx/type_system/deduce_ctx.h"
+#include "xls/dslx/type_system/type_info.h"
+#include "xls/dslx/warning_collector.h"
 
 namespace xls::dslx {
 
-// Emit warnings (into the WarningCollector on "ctx") for any bindings
-// considered defined-but-unused variables present in function "f".
-absl::Status WarnOnDefinedButUnused(Function& f, DeduceCtx* ctx);
+// Emit warnings into the `WarningCollector` for any bindings considered
+// defined-but-unused in function "f".
+absl::Status WarnOnDefinedButUnused(Function& f, TypeInfo& type_info,
+                                    WarningCollector& warnings);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/diagnostics/warn_on_defined_but_unused_test.cc
+++ b/xls/dslx/diagnostics/warn_on_defined_but_unused_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/dslx/diagnostics/warn_on_defined_but_unused.h"
+
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/import_data.h"
+#include "xls/dslx/parse_and_typecheck.h"
+
+namespace xls::dslx {
+namespace {
+
+TEST(WarnOnDefinedButUnusedTest, SimpleUnusedLocalLetBinding) {
+  const std::string program = "fn f() { let x = u32:1; }";
+
+  ImportData import_data = CreateImportDataForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule tm,
+      ParseAndTypecheck(program, "test.x", "test.x", &import_data));
+
+  WarningCollector warnings{kAllWarningsSet};
+  std::optional<Function*> f = tm.module->GetFunction("f");
+  ASSERT_TRUE(f.has_value());
+  XLS_ASSERT_OK(WarnOnDefinedButUnused(*f.value(), *tm.type_info, warnings));
+  ASSERT_EQ(warnings.warnings().size(), 1);
+  EXPECT_EQ(warnings.warnings()[0].message,
+            "Definition of `x` (type `uN[32]`) is not used in function `f`");
+}
+
+TEST(WarnOnDefinedButUnusedTest, MatchWithUnusedNameDefArm) {
+  const std::string program = "fn f(x: u32) -> u32 { match x { y => x } }";
+
+  ImportData import_data = CreateImportDataForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule tm,
+      ParseAndTypecheck(program, "test.x", "test.x", &import_data));
+
+  WarningCollector warnings{kAllWarningsSet};
+  std::optional<Function*> f = tm.module->GetFunction("f");
+  ASSERT_TRUE(f.has_value());
+  XLS_ASSERT_OK(WarnOnDefinedButUnused(*f.value(), *tm.type_info, warnings));
+  ASSERT_EQ(warnings.warnings().size(), 1);
+  EXPECT_EQ(warnings.warnings()[0].message,
+            "Definition of `y` (type `uN[32]`) is not used in function `f`");
+}
+
+// This one looks like the arms could be making a binding but they are in fact
+// doing an equality comparison as the names are already bound.
+TEST(WarnOnDefinedButUnusedTest, MatchWithArmsDoingEqualityComparisonVsParams) {
+  const std::string program = R"(fn f(x: bool, y: bool, z: bool) -> u32 {
+  let u = u32:42;
+  match true {
+    x => u32:42,
+    y => u32:43,
+    z => u32:44,
+    _ => u32:45
+  }
+})";
+  ImportData import_data = CreateImportDataForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule tm,
+      ParseAndTypecheck(program, "test.x", "test.x", &import_data));
+  WarningCollector warnings{kAllWarningsSet};
+  std::optional<Function*> f = tm.module->GetFunction("f");
+  ASSERT_TRUE(f.has_value());
+  XLS_ASSERT_OK(WarnOnDefinedButUnused(*f.value(), *tm.type_info, warnings));
+  EXPECT_EQ(warnings.warnings().size(), 1);
+  EXPECT_EQ(warnings.warnings()[0].message,
+            "Definition of `u` (type `uN[32]`) is not used in function `f`");
+}
+
+}  // namespace
+}  // namespace xls::dslx

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -1482,12 +1482,13 @@ absl::StatusOr<NameDefTree*> Parser::ParsePattern(Bindings& bindings,
       return module_->Make<NameDefTree>(span, colon_ref);
     }
 
-    std::optional<BoundNode> resolved = bindings.ResolveNode(*tok.GetValue());
-    if (resolved) {
-      AnyNameDef name_def =
-          bindings.ResolveNameOrNullopt(*tok.GetValue()).value();
+    std::string identifier = tok.GetValue().value();
+    if (std::optional<BoundNode> resolved = bindings.ResolveNode(identifier);
+        resolved.has_value()) {
+      AnyNameDef any_name_def =
+          bindings.ResolveNameOrNullopt(identifier).value();
       NameRef* ref =
-          module_->Make<NameRef>(tok.span(), *tok.GetValue(), name_def);
+          module_->Make<NameRef>(tok.span(), identifier, any_name_def);
       return module_->Make<NameDefTree>(tok.span(), ref);
     }
 

--- a/xls/dslx/type_system/typecheck_function.cc
+++ b/xls/dslx/type_system/typecheck_function.cc
@@ -255,7 +255,8 @@ absl::Status TypecheckFunction(Function& f, DeduceCtx* ctx) {
 
   // Implementation note: we have to check for defined-but-unused values before
   // we pop derived type info below.
-  XLS_RETURN_IF_ERROR(WarnOnDefinedButUnused(f, ctx));
+  XLS_RETURN_IF_ERROR(
+      WarnOnDefinedButUnused(f, *ctx->type_info(), *ctx->warnings()));
 
   if (f.tag() != FunctionTag::kNormal) {
     XLS_RET_CHECK(derived_type_info != nullptr);


### PR DESCRIPTION
- Makes WarnOnDefinedButUnused take a TypeInfo and a WarningCollector instead of a DeduceCtx to make it more capable of being unit tested
- Write a few unit tests for scenarios of interest

Towards #1909 