### PR TITLE
Adapt fuzzer known failure regex to new error message format.

### DIFF
--- a/xls/fuzzer/sample.cc
+++ b/xls/fuzzer/sample.cc
@@ -140,13 +140,13 @@ bool SampleOptions::operator==(const SampleOptions& other) const {
   auto* pipeline = proto.add_known_failure();
   pipeline->set_tool(".*codegen_main");
   pipeline->set_stderr_regex(
-      ".*Impossible to schedule proc .* as specified; cannot achieve the "
+      ".*Impossible to schedule proc .* as specified; .*: cannot achieve the "
       "specified pipeline length.*");
   // TODO(https://github.com/google/xls/issues/1141): Remove when fixed.
   auto* throughput = proto.add_known_failure();
   throughput->set_tool(".*codegen_main");
   throughput->set_stderr_regex(
-      ".*Impossible to schedule proc .* as specified; cannot achieve full "
+      ".*Impossible to schedule proc .* as specified; .*: cannot achieve full "
       "throughput.*");
   return proto;
 }


### PR DESCRIPTION
Introduced in https://github.com/google/xls/commit/adcc9707cc4c0ef1eaf6264144d34c0ea8463e5c

@grebe 