### PR TITLE
Encapsulate some codegen metadata data structures as classes.

### DIFF
--- a/xls/codegen/block_conversion.cc
+++ b/xls/codegen/block_conversion.cc
@@ -340,52 +340,55 @@ absl::Status UpdateChannelMetadata(const StreamingIOPipeline& io,
                                    Block* block) {
   for (const auto& inputs : io.inputs) {
     for (const StreamingInput& input : inputs) {
-      CHECK_NE(*input.port, nullptr);
-      CHECK_NE(input.port_valid, nullptr);
-      CHECK_NE(input.port_ready, nullptr);
+      CHECK_NE(*input.GetDataPort(), nullptr);
+      CHECK_NE(input.GetValidPort(), nullptr);
+      CHECK_NE(input.GetReadyPort(), nullptr);
       // Ports are either all external IOs or all from instantiations.
       CHECK(input.IsExternal() || input.IsInstantiation());
 
       if (input.IsExternal()) {
         XLS_RETURN_IF_ERROR(block->AddChannelPortMetadata(
-            input.channel, ChannelDirection::kReceive,
-            input.port.value()->GetName(), input.port_valid->GetName(),
-            input.port_ready->GetName()));
+            input.GetChannel(), ChannelDirection::kReceive,
+            input.GetDataPort().value()->GetName(),
+            input.GetValidPort()->GetName(), input.GetReadyPort()->GetName()));
       }
     }
   }
 
   for (const auto& outputs : io.outputs) {
     for (const StreamingOutput& output : outputs) {
-      CHECK_NE(*output.port, nullptr);
-      CHECK_NE(output.port_valid, nullptr);
-      CHECK_NE(output.port_ready, nullptr);
+      CHECK_NE(*output.GetDataPort(), nullptr);
+      CHECK_NE(output.GetValidPort(), nullptr);
+      CHECK_NE(output.GetReadyPort(), nullptr);
       // Ports are either all external IOs or all from instantiations.
       CHECK(output.IsExternal() || output.IsInstantiation());
 
       if (output.IsExternal()) {
         XLS_RETURN_IF_ERROR(block->AddChannelPortMetadata(
-            output.channel, ChannelDirection::kSend,
-            output.port.value()->GetName(), output.port_valid->GetName(),
-            output.port_ready->GetName()));
+            output.GetChannel(), ChannelDirection::kSend,
+            output.GetDataPort().value()->GetName(),
+            output.GetValidPort()->GetName(),
+            output.GetReadyPort()->GetName()));
       }
     }
   }
 
   for (const SingleValueInput& input : io.single_value_inputs) {
-    CHECK_NE(input.port, nullptr);
+    CHECK_NE(input.GetDataPort(), nullptr);
 
     XLS_RETURN_IF_ERROR(block->AddChannelPortMetadata(
-        input.channel, ChannelDirection::kReceive, input.port->GetName(),
+        input.GetChannel(), ChannelDirection::kReceive,
+        input.GetDataPort()->GetName(),
         /*valid_port=*/std::nullopt,
         /*ready_port=*/std::nullopt));
   }
 
   for (const SingleValueOutput& output : io.single_value_outputs) {
-    CHECK_NE(output.port, nullptr);
+    CHECK_NE(output.GetDataPort(), nullptr);
 
     XLS_RETURN_IF_ERROR(block->AddChannelPortMetadata(
-        output.channel, ChannelDirection::kSend, output.port->GetName(),
+        output.GetChannel(), ChannelDirection::kSend,
+        output.GetDataPort()->GetName(),
         /*valid_port=*/std::nullopt,
         /*ready_port=*/std::nullopt));
   }

--- a/xls/codegen/codegen_checker.cc
+++ b/xls/codegen/codegen_checker.cc
@@ -63,52 +63,56 @@ absl::Status CheckStreamingIO(const StreamingIOPipeline& streaming_io,
   for (absl::Span<StreamingInput const> streaming_inputs :
        streaming_io.inputs) {
     for (const StreamingInput& input : streaming_inputs) {
-      XLS_RET_CHECK(!input.fifo_instantiation.has_value() ||
-                    instantiations.contains(*input.fifo_instantiation));
-      if (input.port.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*input.port)) << absl::StreamFormat(
-            "Port not found for %s", ChannelRefName(input.channel));
+      XLS_RET_CHECK(!input.GetFifoInstantiation().has_value() ||
+                    instantiations.contains(*input.GetFifoInstantiation()));
+      if (input.GetDataPort().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*input.GetDataPort()))
+            << absl::StreamFormat("Port not found for %s",
+                                  ChannelRefName(input.GetChannel()));
       }
-      XLS_RET_CHECK(nodes.contains(input.port_ready)) << absl::StreamFormat(
-          "Ready port not found for %s", ChannelRefName(input.channel));
-      XLS_RET_CHECK(nodes.contains(input.port_valid)) << absl::StreamFormat(
-          "Valid port not found for %s", ChannelRefName(input.channel));
-      if (input.signal_data.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*input.signal_data)) << absl::StreamFormat(
-            "Signal data not found for %s", ChannelRefName(input.channel));
+      XLS_RET_CHECK(nodes.contains(input.GetReadyPort())) << absl::StreamFormat(
+          "Ready port not found for %s", ChannelRefName(input.GetChannel()));
+      XLS_RET_CHECK(nodes.contains(input.GetValidPort())) << absl::StreamFormat(
+          "Valid port not found for %s", ChannelRefName(input.GetChannel()));
+      if (input.GetSignalData().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*input.GetSignalData()))
+            << absl::StreamFormat("Signal data not found for %s",
+                                  ChannelRefName(input.GetChannel()));
       }
-      if (input.signal_valid.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*input.signal_valid))
+      if (input.GetSignalValid().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*input.GetSignalValid()))
             << absl::StreamFormat("Signal valid not found for %s",
-                                  ChannelRefName(input.channel));
+                                  ChannelRefName(input.GetChannel()));
       }
-      if (input.predicate.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*input.predicate)) << absl::StreamFormat(
-            "Predicate not found for %s", ChannelRefName(input.channel));
+      if (input.GetPredicate().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*input.GetPredicate()))
+            << absl::StreamFormat("Predicate not found for %s",
+                                  ChannelRefName(input.GetChannel()));
       }
     }
   }
   for (absl::Span<StreamingOutput const> streaming_outputs :
        streaming_io.outputs) {
     for (const StreamingOutput& output : streaming_outputs) {
-      XLS_RET_CHECK(!output.fifo_instantiation.has_value() ||
-                    instantiations.contains(*output.fifo_instantiation));
-      if (output.port.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*output.port));
+      XLS_RET_CHECK(!output.GetFifoInstantiation().has_value() ||
+                    instantiations.contains(*output.GetFifoInstantiation()));
+      if (output.GetDataPort().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*output.GetDataPort()));
       }
-      XLS_RET_CHECK(nodes.contains(output.port_ready));
-      XLS_RET_CHECK(nodes.contains(output.port_valid));
-      if (output.predicate.has_value()) {
-        XLS_RET_CHECK(nodes.contains(*output.predicate)) << absl::StreamFormat(
-            "Predicate not found for %s", ChannelRefName(output.channel));
+      XLS_RET_CHECK(nodes.contains(output.GetReadyPort()));
+      XLS_RET_CHECK(nodes.contains(output.GetValidPort()));
+      if (output.GetPredicate().has_value()) {
+        XLS_RET_CHECK(nodes.contains(*output.GetPredicate()))
+            << absl::StreamFormat("Predicate not found for %s",
+                                  ChannelRefName(output.GetChannel()));
       }
     }
   }
   for (const SingleValueInput& input : streaming_io.single_value_inputs) {
-    XLS_RET_CHECK(nodes.contains(input.port));
+    XLS_RET_CHECK(nodes.contains(input.GetDataPort()));
   }
   for (const SingleValueOutput& output : streaming_io.single_value_outputs) {
-    XLS_RET_CHECK(nodes.contains(output.port));
+    XLS_RET_CHECK(nodes.contains(output.GetDataPort()));
   }
   for (const PipelineStageRegisters& stage_registers :
        streaming_io.pipeline_registers) {

--- a/xls/codegen/codegen_pass.cc
+++ b/xls/codegen/codegen_pass.cc
@@ -66,41 +66,44 @@ void CodegenPassUnit::GcMetadata() {
     for (std::vector<StreamingInput>& inputs :
          block_metadata.streaming_io_and_pipeline.inputs) {
       for (StreamingInput& input : inputs) {
-        if (input.port.has_value() && !nodes.contains(*input.port)) {
-          input.port.reset();
+        if (input.GetDataPort().has_value() &&
+            !nodes.contains(*input.GetDataPort())) {
+          input.SetDataPort(std::nullopt);
         }
-        if (input.signal_data.has_value() &&
-            !nodes.contains(*input.signal_data)) {
-          input.signal_data.reset();
+        if (input.GetSignalData().has_value() &&
+            !nodes.contains(*input.GetSignalData())) {
+          input.SetSignalData(std::nullopt);
         }
-        if (input.signal_valid.has_value() &&
-            !nodes.contains(*input.signal_valid)) {
-          input.signal_valid.reset();
+        if (input.GetSignalValid().has_value() &&
+            !nodes.contains(*input.GetSignalValid())) {
+          input.SetSignalValid(std ::nullopt);
         }
-        if (input.predicate.has_value() && !nodes.contains(*input.predicate)) {
-          input.predicate.reset();
+        if (input.GetPredicate().has_value() &&
+            !nodes.contains(*input.GetPredicate())) {
+          input.SetPredicate(std::nullopt);
         }
       }
     }
     for (std::vector<StreamingOutput>& outputs :
          block_metadata.streaming_io_and_pipeline.outputs) {
       for (StreamingOutput& output : outputs) {
-        if (output.port.has_value() && !nodes.contains(*output.port)) {
-          output.port.reset();
+        if (output.GetDataPort().has_value() &&
+            !nodes.contains(*output.GetDataPort())) {
+          output.SetDataPort(std::nullopt);
         }
-        if (output.predicate.has_value() &&
-            !nodes.contains(*output.predicate)) {
-          output.predicate.reset();
+        if (output.GetPredicate().has_value() &&
+            !nodes.contains(*output.GetPredicate())) {
+          output.SetPredicate(std::nullopt);
         }
       }
     }
     std::erase_if(block_metadata.streaming_io_and_pipeline.single_value_inputs,
                   [&nodes](const SingleValueInput& input) {
-                    return !nodes.contains(input.port);
+                    return !nodes.contains(input.GetDataPort());
                   });
     std::erase_if(block_metadata.streaming_io_and_pipeline.single_value_outputs,
                   [&nodes](const SingleValueOutput& output) {
-                    return !nodes.contains(output.port);
+                    return !nodes.contains(output.GetDataPort());
                   });
     for (std::optional<Node*>& valid :
          block_metadata.streaming_io_and_pipeline.pipeline_valid) {
@@ -134,40 +137,42 @@ void CodegenPassUnit::GcMetadata() {
          metadata.streaming_io_and_pipeline.inputs) {
       for (const StreamingInput& input : inputs) {
         VLOG(5) << absl::StreamFormat("Input found on %v for %s", *block,
-                                      ChannelRefName(input.channel));
+                                      ChannelRefName(input.GetChannel()));
         if (!input.IsExternal()) {
           VLOG(5) << absl::StreamFormat("Skipping internal input %s",
-                                        ChannelRefName(input.channel));
+                                        ChannelRefName(input.GetChannel()));
           continue;
         }
-        channel_to_streaming_input[std::get<Channel*>(input.channel)] = &input;
+        channel_to_streaming_input[std::get<Channel*>(input.GetChannel())] =
+            &input;
       }
     }
     for (const SingleValueInput& input :
          metadata.streaming_io_and_pipeline.single_value_inputs) {
       VLOG(5) << absl::StreamFormat("Input found on %v for %s", *block,
-                                    ChannelRefName(input.channel));
-      channel_to_single_value_input[std::get<Channel*>(input.channel)] = &input;
+                                    ChannelRefName(input.GetChannel()));
+      channel_to_single_value_input[std::get<Channel*>(input.GetChannel())] =
+          &input;
     }
     for (const std::vector<StreamingOutput>& outputs :
          metadata.streaming_io_and_pipeline.outputs) {
       for (const StreamingOutput& output : outputs) {
         VLOG(5) << absl::StreamFormat("Output found on %v for %s.", *block,
-                                      ChannelRefName(output.channel));
+                                      ChannelRefName(output.GetChannel()));
         if (!output.IsExternal()) {
           VLOG(5) << absl::StreamFormat("Skipping internal output %s",
-                                        ChannelRefName(output.channel));
+                                        ChannelRefName(output.GetChannel()));
           continue;
         }
-        channel_to_streaming_output[std::get<Channel*>(output.channel)] =
+        channel_to_streaming_output[std::get<Channel*>(output.GetChannel())] =
             &output;
       }
     }
     for (const SingleValueOutput& output :
          metadata.streaming_io_and_pipeline.single_value_outputs) {
       VLOG(5) << absl::StreamFormat("Output found on %v for %s.", *block,
-                                    ChannelRefName(output.channel));
-      channel_to_single_value_output[std::get<Channel*>(output.channel)] =
+                                    ChannelRefName(output.GetChannel()));
+      channel_to_single_value_output[std::get<Channel*>(output.GetChannel())] =
           &output;
     }
   }

--- a/xls/codegen/ram_rewrite_pass.cc
+++ b/xls/codegen/ram_rewrite_pass.cc
@@ -228,7 +228,7 @@ void ClearRewrittenMetadata(
     inputs.erase(std::remove_if(inputs.begin(), inputs.end(),
                                 [&channel_names](const StreamingInput& input) {
                                   return channel_names.contains(
-                                      ChannelRefName(input.channel));
+                                      ChannelRefName(input.GetChannel()));
                                 }),
                  inputs.end());
   }
@@ -237,7 +237,7 @@ void ClearRewrittenMetadata(
         std::remove_if(outputs.begin(), outputs.end(),
                        [&channel_names](const StreamingOutput& output) {
                          return channel_names.contains(
-                             ChannelRefName(output.channel));
+                             ChannelRefName(output.GetChannel()));
                        }),
         outputs.end());
   }


### PR DESCRIPTION
This will make it much easier to transition from bag-on-the-side metadata to metadata on the IR.