### PR TITLE
[c_api:vast] Add missing xls_vast_index_as_expression

### DIFF
--- a/xls/public/c_api_symbols.txt
+++ b/xls/public/c_api_symbols.txt
@@ -153,6 +153,7 @@ xls_value_make_ubits
 xls_value_to_string
 xls_value_to_string_format_preference
 xls_vast_concat_as_expression
+xls_vast_index_as_expression
 xls_vast_index_as_indexable_expression
 xls_vast_literal_as_expression
 xls_vast_logic_ref_as_expression

--- a/xls/public/c_api_test.cc
+++ b/xls/public/c_api_test.cc
@@ -21,11 +21,11 @@
 #include <string_view>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/base/macros.h"
 #include "absl/cleanup/cleanup.h"
 #include "absl/log/log.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/file/temp_directory.h"
 #include "xls/common/logging/log_lines.h"

--- a/xls/public/c_api_vast.cc
+++ b/xls/public/c_api_vast.cc
@@ -321,6 +321,13 @@ struct xls_vast_expression* xls_vast_concat_as_expression(
   return reinterpret_cast<xls_vast_expression*>(cpp_expression);
 }
 
+struct xls_vast_expression* xls_vast_index_as_expression(
+    struct xls_vast_index* v) {
+  auto* cpp_v = reinterpret_cast<xls::verilog::Index*>(v);
+  auto* cpp_expression = static_cast<xls::verilog::Expression*>(cpp_v);
+  return reinterpret_cast<xls_vast_expression*>(cpp_expression);
+}
+
 struct xls_vast_indexable_expression*
 xls_vast_logic_ref_as_indexable_expression(
     struct xls_vast_logic_ref* logic_ref) {
@@ -431,6 +438,11 @@ struct xls_vast_index* xls_vast_verilog_file_make_index(
     struct xls_vast_verilog_file* f,
     struct xls_vast_indexable_expression* subject,
     struct xls_vast_expression* index) {
+  // Add a soundness check just in case users confuse this API with
+  // xls_vast_verilog_file_make_index_i64 and pass a literal zero in the place
+  // of the pointer.
+  CHECK(index != nullptr)
+      << "xls_vast_verilog_file_make_index: index is nullptr";
   auto* cpp_file = reinterpret_cast<xls::verilog::VerilogFile*>(f);
   auto* cpp_subject =
       reinterpret_cast<xls::verilog::IndexableExpression*>(subject);

--- a/xls/public/c_api_vast.h
+++ b/xls/public/c_api_vast.h
@@ -208,6 +208,8 @@ struct xls_vast_expression* xls_vast_slice_as_expression(
     struct xls_vast_slice* v);
 struct xls_vast_expression* xls_vast_concat_as_expression(
     struct xls_vast_concat* v);
+struct xls_vast_expression* xls_vast_index_as_expression(
+    struct xls_vast_index* v);
 
 struct xls_vast_indexable_expression*
 xls_vast_logic_ref_as_indexable_expression(


### PR DESCRIPTION
Was required by the xlsynth-crate but it had not been added (lazy loaded symbols hid the fact it was missing): https://github.com/xlsynth/xlsynth-crate/blob/6632f31907f30ad9f51c56ab4301cea90e6b59a5/xlsynth/src/vast.rs#L132

`$ bazel test -c opt --config=asan --action_env=ASAN_OPTIONS=detect_odr_violation=0 //xls/public/...` tested cleanly