### PR TITLE
[xls][mlir] Fix emission of  debug locations in `xls_translate`

### DIFF
--- a/xls/contrib/mlir/IR/xls_ops.td
+++ b/xls/contrib/mlir/IR/xls_ops.td
@@ -159,7 +159,7 @@ def Xls_FlopKindSkid        : I32EnumAttrCase<"kSkid", 2, "skid"> {
     See https://google.github.io/xls/codegen_options/#io-behavior for more information.
   }];
 }
-def Xls_FlopKindZeroLatency : I32EnumAttrCase<"kZeroLatency", 3, "zero-latency"> {
+def Xls_FlopKindZeroLatency : I32EnumAttrCase<"kZeroLatency", 3, "zero_latency"> {
   let summary = "Zero-latency flop.";
   let description = [{
     Adds a zero-latency buffer to the input/output. This is essentially a

--- a/xls/contrib/mlir/testdata/debug_locs.mlir
+++ b/xls/contrib/mlir/testdata/debug_locs.mlir
@@ -1,0 +1,32 @@
+// RUN: xls_translate --mlir-xls-to-xls %s > %t
+// RUN: FileCheck --check-prefix=XLS %s < %t
+// RUN: xls_translate --xls-to-mlir-xls %t --mlir-print-debuginfo | FileCheck --check-prefix=MLIR %s
+
+// XLS: file_number [[$FNO:.*]] "add_one.x"
+
+module {
+  // XLS-LABEL: fn add_one(arg_foo: bits[32]
+  // MLIR-LABEL: func.func @add_one
+  func.func @add_one(%arg0: i32 loc("arg_foo")) -> i32 {
+
+    // MLIR-LABEL: "xls.constant_scalar"
+    // MLIR-SAME:    loc(#[[$LOC1:.*]])
+    // XLS-LABEL:  literal
+    // XLS-SAME:     pos=[([[$FNO]],42,7)]
+    %0 = "xls.constant_scalar"() <{value = 1 : i32}> : () -> i32 loc(#loc1)
+
+    // MLIR-LABEL: xls.add
+    // MLIR-SAME:    loc(#[[$LOC2:.*]])
+    // XLS-LABEL:  add
+    // XLS-SAME:     pos=[([[$FNO]],1999,3)]
+    %1 = xls.add %arg0, %0 : i32 loc(#loc2)
+
+    return %1 : i32 loc(unknown)
+  } loc(unknown)
+} loc(unknown)
+
+
+// MLIR-CHECK: #[[$LOC1]] = loc("add_one.x":42:7)
+#loc1 = loc("add_one.x":42:7)
+// MLIR-CHECK: #[[$LOC2]] = loc("add_one.x":1999:3)
+#loc2 = loc("add_one.x":1999:3)

--- a/xls/contrib/mlir/testdata/debug_locs.mlir
+++ b/xls/contrib/mlir/testdata/debug_locs.mlir
@@ -1,12 +1,13 @@
-// RUN: xls_translate --mlir-xls-to-xls %s > %t
+// RUN: xls_translate --mlir-xls-to-xls --main-function=foo_proc %s > %t
 // RUN: FileCheck --check-prefix=XLS %s < %t
 // RUN: xls_translate --xls-to-mlir-xls %t --mlir-print-debuginfo | FileCheck --check-prefix=MLIR %s
 
 // XLS: file_number [[$FNO:.*]] "add_one.x"
 
 module {
-  // XLS-LABEL: fn add_one(arg_foo: bits[32]
+  // XLS-LABEL:  fn add_one(arg_foo: bits[32]
   // MLIR-LABEL: func.func @add_one
+  // MLIR-SAME:    i32 loc("arg_foo")
   func.func @add_one(%arg0: i32 loc("arg_foo")) -> i32 {
 
     // MLIR-LABEL: "xls.constant_scalar"
@@ -23,6 +24,15 @@ module {
 
     return %1 : i32 loc(unknown)
   } loc(unknown)
+
+  // XLS-LABEL:  proc foo_proc(state_elem: bits[32]
+  // MLIR-LABEL: xls.eproc @foo_proc
+  // MLIR-SAME:    i32 loc("state_elem")
+  xls.eproc @foo_proc(%arg0: i32 loc("state_elem")) zeroinitializer {
+    %result = func.call @add_one(%arg0) : (i32) -> i32
+    xls.yield %result : i32
+  }
+
 } loc(unknown)
 
 

--- a/xls/contrib/mlir/testdata/translate_from_xls/proc.ir
+++ b/xls/contrib/mlir/testdata/translate_from_xls/proc.ir
@@ -9,7 +9,7 @@ chan ch_inp(bits[32], id=0, kind=streaming, ops=receive_only)
 
 // CHECK-LABEL: xls.chan @ch_out {
 // CHECK-SAME:    fifo_config = #xls.fifo_config<fifo_depth = 1, bypass = true, register_push_outputs = true, register_pop_outputs = false>,
-// CHECK-SAME:    input_flop_kind = #xls<flop_kind zero-latency>,
+// CHECK-SAME:    input_flop_kind = #xls<flop_kind zero_latency>,
 // CHECK-SAME:    output_flop_kind = #xls<flop_kind skid>
 // CHECK-SAME:    recv_supported = false
 // CHECK-SAME:  } : i32


### PR DESCRIPTION
As noted in https://github.com/google/xls/pull/1916, I was not able to easily add a round-trip test for channel attributes due to some issues with debug locations in `xls_translate`. 

While fixing this, I wanted to verify that round-trip conversion worked by smoke testing with `ops_translate.mlir`, where I noticed that my xls->mlir translation did not support `trace` and that my naming of the fifo flop kind enum was inconsistent.

---

Poping the stack, this PR contains the following commits addressing all of the above:

### `[xls][mlir] Use underscore in zero latency enum case name`

Makes it consistent with all other values in XLS MLIR assembly.

### `[xls][mlir] Add xls->mlir translation of trace IR node`

### `[xls][mlir] Emit well-formed XLS source location infos in xls_translate`

`xls_translate` previously assigned an ID to every source file encountered in the MLIR `Location` of input ops and referenced these IDs in the XLS `pos` attribute of the produced IR nodes, but did not actually add these source file names to the XLS package, leading to invalid `pos` attributes.

This patch fixes this by relying on `Package::AddSourceLocation` to both construct the `SourceLocation` for nodes and automatically registering the file with the package.

With this, `xls_translate` can also re-use the file name ID assignment/lookup from XLS proper.

### [xls][mlir] Add round-trip conversion test for channel properties

This was previously not easily possible due to the incorrect emission of XLS file locations in `xls_translate`.

### `[xls][mlir] Expand ops_translate.mlir test to round-trip verification.`

---

I rolled all this into a single PR because these are all interdependent, probably making review a bit more annoying. Sorry :innocent: 

@jpienaar @jmolloy
