### PR TITLE
[stdlib] Add new functions for extracting the `n` LSBs/MSBs from a value

### DIFF
--- a/docs_src/dslx_std.md
+++ b/docs_src/dslx_std.md
@@ -939,7 +939,7 @@ Extracts the MSb (Most Significant bit) from the value `x` and returns it.
 pub fn mask_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
-Returns a copy of `x` with all but the `n` least-significant bits set to 0.
+Returns a copy of `x` with all but the `n` least-significant bits set to 0. If `n >= WIDTH`, returns `x`.
 
 #### `std::mask_msbs`
 
@@ -947,7 +947,7 @@ Returns a copy of `x` with all but the `n` least-significant bits set to 0.
 pub fn mask_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
-Returns a copy of `x` with all but the `n` most-significant bits set to 0.
+Returns a copy of `x` with all but the `n` most-significant bits set to 0. If `n >= WIDTH`, returns `x`.
 
 #### `std::without_lsbs`
 
@@ -955,7 +955,7 @@ Returns a copy of `x` with all but the `n` most-significant bits set to 0.
 pub fn without_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
-Returns a copy of `x` with the `n` least-significant bits set to 0.
+Returns a copy of `x` with the `n` least-significant bits set to 0. If `n >= WIDTH`, returns `zero!<uN[WIDTH]>`.
 
 #### `std::without_msbs`
 
@@ -963,7 +963,7 @@ Returns a copy of `x` with the `n` least-significant bits set to 0.
 pub fn without_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
-Returns a copy of `x` with the `n` most-significant bits set to 0.
+Returns a copy of `x` with the `n` most-significant bits set to 0. If `n >= WIDTH`, returns `zero!<uN[WIDTH]>`.
 
 #### `std::or_reduce_lsb`
 

--- a/docs_src/dslx_std.md
+++ b/docs_src/dslx_std.md
@@ -933,34 +933,34 @@ pub fn msb<N: u32>(x: uN[N]) -> u1
 
 Extracts the MSb (Most Significant bit) from the value `x` and returns it.
 
-#### `std::mask_lsbs`
+#### `std::keep_lsbs`
 
 ```dslx-snippet
-pub fn mask_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+pub fn keep_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
 Returns a copy of `x` with all but the `n` least-significant bits set to 0. If `n >= WIDTH`, returns `x`.
 
-#### `std::mask_msbs`
+#### `std::keep_msbs`
 
 ```dslx-snippet
-pub fn mask_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+pub fn keep_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
 Returns a copy of `x` with all but the `n` most-significant bits set to 0. If `n >= WIDTH`, returns `x`.
 
-#### `std::without_lsbs`
+#### `std::clear_lsbs`
 
 ```dslx-snippet
-pub fn without_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+pub fn clear_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
 Returns a copy of `x` with the `n` least-significant bits set to 0. If `n >= WIDTH`, returns `zero!<uN[WIDTH]>`.
 
-#### `std::without_msbs`
+#### `std::clear_msbs`
 
 ```dslx-snippet
-pub fn without_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+pub fn clear_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
 ```
 
 Returns a copy of `x` with the `n` most-significant bits set to 0. If `n >= WIDTH`, returns `zero!<uN[WIDTH]>`.

--- a/docs_src/dslx_std.md
+++ b/docs_src/dslx_std.md
@@ -933,6 +933,38 @@ pub fn msb<N: u32>(x: uN[N]) -> u1
 
 Extracts the MSb (Most Significant bit) from the value `x` and returns it.
 
+#### `std::mask_lsbs`
+
+```dslx-snippet
+pub fn mask_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+```
+
+Returns a copy of `x` with all but the `n` least-significant bits set to 0.
+
+#### `std::mask_msbs`
+
+```dslx-snippet
+pub fn mask_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+```
+
+Returns a copy of `x` with all but the `n` most-significant bits set to 0.
+
+#### `std::without_lsbs`
+
+```dslx-snippet
+pub fn without_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+```
+
+Returns a copy of `x` with the `n` least-significant bits set to 0.
+
+#### `std::without_msbs`
+
+```dslx-snippet
+pub fn without_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH]
+```
+
+Returns a copy of `x` with the `n` most-significant bits set to 0.
+
 #### `std::or_reduce_lsb`
 
 ```dslx-snippet

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -1081,6 +1081,90 @@ pub fn sizeof_signed<N: u32>(x: sN[N]) -> u32 { N }
 
 pub fn sizeof_unsigned<N: u32>(x: uN[N]) -> u32 { N }
 
+// Returns `x` with all but the least-significant `n` bits set to zero.
+pub fn mask_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+    x & !(all_ones!<uN[WIDTH]>() << n)
+}
+
+#[test]
+fn mask_lsbs_test() {
+    assert_eq(u8:0x00, mask_lsbs(u8:0xab, u4:0));
+    assert_eq(u8:0x01, mask_lsbs(u8:0xab, u4:1));
+    assert_eq(u8:0x00, mask_lsbs(u8:0xaa, u4:1));
+    assert_eq(u8:0x00, mask_lsbs(u8:0xa0, u4:4));
+    assert_eq(u8:0x0a, mask_lsbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x08, mask_lsbs(u8:0xa8, u4:4));
+    assert_eq(u8:0xa0, mask_lsbs(u8:0xa0, u4:8));
+    assert_eq(u8:0xaa, mask_lsbs(u8:0xaa, u4:8));
+    assert_eq(u8:0xa8, mask_lsbs(u8:0xa8, u4:8));
+    assert_eq(u8:0xa0, mask_lsbs(u8:0xa0, u4:12));
+    assert_eq(u8:0xaa, mask_lsbs(u8:0xaa, u4:12));
+    assert_eq(u8:0xa8, mask_lsbs(u8:0xa8, u4:12));
+}
+
+// Returns `x` with all but the most-significant `n` bits set to zero.
+pub fn mask_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+    x & !(all_ones!<uN[WIDTH]>() >> n)
+}
+
+#[test]
+fn mask_msbs_test() {
+    assert_eq(u8:0x00, mask_msbs(u8:0xab, u4:0));
+    assert_eq(u8:0x80, mask_msbs(u8:0xab, u4:1));
+    assert_eq(u8:0x00, mask_msbs(u8:0x2b, u4:1));
+    assert_eq(u8:0x00, mask_msbs(u8:0x0a, u4:4));
+    assert_eq(u8:0xa0, mask_msbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x80, mask_msbs(u8:0x8a, u4:4));
+    assert_eq(u8:0xa0, mask_msbs(u8:0xa0, u4:8));
+    assert_eq(u8:0xaa, mask_msbs(u8:0xaa, u4:8));
+    assert_eq(u8:0xa8, mask_msbs(u8:0xa8, u4:8));
+    assert_eq(u8:0xa0, mask_msbs(u8:0xa0, u4:12));
+    assert_eq(u8:0xaa, mask_msbs(u8:0xaa, u4:12));
+    assert_eq(u8:0xa8, mask_msbs(u8:0xa8, u4:12));
+}
+
+// Returns `value` with the least-significant `n` bits set to zero.
+pub fn without_lsbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+    value & (all_ones!<uN[WIDTH]>() << n)
+}
+
+#[test]
+fn without_lsbs_test() {
+    assert_eq(u8:0xab, without_lsbs(u8:0xab, u4:0));
+    assert_eq(u8:0xaa, without_lsbs(u8:0xab, u4:1));
+    assert_eq(u8:0xaa, without_lsbs(u8:0xaa, u4:1));
+    assert_eq(u8:0xa0, without_lsbs(u8:0xa0, u4:4));
+    assert_eq(u8:0xa0, without_lsbs(u8:0xaa, u4:4));
+    assert_eq(u8:0xa0, without_lsbs(u8:0xa8, u4:4));
+    assert_eq(u8:0x00, without_lsbs(u8:0xa0, u4:8));
+    assert_eq(u8:0x00, without_lsbs(u8:0xaa, u4:8));
+    assert_eq(u8:0x00, without_lsbs(u8:0xa8, u4:8));
+    assert_eq(u8:0x00, without_lsbs(u8:0xa0, u4:12));
+    assert_eq(u8:0x00, without_lsbs(u8:0xaa, u4:12));
+    assert_eq(u8:0x00, without_lsbs(u8:0xa8, u4:12));
+}
+
+// Returns `value` with the most-significant `n` bits set to zero.
+pub fn without_msbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+    value & (all_ones!<uN[WIDTH]>() >> n)
+}
+
+#[test]
+fn without_msbs_test() {
+    assert_eq(u8:0xab, without_msbs(u8:0xab, u4:0));
+    assert_eq(u8:0x2b, without_msbs(u8:0xab, u4:1));
+    assert_eq(u8:0x2b, without_msbs(u8:0x2b, u4:1));
+    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:4));
+    assert_eq(u8:0x0a, without_msbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x08, without_msbs(u8:0xa8, u4:4));
+    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:8));
+    assert_eq(u8:0x00, without_msbs(u8:0xaa, u4:8));
+    assert_eq(u8:0x00, without_msbs(u8:0xa8, u4:8));
+    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:12));
+    assert_eq(u8:0x00, without_msbs(u8:0xaa, u4:12));
+    assert_eq(u8:0x00, without_msbs(u8:0xa8, u4:12));
+}
+
 // Implementation of or_reduce_lsb() with choice of implementation.
 // The "do_mask_impl" template parameter chooses the implementation and is
 // subject to change while tested in different contexts.
@@ -1089,7 +1173,7 @@ fn or_reduce_lsb_impl<DO_MASK_IMPL: bool, WIDTH: u32, N_WIDTH: u32>
     (value: uN[WIDTH], n: uN[N_WIDTH]) -> bool {
     if DO_MASK_IMPL {
         // Mask the relevant bits, then compare.
-        value & ((uN[WIDTH]:1 << n) - uN[WIDTH]:1) != uN[WIDTH]:0
+        mask_lsbs(value, n) != uN[WIDTH]:0
     } else {
         // shift out uninteresting bits, then compare.
         value << (WIDTH as uN[N_WIDTH] - n) != uN[WIDTH]:0

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -1082,87 +1082,87 @@ pub fn sizeof_signed<N: u32>(x: sN[N]) -> u32 { N }
 pub fn sizeof_unsigned<N: u32>(x: uN[N]) -> u32 { N }
 
 // Returns `x` with all but the least-significant `n` bits set to zero.
-pub fn mask_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+pub fn keep_lsbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
     x & !(all_ones!<uN[WIDTH]>() << n)
 }
 
 #[test]
-fn mask_lsbs_test() {
-    assert_eq(u8:0x00, mask_lsbs(u8:0xab, u4:0));
-    assert_eq(u8:0x01, mask_lsbs(u8:0xab, u4:1));
-    assert_eq(u8:0x00, mask_lsbs(u8:0xaa, u4:1));
-    assert_eq(u8:0x00, mask_lsbs(u8:0xa0, u4:4));
-    assert_eq(u8:0x0a, mask_lsbs(u8:0xaa, u4:4));
-    assert_eq(u8:0x08, mask_lsbs(u8:0xa8, u4:4));
-    assert_eq(u8:0xa0, mask_lsbs(u8:0xa0, u4:8));
-    assert_eq(u8:0xaa, mask_lsbs(u8:0xaa, u4:8));
-    assert_eq(u8:0xa8, mask_lsbs(u8:0xa8, u4:8));
-    assert_eq(u8:0xa0, mask_lsbs(u8:0xa0, u4:12));
-    assert_eq(u8:0xaa, mask_lsbs(u8:0xaa, u4:12));
-    assert_eq(u8:0xa8, mask_lsbs(u8:0xa8, u4:12));
+fn keep_lsbs_test() {
+    assert_eq(u8:0x00, keep_lsbs(u8:0xab, u4:0));
+    assert_eq(u8:0x01, keep_lsbs(u8:0xab, u4:1));
+    assert_eq(u8:0x00, keep_lsbs(u8:0xaa, u4:1));
+    assert_eq(u8:0x00, keep_lsbs(u8:0xa0, u4:4));
+    assert_eq(u8:0x0a, keep_lsbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x08, keep_lsbs(u8:0xa8, u4:4));
+    assert_eq(u8:0xa0, keep_lsbs(u8:0xa0, u4:8));
+    assert_eq(u8:0xaa, keep_lsbs(u8:0xaa, u4:8));
+    assert_eq(u8:0xa8, keep_lsbs(u8:0xa8, u4:8));
+    assert_eq(u8:0xa0, keep_lsbs(u8:0xa0, u4:12));
+    assert_eq(u8:0xaa, keep_lsbs(u8:0xaa, u4:12));
+    assert_eq(u8:0xa8, keep_lsbs(u8:0xa8, u4:12));
 }
 
 // Returns `x` with all but the most-significant `n` bits set to zero.
-pub fn mask_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+pub fn keep_msbs<WIDTH: u32, N_WIDTH: u32>(x: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
     x & !(all_ones!<uN[WIDTH]>() >> n)
 }
 
 #[test]
-fn mask_msbs_test() {
-    assert_eq(u8:0x00, mask_msbs(u8:0xab, u4:0));
-    assert_eq(u8:0x80, mask_msbs(u8:0xab, u4:1));
-    assert_eq(u8:0x00, mask_msbs(u8:0x2b, u4:1));
-    assert_eq(u8:0x00, mask_msbs(u8:0x0a, u4:4));
-    assert_eq(u8:0xa0, mask_msbs(u8:0xaa, u4:4));
-    assert_eq(u8:0x80, mask_msbs(u8:0x8a, u4:4));
-    assert_eq(u8:0xa0, mask_msbs(u8:0xa0, u4:8));
-    assert_eq(u8:0xaa, mask_msbs(u8:0xaa, u4:8));
-    assert_eq(u8:0xa8, mask_msbs(u8:0xa8, u4:8));
-    assert_eq(u8:0xa0, mask_msbs(u8:0xa0, u4:12));
-    assert_eq(u8:0xaa, mask_msbs(u8:0xaa, u4:12));
-    assert_eq(u8:0xa8, mask_msbs(u8:0xa8, u4:12));
+fn keep_msbs_test() {
+    assert_eq(u8:0x00, keep_msbs(u8:0xab, u4:0));
+    assert_eq(u8:0x80, keep_msbs(u8:0xab, u4:1));
+    assert_eq(u8:0x00, keep_msbs(u8:0x2b, u4:1));
+    assert_eq(u8:0x00, keep_msbs(u8:0x0a, u4:4));
+    assert_eq(u8:0xa0, keep_msbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x80, keep_msbs(u8:0x8a, u4:4));
+    assert_eq(u8:0xa0, keep_msbs(u8:0xa0, u4:8));
+    assert_eq(u8:0xaa, keep_msbs(u8:0xaa, u4:8));
+    assert_eq(u8:0xa8, keep_msbs(u8:0xa8, u4:8));
+    assert_eq(u8:0xa0, keep_msbs(u8:0xa0, u4:12));
+    assert_eq(u8:0xaa, keep_msbs(u8:0xaa, u4:12));
+    assert_eq(u8:0xa8, keep_msbs(u8:0xa8, u4:12));
 }
 
 // Returns `value` with the least-significant `n` bits set to zero.
-pub fn without_lsbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+pub fn clear_lsbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
     value & (all_ones!<uN[WIDTH]>() << n)
 }
 
 #[test]
-fn without_lsbs_test() {
-    assert_eq(u8:0xab, without_lsbs(u8:0xab, u4:0));
-    assert_eq(u8:0xaa, without_lsbs(u8:0xab, u4:1));
-    assert_eq(u8:0xaa, without_lsbs(u8:0xaa, u4:1));
-    assert_eq(u8:0xa0, without_lsbs(u8:0xa0, u4:4));
-    assert_eq(u8:0xa0, without_lsbs(u8:0xaa, u4:4));
-    assert_eq(u8:0xa0, without_lsbs(u8:0xa8, u4:4));
-    assert_eq(u8:0x00, without_lsbs(u8:0xa0, u4:8));
-    assert_eq(u8:0x00, without_lsbs(u8:0xaa, u4:8));
-    assert_eq(u8:0x00, without_lsbs(u8:0xa8, u4:8));
-    assert_eq(u8:0x00, without_lsbs(u8:0xa0, u4:12));
-    assert_eq(u8:0x00, without_lsbs(u8:0xaa, u4:12));
-    assert_eq(u8:0x00, without_lsbs(u8:0xa8, u4:12));
+fn clear_lsbs_test() {
+    assert_eq(u8:0xab, clear_lsbs(u8:0xab, u4:0));
+    assert_eq(u8:0xaa, clear_lsbs(u8:0xab, u4:1));
+    assert_eq(u8:0xaa, clear_lsbs(u8:0xaa, u4:1));
+    assert_eq(u8:0xa0, clear_lsbs(u8:0xa0, u4:4));
+    assert_eq(u8:0xa0, clear_lsbs(u8:0xaa, u4:4));
+    assert_eq(u8:0xa0, clear_lsbs(u8:0xa8, u4:4));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xa0, u4:8));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xaa, u4:8));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xa8, u4:8));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xa0, u4:12));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xaa, u4:12));
+    assert_eq(u8:0x00, clear_lsbs(u8:0xa8, u4:12));
 }
 
 // Returns `value` with the most-significant `n` bits set to zero.
-pub fn without_msbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
+pub fn clear_msbs<WIDTH: u32, N_WIDTH: u32>(value: uN[WIDTH], n: uN[N_WIDTH]) -> uN[WIDTH] {
     value & (all_ones!<uN[WIDTH]>() >> n)
 }
 
 #[test]
-fn without_msbs_test() {
-    assert_eq(u8:0xab, without_msbs(u8:0xab, u4:0));
-    assert_eq(u8:0x2b, without_msbs(u8:0xab, u4:1));
-    assert_eq(u8:0x2b, without_msbs(u8:0x2b, u4:1));
-    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:4));
-    assert_eq(u8:0x0a, without_msbs(u8:0xaa, u4:4));
-    assert_eq(u8:0x08, without_msbs(u8:0xa8, u4:4));
-    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:8));
-    assert_eq(u8:0x00, without_msbs(u8:0xaa, u4:8));
-    assert_eq(u8:0x00, without_msbs(u8:0xa8, u4:8));
-    assert_eq(u8:0x00, without_msbs(u8:0xa0, u4:12));
-    assert_eq(u8:0x00, without_msbs(u8:0xaa, u4:12));
-    assert_eq(u8:0x00, without_msbs(u8:0xa8, u4:12));
+fn clear_msbs_test() {
+    assert_eq(u8:0xab, clear_msbs(u8:0xab, u4:0));
+    assert_eq(u8:0x2b, clear_msbs(u8:0xab, u4:1));
+    assert_eq(u8:0x2b, clear_msbs(u8:0x2b, u4:1));
+    assert_eq(u8:0x00, clear_msbs(u8:0xa0, u4:4));
+    assert_eq(u8:0x0a, clear_msbs(u8:0xaa, u4:4));
+    assert_eq(u8:0x08, clear_msbs(u8:0xa8, u4:4));
+    assert_eq(u8:0x00, clear_msbs(u8:0xa0, u4:8));
+    assert_eq(u8:0x00, clear_msbs(u8:0xaa, u4:8));
+    assert_eq(u8:0x00, clear_msbs(u8:0xa8, u4:8));
+    assert_eq(u8:0x00, clear_msbs(u8:0xa0, u4:12));
+    assert_eq(u8:0x00, clear_msbs(u8:0xaa, u4:12));
+    assert_eq(u8:0x00, clear_msbs(u8:0xa8, u4:12));
 }
 
 // Implementation of or_reduce_lsb() with choice of implementation.
@@ -1173,7 +1173,7 @@ fn or_reduce_lsb_impl<DO_MASK_IMPL: bool, WIDTH: u32, N_WIDTH: u32>
     (value: uN[WIDTH], n: uN[N_WIDTH]) -> bool {
     if DO_MASK_IMPL {
         // Mask the relevant bits, then compare.
-        mask_lsbs(value, n) != uN[WIDTH]:0
+        keep_lsbs(value, n) != uN[WIDTH]:0
     } else {
         // shift out uninteresting bits, then compare.
         value << (WIDTH as uN[N_WIDTH] - n) != uN[WIDTH]:0


### PR DESCRIPTION
Where `n` is variable, there are many suboptimal ways to do this; to guide users to more efficient implementations, we provide stdlib functions `std::mask_lsbs` and `std::mask_msbs`, along with their complements `std::without_lsbs` and `std::without_msbs`.