### PR TITLE
Add `compile_flags.txt` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bazel-*
 __pycache__
 *~
 compile_commands.json
+compile_flags.txt
 xls_clang-tidy.out
 user.bazelrc
 .vscode


### PR DESCRIPTION
The new compilation DB extraction setup produces a `compile_flags.txt` instead of a `compile_commands.json` file.