### PR TITLE
[c_api] Expose function JIT facilities (used in xlsynth crate)

### DIFF
--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -239,6 +239,7 @@ cc_library(
         "//xls/ir:ir_parser",
         "//xls/ir:type",
         "//xls/ir:value",
+        "//xls/jit:function_jit",
         "//xls/tools:codegen_flags_cc_proto",
         "//xls/tools:scheduling_options_flags_cc_proto",
         "@com_google_absl//absl/log",

--- a/xls/public/c_api.cc
+++ b/xls/public/c_api.cc
@@ -45,6 +45,7 @@
 #include "xls/ir/package.h"
 #include "xls/ir/type.h"
 #include "xls/ir/value.h"
+#include "xls/jit/function_jit.h"
 #include "xls/public/c_api_format_preference.h"
 #include "xls/public/c_api_impl_helpers.h"
 #include "xls/public/c_api_vast.h"
@@ -600,7 +601,16 @@ void xls_value_free(xls_value* v) { delete reinterpret_cast<xls::Value*>(v); }
 struct xls_value* xls_value_from_bits(const struct xls_bits* bits) {
   CHECK(bits != nullptr);
   const auto* cpp_bits = reinterpret_cast<const xls::Bits*>(bits);
-  return reinterpret_cast<xls_value*>(new xls::Value(std::move(*cpp_bits)));
+  return reinterpret_cast<xls_value*>(new xls::Value(*cpp_bits));
+}
+
+struct xls_value* xls_value_from_bits_owned(struct xls_bits* bits) {
+  CHECK(bits != nullptr);
+  auto* cpp_bits = reinterpret_cast<xls::Bits*>(bits);
+  auto* result =
+      reinterpret_cast<xls_value*>(new xls::Value(std::move(*cpp_bits)));
+  delete cpp_bits;
+  return result;
 }
 
 struct xls_function_base* xls_package_get_top(struct xls_package* p) {
@@ -848,9 +858,87 @@ bool xls_function_type_to_string(struct xls_function_type* type,
   return true;
 }
 
+bool xls_make_function_jit(struct xls_function* function, char** error_out,
+                           struct xls_function_jit** result_out) {
+  CHECK(function != nullptr);
+  CHECK(error_out != nullptr);
+  CHECK(result_out != nullptr);
+
+  xls::Function* xls_function = reinterpret_cast<xls::Function*>(function);
+  absl::StatusOr<std::unique_ptr<xls::FunctionJit>> jit =
+      xls::FunctionJit::Create(xls_function);
+  if (!jit.ok()) {
+    *error_out = xls::ToOwnedCString(jit.status().ToString());
+    return false;
+  }
+  *result_out = reinterpret_cast<struct xls_function_jit*>(jit->release());
+  *error_out = nullptr;
+  return true;
+}
+
+void xls_function_jit_free(struct xls_function_jit* jit) {
+  delete reinterpret_cast<xls::FunctionJit*>(jit);
+}
+
+bool xls_function_jit_run(struct xls_function_jit* jit, size_t argc,
+                          const struct xls_value* const* args, char** error_out,
+                          struct xls_trace_message** trace_messages_out,
+                          size_t* trace_messages_count_out,
+                          char*** assert_messages_out,
+                          size_t* assert_messages_count_out,
+                          struct xls_value** result_out) {
+  CHECK(jit != nullptr);
+  CHECK(error_out != nullptr);
+  CHECK(result_out != nullptr);
+
+  std::vector<xls::Value> cpp_args;
+  cpp_args.reserve(argc);
+  for (size_t i = 0; i < argc; ++i) {
+    CHECK(args[i] != nullptr);
+    cpp_args.push_back(*reinterpret_cast<const xls::Value*>(args[i]));
+  }
+
+  xls::FunctionJit* xls_jit = reinterpret_cast<xls::FunctionJit*>(jit);
+  absl::StatusOr<xls::InterpreterResult<xls::Value>> result =
+      xls_jit->Run(absl::MakeConstSpan(cpp_args));
+  if (!result.ok()) {
+    *error_out = xls::ToOwnedCString(result.status().ToString());
+    return false;
+  }
+
+  std::unique_ptr<xls_trace_message[]> trace_messages =
+      std::make_unique<xls_trace_message[]>(result->events.trace_msgs.size());
+  for (size_t i = 0; i < result->events.trace_msgs.size(); ++i) {
+    trace_messages[i].message =
+        xls::ToOwnedCString(result->events.trace_msgs[i].message);
+    trace_messages[i].verbosity = result->events.trace_msgs[i].verbosity;
+  }
+  *trace_messages_out = trace_messages.release();
+  *trace_messages_count_out = result->events.trace_msgs.size();
+
+  xls::ToOwnedCStrings(result->events.assert_msgs, assert_messages_out,
+                       assert_messages_count_out);
+
+  *result_out = reinterpret_cast<struct xls_value*>(
+      new xls::Value(std::move(result->value)));
+  *error_out = nullptr;
+  return true;
+}
+
+void xls_trace_messages_free(struct xls_trace_message* trace_messages,
+                             size_t count) {
+  if (trace_messages == nullptr) {
+    return;
+  }
+  for (size_t i = 0; i < count; ++i) {
+    xls_c_str_free(trace_messages[i].message);
+  }
+  delete[] trace_messages;
+}
+
 bool xls_interpret_function(struct xls_function* function, size_t argc,
-                            const struct xls_value** args, char** error_out,
-                            struct xls_value** result_out) {
+                            const struct xls_value* const* args,
+                            char** error_out, struct xls_value** result_out) {
   CHECK(function != nullptr);
   CHECK(args != nullptr);
 

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -50,6 +50,7 @@ struct xls_function_base;
 struct xls_type;
 struct xls_function_type;
 struct xls_schedule_and_codegen_result;
+struct xls_function_jit;
 
 void xls_init_xls(const char* usage, int argc, char* argv[]);
 
@@ -259,7 +260,15 @@ bool xls_bits_to_string(const struct xls_bits* bits,
 // Deallocates a value, e.g. one as created by `xls_parse_typed_value`.
 void xls_value_free(struct xls_value* v);
 
+// Returns a value (box) that wraps the given bits value.
+//
+// No ownership is taken over the given bits value. See
+// `xls_value_from_bits_owned` if you want to "gift" the value to the API.
 struct xls_value* xls_value_from_bits(const struct xls_bits* bits);
+
+// As above but takes ownership of the bits value (so it should no longer be
+// freed by the caller).
+struct xls_value* xls_value_from_bits_owned(struct xls_bits* bits);
 
 // Flattens the given value to a sequence of bits in a bits "buffer" value.
 //
@@ -347,8 +356,34 @@ bool xls_function_type_to_string(struct xls_function_type* xls_function_type,
 // `argc`) -- interpretation runs to a function result placed in `result_out`,
 // or `error_out` is populated and false is returned in the event of an error.
 bool xls_interpret_function(struct xls_function* function, size_t argc,
-                            const struct xls_value** args, char** error_out,
-                            struct xls_value** result_out);
+                            const struct xls_value* const* args,
+                            char** error_out, struct xls_value** result_out);
+
+bool xls_make_function_jit(struct xls_function* function, char** error_out,
+                           struct xls_function_jit** result_out);
+
+void xls_function_jit_free(struct xls_function_jit* jit);
+
+struct xls_trace_message {
+  char* message;
+  int64_t verbosity;
+};
+
+// Runs the given `jit` function with the given `args` (an array of size `argc`)
+// and returns the result in `result_out`.
+//
+// `trace_messages_out` should be freed by the caller via ...
+// `assert_messages_out` should be freed by the caller via ...
+bool xls_function_jit_run(struct xls_function_jit* jit, size_t argc,
+                          const struct xls_value* const* args, char** error_out,
+                          struct xls_trace_message** trace_messages_out,
+                          size_t* trace_messages_count_out,
+                          char*** assert_messages_out,
+                          size_t* assert_messages_count_out,
+                          struct xls_value** result_out);
+
+void xls_trace_messages_free(struct xls_trace_message* trace_messages,
+                             size_t count);
 
 }  // extern "C"
 

--- a/xls/public/c_api_impl_helpers.cc
+++ b/xls/public/c_api_impl_helpers.cc
@@ -130,4 +130,19 @@ bool FormatPreferenceFromC(xls_format_preference c_pref,
   return true;
 }
 
+void ToOwnedCStrings(absl::Span<const std::string_view> cpp,
+                     char*** c_string_array_out, size_t* count_out) {
+  CHECK(count_out != nullptr);
+  CHECK(c_string_array_out != nullptr);
+  *count_out = cpp.size();
+  if (cpp.empty()) {
+    *c_string_array_out = nullptr;
+    return;
+  }
+  *c_string_array_out = new char*[cpp.size()];
+  for (size_t i = 0; i < cpp.size(); ++i) {
+    (*c_string_array_out)[i] = ToOwnedCString(cpp[i]);
+  }
+}
+
 }  // namespace xls

--- a/xls/public/c_api_symbols.txt
+++ b/xls/public/c_api_symbols.txt
@@ -97,9 +97,12 @@ xls_dslx_typechecked_module_get_type_info
 xls_format_preference_from_string
 xls_function_get_name
 xls_function_get_type
+xls_function_jit_free
+xls_function_jit_run
 xls_function_type_to_string
 xls_init_xls
 xls_interpret_function
+xls_make_function_jit
 xls_mangle_dslx_name
 xls_optimize_ir
 xls_package_free
@@ -113,12 +116,14 @@ xls_parse_typed_value
 xls_schedule_and_codegen_package
 xls_schedule_and_codegen_result_free
 xls_schedule_and_codegen_result_get_verilog_text
+xls_trace_messages_free
 xls_type_to_string
 xls_value_clone
 xls_value_eq
 xls_value_flatten_to_bits
 xls_value_free
 xls_value_from_bits
+xls_value_from_bits_owned
 xls_value_get_bits
 xls_value_get_element
 xls_value_get_element_count

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -1374,4 +1374,111 @@ TEST(XlsCApiTest, ValueGetElementCount) {
   }
 }
 
+// In the `_owned` variation of the API we don't need to free the bits value.
+TEST(XlsCApiTest, ValueFromBitsOwned) {
+  xls_bits* bits = nullptr;
+  char* error = nullptr;
+  ASSERT_TRUE(xls_bits_make_ubits(32, 42, &error, &bits));
+
+  {
+    char* bits_str = xls_bits_to_debug_string(bits);
+    absl::Cleanup free_bits_str([=] { xls_c_str_free(bits_str); });
+    EXPECT_EQ(std::string_view{bits_str}, "0b00000000000000000000000000101010");
+  }
+
+  xls_value* value = xls_value_from_bits_owned(bits);
+  absl::Cleanup free_value([=] { xls_value_free(value); });
+
+  {
+    char* value_str = nullptr;
+    ASSERT_TRUE(xls_value_to_string(value, &value_str));
+    absl::Cleanup free_value_str([=] { xls_c_str_free(value_str); });
+    EXPECT_EQ(std::string_view{value_str}, "bits[32]:42");
+  }
+}
+
+TEST(XlsCApiTest, ValueFromBitsUnowned) {
+  xls_bits* bits = nullptr;
+  char* error = nullptr;
+  ASSERT_TRUE(xls_bits_make_ubits(32, 42, &error, &bits));
+  absl::Cleanup free_bits([=] { xls_bits_free(bits); });
+
+  // We'll create two values from this one bits object to try to show its guts
+  // are not moved or corrupted in some way.
+  xls_value* value1 = xls_value_from_bits(bits);
+  absl::Cleanup free_value1([=] { xls_value_free(value1); });
+  xls_value* value2 = xls_value_from_bits(bits);
+  absl::Cleanup free_value2([=] { xls_value_free(value2); });
+
+  EXPECT_TRUE(xls_value_eq(value1, value2));
+  EXPECT_TRUE(xls_value_eq(value2, value1));
+
+  // Check that the bits object can be turned to string still.
+  char* bits_str = xls_bits_to_debug_string(bits);
+  absl::Cleanup free_bits_str([=] { xls_c_str_free(bits_str); });
+  EXPECT_EQ(std::string_view{bits_str}, "0b00000000000000000000000000101010");
+}
+
+TEST(XlsCApiTest, FunctionJit) {
+  const std::string_view kIr = R"(package my_package
+
+top fn add_one(tok: token, x: bits[32]) -> bits[32] {
+  one: bits[32] = literal(value=1)
+  add: bits[32] = add(x, one)
+  always_on: bits[1] = literal(value=1)
+  trace: token = trace(tok, always_on, format="result: {}", data_operands=[add])
+  ret result: bits[32] =identity(add)
+}
+)";
+  char* error = nullptr;
+  xls_package* package = nullptr;
+  ASSERT_TRUE(xls_parse_ir_package(kIr.data(), "test.ir", &error, &package))
+      << "error: " << error;
+  ASSERT_NE(package, nullptr);
+  absl::Cleanup free_package([=] { xls_package_free(package); });
+
+  xls_function* function = nullptr;
+  ASSERT_TRUE(xls_package_get_function(package, "add_one", &error, &function));
+  ASSERT_NE(function, nullptr);
+
+  xls_function_jit* fn_jit = nullptr;
+  ASSERT_TRUE(xls_make_function_jit(function, &error, &fn_jit));
+  ASSERT_NE(fn_jit, nullptr);
+  absl::Cleanup free_fn_jit([=] { xls_function_jit_free(fn_jit); });
+
+  xls_bits* mol_bits = nullptr;
+  ASSERT_TRUE(xls_bits_make_ubits(32, 42, &error, &mol_bits));
+  xls_value* mol = xls_value_from_bits_owned(mol_bits);
+  absl::Cleanup free_mol([=] { xls_value_free(mol); });
+
+  xls_value* tok = xls_value_make_token();
+  absl::Cleanup free_tok([=] { xls_value_free(tok); });
+
+  std::vector<xls_value*> args = {tok, mol};
+  xls_value* result = nullptr;
+  xls_trace_message* trace_messages = nullptr;
+  size_t trace_messages_count = 0;
+  char** assert_messages = nullptr;
+  size_t assert_messages_count = 0;
+  ASSERT_TRUE(xls_function_jit_run(fn_jit, args.size(), args.data(), &error,
+                                   &trace_messages, &trace_messages_count,
+                                   &assert_messages, &assert_messages_count,
+                                   &result));
+  absl::Cleanup free_result([=] { xls_value_free(result); });
+  absl::Cleanup free_trace_messages(
+      [=] { xls_trace_messages_free(trace_messages, trace_messages_count); });
+  absl::Cleanup free_assert_messages(
+      [=] { xls_c_strs_free(assert_messages, assert_messages_count); });
+
+  ASSERT_EQ(trace_messages_count, 1);
+  ASSERT_EQ(assert_messages_count, 0);
+  EXPECT_EQ(std::string_view{trace_messages[0].message}, "result: 43");
+  EXPECT_EQ(trace_messages[0].verbosity, 0);
+
+  char* result_str = nullptr;
+  ASSERT_TRUE(xls_value_to_string(result, &result_str));
+  absl::Cleanup free_result_str([=] { xls_c_str_free(result_str); });
+  EXPECT_EQ(std::string_view{result_str}, "bits[32]:43");
+}
+
 }  // namespace


### PR DESCRIPTION
Note that `xls_value_from_bits` erroneously moved out of the const ref before and that's fixed in this PR (I didn't know you could even do that).