### PR TITLE
Fix incorrect rounding in apfloat::downcast

### DIFF
--- a/xls/dslx/stdlib/tests/BUILD
+++ b/xls/dslx/stdlib/tests/BUILD
@@ -150,6 +150,41 @@ cc_test(
 )
 
 xls_dslx_test(
+    name = "float32_downcast_test",
+    srcs = ["float32_downcast_test.x"],
+)
+
+xls_dslx_opt_ir(
+    name = "float32_downcast",
+    srcs = ["float32_downcast_test.x"],
+    dslx_top = "f64_to_f32",
+    ir_file = "float32_downcast.ir",
+    opt_ir_file = "float32_downcast.opt.ir",
+)
+
+cc_xls_ir_jit_wrapper(
+    name = "float32_downcast_jit_wrapper",
+    src = ":float32_downcast",
+    jit_wrapper_args = {
+        "class_name": "F64ToF32",
+        "namespace": "xls::fp",
+    },
+)
+
+cc_test(
+    name = "float32_downcast_test_cc",
+    srcs = ["float32_downcast_test.cc"],
+    tags = ["optonly"],
+    deps = [
+        ":float32_downcast_jit_wrapper",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/fuzzing:fuzztest",
+        "@com_google_absl//absl/base",
+        "@googletest//:gtest",
+    ],
+)
+
+xls_dslx_test(
     name = "float32_upcast_test",
     srcs = ["float32_upcast_test.x"],
 )

--- a/xls/dslx/stdlib/tests/float32_downcast_test.cc
+++ b/xls/dslx/stdlib/tests/float32_downcast_test.cc
@@ -1,0 +1,60 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fenv.h>  // NOLINT - Allow fenv header.
+
+#include <cmath>
+#include <cstdint>
+#include <ios>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/fuzzing/fuzztest.h"
+#include "absl/base/casts.h"
+#include "xls/dslx/stdlib/tests/float32_downcast_jit_wrapper.h"
+
+namespace xls {
+namespace {
+
+static_assert(sizeof(double) == 8, "8 byte double required");
+static_assert(sizeof(float) == 4, "4 byte float required");
+
+class F64ToF32 {
+ public:
+  F64ToF32() { jit_ = std::move(fp::F64ToF32::Create()).value(); }
+  void F64ToF32Test(uint64_t v) {
+    if (fegetround() != FE_TONEAREST) {
+      GTEST_SKIP() << "Unexpected rounding mode";
+    }
+    double d = absl::bit_cast<double>(v);
+    float f = (float)d;
+    float j = jit_->Run(d).value();
+    if (std::isnan(f)) {
+      ASSERT_THAT(j, testing::IsNan());
+    } else {
+      ASSERT_EQ(f, j) << std::boolalpha
+                      << "is subnormal: " << (fpclassify(f) == FP_SUBNORMAL)
+                      << " inp: " << std::hex << "0x" << v << " "
+                      << std::hexfloat << d << " f=" << f << " j=" << j;
+    }
+  }
+
+ private:
+  std::unique_ptr<fp::F64ToF32> jit_;
+};
+FUZZ_TEST_F(F64ToF32, F64ToF32Test).WithDomains(fuzztest::Arbitrary<int64_t>());
+
+}  // namespace
+}  // namespace xls

--- a/xls/dslx/stdlib/tests/float32_downcast_test.x
+++ b/xls/dslx/stdlib/tests/float32_downcast_test.x
@@ -1,0 +1,25 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import apfloat;
+import float32;
+import float64;
+
+fn f64_to_f32(f: float64::F64) -> float32::F32 {
+    apfloat::downcast<float32::F32::FRACTION_SIZE, float32::F32::EXP_SIZE>(
+        f, apfloat::RoundStyle::TIES_TO_EVEN)
+}
+
+#[test]
+fn f64_to_f32_test() { assert_eq(f64_to_f32(float64::one(u1:0)), float32::one(u1:0)); }


### PR DESCRIPTION
When downcasting to a subnormal previously we first did a downcast of just the fractional part followed by the downcast of the exponent, where subnormals are generated. This led to the fraction being rounded twice, once for the downcast of just the fractional part and again for the subnormal fractional. This could lead to some values being rounded up twice, ending up 1 ulp larger than intended.