### PR TITLE
[docs] Fix docs for encode IR op, it does not take a width attribute.

### DIFF
--- a/docs_src/ir_semantics.md
+++ b/docs_src/ir_semantics.md
@@ -927,7 +927,7 @@ is zero.
 Implements a binary encoder.
 
 ```
-result = encode(operand, width=<width>)
+result = encode(operand)
 ```
 
 **Types**


### PR DESCRIPTION
See the node definition https://sourcegraph.com/github.com/google/xls@8a3b8b0a7b4fbfce6f6d428c9d6c9c4f8f63f6f0/-/blob/xls/ir/nodes.h?L484 and the IR parser which parses it as a normal unary op: https://sourcegraph.com/github.com/google/xls/-/blob/xls/ir/ir_parser.cc?L1017

(This may have been a copy pasta from `decode`)