### PR TITLE
[DSLX:TS] Give non-internal error when using binops on functions.

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1677,8 +1677,7 @@ DocRef Fmt(const AllOnesMacro& n, Comments& comments, DocArena& arena) {
 }
 
 DocRef Fmt(const Unop& n, Comments& comments, DocArena& arena) {
-  std::vector<DocRef> pieces = {
-      arena.MakeText(UnopKindToString(n.unop_kind()))};
+  std::vector<DocRef> pieces = {arena.MakeText(UnopKindFormat(n.unop_kind()))};
   if (WeakerThan(n.operand()->GetPrecedence(), n.GetPrecedence())) {
     pieces.push_back(arena.oparen());
     pieces.push_back(Fmt(*n.operand(), comments, arena));

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -1841,10 +1841,10 @@ std::string Unop::ToStringInternal() const {
   if (WeakerThan(operand_->GetPrecedence(), GetPrecedenceWithoutParens())) {
     Parenthesize(&operand);
   }
-  return absl::StrFormat("%s%s", UnopKindToString(unop_kind_), operand);
+  return absl::StrFormat("%s%s", UnopKindFormat(unop_kind_), operand);
 }
 
-std::string UnopKindToString(UnopKind k) {
+std::string UnopKindFormat(UnopKind k) {
   switch (k) {
     case UnopKind::kInvert:
       return "!";

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -1818,12 +1818,27 @@ class Param : public AstNode {
   Span span_;
 };
 
+#define XLS_DSLX_UNOP_KIND_EACH(X)                 \
+  /* one's complement inversion (bit flip) */      \
+  X(kInvert, "INVERT", "!")                        \
+  /* two's complement aritmetic negation (~x+1) */ \
+  X(kNegate, "NEGATE", "-")
+
 enum class UnopKind : uint8_t {
-  kInvert,  // one's complement inversion (bit flip)
-  kNegate,  // two's complement aritmetic negation (~x+1)
+#define FIRST_COMMA(A, ...) A,
+  XLS_DSLX_UNOP_KIND_EACH(FIRST_COMMA)
+#undef FIRST_COMMA
 };
 
-std::string UnopKindToString(UnopKind k);
+inline constexpr UnopKind kAllUnopKinds[] = {
+#define FIRST_COMMA(A, ...) UnopKind::A,
+    XLS_DSLX_UNOP_KIND_EACH(FIRST_COMMA)
+#undef FIRST_COMMA
+};
+
+// Analogous to `BinopKindFormat`, returns the string representation of the
+// given unary operation kind; e.g. "!"
+std::string UnopKindFormat(UnopKind kind);
 
 // Represents a unary operation expression; e.g. `!x`.
 class Unop : public Expr {
@@ -1894,6 +1909,12 @@ class Unop : public Expr {
 enum class BinopKind : uint8_t {
 #define FIRST_COMMA(A, ...) A,
   XLS_DSLX_BINOP_KIND_EACH(FIRST_COMMA)
+#undef FIRST_COMMA
+};
+
+inline constexpr BinopKind kAllBinopKinds[] = {
+#define FIRST_COMMA(A, ...) BinopKind::A,
+    XLS_DSLX_BINOP_KIND_EACH(FIRST_COMMA)
 #undef FIRST_COMMA
 };
 

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1301,6 +1301,14 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
     )
     self.assertIn('Match is already exhaustive', stderr)
 
+  def test_logical_and_on_functions(self):
+    stderr = self._run('xls/dslx/tests/errors/logical_and_on_functions.x')
+    self.assertIn('TypeInferenceError:', stderr)
+    self.assertIn(
+        "Cannot use operator `&&` on functions.",
+        stderr,
+    )
+
 
 if __name__ == '__main__':
   test_base.main()

--- a/xls/dslx/tests/errors/logical_and_on_functions.x
+++ b/xls/dslx/tests/errors/logical_and_on_functions.x
@@ -1,0 +1,28 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub fn is_x(x: u32) -> bool {
+    x > u32:0
+}
+
+pub fn is_y(y: u32) -> (bool, u32) {
+    (y > u32:0, y)
+}
+
+pub fn main(x: u32, y: u32) -> bool {
+    let is: bool = is_x(x);
+    let (is, y): (bool, u32) = is_y(y);
+    let is_z: bool = is_x && is_y;
+    is_z
+}

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -19,14 +19,14 @@
 #include <string_view>
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_replace.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/dslx/create_import_data.h"
@@ -4455,6 +4455,45 @@ fn main() -> u32 {
               StatusIs(absl::StatusCode::kInvalidArgument,
                        HasSubstr("The parametric argument for 'bit_count' "
                                  "should be a type and not a value.")));
+}
+
+// Note: we use two different type signatures here for the two functions being
+// binop'd -- this can help show any place we assume we can "diff" the two
+// function types when they're not type-compatible.
+TEST(TypecheckTest, BinaryOpsOnFunctionType) {
+  const std::string kProgramTemplate = R"(fn f() -> u32 { u32:42 }
+fn g() -> u8 { u8:43 }
+
+fn main() {
+  f {op} g
+}
+)";
+  for (BinopKind binop : kAllBinopKinds) {
+    std::string program = absl::StrReplaceAll(
+        kProgramTemplate, {{"{op}", BinopKindFormat(binop)}});
+    EXPECT_THAT(Typecheck(program).status(),
+                StatusIs(absl::StatusCode::kInvalidArgument,
+                         AnyOf(HasSubstr("can only be applied to"),
+                               HasSubstr("requires operand types to be"),
+                               HasSubstr("Cannot use operator"))));
+  }
+}
+
+TEST(TypecheckTest, UnaryOpsOnFunctionType) {
+  const std::string kProgramTemplate = R"(fn f() -> u32 { u32:42 }
+fn main() -> u32 {
+  {op} f
+}
+)";
+  for (UnopKind unop : kAllUnopKinds) {
+    std::string program =
+        absl::StrReplaceAll(kProgramTemplate, {{"{op}", UnopKindFormat(unop)}});
+    EXPECT_THAT(Typecheck(program).status(),
+                StatusIs(absl::StatusCode::kInvalidArgument,
+                         AnyOf(HasSubstr("can only be applied to"),
+                               HasSubstr("requires operand types to be"),
+                               HasSubstr("Cannot use operator"))));
+  }
 }
 
 // Table-oriented test that lets us validate that *types on parameters* are

--- a/xls/dslx/type_system_v2/typecheck_module_v2.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2.cc
@@ -356,7 +356,7 @@ class PopulateInferenceTableVisitor : public AstNodeVisitorWithDefault {
   // similar to `HandleXlsTuple` but without access to an explicit type
   // annotation. It's only necessary when a `NameDefTree` is not associated with
   // a tuple (e.g., outside a `let` assignment).
-  absl::Status HandleNameDefTree(const NameDefTree* node) {
+  absl::Status HandleNameDefTree(const NameDefTree* node) override {
     VLOG(5) << "HandleNameDefTree: " << node->ToString();
     if (node->is_leaf()) {
       return DefaultHandler(node);


### PR DESCRIPTION
Previously this sample would give an internal error because it would try to diff two function types. However, the real error we want to present here is that the operator cannot be used on function types at all, instead of trying to diff the function types.