### PR TITLE
[DSLX] Fix IR conversion when helper functions are used to do `assert_eq`

### DIFF
--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -17,7 +17,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
@@ -41,9 +40,15 @@ namespace xls::dslx {
 bool IsBuiltinFn(Expr* callee,
                  std::optional<std::string_view> target = std::nullopt);
 
-// Returns the name of `callee` if it's a builtin function and an error
-// otherwise.
-absl::StatusOr<std::string> GetBuiltinName(Expr* callee);
+// Returns the name of the builtin function referred to by `callee` if it is a
+// builtin function. If `callee` isn't a builtin function, returns std::nullopt.
+std::optional<std::string_view> GetBuiltinFnName(Expr* callee);
+
+// Returns true if `callee` refers to a builtin function that requires an
+// implicit token parameter.
+//
+// Precondition: `IsBuiltinFn(callee)`.
+bool GetBuiltinFnRequiresImplicitToken(Expr* callee);
 
 // Resolves the given TypeDefinition to a struct definition node local to the
 // module.

--- a/xls/dslx/frontend/builtins_metadata.h
+++ b/xls/dslx/frontend/builtins_metadata.h
@@ -24,7 +24,18 @@ namespace xls::dslx {
 
 struct BuiltinsData {
   std::string signature;
-  bool is_ast_node;
+
+  // Indicates whether this builtin is represented in the AST as a "first class
+  // node" or as an invocation of a builtin name-definition. Most builtins don't
+  // need to be AST nodes and thus this is false by default, which is the most
+  // common case.
+  bool is_ast_node = false;
+
+  // Indicates whether this builtin requires an implicit token parameter when it
+  // is used/invoked within a function. For most builtins this is not required,
+  // but built-ins that demand a token like `assert!`, `cover!`, `fail!` etc do
+  // have this set.
+  bool requires_implicit_token = false;
 };
 
 // Map from the name of the parametric builtin function; e.g. `assert_eq` to a

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -879,9 +879,9 @@ dslx_lang_test(
     convert_to_ir = False,
 )
 
-dslx_lang_test(
-    name = "test_f_calls_parametric_f",
-)
+dslx_lang_test(name = "test_f_calls_parametric_f")
+
+dslx_lang_test(name = "test_assert_helper")
 
 dslx_lang_test(name = "array_concat")
 

--- a/xls/dslx/tests/test_assert_helper.x
+++ b/xls/dslx/tests/test_assert_helper.x
@@ -1,0 +1,20 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test case that uses a helper function to call assert_eq.
+
+fn main(x: u32) { assert_eq(x, x); }
+
+#[test]
+fn test_do_assert_eq_reflexive() { main(u32:42); }

--- a/xls/dslx/type_system/typecheck_invocation.cc
+++ b/xls/dslx/type_system/typecheck_invocation.cc
@@ -216,12 +216,6 @@ TypecheckParametricBuiltinInvocation(DeduceCtx* ctx,
     arg_spans.push_back(arg->span());
   }
 
-  if ((callee_name == "fail!" || callee_name == "assert!" ||
-       callee_name == "cover!") &&
-      caller != nullptr) {
-    ctx->type_info()->NoteRequiresImplicitToken(*caller, true);
-  }
-
   VLOG(5) << "Instantiating builtin parametric: "
           << callee_nameref->identifier();
   XLS_ASSIGN_OR_RETURN(


### PR DESCRIPTION
Observed doing `--compare=jit` where there were helper functions for test scaffolding.

Previously the metadata that `assert_eq` requires an implicit token calling convention was not properly reflected. Organized some of the builtins metadata in the process since having the strings embedded into the deduce function is non ideal.