### PR TITLE
[DSLX:ir_conv] IR convert trailing match arms w/ multiple patterns.

### DIFF
--- a/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveMultiplePatternLastArm.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveMultiplePatternLastArm.ir
@@ -1,0 +1,17 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__main(x: bits[2] id=1) -> bits[32] {
+  literal.2: bits[2] = literal(value=0, id=2)
+  literal.4: bits[2] = literal(value=1, id=4)
+  eq.3: bits[1] = eq(literal.2, x, id=3)
+  eq.5: bits[1] = eq(literal.4, x, id=5)
+  or.6: bits[1] = or(eq.3, eq.5, id=6)
+  literal.8: bits[2] = literal(value=2, id=8)
+  concat.11: bits[1] = concat(or.6, id=11)
+  literal.7: bits[32] = literal(value=0, id=7)
+  literal.10: bits[32] = literal(value=1, id=10)
+  eq.9: bits[1] = eq(literal.8, x, id=9)
+  ret priority_sel.12: bits[32] = priority_sel(concat.11, cases=[literal.7], default=literal.10, id=12)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveOneRangeAndValueInSingleArm.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveOneRangeAndValueInSingleArm.ir
@@ -1,0 +1,12 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__main(x: bits[2] id=1) -> bits[32] {
+  literal.2: bits[2] = literal(value=0, id=2)
+  literal.3: bits[2] = literal(value=3, id=3)
+  uge.4: bits[1] = uge(x, literal.2, id=4)
+  ult.5: bits[1] = ult(x, literal.3, id=5)
+  and.6: bits[1] = and(uge.4, ult.5, id=6)
+  ret literal.7: bits[32] = literal(value=42, id=7)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveRangeInTrailingArm.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_MatchExhaustiveRangeInTrailingArm.ir
@@ -1,0 +1,17 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__main(x: bits[2] id=1) -> bits[32] {
+  literal.2: bits[2] = literal(value=3, id=2)
+  literal.5: bits[2] = literal(value=0, id=5)
+  literal.6: bits[2] = literal(value=3, id=6)
+  eq.3: bits[1] = eq(literal.2, x, id=3)
+  uge.7: bits[1] = uge(x, literal.5, id=7)
+  ult.8: bits[1] = ult(x, literal.6, id=8)
+  concat.11: bits[1] = concat(eq.3, id=11)
+  literal.4: bits[32] = literal(value=42, id=4)
+  literal.10: bits[32] = literal(value=64, id=10)
+  and.9: bits[1] = and(uge.7, ult.8, id=9)
+  ret priority_sel.12: bits[32] = priority_sel(concat.11, cases=[literal.4], default=literal.10, id=12)
+}


### PR DESCRIPTION
Previously we would give an IR conversion error, which was a vestige from where we needed the trailing arm to be a wildcard. Now with exhaustiveness we know the trailing match arm must be usable as a default case in the priority select that we lower to.