### PR TITLE
[RFC] Multi-Proc AST-gen + fuzzing

### DIFF
--- a/xls/fuzzer/BUILD
+++ b/xls/fuzzer/BUILD
@@ -752,6 +752,25 @@ cc_library(
     ],
 )
 
+cc_binary(
+    name = "ast_generator_main",
+    srcs = ["ast_generator_main.cc"],
+    deps = [
+        ":ast_generator",
+        "//xls/common:exit_status",
+        "//xls/common:init_xls",
+        "//xls/common/logging:log_lines",
+        "//xls/dslx:create_import_data",
+        "//xls/dslx:import_data",
+        "//xls/dslx:parse_and_typecheck",
+        "//xls/dslx/frontend:module",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/strings",
+    ],
+)
+
 cc_test(
     name = "ast_generator_test",
     srcs = ["ast_generator_test.cc"],

--- a/xls/fuzzer/ast_generator_main.cc
+++ b/xls/fuzzer/ast_generator_main.cc
@@ -44,6 +44,9 @@ ABSL_FLAG(bool, generate_proc, false, "Generate a proc.");
 
 ABSL_FLAG(bool, emit_stateless_proc, false, "Emit only stateless procs.");
 
+ABSL_FLAG(bool, emit_proc_spawns, true,
+          "Emit helper procs spawned by top proc.");
+
 ABSL_FLAG(bool, emit_zero_width_bits_types, false,
           "Emit zero-wdith bits types.");
 
@@ -77,6 +80,7 @@ absl::Status RealMain() {
       .emit_gate = absl::GetFlag(FLAGS_emit_gate),
       .generate_proc = absl::GetFlag(FLAGS_generate_proc),
       .emit_stateless_proc = absl::GetFlag(FLAGS_emit_stateless_proc),
+      .emit_proc_spawns = absl::GetFlag(FLAGS_emit_proc_spawns),
       .emit_zero_width_bits_types =
           absl::GetFlag(FLAGS_emit_zero_width_bits_types),
   };

--- a/xls/fuzzer/ast_generator_main.cc
+++ b/xls/fuzzer/ast_generator_main.cc
@@ -1,0 +1,127 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ctime>
+
+#include "absl/flags/flag.h"
+#include "absl/log/log.h"
+#include "absl/random/random.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_join.h"
+#include "xls/common/exit_status.h"
+#include "xls/common/init_xls.h"
+#include "xls/common/logging/log_lines.h"
+#include "xls/dslx/create_import_data.h"
+#include "xls/dslx/frontend/module.h"
+#include "xls/dslx/import_data.h"
+#include "xls/dslx/parse_and_typecheck.h"
+#include "xls/fuzzer/ast_generator.h"
+
+ABSL_FLAG(bool, emit_signed_types, true, "Emit signed types.");
+
+ABSL_FLAG(int64_t, max_width_bits_types, 64,
+          "Maximum width of generated bits types.");
+
+ABSL_FLAG(int64_t, max_width_aggregate_types, 1024,
+          "Maximum width of generated aggregate types (tuples, arrays, ..).");
+
+ABSL_FLAG(bool, emit_loops, true, "Emit loops.");
+
+ABSL_FLAG(bool, emit_gate, true, "Emit gates.");
+
+ABSL_FLAG(bool, generate_proc, false, "Generate a proc.");
+
+ABSL_FLAG(bool, emit_stateless_proc, false, "Emit only stateless procs.");
+
+ABSL_FLAG(bool, emit_zero_width_bits_types, false,
+          "Emit zero-wdith bits types.");
+
+ABSL_FLAG(std::optional<int64_t>, seed, std::nullopt,
+          "Seed value for generation. By default, a nondetermistic seed is "
+          "used; if a seed is provided, it is used for determinism");
+
+ABSL_FLAG(std::string, top_entity_name, "test_top",
+          "Name of the generated top entity.");
+
+ABSL_FLAG(std::string, module_name, "test_mod",
+          "Name of the generated module.");
+
+namespace xls {
+namespace {
+
+absl::Status RealMain() {
+  std::optional<uint64_t> seed_flag = absl::GetFlag(FLAGS_seed);
+  uint64_t rng_seed = seed_flag.has_value()
+                          ? *seed_flag
+                          : absl::Uniform<uint64_t>(absl::BitGen());
+  std::mt19937_64 rng(rng_seed);
+
+  xls::dslx::FileTable ft;
+  xls::dslx::AstGeneratorOptions opts = {
+      .emit_signed_types = absl::GetFlag(FLAGS_emit_signed_types),
+      .max_width_bits_types = absl::GetFlag(FLAGS_max_width_bits_types),
+      .max_width_aggregate_types =
+          absl::GetFlag(FLAGS_max_width_aggregate_types),
+      .emit_loops = absl::GetFlag(FLAGS_emit_loops),
+      .emit_gate = absl::GetFlag(FLAGS_emit_gate),
+      .generate_proc = absl::GetFlag(FLAGS_generate_proc),
+      .emit_stateless_proc = absl::GetFlag(FLAGS_emit_stateless_proc),
+      .emit_zero_width_bits_types =
+          absl::GetFlag(FLAGS_emit_zero_width_bits_types),
+  };
+
+  std::string top_entity_name = absl::GetFlag(FLAGS_top_entity_name);
+  std::string module_name = absl::GetFlag(FLAGS_module_name);
+
+  xls::dslx::AstGenerator g(opts, rng, ft);
+  XLS_ASSIGN_OR_RETURN(auto result, g.Generate(top_entity_name, module_name));
+
+  auto dslx_text = result.module->ToString();
+
+  // Parse and type check the DSLX program.
+  dslx::ImportData import_data(
+      dslx::CreateImportData(/*stdlib_path=*/"",
+                             /*additional_search_paths=*/{},
+                             /*enabled_warnings=*/dslx::kAllWarningsSet,
+                             std::make_unique<dslx::RealFilesystem>()));
+  absl::StatusOr<dslx::TypecheckedModule> tm =
+      ParseAndTypecheck(dslx_text, "sample.x", "sample", &import_data);
+  if (!tm.ok()) {
+    LOG(ERROR) << "Generated sample failed to parse-and-typecheck ("
+               << dslx_text.size() << " bytes):";
+    XLS_LOG_LINES(ERROR, dslx_text);
+    return tm.status();
+  }
+
+  std::cout << "// min_stages: " << result.min_stages << std::endl;
+  std::cout << dslx_text << std::endl;
+
+  return absl::OkStatus();
+}
+
+}  // namespace
+}  // namespace xls
+
+int main(int argc, char** argv) {
+  std::vector<std::string_view> positional_arguments = xls::InitXls(
+      absl::StrCat("Generate a random DSLX module; sample usage:\n\n\t",
+                   argv[0]),
+      argc, argv);
+
+  if (!positional_arguments.empty()) {
+    LOG(QFATAL) << "Unexpected positional arguments: "
+                << absl::StrJoin(positional_arguments, ", ");
+  }
+  return xls::ExitStatus(xls::RealMain());
+}

--- a/xls/fuzzer/ast_generator_options.proto
+++ b/xls/fuzzer/ast_generator_options.proto
@@ -43,6 +43,12 @@ message AstGeneratorOptionsProto {
   // `true`.
   optional bool emit_stateless_proc = 7;
 
+  // Whether to emit a top proc that spawns other procs. When true, a small
+  // helper proc may randomly be generated and spawned from the top proc, and
+  // the top proc's next function will interact with the child proc's channels.
+  // Its value is only meaningful when generate_proc is `true`.
+  optional bool emit_proc_spawns = 9;
+
   // Whether to emit zero-width bits types.
   optional bool emit_zero_width_bits_types = 8;
 }

--- a/xls/fuzzer/run_fuzz_multiprocess_main.cc
+++ b/xls/fuzzer/run_fuzz_multiprocess_main.cc
@@ -47,6 +47,7 @@ ABSL_FLAG(
     bool, force_failure, false,
     "Forces the samples to fail. Can be used to test failure code paths.");
 ABSL_FLAG(bool, generate_proc, false, "Generate a proc sample.");
+ABSL_FLAG(bool, emit_proc_spawns, false, "Emit helper procs spawned by top proc.");
 ABSL_FLAG(int64_t, max_width_aggregate_types, 1024,
           "The maximum width of aggregate types (tuples and arrays) in the "
           "generated samples.");
@@ -97,6 +98,7 @@ struct Options {
   bool emit_loops;
   bool force_failure;
   bool generate_proc;
+  bool emit_proc_spawns;
   int64_t max_width_aggregate_types;
   int64_t max_width_bits_types;
   int64_t proc_ticks;
@@ -149,6 +151,7 @@ absl::Status RealMain(const Options& options) {
   ast_generator_options.max_width_aggregate_types =
       options.max_width_aggregate_types;
   ast_generator_options.generate_proc = options.generate_proc;
+  ast_generator_options.emit_proc_spawns = options.emit_proc_spawns;
 
   SampleOptions sample_options;
   sample_options.set_calls_per_sample(
@@ -206,6 +209,7 @@ int main(int argc, char** argv) {
       .emit_loops = absl::GetFlag(FLAGS_emit_loops),
       .force_failure = absl::GetFlag(FLAGS_force_failure),
       .generate_proc = absl::GetFlag(FLAGS_generate_proc),
+      .emit_proc_spawns = absl::GetFlag(FLAGS_emit_proc_spawns),
       .max_width_aggregate_types =
           absl::GetFlag(FLAGS_max_width_aggregate_types),
       .max_width_bits_types = absl::GetFlag(FLAGS_max_width_bits_types),

--- a/xls/fuzzer/sample.cc
+++ b/xls/fuzzer/sample.cc
@@ -155,6 +155,12 @@ bool SampleOptions::operator==(const SampleOptions& other) const {
       ".*Proc combinational generator only supports streaming output channels "
       "which can be determined to be mutually exclusive, got .* output "
       "channels which were not proven to be mutually exclusive.*");
+  // TODO: Remove when fixed.
+  auto* proc_deadlock = proto.add_known_failure();
+  proc_deadlock->set_tool(".*eval_proc_main");
+  proc_deadlock->set_stderr_regex(
+      ".*Error: INTERNAL: Proc network is deadlocked. Blocked channel "
+      "instances: .*");
   return proto;
 }
 

--- a/xls/fuzzer/sample.cc
+++ b/xls/fuzzer/sample.cc
@@ -148,6 +148,13 @@ bool SampleOptions::operator==(const SampleOptions& other) const {
   throughput->set_stderr_regex(
       ".*Impossible to schedule proc .* as specified; .*: cannot achieve full "
       "throughput.*");
+  // TODO: Remove when fixed.
+  auto* combinational_proc = proto.add_known_failure();
+  combinational_proc->set_tool(".*codegen_main");
+  combinational_proc->set_stderr_regex(
+      ".*Proc combinational generator only supports streaming output channels "
+      "which can be determined to be mutually exclusive, got .* output "
+      "channels which were not proven to be mutually exclusive.*");
   return proto;
 }
 

--- a/xls/fuzzer/sample_generator.cc
+++ b/xls/fuzzer/sample_generator.cc
@@ -286,9 +286,9 @@ GetInputChannelPayloadTypesOfProc(dslx::Proc* proc,
   std::vector<std::unique_ptr<dslx::Type>> input_channel_payload_types;
   XLS_ASSIGN_OR_RETURN(dslx::TypeInfo * proc_type_info,
                        tm.type_info->GetTopLevelProcTypeInfo(proc));
-  for (dslx::ProcMember* member : proc->members()) {
+  for (dslx::Param* param : proc->config().params()) {
     dslx::ChannelTypeAnnotation* channel_type =
-        dynamic_cast<dslx::ChannelTypeAnnotation*>(member->type_annotation());
+        dynamic_cast<dslx::ChannelTypeAnnotation*>(param->type_annotation());
     if (channel_type == nullptr) {
       continue;
     }
@@ -309,16 +309,16 @@ GetInputChannelPayloadTypesOfProc(dslx::Proc* proc,
 // Returns the input channel names of the proc.
 static std::vector<std::string> GetInputChannelNamesOfProc(dslx::Proc* proc) {
   std::vector<std::string> channel_names;
-  for (dslx::ProcMember* member : proc->members()) {
+  for (dslx::Param* param : proc->config().params()) {
     dslx::ChannelTypeAnnotation* channel_type =
-        dynamic_cast<dslx::ChannelTypeAnnotation*>(member->type_annotation());
+        dynamic_cast<dslx::ChannelTypeAnnotation*>(param->type_annotation());
     if (channel_type == nullptr) {
       continue;
     }
     if (channel_type->direction() != dslx::ChannelDirection::kIn) {
       continue;
     }
-    channel_names.push_back(member->identifier());
+    channel_names.push_back(param->identifier());
   }
   return channel_names;
 }
@@ -435,7 +435,9 @@ absl::StatusOr<Sample> GenerateSample(
     // If this sample is going through codegen, regenerate the sample until it's
     // legal; we currently can't verify latency-sensitive samples, which means
     // we can't have a non-blocking recv except with 1 pipeline stage.
-  } while (sample_options.codegen() && has_nb_recv && min_stages > 1);
+  } while (((sample_options.codegen() && min_stages > 1) ||
+            generator_options.emit_proc_spawns) &&
+           has_nb_recv);
 
   // Parse and type check the DSLX input to retrieve the top entity. The top
   // member must be a proc or a function.

--- a/xls/tools/eval_proc_main.cc
+++ b/xls/tools/eval_proc_main.cc
@@ -493,7 +493,7 @@ static absl::Status EvaluateProcs(
 
   if (expected_outputs_for_channels.empty()) {
     for (const Channel* channel : package->channels()) {
-      if (!channel->CanSend()) {
+      if (channel->supported_ops() != ChannelOps::kSendOnly) {
         continue;
       }
       XLS_ASSIGN_OR_RETURN(ChannelQueue * out_queue,


### PR DESCRIPTION
Hi All!

Because I wanted to dig around the AST generator/fuzzing subsystems a bit (and the other admin stuff I should actually be doing is totally boring), I tried my hand at improving the fuzzing subsystem to cover multi-proc DSLX programs.

I realize I committed the sin of "building a bunch of things without ever asking if you actually want it" - but my motivation for working on this was mostly personal interest. Since I probably won't have much more time to play around with it (the boring admin stuff is getting more pressing), I thought I would open this to get a sense if there are any bits and pieces in here that you would actually want. No worries if you don't. At the very least it forces me to write everything down in case someone ever does want to look into this.

I have marked this as a draft PR because I assume that, if you are interested in some part of this, it will be much easier if I break it out into multiple PRs. The code is also not yet "well-backed" in many places, so I would clean those parts up as well before actually sending them in of course:)

## Motivation

From my side: Most of the bugs I have run into have been related to proc interaction/FIFOs ([1](https://github.com/google/xls/pull/1945) [2](https://github.com/google/xls/pull/1927) [3](https://github.com/google/xls/pull/1896)) so I got thinking about how difficult it would be to cover some of these paths with the fuzzer.

In general, I feel there is some asymmetry between the test coverage of the "creating procs" and the "connecting procs together" parts of XLS. Hence it seemed potentially worthwhile to work on this a bit.

## State

I mostly focused on the AST generator, and building the ground work for generating random hierarchies of procs. I have spent some time running these ASTs through the sample runner and worked on some of the immediate issues, but there are numerous points of friction left - see below.

In short, it is possible to now run the fuzzer reliably with the following flow:
- Generate random ASTs containing procs that spawn a random "child" proc, with this child being both being connected to the parent proc body and directly being exposed via the parent proc's interface.
- Generate test vectors for these mutli-proc samples.
- Have the sample runner perform IR conversion, IR optimization, and codegen.
- While I have added quite some deadlock mitigation to the AST generator (see below), there are still plenty of deadlocks left. If adding a deadlock known failure, the sample runner can also reliably:
    - Run the DSLX evaluator
    - Run the IR interpreter / JIT on both the un-optimized and optimized IR.

Trying to run simlulation as well causes everything to go haywire. I have not dug into it much.

## Implementation

Roughly, my implementation strategy is as follows:

- Fix some small fuzzer/AST generator bugs (mostly already upstreamed)

- Add an `ast_generator_main` tool to allow me to manually drive the AST generator. This made testing it during development a whole bunch easier :)

- Refactor the `AstGenerator` to pull all proc-related generation state from `AstGenerator` itself into a separate `ProcContext` inside `AstGenerator::Context`, making it possible for proc generations to nest.

- Re-work proc generation to make it "signature driven", just like the function AST generation.
    - For functions, a random signature is chosen, then a matching function body is generated.
    - For procs, the state type was pre-determined, but channels were created every time a new `ChannelOp` was generated, changing the proc's interface.
    - This patch reworks the proc generation to also first generate a proc interface (set of input/output channels), then generates a matching proc body.
    - This makes it much easier to generate proc hierarchies: When generating a child proc we can pick signature we want (as is done for child functions for `map` calls) instead of having to make a random child proc signature work.

    - This significantly increased the number of channel ops generated, which is how I found the incorrect pipeline stage count propagation through counted for loops - It was result in tens of "too few pipeline stages" known failures a second. It also exposed some other limitations related to combinational proc codegen - see below.

- Add the ability to generate proc hierarchies;
    - When generating a proc, if enabled, we sometimes generate a random child proc that interacts with the parent proc. To keep things simple I generate at most one child proc. Currently, the "spawn-depth" is limited to one, to maintain sanity.

- Some initial/WIP small hacks to the sample runner/generator to support multi-proc samples.

The commits mirror this flow, hopefully making them a bit easier to look at.

#### Wiring the Proc Config Function

Some notes about how the channels are routed in the generated config function, if we are generating a child:

Since the proc interface (the arguments of the proc's config function) are now pre-defined, we send a random portion of these channels to the generated child (`chns_io_child`). The rest of the channels are used as proc members and are interacted with in the proc next function (`chns_io_body`).

We also generate a random set of internal channels (`chns_child_body`) that connect the child proc to the proc members, allowing the us to interact with it from the next function. The required interface for the child proc is therefor the combination of channels connecting it to the parent proc interface and parent proc next function (`chns_io_child` and `chns_io_body`).

This scheme is illustrated below:

```
                          Proc I/O
                   (Config func. params)
                        ▲         ▲
                        │ │       │ │
                   ─────┼─┼───────┼─┼──
                        │ │       │ │
       chns_io_child    │ │       │ │
                        │ │       │ │
                     ┌──┴─▼──┐    │ │
                     │       │    │ │
          child proc │       │    │ │ chns_io_body
                     │       │    │ │
                     └──▲─┬──┘    │ │
                        │ │       │ │
     chns_child_body    │ │       │ │
                        │ │       │ │
                   ─────┼─┼───────┼─┼───
                        │ │       │ │
                          ▼         ▼
                       Proc Members
                 (Channels used in `next`)
```


We always use the following channel ordering:

Proc I/O:      `[*chns_io_child, *chns_io_body]`

Child I/O:     `[*chns_io_child, *chns_child_body]`

Proc Members:  `[*chns_child_body, *chns_io_body]`

## Known Points of Friction

Some notes on places that will likely need attention to "finish" full multi-proc fuzzing.

### Deadlocks (ofc..)

The immediate issue with random multi-proc ASTs is the potential for deadlock.

I added the following AST generation restrictions to reduce the chance of deadlock:

- 1) The child proc must send first on all channels before receiving.
- 2) The child proc may only contain unconditional sends/receives.
- 3) The top proc may only interact with the child proc using unconditional sends/receives
- 4) The FIFOs connecting the child and top proc have a minimum depth of 1.

At a first glance it seemed to me that these ought to be enough to prevent dead locking of fuzzing samples, but there are still plenty of deadlocks to be had.

For now, I added a `known_failure`.

There is a discussion to be had about if it might be worth actually fuzzing these deadlocking samples. If, instead of crashing if we can't tick N times, we tick "as many times as we can but at most N times", it might be possible to still check that these samples behave well. The non-greediness of interpreters would make this difficult thought (see below).

### The AST generator does not know about "combinational proc codegen"

Related to this discussion here: https://github.com/google/xls/discussions/1996

It seems that the combinational proc codegen pipeline has more restrictive/different limitations on channel exclusivity.

The proc generator has no notion of these, and the sample runner will attempt to run the combinational backend with incompatible procs.

As far as I can see this is a limitation even without my changes, but the much higher frequency of channel ops being generated has surfaced it more.

For now, I have added this as a "known failure". It is fairly rare and a limitation of the fuzzer and not the codegen afterall.

### "The interpreters are not greedy enough"

The interpreters are sensitive to the order of operations, even if the IR is semantically equivalent. This surfaces in "pseudo-deadlocks" (samples that are deadlocked but not detected as such because one proc is running in a circle doing nothing). This results in fuzzing failures because optimization can change the order of operations, causing such pseudo-deadlock samples to behave differently before and after optimization.

For example, consider this snippet:

```rust
package repro

chan output(bits[10], id=2, kind=streaming, ops=send_only, flow_control=ready_valid, strictness=proven_mutually_exclusive)
chan always_empty(bits[64], id=10, kind=streaming, ops=send_receive, flow_control=ready_valid, strictness=proven_mutually_exclusive, fifo_depth=1, bypass=true, register_push_outputs=true, register_pop_outputs=false)

top proc __sample__main_0_next() {
  ready: token = after_all(id=4839)
  data: bits[10] = literal(value=0, id=4840)
  x95: (token, bits[64]) = receive(ready, channel=always_empty, id=4845) // A
  x110: token = send(ready, data, channel=output, id=4846)               // B
}

proc never_send() {
  now: token = after_all(id=4841)
  data: bits[64] = literal(value=0, id=4843)
  zero: bits[1] = literal(value=0, id=4842)
  x46: token = send(now, data, predicate=zero, channel=always_empty, id=4844)
}
```

Note that line `A` will never complete since the channel is always empty. Semantically, the send on line `B` is not blocked by this, meaning I would expect the proc to send to the output channel once. I guess this is what the physical circuit would do.

However, the interpreters get "blocked" on line `A`, and `B` never executes.

If the two lines are swapped, we see the single send. If optimizations cause this swap to occur, we have a mismatch in behavior between optimized and un-optimized interpreted IR.

I currently work around this also using the deadlock mitigation restrictions:
- 1) The child proc must send first on all channels before receiving.
- 2) The child proc may only contain unconditional sends/receives.
- 3) The top proc may only interact with the child proc using unconditional sends/receives
- 4) The FIFOs connecting the child and top proc have a minimum depth of 1.

These restrictions mean that every cycle both procs can activate fully, and there is always data available to the top proc from the child proc.

While troubleshooting this and before realizing that this a fundamental limitation of the interpreters, I had written a unit test that exercises this here: https://github.com/schilkp/xls/tree/schilkp/interpreter_is_not_greedy - Should that be of use to anyone.

### Extracting Proc Signature/Logging output channels

When extracting the "signature" of the top proc to generate test vectors, the sample generator previously used the proc members. However, with interface-to-child and child-to-body/members channels,
this is not correct:

- Input channels to the top proc that are directly connected to the child proc are missed.
- Channels from the child proc to the top proc are treated as top inputs.
- ...

Instead I - for now - the set of input channels from the config function parameters. This is "good enough" for the current AST generator, but only works because we give the proc member the same name as the config function parameter that feeds it. The name of the actual input to the proc is the name of the proc member and not the config function parameter after all.

Similarly, the interpreters would dump the values send to any channel as the proc output. I restricted it to only dump channels that are `kSendOnly` which seems to do the trick but feels a bit hacky.

I guess this might all get easier with proc-scoped channels?

---

Sorry for another wall-of-text...

Cheers!
