### PR TITLE
Generate `nodata` fifo wrapper for FIFOs with width 0.

### DIFF
--- a/xls/codegen/block_generator.cc
+++ b/xls/codegen/block_generator.cc
@@ -837,46 +837,56 @@ class BlockGenerator {
             connections);
       } else if (xls::FifoInstantiation* fifo_instantiation =
                      dynamic_cast<FifoInstantiation*>(instantiation)) {
-        std::initializer_list<Connection> parameters{
-            Connection{
-                .port_name = "Width",
-                .expression = mb_.file()->Literal(
-                    UBits(fifo_instantiation->data_type()->GetFlatBitCount(),
-                          32),
-                    SourceInfo(),
-                    /*format=*/FormatPreference::kUnsignedDecimal)},
-            Connection{.port_name = "Depth",
-                       .expression = mb_.file()->Literal(
-                           UBits(fifo_instantiation->fifo_config().depth(), 32),
-                           SourceInfo(),
-                           /*format=*/FormatPreference::kUnsignedDecimal)},
-            Connection{
-                .port_name = "EnableBypass",
-                .expression = mb_.file()->Literal(
-                    UBits(fifo_instantiation->fifo_config().bypass() ? 1 : 0,
-                          1),
-                    SourceInfo(),
-                    /*format=*/FormatPreference::kUnsignedDecimal)},
-            Connection{.port_name = "RegisterPushOutputs",
-                       .expression = mb_.file()->Literal(
-                           UBits(fifo_instantiation->fifo_config()
-                                         .register_push_outputs()
-                                     ? 1
-                                     : 0,
-                                 1),
-                           SourceInfo(),
-                           /*format=*/FormatPreference::kUnsignedDecimal)},
-            Connection{
-                .port_name = "RegisterPopOutputs",
-                .expression = mb_.file()->Literal(
-                    UBits(
-                        fifo_instantiation->fifo_config().register_pop_outputs()
-                            ? 1
-                            : 0,
-                        1),
-                    SourceInfo(),
-                    /*format=*/FormatPreference::kUnsignedDecimal)},
-        };
+        std::vector<Connection> parameters;
+        parameters.reserve(6);
+
+        bool have_data = fifo_instantiation->data_type()->GetFlatBitCount() > 0;
+
+        if (have_data) {
+          parameters.push_back(Connection{
+              .port_name = "Width",
+              .expression = mb_.file()->Literal(
+                  UBits(fifo_instantiation->data_type()->GetFlatBitCount(), 32),
+                  SourceInfo(),
+                  /*format=*/FormatPreference::kUnsignedDecimal)});
+        }
+
+        parameters.insert(
+            parameters.end(),
+            {
+                Connection{
+                    .port_name = "Depth",
+                    .expression = mb_.file()->Literal(
+                        UBits(fifo_instantiation->fifo_config().depth(), 32),
+                        SourceInfo(),
+                        /*format=*/FormatPreference::kUnsignedDecimal)},
+                Connection{
+                    .port_name = "EnableBypass",
+                    .expression = mb_.file()->Literal(
+                        UBits(
+                            fifo_instantiation->fifo_config().bypass() ? 1 : 0,
+                            1),
+                        SourceInfo(),
+                        /*format=*/FormatPreference::kUnsignedDecimal)},
+                Connection{.port_name = "RegisterPushOutputs",
+                           .expression = mb_.file()->Literal(
+                               UBits(fifo_instantiation->fifo_config()
+                                             .register_push_outputs()
+                                         ? 1
+                                         : 0,
+                                     1),
+                               SourceInfo(),
+                               /*format=*/FormatPreference::kUnsignedDecimal)},
+                Connection{.port_name = "RegisterPopOutputs",
+                           .expression = mb_.file()->Literal(
+                               UBits(fifo_instantiation->fifo_config()
+                                             .register_pop_outputs()
+                                         ? 1
+                                         : 0,
+                                     1),
+                               SourceInfo(),
+                               /*format=*/FormatPreference::kUnsignedDecimal)},
+            });
 
         // Append clock to connections.
         connections.push_back(
@@ -908,8 +918,11 @@ class BlockGenerator {
           return a.port_name < b.port_name;
         });
 
+        std::string_view wrapper_name =
+            have_data ? "xls_fifo_wrapper" : "xls_nodata_fifo_wrapper";
+
         mb_.instantiation_section()->Add<Instantiation>(
-            SourceInfo(), "xls_fifo_wrapper", fifo_instantiation->name(),
+            SourceInfo(), wrapper_name, fifo_instantiation->name(),
             /*parameters=*/parameters, connections);
       } else {
         return absl::UnimplementedError(absl::StrFormat(

--- a/xls/codegen/block_generator_test.cc
+++ b/xls/codegen/block_generator_test.cc
@@ -24,8 +24,6 @@
 #include <tuple>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -36,6 +34,8 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -146,6 +146,53 @@ pop_ready,  pop_data,  pop_valid);
 endmodule
 )";
 
+inline constexpr std::string_view kDepth1NoDataFifoRTLText =
+    R"(// simple nodata fifo depth-1 implementation
+module xls_nodata_fifo_wrapper (
+clk, rst,
+push_ready, push_valid,
+pop_ready,  pop_valid);
+  parameter Depth = 32,
+            EnableBypass = 0,
+            RegisterPushOutputs = 1,
+            RegisterPopOutputs = 1;
+  localparam AddrWidth = $clog2(Depth) + 1;
+  input  wire             clk;
+  input  wire             rst;
+  output wire             push_ready;
+  input  wire             push_valid;
+  input  wire             pop_ready;
+  output wire             pop_valid;
+
+  // Require depth be 1 and bypass disabled.
+  initial begin
+    if (EnableBypass || Depth != 1 || !RegisterPushOutputs || RegisterPopOutputs) begin
+      // FIFO configuration not supported.
+      $fatal(1);
+    end
+  end
+
+  reg full;
+
+  assign push_ready = !full;
+  assign pop_valid = full;
+
+  always @(posedge clk) begin
+    if (rst == 1'b1) begin
+      full <= 1'b0;
+    end else begin
+      if (push_valid && push_ready) begin
+        full <= 1'b1;
+      end else if (pop_valid && pop_ready) begin
+        full <= 1'b0;
+      end else begin
+        full <= full;
+      end
+    end
+  end
+endmodule
+)";
+
 inline constexpr std::string_view kDepth0FifoRTLText =
     R"(// simple fifo depth-1 implementation
 module xls_fifo_wrapper (
@@ -179,6 +226,38 @@ pop_ready,  pop_data,  pop_valid);
   assign push_ready = pop_ready;
   assign pop_valid = push_valid;
   assign pop_data = push_data;
+
+endmodule
+)";
+
+inline constexpr std::string_view kDepth0NoDataFifoRTLText =
+    R"(// simple nodata fifo depth-1 implementation
+module xls_nodata_fifo_wrapper (
+clk, rst,
+push_ready, push_valid,
+pop_ready,  pop_valid);
+  parameter Depth = 32,
+            EnableBypass = 0,
+            RegisterPushOutputs = 1,
+            RegisterPopOutputs = 1;
+  localparam AddrWidth = $clog2(Depth) + 1;
+  input  wire             clk;
+  input  wire             rst;
+  output wire             push_ready;
+  input  wire             push_valid;
+  input  wire             pop_ready;
+  output wire             pop_valid;
+
+  // Require depth be 1 and bypass disabled.
+  initial begin
+    if (EnableBypass != 1 || Depth != 0 || RegisterPushOutputs || RegisterPopOutputs) begin
+      // FIFO configuration not supported.
+      $fatal(1);
+    end
+  end
+
+  assign push_ready = pop_ready;
+  assign pop_valid = push_valid;
 
 endmodule
 )";
@@ -259,21 +338,22 @@ class BlockGeneratorTest : public VerilogTestBase {
     return bb.Build();
   }
 
-  absl::StatusOr<CodegenResult> MakeMultiProc(FifoConfig fifo_config) {
+  absl::StatusOr<CodegenResult> MakeMultiProc(FifoConfig fifo_config,
+                                              uint64_t data_width) {
     Package package(TestName());
-    Type* u32 = package.GetBitsType(32);
+    Type* uN = package.GetBitsType(data_width);
     XLS_ASSIGN_OR_RETURN(
         Channel * in,
-        package.CreateStreamingChannel("in", ChannelOps::kReceiveOnly, u32, {},
+        package.CreateStreamingChannel("in", ChannelOps::kReceiveOnly, uN, {},
                                        std::nullopt, FlowControl::kReadyValid));
     XLS_ASSIGN_OR_RETURN(
         Channel * internal,
         package.CreateStreamingChannel(
-            "internal", ChannelOps::kSendReceive, u32, {},
+            "internal", ChannelOps::kSendReceive, uN, {},
             /*fifo_config=*/fifo_config, FlowControl::kReadyValid));
     XLS_ASSIGN_OR_RETURN(
         Channel * out,
-        package.CreateStreamingChannel("out", ChannelOps::kSendOnly, u32, {},
+        package.CreateStreamingChannel("out", ChannelOps::kSendOnly, uN, {},
                                        std::nullopt, FlowControl::kReadyValid));
     TokenlessProcBuilder in_pb("proc_in", "tkn", &package);
     {
@@ -1953,7 +2033,8 @@ TEST_P(BlockGeneratorTest, MultiProcWithInternalFifo) {
       CodegenResult result,
       MakeMultiProc(FifoConfig(/*depth=*/1, /*bypass=*/false,
                                /*register_push_outputs=*/true,
-                               /*register_pop_outputs=*/false)));
+                               /*register_pop_outputs=*/false),
+                    /*data_width=*/32));
   VerilogInclude fifo_definition{
       .relative_path = "fifo.v",
       .verilog_text = std::string{kDepth1FifoRTLText}};
@@ -1986,12 +2067,53 @@ TEST_P(BlockGeneratorTest, MultiProcWithInternalFifo) {
               absl_testing::IsOkAndHolds(output_values));
 }
 
+TEST_P(BlockGeneratorTest, MultiProcWithInternalNoDataFifo) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      CodegenResult result,
+      MakeMultiProc(FifoConfig(/*depth=*/1, /*bypass=*/false,
+                               /*register_push_outputs=*/true,
+                               /*register_pop_outputs=*/false),
+                    /*data_width=*/0));
+
+  VerilogInclude fifo_definition{
+      .relative_path = "fifo.v",
+      .verilog_text = std::string{kDepth1NoDataFifoRTLText}};
+  std::initializer_list<VerilogInclude> include_definitions = {fifo_definition};
+
+  result.module_generator_result.verilog_text = absl::StrCat(
+      "`include \"fifo.v\"\n\n", result.module_generator_result.verilog_text);
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.module_generator_result.verilog_text,
+                                 /*macro_definitions=*/{}, include_definitions);
+
+  ModuleSimulator simulator = NewModuleSimulator(
+      result.module_generator_result.verilog_text,
+      result.module_generator_result.signature, include_definitions);
+
+  absl::flat_hash_map<std::string, std::vector<Bits>> input_values;
+  input_values["in"] = {UBits(0, 0), UBits(0, 0), UBits(0, 0)};
+  std::vector<ValidHoldoff> valid_holdoffs = {
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+  };
+  auto ready_valid_holdoffs =
+      ReadyValidHoldoffs{.valid_holdoffs = {{"in", valid_holdoffs}}};
+
+  absl::flat_hash_map<std::string, std::vector<Bits>> output_values{
+      {"out", {UBits(0, 0), UBits(0, 0), UBits(0, 0)}}};
+  EXPECT_THAT(simulator.RunInputSeriesProc(input_values, {{"out", 3}},
+                                           ready_valid_holdoffs),
+              absl_testing::IsOkAndHolds(output_values));
+}
+
 TEST_P(BlockGeneratorTest, MultiProcDirectConnect) {
   XLS_ASSERT_OK_AND_ASSIGN(
       CodegenResult result,
       MakeMultiProc(FifoConfig(/*depth=*/0, /*bypass=*/true,
                                /*register_push_outputs=*/false,
-                               /*register_pop_outputs=*/false)));
+                               /*register_pop_outputs=*/false),
+                    /*data_width=*/32));
   VerilogInclude fifo_definition{
       .relative_path = "fifo.v",
       .verilog_text = std::string{kDepth0FifoRTLText}};
@@ -2020,6 +2142,46 @@ TEST_P(BlockGeneratorTest, MultiProcDirectConnect) {
 
   absl::flat_hash_map<std::string, std::vector<Bits>> output_values{
       {"out", {UBits(0, 32), UBits(20, 32), UBits(30, 32)}}};
+  EXPECT_THAT(simulator.RunInputSeriesProc(input_values, {{"out", 3}},
+                                           ready_valid_holdoffs),
+              absl_testing::IsOkAndHolds(output_values));
+}
+
+TEST_P(BlockGeneratorTest, MultiProcNoDataDirectConnect) {
+  XLS_ASSERT_OK_AND_ASSIGN(
+      CodegenResult result,
+      MakeMultiProc(FifoConfig(/*depth=*/0, /*bypass=*/true,
+                               /*register_push_outputs=*/false,
+                               /*register_pop_outputs=*/false),
+                    /*data_width=*/0));
+  VerilogInclude fifo_definition{
+      .relative_path = "fifo.v",
+      .verilog_text = std::string{kDepth0NoDataFifoRTLText}};
+  std::initializer_list<VerilogInclude> include_definitions = {fifo_definition};
+
+  result.module_generator_result.verilog_text = absl::StrCat(
+      "`include \"fifo.v\"\n\n", result.module_generator_result.verilog_text);
+
+  ExpectVerilogEqualToGoldenFile(GoldenFilePath(kTestName, kTestdataPath),
+                                 result.module_generator_result.verilog_text,
+                                 /*macro_definitions=*/{}, include_definitions);
+
+  ModuleSimulator simulator = NewModuleSimulator(
+      result.module_generator_result.verilog_text,
+      result.module_generator_result.signature, include_definitions);
+
+  absl::flat_hash_map<std::string, std::vector<Bits>> input_values;
+  input_values["in"] = {UBits(0, 0), UBits(0, 0), UBits(0, 0)};
+  std::vector<ValidHoldoff> valid_holdoffs = {
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+      ValidHoldoff{.cycles = 2, .driven_values = {IsX(), IsX()}},
+  };
+  auto ready_valid_holdoffs =
+      ReadyValidHoldoffs{.valid_holdoffs = {{"in", valid_holdoffs}}};
+
+  absl::flat_hash_map<std::string, std::vector<Bits>> output_values{
+      {"out", {UBits(0, 0), UBits(0, 0), UBits(0, 0)}}};
   EXPECT_THAT(simulator.RunInputSeriesProc(input_values, {{"out", 3}},
                                            ready_valid_holdoffs),
               absl_testing::IsOkAndHolds(output_values));

--- a/xls/codegen/testdata/block_generator_test_MultiProcNoDataDirectConnect.vtxt
+++ b/xls/codegen/testdata/block_generator_test_MultiProcNoDataDirectConnect.vtxt
@@ -1,0 +1,144 @@
+`include "fifo.v"
+
+module pipelined_proc__1(
+  input wire clk,
+  input wire rst,
+  input wire in_vld,
+  input wire internal_rdy,
+  output wire internal_vld,
+  output wire in_rdy
+);
+  reg p0_valid;
+  reg __in_valid_reg;
+  reg __internal_valid_reg;
+  wire internal_valid_inv;
+  wire internal_valid_load_en;
+  wire internal_load_en;
+  wire p1_stage_done;
+  wire p1_not_valid;
+  wire p0_enable;
+  wire p0_data_enable;
+  wire in_valid_inv;
+  wire in_valid_load_en;
+  wire in_load_en;
+  assign internal_valid_inv = ~__internal_valid_reg;
+  assign internal_valid_load_en = internal_rdy | internal_valid_inv;
+  assign internal_load_en = p0_valid & internal_valid_load_en;
+  assign p1_stage_done = p0_valid & internal_load_en;
+  assign p1_not_valid = ~p0_valid;
+  assign p0_enable = p1_stage_done | p1_not_valid;
+  assign p0_data_enable = p0_enable & __in_valid_reg;
+  assign in_valid_inv = ~__in_valid_reg;
+  assign in_valid_load_en = p0_data_enable | in_valid_inv;
+  assign in_load_en = in_vld & in_valid_load_en;
+  always @ (posedge clk) begin
+    if (rst) begin
+      p0_valid <= 1'h0;
+      __in_valid_reg <= 1'h0;
+      __internal_valid_reg <= 1'h0;
+    end else begin
+      p0_valid <= p0_enable ? __in_valid_reg : p0_valid;
+      __in_valid_reg <= in_valid_load_en ? in_vld : __in_valid_reg;
+      __internal_valid_reg <= internal_valid_load_en ? p0_valid : __internal_valid_reg;
+    end
+  end
+  assign internal_vld = __internal_valid_reg;
+  assign in_rdy = in_load_en;
+endmodule
+
+
+module proc_out(
+  input wire clk,
+  input wire rst,
+  input wire internal_vld,
+  input wire out_rdy,
+  output wire out_vld,
+  output wire internal_rdy
+);
+  reg p0_valid;
+  reg __internal_valid_reg;
+  reg __out_valid_reg;
+  wire out_valid_inv;
+  wire out_valid_load_en;
+  wire out_load_en;
+  wire p1_stage_done;
+  wire p1_not_valid;
+  wire p0_enable;
+  wire p0_data_enable;
+  wire internal_valid_inv;
+  wire internal_valid_load_en;
+  wire internal_load_en;
+  assign out_valid_inv = ~__out_valid_reg;
+  assign out_valid_load_en = out_rdy | out_valid_inv;
+  assign out_load_en = p0_valid & out_valid_load_en;
+  assign p1_stage_done = p0_valid & out_load_en;
+  assign p1_not_valid = ~p0_valid;
+  assign p0_enable = p1_stage_done | p1_not_valid;
+  assign p0_data_enable = p0_enable & __internal_valid_reg;
+  assign internal_valid_inv = ~__internal_valid_reg;
+  assign internal_valid_load_en = p0_data_enable | internal_valid_inv;
+  assign internal_load_en = internal_vld & internal_valid_load_en;
+  always @ (posedge clk) begin
+    if (rst) begin
+      p0_valid <= 1'h0;
+      __internal_valid_reg <= 1'h0;
+      __out_valid_reg <= 1'h0;
+    end else begin
+      p0_valid <= p0_enable ? __internal_valid_reg : p0_valid;
+      __internal_valid_reg <= internal_valid_load_en ? internal_vld : __internal_valid_reg;
+      __out_valid_reg <= out_valid_load_en ? p0_valid : __out_valid_reg;
+    end
+  end
+  assign out_vld = __out_valid_reg;
+  assign internal_rdy = internal_load_en;
+endmodule
+
+
+module pipelined_proc(
+  input wire clk,
+  input wire rst,
+  input wire in_vld,
+  input wire out_rdy,
+  output wire in_rdy,
+  output wire out_vld
+);
+  wire instantiation_output_138;
+  wire instantiation_output_144;
+  wire instantiation_output_151;
+  wire instantiation_output_156;
+  wire instantiation_output_145;
+  wire instantiation_output_150;
+
+  // ===== Instantiations
+  pipelined_proc__1 pipelined_proc__1_inst0 (
+    .rst(rst),
+    .in_vld(in_vld),
+    .internal_rdy(instantiation_output_145),
+    .in_rdy(instantiation_output_138),
+    .internal_vld(instantiation_output_144),
+    .clk(clk)
+  );
+  proc_out proc_out_inst1 (
+    .rst(rst),
+    .internal_vld(instantiation_output_150),
+    .out_rdy(out_rdy),
+    .internal_rdy(instantiation_output_151),
+    .out_vld(instantiation_output_156),
+    .clk(clk)
+  );
+  xls_nodata_fifo_wrapper #(
+    .Depth(32'd0),
+    .EnableBypass(1'd1),
+    .RegisterPushOutputs(1'd0),
+    .RegisterPopOutputs(1'd0)
+  ) fifo_internal (
+    .clk(clk),
+    .rst(rst),
+    .push_valid(instantiation_output_144),
+    .pop_ready(instantiation_output_151),
+    .push_ready(instantiation_output_145),
+    .pop_valid(instantiation_output_150)
+  );
+  assign in_rdy = instantiation_output_138;
+  assign out_vld = instantiation_output_156;
+endmodule

--- a/xls/codegen/testdata/block_generator_test_MultiProcWithInternalNoDataFifo.vtxt
+++ b/xls/codegen/testdata/block_generator_test_MultiProcWithInternalNoDataFifo.vtxt
@@ -1,0 +1,144 @@
+`include "fifo.v"
+
+module pipelined_proc__1(
+  input wire clk,
+  input wire rst,
+  input wire in_vld,
+  input wire internal_rdy,
+  output wire internal_vld,
+  output wire in_rdy
+);
+  reg p0_valid;
+  reg __in_valid_reg;
+  reg __internal_valid_reg;
+  wire internal_valid_inv;
+  wire internal_valid_load_en;
+  wire internal_load_en;
+  wire p1_stage_done;
+  wire p1_not_valid;
+  wire p0_enable;
+  wire p0_data_enable;
+  wire in_valid_inv;
+  wire in_valid_load_en;
+  wire in_load_en;
+  assign internal_valid_inv = ~__internal_valid_reg;
+  assign internal_valid_load_en = internal_rdy | internal_valid_inv;
+  assign internal_load_en = p0_valid & internal_valid_load_en;
+  assign p1_stage_done = p0_valid & internal_load_en;
+  assign p1_not_valid = ~p0_valid;
+  assign p0_enable = p1_stage_done | p1_not_valid;
+  assign p0_data_enable = p0_enable & __in_valid_reg;
+  assign in_valid_inv = ~__in_valid_reg;
+  assign in_valid_load_en = p0_data_enable | in_valid_inv;
+  assign in_load_en = in_vld & in_valid_load_en;
+  always @ (posedge clk) begin
+    if (rst) begin
+      p0_valid <= 1'h0;
+      __in_valid_reg <= 1'h0;
+      __internal_valid_reg <= 1'h0;
+    end else begin
+      p0_valid <= p0_enable ? __in_valid_reg : p0_valid;
+      __in_valid_reg <= in_valid_load_en ? in_vld : __in_valid_reg;
+      __internal_valid_reg <= internal_valid_load_en ? p0_valid : __internal_valid_reg;
+    end
+  end
+  assign internal_vld = __internal_valid_reg;
+  assign in_rdy = in_load_en;
+endmodule
+
+
+module proc_out(
+  input wire clk,
+  input wire rst,
+  input wire internal_vld,
+  input wire out_rdy,
+  output wire out_vld,
+  output wire internal_rdy
+);
+  reg p0_valid;
+  reg __internal_valid_reg;
+  reg __out_valid_reg;
+  wire out_valid_inv;
+  wire out_valid_load_en;
+  wire out_load_en;
+  wire p1_stage_done;
+  wire p1_not_valid;
+  wire p0_enable;
+  wire p0_data_enable;
+  wire internal_valid_inv;
+  wire internal_valid_load_en;
+  wire internal_load_en;
+  assign out_valid_inv = ~__out_valid_reg;
+  assign out_valid_load_en = out_rdy | out_valid_inv;
+  assign out_load_en = p0_valid & out_valid_load_en;
+  assign p1_stage_done = p0_valid & out_load_en;
+  assign p1_not_valid = ~p0_valid;
+  assign p0_enable = p1_stage_done | p1_not_valid;
+  assign p0_data_enable = p0_enable & __internal_valid_reg;
+  assign internal_valid_inv = ~__internal_valid_reg;
+  assign internal_valid_load_en = p0_data_enable | internal_valid_inv;
+  assign internal_load_en = internal_vld & internal_valid_load_en;
+  always @ (posedge clk) begin
+    if (rst) begin
+      p0_valid <= 1'h0;
+      __internal_valid_reg <= 1'h0;
+      __out_valid_reg <= 1'h0;
+    end else begin
+      p0_valid <= p0_enable ? __internal_valid_reg : p0_valid;
+      __internal_valid_reg <= internal_valid_load_en ? internal_vld : __internal_valid_reg;
+      __out_valid_reg <= out_valid_load_en ? p0_valid : __out_valid_reg;
+    end
+  end
+  assign out_vld = __out_valid_reg;
+  assign internal_rdy = internal_load_en;
+endmodule
+
+
+module pipelined_proc(
+  input wire clk,
+  input wire rst,
+  input wire in_vld,
+  input wire out_rdy,
+  output wire in_rdy,
+  output wire out_vld
+);
+  wire instantiation_output_138;
+  wire instantiation_output_144;
+  wire instantiation_output_151;
+  wire instantiation_output_156;
+  wire instantiation_output_145;
+  wire instantiation_output_150;
+
+  // ===== Instantiations
+  pipelined_proc__1 pipelined_proc__1_inst0 (
+    .rst(rst),
+    .in_vld(in_vld),
+    .internal_rdy(instantiation_output_145),
+    .in_rdy(instantiation_output_138),
+    .internal_vld(instantiation_output_144),
+    .clk(clk)
+  );
+  proc_out proc_out_inst1 (
+    .rst(rst),
+    .internal_vld(instantiation_output_150),
+    .out_rdy(out_rdy),
+    .internal_rdy(instantiation_output_151),
+    .out_vld(instantiation_output_156),
+    .clk(clk)
+  );
+  xls_nodata_fifo_wrapper #(
+    .Depth(32'd1),
+    .EnableBypass(1'd0),
+    .RegisterPushOutputs(1'd1),
+    .RegisterPopOutputs(1'd0)
+  ) fifo_internal (
+    .clk(clk),
+    .rst(rst),
+    .push_valid(instantiation_output_144),
+    .pop_ready(instantiation_output_151),
+    .push_ready(instantiation_output_145),
+    .pop_valid(instantiation_output_150)
+  );
+  assign in_rdy = instantiation_output_138;
+  assign out_vld = instantiation_output_156;
+endmodule


### PR DESCRIPTION
Since verilog does not allow zero-width channels or parametric removal of module I/O, a FIFO with zero data cannot be (ergonomically) implemented by parameterizing the general "with data" FIFO.

Update the block generator to generate instantiations of `xls_nodata_fifo_wrapper` instead of `xls_fifo_wrapper` in this case.

Also add test cases that exercise this instantiation.

---

*Note:*
ATM the tests are just copies of the other two fifo block generator tests with small adjustments. I looked into parameterizing the tests with fifo width so the same ones can be used, but because the tests already use the parametric `VerilogTestBase ` (which selects different simulation targets) I don't see a clean and simple way of doing this? 