### PR TITLE
dslx/stdlib: Add missing acm_random DSLX library

### DIFF
--- a/xls/dslx/stdlib/BUILD
+++ b/xls/dslx/stdlib/BUILD
@@ -59,6 +59,11 @@ xls_dslx_prove_quickcheck_test(
     srcs = ["std.x"],
 )
 
+xls_dslx_library(
+    name = "acm_random_dslx",
+    srcs = ["acm_random.x"],
+)
+
 xls_dslx_test(
     name = "acm_random_dslx_test",
     srcs = ["acm_random.x"],


### PR DESCRIPTION
This PR adds a `acm_random_dslx` DSLX library to enable pulling this module into other designs.

It is required for merging #1857.

CC @proppy 