### PR TITLE
Fuzzer: Correctly propagate pipeline info through counted-fors

### DIFF
--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -1894,7 +1894,10 @@ absl::StatusOr<TypedExpr> AstGenerator::GenerateCountedFor(Context* ctx) {
       fake_span_, std::vector<Statement*>{body_stmt}, /*trailing_semi=*/false);
   For* for_ = module_->Make<For>(fake_span_, name_def_tree, tree_type, iterable,
                                  block, /*init=*/e.expr);
-  return TypedExpr{for_, e.type};
+  return TypedExpr{.expr = for_,
+                   .type = e.type,
+                   .last_delaying_op = e.last_delaying_op,
+                   .min_stage = e.min_stage};
 }
 
 absl::StatusOr<TypedExpr> AstGenerator::GenerateTupleOrIndex(Context* ctx) {


### PR DESCRIPTION
This is one of the cause of https://github.com/google/xls/issues/1140.

A token produced by a send, passed through a counted_for, and then consumed by a receive would not correctly increase the `min_stage`. For example, the following would incorrectly report a min pipeline stages of 1:

```rust
let x3: token = send(join(), x0, u1:1);
let x4: token = for (i, x) in u4:0x0..u4:0x8 {
    x
}(x3);
let x5: (token, u37, bool) = recv_non_blocking(x4, x1, u37:45812984490);
```

Not sure if there are other reasons for https://github.com/google/xls/issues/1140 or if the `known_failure` can be removed?

Edit: Still seems to happen - 1140 not resolved.