### PR TITLE
fuzzer: gather total crashers and skipped sample stats.

### DIFF
--- a/xls/fuzzer/run_crasher.cc
+++ b/xls/fuzzer/run_crasher.cc
@@ -57,7 +57,7 @@ absl::Status RealMain(const std::filesystem::path& crasher_path,
   }
 
   LOG(INFO) << "Running crasher in directory " << run_dir;
-  return RunSample(crasher, run_dir);
+  return RunSample(crasher, run_dir).status();
 }
 
 }  // namespace

--- a/xls/fuzzer/run_fuzz.h
+++ b/xls/fuzzer/run_fuzz.h
@@ -19,12 +19,12 @@
 #include <optional>
 
 #include "absl/random/bit_gen_ref.h"
-#include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/time/time.h"
 #include "xls/dslx/frontend/pos.h"
 #include "xls/fuzzer/ast_generator.h"
 #include "xls/fuzzer/sample.h"
+#include "xls/fuzzer/sample_runner.h"
 
 namespace xls {
 
@@ -33,12 +33,12 @@ namespace xls {
 // given, it will be recorded in the timings in the sample summary.
 //
 // `run_dir` must be an empty directory.
-absl::Status RunSample(
+absl::StatusOr<CompletedSampleKind> RunSample(
     const Sample& smp, const std::filesystem::path& run_dir,
     const std::optional<std::filesystem::path>& summary_file = std::nullopt,
     std::optional<absl::Duration> generate_sample_elapsed = std::nullopt);
 
-absl::StatusOr<Sample> GenerateSampleAndRun(
+absl::StatusOr<std::pair<Sample, CompletedSampleKind>> GenerateSampleAndRun(
     dslx::FileTable& file_table, absl::BitGenRef bit_gen,
     const dslx::AstGeneratorOptions& ast_generator_options,
     const SampleOptions& sample_options, const std::filesystem::path& run_dir,

--- a/xls/fuzzer/run_fuzz_codegen_test.cc
+++ b/xls/fuzzer/run_fuzz_codegen_test.cc
@@ -134,11 +134,12 @@ class RunFuzzCodegenTest : public ::testing::Test {
     return options;
   }
 
-  absl::StatusOr<Sample> RunFuzz(int64_t seed) {
+  absl::Status RunFuzz(int64_t seed) {
     std::mt19937_64 rng(seed);
     return GenerateSampleAndRun(file_table_, rng, GetAstGeneratorOptions(),
                                 GetSampleOptions(), /*run_dir=*/GetTempPath(),
-                                crasher_dir_);
+                                crasher_dir_)
+        .status();
   }
 
  private:

--- a/xls/fuzzer/run_fuzz_test.cc
+++ b/xls/fuzzer/run_fuzz_test.cc
@@ -128,7 +128,7 @@ class RunFuzzTest : public ::testing::Test {
     return options;
   }
 
-  absl::StatusOr<Sample> RunFuzz(
+  absl::StatusOr<std::pair<Sample, CompletedSampleKind>> RunFuzz(
       int64_t seed, SampleOptions sample_options = GetSampleOptions()) {
     std::mt19937_64 rng(seed);
 
@@ -155,12 +155,12 @@ TEST_F(RunFuzzTest, DifferentSeedsProduceDifferentSamples) {
 TEST_F(RunFuzzTest, SequentialSamplesAreDifferent) {
   std::mt19937_64 rng{42};
   XLS_ASSERT_OK_AND_ASSIGN(
-      Sample sample1,
+      auto sample1,
       GenerateSampleAndRun(file_table_, rng, GetAstGeneratorOptions(),
                            GetSampleOptions(),
                            /*run_dir=*/GetTempPath(), crasher_dir_));
   XLS_ASSERT_OK_AND_ASSIGN(
-      Sample sample2,
+      auto sample2,
       GenerateSampleAndRun(file_table_, rng, GetAstGeneratorOptions(),
                            GetSampleOptions(),
                            /*run_dir=*/GetTempPath(), crasher_dir_));

--- a/xls/fuzzer/sample_runner.h
+++ b/xls/fuzzer/sample_runner.h
@@ -29,6 +29,11 @@
 
 namespace xls {
 
+enum class CompletedSampleKind : std::uint8_t {
+  kSuccess,  // Sample completed succesfully.
+  kSkipped,  // Sample triggered known failure.
+};
+
 // A class for performing various operations on a code sample.
 
 // Code sample can be in DSLX or IR. The possible operations include:
@@ -67,13 +72,14 @@ class SampleRunner {
 
   // Runs the provided sample, writing out files under the SampleRunner's
   // `run_dir` as appropriate.
-  absl::Status Run(const Sample& sample);
+  absl::StatusOr<CompletedSampleKind> Run(const Sample& sample);
 
   // Runs the provided files as a sample, writing out only outputs under the
   // SampleRunner's `run_dir`.
-  absl::Status RunFromFiles(const std::filesystem::path& input_path,
-                            const std::filesystem::path& options_path,
-                            const std::filesystem::path& testvector_path);
+  absl::StatusOr<CompletedSampleKind> RunFromFiles(
+      const std::filesystem::path& input_path,
+      const std::filesystem::path& options_path,
+      const std::filesystem::path& testvector_path);
 
   const fuzzer::SampleTimingProto& timing() const { return timing_; }
 

--- a/xls/fuzzer/sample_runner_main.cc
+++ b/xls/fuzzer/sample_runner_main.cc
@@ -81,8 +81,9 @@ static absl::Status RealMain(const std::filesystem::path& run_dir,
   std::filesystem::path options_filename = MaybeCopyFile(options_file, run_dir);
   std::filesystem::path testvector_filename =
       MaybeCopyFile(testvector_file, run_dir);
-  return runner.RunFromFiles(input_filename, options_filename,
-                             testvector_filename);
+  return runner
+      .RunFromFiles(input_filename, options_filename, testvector_filename)
+      .status();
 }
 
 }  // namespace xls


### PR DESCRIPTION
While working on fuzzer stuff, I found it useful to track the actual rate of skipped/`known_failure` samples generated. This adds bookkeeping to count the total number of samples, skipped samples, and crashes. The multiproc runner is updated to accumulate these statistics from all workers and print the totals.