### PR TITLE
[solvers] Switch signature mismatches away from XLS_RET_CHECK to InvalidArgumentError...

### DIFF
--- a/xls/solvers/z3_ir_equivalence.h
+++ b/xls/solvers/z3_ir_equivalence.h
@@ -26,7 +26,7 @@
 
 namespace xls::solvers::z3 {
 
-// Verify that the original function's behavior stays the same after running
+// Verifies that the original function's behavior stays the same after running
 // 'run_pass' on it. The callback *must* use the provided package and function
 // and not the one passed to this call. The pass may not alter the type
 // signature of the function. The pass must modify the provided function
@@ -40,8 +40,8 @@ absl::StatusOr<ProverResult> TryProveEquivalence(
     const std::function<absl::Status(Package*, Function*)>& run_pass,
     absl::Duration timeout = absl::InfiniteDuration());
 
-// Verify that both functions have the same behaviors. Both functions must have
-// exactly the same types.
+// Verifies that both functions have the same behaviors. Both functions must
+// have exactly the same signatures, or an invalid argument error is returned.
 //
 // This call does not alter either function.
 //

--- a/xls/solvers/z3_ir_equivalence_test.cc
+++ b/xls/solvers/z3_ir_equivalence_test.cc
@@ -287,7 +287,7 @@ TEST_F(EquivalenceTest, ScopedDetectsReturnTypeChange) {
   fb.Tuple({fb.UDiv(x, y), fb.Subtract(x, y), fb.UMod(x, y)});
   XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
 
-  EXPECT_NONFATAL_FAILURE(ScopedReturnTypeChange(f), "return_value");
+  EXPECT_NONFATAL_FAILURE(ScopedReturnTypeChange(f), "differing return types");
 }
 
 TEST_F(EquivalenceTest, CounterexampleIsValidPointers) {
@@ -352,7 +352,7 @@ TEST_F(EquivalenceTest, ScopedDetectsParamShift) {
   fb.Tuple({fb.UDiv(x, y), fb.Subtract(x, y), fb.UMod(x, y)});
   XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
 
-  EXPECT_NONFATAL_FAILURE(ScopedParamShift(f), "params");
+  EXPECT_NONFATAL_FAILURE(ScopedParamShift(f), "differing parameter 0 types");
 }
 
 TEST_F(EquivalenceTest, MultiFunctionDetectsSame) {


### PR DESCRIPTION
…since they are exposed to the user via programs like check_ir_equivalence_main.