### PR TITLE
Distinguish sources of asserts in a proc chain

### DIFF
--- a/xls/dslx/bytecode/BUILD
+++ b/xls/dslx/bytecode/BUILD
@@ -236,6 +236,7 @@ cc_library(
         "//xls/dslx:make_value_format_descriptor",
         "//xls/dslx:value_format_descriptor",
         "//xls/dslx/frontend:ast",
+        "//xls/dslx/frontend:proc_id",
         "//xls/dslx/type_system:type",
         "//xls/dslx/type_system:type_info",
         "//xls/ir:bits",

--- a/xls/dslx/bytecode/builtins.cc
+++ b/xls/dslx/bytecode/builtins.cc
@@ -41,6 +41,7 @@
 #include "xls/dslx/bytecode/interpreter_stack.h"
 #include "xls/dslx/errors.h"
 #include "xls/dslx/frontend/ast.h"
+#include "xls/dslx/frontend/proc_id.h"
 #include "xls/dslx/interp_value.h"
 #include "xls/dslx/interp_value_utils.h"
 #include "xls/dslx/make_value_format_descriptor.h"
@@ -390,7 +391,8 @@ GetAssertFormattedStrings(const InterpreterStack::FormattedInterpValue& lhs,
 
 absl::Status RunBuiltinAssertEq(const Bytecode& bytecode,
                                 InterpreterStack& stack, const Frame& frame,
-                                const BytecodeInterpreterOptions& options) {
+                                const BytecodeInterpreterOptions& options,
+                                const std::optional<ProcId>& caller_proc_id) {
   VLOG(3) << "Executing builtin AssertEq.";
   XLS_RET_CHECK_GE(stack.size(), 2);
 
@@ -424,6 +426,10 @@ absl::Status RunBuiltinAssertEq(const Bytecode& bytecode,
                                  lhs_values[*i].ToHumanString(),
                                  rhs_values[*i].ToHumanString());
     }
+    if (caller_proc_id.has_value()) {
+      message += absl::StrFormat(" (called from %s)",
+                                 caller_proc_id.value().ToString());
+    }
     return FailureErrorStatus(bytecode.source_span(), message,
                               stack.file_table());
   }
@@ -433,7 +439,8 @@ absl::Status RunBuiltinAssertEq(const Bytecode& bytecode,
 
 absl::Status RunBuiltinAssertLt(const Bytecode& bytecode,
                                 InterpreterStack& stack, const Frame& frame,
-                                const BytecodeInterpreterOptions& options) {
+                                const BytecodeInterpreterOptions& options,
+                                const std::optional<ProcId>& caller_proc_id) {
   VLOG(3) << "Executing builtin AssertLt.";
   XLS_RET_CHECK_GE(stack.size(), 2);
 
@@ -452,6 +459,10 @@ absl::Status RunBuiltinAssertLt(const Bytecode& bytecode,
                                                    bytecode, frame, options));
     std::string message = absl::StrFormat(
         "\n  lhs: %s\n was not less than rhs: %s", lhs_string, rhs_string);
+    if (caller_proc_id.has_value()) {
+      message += absl::StrFormat(" (called from %s)",
+                                 caller_proc_id.value().ToString());
+    }
     return FailureErrorStatus(bytecode.source_span(), message,
                               stack.file_table());
   }

--- a/xls/dslx/bytecode/builtins.h
+++ b/xls/dslx/bytecode/builtins.h
@@ -23,6 +23,7 @@
 #include "xls/dslx/bytecode/bytecode_interpreter_options.h"
 #include "xls/dslx/bytecode/frame.h"
 #include "xls/dslx/bytecode/interpreter_stack.h"
+#include "xls/dslx/frontend/proc_id.h"
 
 namespace xls::dslx {
 
@@ -83,10 +84,12 @@ absl::Status RunBuiltinXorReduce(const Bytecode& bytecode,
 
 absl::Status RunBuiltinAssertEq(const Bytecode& bytecode,
                                 InterpreterStack& stack, const Frame& frame,
-                                const BytecodeInterpreterOptions& options);
+                                const BytecodeInterpreterOptions& options,
+                                const std::optional<ProcId>& caller_proc_id);
 absl::Status RunBuiltinAssertLt(const Bytecode& bytecode,
                                 InterpreterStack& stack, const Frame& frame,
-                                const BytecodeInterpreterOptions& options);
+                                const BytecodeInterpreterOptions& options,
+                                const std::optional<ProcId>& caller_proc_id);
 
 // Returns a differences string in the style of Rust's pretty_assertions.
 // All lines are indented by two positions.


### PR DESCRIPTION
This PR contains the changes requested in  https://github.com/google/xls/issues/1874, that add printing proc hierarchy in assertions and fail! macro. Here are some error messages shouwing the final result:

1. `assert` in a hierarchy:
```[ RUN UNITTEST  ] TestAssertInHierarchy
xls/examples/assert.x:39:16-39:43
0037:     next(state: ()) {
0038:         let (tok, predicate) = recv(join(), req_r);
0039:         assert!(predicate, "assert_label");
~~~~~~~~~~~~~~~~~~~~~^-------------------------^ FailureError: The program being interpreted failed! assert_label (called from TestAssertInHierarchy->Assert:7)
0040:         send(tok, resp_s, ());
0041:     }
[        FAILED ] TestAssertInHierarchy
```

2. `assert` directly in a test
```
[ RUN UNITTEST  ] TestAssert
xls/examples/assert.x:75:16-75:39
0073:     config(terminator: chan<bool> out) { (terminator,) }
0074:     next(state: ()) {
0075:         assert!(false, "assert_label");
~~~~~~~~~~~~~~~~~~~~~^---------------------^ FailureError: The program being interpreted failed! assert_label (called from TestAssert:0)
0076:         send(join(), terminator, true);
0077:     }
[        FAILED ] TestAssert
```

3. `fail!` directly in a test
```
[ RUN UNITTEST  ] TestFail
xls/examples/assert.x:87:14-87:32
0085:     config(terminator: chan<bool> out) { (terminator,) }
0086:     next(state: ()) {
0087:         fail!("fail_label", ());
~~~~~~~~~~~~~~~~~~~^----------------^ FailureError: The program being interpreted failed! () (called from TestFail:0)
0088:         send(join(), terminator, true);
0089:     }
[        FAILED ] TestFail
```
4 . `assert_lt` directly in a test
```
[ RUN UNITTEST  ] TestAssertLt
xls/examples/assert.x:99:18-99:32
0097:     config(terminator: chan<bool> out) { (terminator,) }
0098:     next(state: ()) {
0099:         assert_lt(u32:1, u32:0);
~~~~~~~~~~~~~~~~~~~~~~~^------------^ FailureError: The program being interpreted failed!
  lhs: u32:1
 was not less than rhs: u32:0 (called from TestAssertLt:0)
0100:         send(join(), terminator, true);
0101:     }
[        FAILED ] TestAssertLt
```
5. `assert_eq` directly in a test
```
[ RUN UNITTEST  ] TestAssertEq
xls/examples/assert.x:111:18-111:35
0109:     config(terminator: chan<bool> out) { (terminator,) }
0110:     next(state: ()) {
0111:         assert_eq(u32:100, u32:99);
~~~~~~~~~~~~~~~~~~~~~~~^---------------^ FailureError: The program being interpreted failed!
  lhs: u32:100
  rhs: u32:99
  were not equal (called from TestAssertEq:0)
0112:         send(join(), terminator, true);
0113:     }
[        FAILED ] TestAssertEq
```
More examples can be found [[HERE]](https://github.com/antmicro/xls/commit/e838ba63b85a6bc2bde7104e4a8831dd2058f8bc)

FYI: @richmckeever 
Resolves #1874