### PR TITLE
[DSLX] `use` syntax: enable using a module.

### DIFF
--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -951,7 +951,7 @@ ColonRef::ColonRef(Module* owner, Span span, Subject subject, std::string attr,
 
 ColonRef::~ColonRef() = default;
 
-std::optional<Import*> ColonRef::ResolveImportSubject() const {
+std::optional<ImportSubject> ColonRef::ResolveImportSubject() const {
   if (!std::holds_alternative<NameRef*>(subject_)) {
     return std::nullopt;
   }
@@ -962,6 +962,11 @@ std::optional<Import*> ColonRef::ResolveImportSubject() const {
   }
   const auto* name_def = std::get<const NameDef*>(any_name_def);
   AstNode* definer = name_def->definer();
+
+  if (auto* use_tree_entry = dynamic_cast<UseTreeEntry*>(definer)) {
+    return use_tree_entry;
+  }
+
   Import* import = dynamic_cast<Import*>(definer);
   if (import == nullptr) {
     return std::nullopt;

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -1707,6 +1707,10 @@ class Use : public AstNode {
   UseTreeEntry* root_;
 };
 
+// Both a `UseTreeEntry` and an `Import` are nodes that directly indicate a
+// module being imported. See e.g. `ColonRef::ResolveImportSubject`.
+using ImportSubject = std::variant<UseTreeEntry*, Import*>;
+
 // Represents a module-value or enum-value style reference when the LHS
 // expression is unknown; e.g. when accessing a member in a module:
 //
@@ -1745,7 +1749,7 @@ class ColonRef : public Expr {
   //
   // Note: if the value is not nullopt, it will be a valid pointer (not
   // nullptr).
-  std::optional<Import*> ResolveImportSubject() const;
+  std::optional<ImportSubject> ResolveImportSubject() const;
 
   Precedence GetPrecedenceWithoutParens() const final {
     return Precedence::kPaths;

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -3056,7 +3056,8 @@ absl::StatusOr<TypeRef*> Parser::ParseModTypeRef(Bindings& bindings,
   XLS_ASSIGN_OR_RETURN(
       BoundNode bn, bindings.ResolveNodeOrError(
                         *start_tok.GetValue(), start_tok.span(), file_table()));
-  if (!std::holds_alternative<Import*>(bn)) {
+  if (!std::holds_alternative<Import*>(bn) &&
+      !std::holds_alternative<UseTreeEntry*>(bn)) {
     return ParseErrorStatus(
         start_tok.span(),
         absl::StrFormat("Expected module for module-reference; got %s",

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -22,15 +22,15 @@
 #include <variant>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest-spi.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest-spi.h"
+#include "gtest/gtest.h"
 #include "xls/common/casts.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/file/get_runfile_path.h"

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -451,9 +451,10 @@ class InvocationVisitor : public ExprVisitor {
   // Helper for invocations of ColonRef callees.
   absl::StatusOr<CalleeInfo> HandleColonRefInvocation(
       const ColonRef* colon_ref) {
-    std::optional<Import*> import = colon_ref->ResolveImportSubject();
+    std::optional<ImportSubject> import = colon_ref->ResolveImportSubject();
     XLS_RET_CHECK(import.has_value());
-    std::optional<const ImportedInfo*> info = type_info_->GetImported(*import);
+    std::optional<const ImportedInfo*> info =
+        type_info_->GetImported(import.value());
     XLS_RET_CHECK(info.has_value());
     Module* module = (*info)->module;
     XLS_ASSIGN_OR_RETURN(Function * f,
@@ -477,10 +478,11 @@ class InvocationVisitor : public ExprVisitor {
     if (auto* mapped_colon_ref = dynamic_cast<ColonRef*>(fn_node)) {
       VLOG(5) << "map() invoking ColonRef: " << mapped_colon_ref->ToString();
       const std::string& identifier = mapped_colon_ref->attr();
-      std::optional<Import*> import = mapped_colon_ref->ResolveImportSubject();
+      std::optional<ImportSubject> import =
+          mapped_colon_ref->ResolveImportSubject();
       XLS_RET_CHECK(import.has_value());
       std::optional<const ImportedInfo*> info =
-          type_info_->GetImported(*import);
+          type_info_->GetImported(import.value());
       XLS_RET_CHECK(info.has_value());
       Module* this_m = (*info)->module;
       TypeInfo* callee_type_info = (*info)->type_info;

--- a/xls/dslx/ir_convert/ir_conversion_utils.cc
+++ b/xls/dslx/ir_convert/ir_conversion_utils.cc
@@ -147,6 +147,10 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
                            TypeToIr(package_, *t.wrapped(), bindings_));
       return absl::OkStatus();
     }
+    absl::Status HandleModule(const ModuleType& t) override {
+      return absl::UnimplementedError(
+          "Cannot convert module type to XLS IR type: " + t.ToString());
+    }
 
     xls::Type* retval() const { return retval_; }
 

--- a/xls/dslx/make_value_format_descriptor.cc
+++ b/xls/dslx/make_value_format_descriptor.cc
@@ -149,6 +149,10 @@ absl::StatusOr<ValueFormatDescriptor> MakeValueFormatDescriptor(
       return absl::InvalidArgumentError(
           "Cannot format a bits constructor; got: " + t.ToString());
     }
+    absl::Status HandleModule(const ModuleType& t) override {
+      return absl::InvalidArgumentError("Cannot format a module type; got: " +
+                                        t.ToString());
+    }
 
     ValueFormatDescriptor& result() { return result_; }
 

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -712,6 +712,13 @@ dslx_lang_test(
 
 dslx_lang_test(name = "mod_use_in_parametric")
 
+dslx_lang_test(name = "mod_use_stdlib")
+
+dslx_lang_test(
+    name = "mod_use_simple_enum",
+    dslx_deps = [":mod_simple_enum_dslx"],
+)
+
 dslx_lang_test(
     name = "mod_importer",
     dslx_deps = [":mod_imported_dslx"],

--- a/xls/dslx/tests/mod_use_simple_enum.x
+++ b/xls/dslx/tests/mod_use_simple_enum.x
@@ -1,0 +1,22 @@
+#![feature(use_syntax)]
+
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use xls::dslx::tests::mod_simple_enum;
+
+fn main() -> mod_simple_enum::EnumType { mod_simple_enum::EnumType::FIRST }
+
+#[test]
+fn test_main() { assert_eq(main(), mod_simple_enum::EnumType::FIRST); }

--- a/xls/dslx/tests/mod_use_stdlib.x
+++ b/xls/dslx/tests/mod_use_stdlib.x
@@ -1,0 +1,22 @@
+#![feature(use_syntax)]
+
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std;
+
+fn main() -> u32 { std::popcount(u32:31) }
+
+#[test]
+fn test_popcount() { assert_eq(main(), u32:5); }

--- a/xls/dslx/type_system/BUILD
+++ b/xls/dslx/type_system/BUILD
@@ -41,6 +41,7 @@ cc_library(
         "//xls/dslx:channel_direction",
         "//xls/dslx:interp_value",
         "//xls/dslx/frontend:ast",
+        "//xls/dslx/frontend:module",
         "//xls/dslx/frontend:pos",
         "//xls/ir:bits_ops",
         "@com_google_absl//absl/algorithm:container",

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -1391,6 +1391,9 @@ static absl::Status ValidateMatchable(const Type& type, const Span& span,
     absl::Status HandleProc(const ProcType& type) override {
       return Error(type);
     }
+    absl::Status HandleModule(const ModuleType& type) override {
+      return Error(type);
+    }
 
    private:
     absl::Status Error(const Type& type) {

--- a/xls/dslx/type_system/type_info.proto
+++ b/xls/dslx/type_system/type_info.proto
@@ -253,6 +253,10 @@ message TokenTypeProto {
   // Empty.
 }
 
+message ModuleTypeProto {
+  // Empty.
+}
+
 message TypeProto {
   oneof type_oneof {
     BitsTypeProto bits_type = 1;
@@ -266,6 +270,7 @@ message TypeProto {
     ChannelTypeProto channel_type = 9;
     BitsConstructorTypeProto bits_constructor_type = 10;
     ProcTypeProto proc_type = 11;
+    ModuleTypeProto module_type = 12;
   }
 }
 

--- a/xls/dslx/type_system/type_zero_value.cc
+++ b/xls/dslx/type_system/type_zero_value.cc
@@ -250,6 +250,13 @@ class MakeValueVisitor : public TypeVisitor {
         file_table());
   }
 
+  absl::Status HandleModule(const ModuleType& t) override {
+    return TypeInferenceErrorStatus(
+        span_, &t,
+        absl::StrFormat("Cannot make a %s of a module type.", value_name_),
+        file_table());
+  }
+
   absl::StatusOr<InterpValue> ResultOrError() const {
     XLS_RET_CHECK(result_.has_value());
     return *result_;

--- a/xls/dslx/type_system/typecheck_invocation.cc
+++ b/xls/dslx/type_system/typecheck_invocation.cc
@@ -64,8 +64,7 @@ namespace xls::dslx {
 
 static absl::StatusOr<std::unique_ptr<DeduceCtx>> GetImportedDeduceCtx(
     DeduceCtx* ctx, const Invocation* invocation,
-    const ParametricEnv& caller_bindings,
-    std::variant<UseTreeEntry*, Import*> import_key) {
+    const ParametricEnv& caller_bindings, ImportSubject import_key) {
   auto it = ctx->type_info()->GetRootImports().find(import_key);
   XLS_RET_CHECK(it != ctx->type_info()->GetRootImports().end())
       << "Could not find import for key: " << ToAstNode(import_key)->ToString();
@@ -333,10 +332,10 @@ TypecheckParametricBuiltinInvocation(DeduceCtx* ctx,
 // Inspects to see whether the given `ref` is a reference to an externally
 // defined entity -- if so, returns the "import key" we can use to resolve the
 // module information for it.
-static std::optional<std::variant<UseTreeEntry*, Import*>> IsExternRef(
-    Expr& ref, Module& current_module) {
+static std::optional<ImportSubject> IsExternRef(Expr& ref,
+                                                Module& current_module) {
   if (auto* colon_ref = dynamic_cast<ColonRef*>(&ref); colon_ref != nullptr) {
-    std::optional<Import*> import = colon_ref->ResolveImportSubject();
+    std::optional<ImportSubject> import = colon_ref->ResolveImportSubject();
     if (import.has_value()) {
       return import.value();
     }

--- a/xls/dslx/type_system/typecheck_module.cc
+++ b/xls/dslx/type_system/typecheck_module.cc
@@ -282,14 +282,9 @@ absl::Status TypecheckModuleMember(const ModuleMember& member, Module* module,
                   ctx->type_info()->SetItem(&subject.name_def(), *type.value());
                 }
               } else {
-                // TODO(cdleary): 2024-12-31 If somebody imports a module as a
-                // name and then refers to it via colon-refs, we probably want
-                // to have a "module type" to tag the used `NameDef` with.
-                return TypeInferenceErrorStatus(
-                    subject.name_def().span(), nullptr,
-                    "Only importing members from modules is currently "
-                    "supported.",
-                    ctx->file_table());
+                ctx->type_info()->SetItem(
+                    &subject.name_def(), std::make_unique<ModuleType>(
+                                             result.imported_module->module()));
               }
             }
             return absl::OkStatus();

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -603,6 +603,17 @@ fn f() -> u32 {
   XLS_EXPECT_OK(main_module.status()) << main_module.status();
 }
 
+TEST(TypecheckTest, UseOfStdlibModule) {
+  constexpr std::string_view kProgram = R"(#![feature(use_syntax)]
+use std;
+
+fn main() -> u32 {
+  std::popcount(u32:42)
+}
+)";
+  XLS_EXPECT_OK(Typecheck(kProgram));
+}
+
 TEST(TypecheckTest, FailsOnProcWithImplAsImportedStructMember) {
   constexpr std::string_view kImported = R"(
 pub proc Foo {

--- a/xls/dslx/type_system/zip_types.cc
+++ b/xls/dslx/type_system/zip_types.cc
@@ -168,6 +168,11 @@ class ZipTypeVisitor : public TypeVisitor {
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
 
+  absl::Status HandleModule(const ModuleType& lhs) override {
+    return absl::InvalidArgumentError("Cannot zip module types; got: " +
+                                      lhs.ToString());
+  }
+
   const Type& rhs_;
   const Type* lhs_parent_;
   const Type* rhs_parent_;

--- a/xls/public/c_api_dslx.cc
+++ b/xls/public/c_api_dslx.cc
@@ -302,12 +302,21 @@ int64_t xls_dslx_struct_def_get_member_count(struct xls_dslx_struct_def* n) {
 struct xls_dslx_import* xls_dslx_colon_ref_resolve_import_subject(
     struct xls_dslx_colon_ref* n) {
   auto* cpp_colon_ref = reinterpret_cast<xls::dslx::ColonRef*>(n);
-  std::optional<xls::dslx::Import*> cpp_import =
-      cpp_colon_ref->ResolveImportSubject();
+  std::optional<std::variant<xls::dslx::UseTreeEntry*, xls::dslx::Import*>>
+      cpp_import = cpp_colon_ref->ResolveImportSubject();
   if (!cpp_import.has_value()) {
     return nullptr;
   }
-  return reinterpret_cast<xls_dslx_import*>(cpp_import.value());
+  return absl::visit(
+      xls::Visitor{
+          [](xls::dslx::UseTreeEntry* entry) -> xls_dslx_import* {
+            return nullptr;
+          },
+          [](xls::dslx::Import* import) -> xls_dslx_import* {
+            return reinterpret_cast<xls_dslx_import*>(import);
+          },
+      },
+      cpp_import.value());
 }
 
 char* xls_dslx_colon_ref_get_attr(struct xls_dslx_colon_ref* n) {


### PR DESCRIPTION
analogous (but more powerful than) import, e.g.

```
use std;
```

and

```
use path::to::my_module;
```

Then we can colon-ref off of that module name.

The type of a module reference is an existential wrapper of the module identity itself. This lets us keep type information for the AST node in the TypeInfo mapping without having a "hole" where an AST node has no associated type information.

Implementation-wise this mostly means that `UseTreeEntry*` nodes have to ride the same pathways that `Import*` nodes were already riding in order to resolve module attributes.