### PR TITLE
Centralize definition/validation of supported FIFO config.

### DIFF
--- a/xls/codegen/fifo_model_test_utils.h
+++ b/xls/codegen/fifo_model_test_utils.h
@@ -19,9 +19,9 @@
 #include <string>
 #include <variant>
 
+#include "absl/container/flat_hash_map.h"
 #include "gmock/gmock.h"
 #include "xls/common/fuzzing/fuzztest.h"
-#include "absl/container/flat_hash_map.h"
 #include "xls/ir/bits.h"
 #include "xls/ir/channel.h"
 #include "xls/ir/instantiation.h"
@@ -257,22 +257,7 @@ void AbslStringify(Sink& sink, const FifoTestParam& value) {
 
 inline auto FifoTestParamDomain() {
   return fuzztest::Filter(
-      [](const FifoTestParam& params) {
-        if (params.config.depth() == 0 &&
-            (!params.config.bypass() || params.config.register_push_outputs() ||
-             params.config.register_pop_outputs())) {
-          // Unsupported configurations of depth=0 fifos.
-          return false;
-        }
-        if (params.config.depth() == 1 &&
-            params.config.register_pop_outputs()) {
-          // Unsupported configuration of depth=1 fifo with
-          // register_pop_outputs.
-          return false;
-        }
-
-        return true;
-      },
+      [](const FifoTestParam& params) { return params.config.Validate().ok(); },
       fuzztest::ConstructorOf<FifoTestParam>(
           /*data_bit_count=*/fuzztest::OneOf(fuzztest::Just(0),
                                              fuzztest::Just(32)),

--- a/xls/codegen/materialize_fifos_pass.cc
+++ b/xls/codegen/materialize_fifos_pass.cc
@@ -282,11 +282,7 @@ absl::StatusOr<bool> MaterializeFifosPass::RunInternal(
       if (i->kind() == InstantiationKind::kFifo) {
         XLS_ASSIGN_OR_RETURN(FifoInstantiation * fifo,
                              i->AsFifoInstantiation());
-        if (fifo->fifo_config().depth() == 1 &&
-            fifo->fifo_config().register_pop_outputs()) {
-          return absl::InvalidArgumentError(
-              "Cannot materialize fifo with register_pop_outputs and depth 1.");
-        }
+        XLS_RETURN_IF_ERROR(fifo->fifo_config().Validate());
         insts.push_back(fifo);
       }
     }

--- a/xls/interpreter/block_evaluator_test_base.h
+++ b/xls/interpreter/block_evaluator_test_base.h
@@ -19,8 +19,8 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
 #include "absl/strings/str_cat.h"
+#include "gtest/gtest.h"
 #include "xls/interpreter/block_evaluator.h"
 #include "xls/ir/channel.h"
 #include "xls/ir/ir_test_base.h"
@@ -69,20 +69,14 @@ inline std::vector<FifoTestParam> GenerateFifoTestParams(
     for (bool bypass : {true, false}) {
       for (bool register_push_outputs : {true, false}) {
         for (bool register_pop_outputs : {true, false}) {
-          if (depth == 0 &&
-              (!bypass || register_push_outputs || register_pop_outputs)) {
-            // Unsupported configurations of depth=0 fifos.
-            continue;
-          }
-          if (depth == 1 && register_pop_outputs) {
-            // Unsupported configuration of depth=1 fifo with
-            // register_pop_outputs.
+          FifoConfig config = FifoConfig(depth, bypass, register_push_outputs,
+                                         register_pop_outputs);
+          if (!config.Validate().ok()) {
             continue;
           }
           params.push_back(FifoTestParam{
               .block_evaluator_test_param = block_evaluator_test_param,
-              .fifo_config = FifoConfig(depth, bypass, register_push_outputs,
-                                        register_pop_outputs)});
+              .fifo_config = config});
         }
       }
     }

--- a/xls/interpreter/block_interpreter.cc
+++ b/xls/interpreter/block_interpreter.cc
@@ -169,10 +169,7 @@ class FifoModel {
             absl::StrCat(instance_prefix_, kOutputValidRegisterName)),
         reg_state_(reg_state),
         next_reg_state_(next_reg_state) {
-    if (config_.depth() == 0) {
-      CHECK(config_.bypass() && !config_.register_pop_outputs() &&
-            !config_.register_push_outputs());
-    }
+    CHECK_OK(config.Validate());
   }
 
   absl::Status HandleInput(InstantiationInput* input, const Value& value) {


### PR DESCRIPTION
Replace distributed (and inconsistent) checks for supported FIFO configs.

Fixes tests with unsupported FIFO configs.

---

As mentioned in https://github.com/google/xls/pull/1896.

I assume the mismatch here is because they got out of sync, and not because of different requirements.

Note that, because the checks were inconsistent and there is little documentation on the purpose of these restrictions, I took the union/most restrictive set.

Also it would be helpful to add documentation/comments to the `isSupported` function that explain these limits. I don't quite know where they come from  :)

I assume that @allight and @grebe are responsible here. Thanks! :)