### PR TITLE
Fix seed-dependent proc sample generator test.

### DIFF
--- a/xls/fuzzer/sample_generator_test.cc
+++ b/xls/fuzzer/sample_generator_test.cc
@@ -110,6 +110,7 @@ TEST(SampleGeneratorTest, GenerateBasicProcSample) {
   std::mt19937_64 rng;
   SampleOptions sample_options;
   constexpr int64_t kProcTicks = 3;
+  sample_options.set_sample_type(fuzzer::SampleType::SAMPLE_TYPE_PROC);
   sample_options.set_calls_per_sample(0);
   sample_options.set_proc_ticks(kProcTicks);
   XLS_ASSERT_OK_AND_ASSIGN(
@@ -126,10 +127,6 @@ TEST(SampleGeneratorTest, GenerateBasicProcSample) {
   std::vector<std::string> ir_channel_names;
   XLS_EXPECT_OK(sample.GetArgsAndChannels(args_batch, &ir_channel_names));
   EXPECT_EQ(args_batch.size(), kProcTicks);
-
-  // Just kProcTicks ticks, no channels with content
-  EXPECT_TRUE(args_batch[0].empty());
-  EXPECT_TRUE(ir_channel_names.empty());
 
   EXPECT_THAT(sample.input_text(), HasSubstr("proc main"));
 }


### PR DESCRIPTION
The test `GenerateBasicProcSample` asserted that the proc generated does not feature any channels. This is the case for the (fixed) default seed but not true in general. For example, a seed of `4` causes the test to fail:

```cpp
std::mt19937_64 rng(4);
```

This removes the seed-dependent assertions.

Also explicitly set the sample type to `proc`, instead of the default (unknown).

Pinging @hzeller since you added these assertions :)