### PR TITLE
[DSLX] Allow exhaustive quickchecks to target implicit-token-calling-convention

### DIFF
--- a/xls/data_structures/inline_bitmap.h
+++ b/xls/data_structures/inline_bitmap.h
@@ -168,6 +168,9 @@ class InlineBitmap {
   bool operator!=(const InlineBitmap& other) const { return !(*this == other); }
 
   int64_t bit_count() const { return bit_count_; }
+
+  bool empty() const { return bit_count_ == 0; }
+
   bool IsAllOnes() const {
     for (int64_t wordno = 0; wordno < word_count(); ++wordno) {
       if (data_[wordno] != MaskForWord(wordno)) {

--- a/xls/dslx/tests/quickcheck_fn_with_fail.x
+++ b/xls/dslx/tests/quickcheck_fn_with_fail.x
@@ -16,3 +16,10 @@ fn seemingly_can_fail(x: u32) -> u32 { if x != x { fail!("should_be_impossible",
 
 #[quickcheck]
 fn prop_effectively_identity(x: u32) -> bool { seemingly_can_fail(x) == x }
+
+// As above, but tests exhaustive input stimulus generation for the signature.
+#[quickcheck(exhaustive)]
+fn prop_effectively_identity_small_space(x: u2) -> bool {
+    let y = x as u32;
+    seemingly_can_fail(y) == y
+}

--- a/xls/ir/value.cc
+++ b/xls/ir/value.cc
@@ -247,6 +247,8 @@ void Value::FlattenTo(BitPushBuffer* buffer) const {
       }
       return;
     case ValueKind::kToken:
+      // Zero-bit encoding.
+      return;
     case ValueKind::kInvalid:
       break;
   }
@@ -279,6 +281,8 @@ absl::Status Value::PopulateFrom(BitmapView bitmap) {
       return absl::OkStatus();
     }
     case ValueKind::kToken:
+      // No information encoded in the bitmap for a token.
+      return absl::OkStatus();
     case ValueKind::kInvalid:
       return absl::InvalidArgumentError(absl::StrFormat(
           "Cannot populate value of kind: %s", ValueKindToString(kind_)));

--- a/xls/ir/value_test.cc
+++ b/xls/ir/value_test.cc
@@ -692,6 +692,21 @@ TEST(ValueTest, FromProtoMaxBitSize) {
   }
 }
 
+// We need this functionality so that we can craft tokens to feed to function
+// signatures, e.g. in exhaustive quickchecks.
+TEST(ValueTest, CanPopulateTokenFromEmptyBitmap) {
+  Value v = Value::Token();
+  BitPushBuffer push_buffer;
+  v.FlattenTo(&push_buffer);
+  InlineBitmap bitmap = push_buffer.ToBitmap();
+  ASSERT_TRUE(bitmap.empty());
+
+  TokenType token_type;
+  Value v2 = ZeroOfType(&token_type);
+  XLS_ASSERT_OK(v2.PopulateFrom(BitmapView(bitmap)));
+  EXPECT_EQ(v, v2);
+}
+
 void ProtoValueRoundTripWorks(const ValueProto& v) {
   auto value = Value::FromProto(v, /*max_bit_size=*/1 << 16);
   if (!value.ok()) {


### PR DESCRIPTION
Previously we would refuse to populate a token if it was in the signature.