### PR TITLE
[c_api] Add ir builder target to `:c_api` as dep and header to `c_api.h`.

### DIFF
--- a/xls/public/BUILD
+++ b/xls/public/BUILD
@@ -243,6 +243,7 @@ cc_library(
         ":c_api_dslx",
         ":c_api_format_preference",
         ":c_api_impl_helpers",
+        ":c_api_ir_builder",
         ":c_api_vast",
         ":runtime_build_actions",
         "//xls/common:init_xls",

--- a/xls/public/c_api.h
+++ b/xls/public/c_api.h
@@ -20,6 +20,7 @@
 
 #include "xls/public/c_api_dslx.h"
 #include "xls/public/c_api_format_preference.h"
+#include "xls/public/c_api_ir_builder.h"
 #include "xls/public/c_api_vast.h"
 
 // C API that exposes the functionality in various public headers in a way that


### PR DESCRIPTION
This seems required for OS X builds to link the artifact -- not sure why it wasn't required on other platforms, maybe there's some different per-object-artifact culling.