### PR TITLE
[dev_tools] Flag when a package has no top in `check_ir_equivalence_main`.

### DIFF
--- a/xls/dev_tools/check_ir_equivalence_main.cc
+++ b/xls/dev_tools/check_ir_equivalence_main.cc
@@ -268,8 +268,14 @@ absl::StatusOr<bool> RealMain(const std::vector<std::string_view>& ir_paths,
   std::vector<FunctionBase*> functions;
   functions.reserve(packages.size());
   for (const auto& package : packages) {
-    functions.push_back(*package->GetTop());
+    std::optional<FunctionBase*> top = package->GetTop();
+    if (!top.has_value()) {
+      return absl::InvalidArgumentError("Package has no top entity: " +
+                                        package->name());
+    }
+    functions.push_back(top.value());
   }
+
   solvers::z3::ProverResult result;
   if (functions[0]->IsFunction()) {
     if (!functions[1]->IsFunction()) {

--- a/xls/dev_tools/check_ir_equivalence_main_test.py
+++ b/xls/dev_tools/check_ir_equivalence_main_test.py
@@ -145,35 +145,39 @@ class CheckIrEquivalenceMainTest(absltest.TestCase):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    return res.returncode == 0, res.stdout.decode("utf8"), res.stderr.decode("utf8")
+    stdout = res.stdout.decode("utf8")
+    stderr = res.stderr.decode("utf8")
+    return res.returncode == 0, stdout, stderr
 
   def test_detects_different_functions(self):
-    res, stdout, stderr = self._check_equiv(ADD_IR, NOT_ADD_IR)
+    res, stdout, _ = self._check_equiv(ADD_IR, NOT_ADD_IR)
     self.assertFalse(res)
     self.assertIn("Verified NOT equivalent", stdout)
 
   def test_ignores_assert(self):
-    res, stdout, stderr = self._check_equiv(PROC_IR_WITH_ASSERT, PROC_IR, act_count=3)
+    res, stdout, _ = self._check_equiv(
+      PROC_IR_WITH_ASSERT, PROC_IR, act_count=3)
     self.assertTrue(res)
     self.assertIn("Verified equivalent", stdout)
 
   def test_detects_equiv_functions(self):
-    res, stdout, stderr = self._check_equiv(ADD_IR, NOT_NOT_ADD_IR)
+    res, stdout, _ = self._check_equiv(ADD_IR, NOT_NOT_ADD_IR)
     self.assertTrue(res)
     self.assertIn("Verified equivalent", stdout)
 
   def test_detects_different_procs(self):
-    res, stdout, stderr = self._check_equiv(PROC_IR, NEG_PROC_IR, act_count=14)
+    res, stdout, _ = self._check_equiv(PROC_IR, NEG_PROC_IR, act_count=14)
     self.assertFalse(res)
     self.assertIn("Verified NOT equivalent", stdout)
 
   def test_detects_equiv_procs(self):
-    res, stdout, stderr = self._check_equiv(PROC_IR, NEG_NEG_PROC_IR, act_count=14)
+    res, stdout, _ = self._check_equiv(
+      PROC_IR, NEG_NEG_PROC_IR, act_count=14)
     self.assertTrue(res)
     self.assertIn("Verified equivalent", stdout)
 
   def test_lhs_has_no_top(self):
-    res, msg, stderr = self._check_equiv(ADD_IR, ADD_NO_TOP_IR)
+    res, _, stderr = self._check_equiv(ADD_IR, ADD_NO_TOP_IR)
     self.assertFalse(res)
     self.assertIn("Package has no top entity: add_no_top", stderr)
 

--- a/xls/dev_tools/check_ir_equivalence_main_test.py
+++ b/xls/dev_tools/check_ir_equivalence_main_test.py
@@ -28,6 +28,13 @@ top fn add(x: bits[32], y: bits[32]) -> bits[32] {
   ret add.1: bits[32] = add(x, y)
 }
 """
+# Version of ADD_IR that has no top function.
+ADD_NO_TOP_IR = """package add_no_top
+
+fn add(x: bits[32], y: bits[32]) -> bits[32] {
+  ret add.1: bits[32] = add(x, y)
+}
+"""
 NOT_ADD_IR = """package not_add
 
 top fn not_add(x: bits[32], y: bits[32]) -> bits[32] {
@@ -125,7 +132,8 @@ class CheckIrEquivalenceMainTest(absltest.TestCase):
 
   def _check_equiv(
       self, ir_a: str, ir_b: str, act_count: Union[None, int] = 0
-  ) -> Tuple[bool, str]:
+  ) -> Tuple[bool, str, str]:
+    """Returns `(success, output_message, stderr_message)`."""
     res = subprocess.run(
         [
             _CHECK_EQUIV,
@@ -135,34 +143,39 @@ class CheckIrEquivalenceMainTest(absltest.TestCase):
         ],
         check=False,
         stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
     )
-    return res.returncode == 0, res.stdout.decode("utf8")
+    return res.returncode == 0, res.stdout.decode("utf8"), res.stderr.decode("utf8")
 
   def test_detects_different_functions(self):
-    res, msg = self._check_equiv(ADD_IR, NOT_ADD_IR)
+    res, stdout, stderr = self._check_equiv(ADD_IR, NOT_ADD_IR)
     self.assertFalse(res)
-    self.assertIn("Verified NOT equivalent", msg)
+    self.assertIn("Verified NOT equivalent", stdout)
 
   def test_ignores_assert(self):
-    res, msg = self._check_equiv(PROC_IR_WITH_ASSERT, PROC_IR, act_count=3)
+    res, stdout, stderr = self._check_equiv(PROC_IR_WITH_ASSERT, PROC_IR, act_count=3)
     self.assertTrue(res)
-    self.assertIn("Verified equivalent", msg)
+    self.assertIn("Verified equivalent", stdout)
 
   def test_detects_equiv_functions(self):
-    res, msg = self._check_equiv(ADD_IR, NOT_NOT_ADD_IR)
+    res, stdout, stderr = self._check_equiv(ADD_IR, NOT_NOT_ADD_IR)
     self.assertTrue(res)
-    self.assertIn("Verified equivalent", msg)
+    self.assertIn("Verified equivalent", stdout)
 
   def test_detects_different_procs(self):
-    res, msg = self._check_equiv(PROC_IR, NEG_PROC_IR, act_count=14)
+    res, stdout, stderr = self._check_equiv(PROC_IR, NEG_PROC_IR, act_count=14)
     self.assertFalse(res)
-    self.assertIn("Verified NOT equivalent", msg)
+    self.assertIn("Verified NOT equivalent", stdout)
 
   def test_detects_equiv_procs(self):
-    res, msg = self._check_equiv(PROC_IR, NEG_NEG_PROC_IR, act_count=14)
+    res, stdout, stderr = self._check_equiv(PROC_IR, NEG_NEG_PROC_IR, act_count=14)
     self.assertTrue(res)
-    self.assertIn("Verified equivalent", msg)
+    self.assertIn("Verified equivalent", stdout)
 
+  def test_lhs_has_no_top(self):
+    res, msg, stderr = self._check_equiv(ADD_IR, ADD_NO_TOP_IR)
+    self.assertFalse(res)
+    self.assertIn("Package has no top entity: add_no_top", stderr)
 
 if __name__ == "__main__":
   absltest.main()


### PR DESCRIPTION
Previously this would segfault.

Also adds pylint to the pre-commit yaml; this effectively fixes #1986 as we will now see pylint errors via the pre-commit hook