### PR TITLE
[xlscc] Expression cloning

### DIFF
--- a/xls/contrib/xlscc/BUILD
+++ b/xls/contrib/xlscc/BUILD
@@ -194,6 +194,15 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "expr_clone",
+    srcs = ["expr_clone.cc"],
+    hdrs = ["expr_clone.h"],
+    deps = [
+        "@llvm-project//clang:ast",
+    ],
+)
+
 filegroup(
     name = "synth_only_headers",
     srcs = [

--- a/xls/contrib/xlscc/expr_clone.cc
+++ b/xls/contrib/xlscc/expr_clone.cc
@@ -22,118 +22,120 @@
 
 namespace xlscc {
 namespace {
-using namespace clang;
 
-class ExprClone : public StmtVisitor<ExprClone, Expr*> {
+class ExprClone : public clang::StmtVisitor<ExprClone, clang::Expr*> {
  public:
-  explicit ExprClone(ASTContext& ctx_) : ctx(ctx_) {}
+  explicit ExprClone(clang::ASTContext& ctx_) : ctx(ctx_) {}
 
-  Expr* VisitIntegerLiteral(IntegerLiteral* expr) {
-    return IntegerLiteral::Create(ctx, expr->getValue(), expr->getType(),
-                                  expr->getLocation());
+  clang::Expr* VisitIntegerLiteral(clang::IntegerLiteral* expr) {
+    return clang::IntegerLiteral::Create(ctx, expr->getValue(), expr->getType(),
+                                         expr->getLocation());
   }
 
-  Expr* VisitCharacterLiteral(CharacterLiteral* expr) {
-    return new (ctx) CharacterLiteral(expr->getValue(), expr->getKind(),
-                                      expr->getType(), expr->getLocation());
+  clang::Expr* VisitCharacterLiteral(clang::CharacterLiteral* expr) {
+    return new (ctx)
+        clang::CharacterLiteral(expr->getValue(), expr->getKind(),
+                                expr->getType(), expr->getLocation());
   }
 
-  Expr* VisitFloatingLiteral(FloatingLiteral* expr) {
-    return FloatingLiteral::Create(ctx, expr->getValue(), expr->isExact(),
-                                   expr->getType(), expr->getLocation());
+  clang::Expr* VisitFloatingLiteral(clang::FloatingLiteral* expr) {
+    return clang::FloatingLiteral::Create(ctx, expr->getValue(),
+                                          expr->isExact(), expr->getType(),
+                                          expr->getLocation());
   }
 
-  Expr* VisitStringLiteral(StringLiteral* expr) {
-    return StringLiteral::Create(ctx, expr->getString(), expr->getKind(),
-                                 expr->isPascal(), expr->getType(),
-                                 expr->getExprLoc());
+  clang::Expr* VisitStringLiteral(clang::StringLiteral* expr) {
+    return clang::StringLiteral::Create(ctx, expr->getString(), expr->getKind(),
+                                        expr->isPascal(), expr->getType(),
+                                        expr->getExprLoc());
   }
 
-  Expr* VisitUserDefinedLiteral(UserDefinedLiteral* expr) {
-    std::vector<Expr*> args;
+  clang::Expr* VisitUserDefinedLiteral(clang::UserDefinedLiteral* expr) {
+    std::vector<clang::Expr*> args;
     for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
-    return UserDefinedLiteral::Create(
+    return clang::UserDefinedLiteral::Create(
         ctx, Visit(expr->getCallee()), args, expr->getType(),
         expr->getValueKind(), expr->getRParenLoc(), expr->getUDSuffixLoc(),
         expr->getFPFeatures());
   }
 
-  Expr* VisitCompoundLiteralExpr(CompoundLiteralExpr* expr) {
-    return new (ctx) CompoundLiteralExpr(
+  clang::Expr* VisitCompoundLiteralExpr(clang::CompoundLiteralExpr* expr) {
+    return new (ctx) clang::CompoundLiteralExpr(
         expr->getLParenLoc(), expr->getTypeSourceInfo(), expr->getType(),
         expr->getValueKind(), Visit(expr->getInitializer()),
         expr->getObjectKind());
   }
 
-  Expr* VisitDeclRefExpr(DeclRefExpr* expr) {
-    TemplateArgumentListInfo template_args;
+  clang::Expr* VisitDeclRefExpr(clang::DeclRefExpr* expr) {
+    clang::TemplateArgumentListInfo template_args;
     expr->copyTemplateArgumentsInto(template_args);
-    return DeclRefExpr::Create(
+    return clang::DeclRefExpr::Create(
         ctx, expr->getQualifierLoc(), expr->getTemplateKeywordLoc(),
         expr->getDecl(), expr->refersToEnclosingVariableOrCapture(),
         expr->getNameInfo(), expr->getType(), expr->getValueKind(),
         expr->getFoundDecl(), &template_args, expr->isNonOdrUse());
   }
 
-  Expr* VisitImplicitCastExpr(ImplicitCastExpr* expr) {
-    return ImplicitCastExpr::Create(
+  clang::Expr* VisitImplicitCastExpr(clang::ImplicitCastExpr* expr) {
+    return clang::ImplicitCastExpr::Create(
         ctx, expr->getType(), expr->getCastKind(), Visit(expr->getSubExpr()),
         nullptr, expr->getValueKind(), expr->getFPFeatures());
   }
 
-  Expr* VisitCStyleCastExpr(CStyleCastExpr* expr) {
-    return CStyleCastExpr::Create(
+  clang::Expr* VisitCStyleCastExpr(clang::CStyleCastExpr* expr) {
+    return clang::CStyleCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
         Visit(expr->getSubExpr()), nullptr, expr->getFPFeatures(),
         expr->getTypeInfoAsWritten(), expr->getLParenLoc(),
         expr->getRParenLoc());
   }
 
-  Expr* VisitCXXFunctionalCastExpr(CXXFunctionalCastExpr* expr) {
-    return CXXFunctionalCastExpr::Create(
+  clang::Expr* VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr* expr) {
+    return clang::CXXFunctionalCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(),
         expr->getTypeInfoAsWritten(), expr->getCastKind(),
         Visit(expr->getSubExpr()), nullptr, expr->getFPFeatures(),
         expr->getLParenLoc(), expr->getRParenLoc());
   }
 
-  Expr* VisitCXXStaticCastExpr(CXXStaticCastExpr* expr) {
-    return CXXStaticCastExpr::Create(
+  clang::Expr* VisitCXXStaticCastExpr(clang::CXXStaticCastExpr* expr) {
+    return clang::CXXStaticCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
         Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
         expr->getFPFeatures(), expr->getOperatorLoc(), expr->getRParenLoc(),
         expr->getAngleBrackets());
   }
 
-  Expr* VisitCXXDynamicCastExpr(CXXDynamicCastExpr* expr) {
-    return CXXDynamicCastExpr::Create(
+  clang::Expr* VisitCXXDynamicCastExpr(clang::CXXDynamicCastExpr* expr) {
+    return clang::CXXDynamicCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
         Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
         expr->getOperatorLoc(), expr->getRParenLoc(), expr->getAngleBrackets());
   }
 
-  Expr* VisitCXXReinterpretCastExpr(CXXReinterpretCastExpr* expr) {
-    return CXXReinterpretCastExpr::Create(
+  clang::Expr* VisitCXXReinterpretCastExpr(
+      clang::CXXReinterpretCastExpr* expr) {
+    return clang::CXXReinterpretCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
         Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
         expr->getOperatorLoc(), expr->getRParenLoc(), expr->getAngleBrackets());
   }
 
-  Expr* VisitCXXConstCastExpr(CXXConstCastExpr* expr) {
-    return CXXConstCastExpr::Create(
+  clang::Expr* VisitCXXConstCastExpr(clang::CXXConstCastExpr* expr) {
+    return clang::CXXConstCastExpr::Create(
         ctx, expr->getType(), expr->getValueKind(), Visit(expr->getSubExpr()),
         expr->getTypeInfoAsWritten(), expr->getOperatorLoc(),
         expr->getRParenLoc(), expr->getAngleBrackets());
   }
 
-  Expr* VisitMemberExpr(MemberExpr* expr) {
-    TemplateArgumentListInfo template_args;
+  clang::Expr* VisitMemberExpr(clang::MemberExpr* expr) {
+    clang::TemplateArgumentListInfo template_args;
     if (expr->hasExplicitTemplateArgs()) {
       expr->copyTemplateArgumentsInto(template_args);
     }
-    return MemberExpr::Create(
+    return clang::MemberExpr::Create(
         ctx, Visit(expr->getBase()), expr->isArrow(), expr->getOperatorLoc(),
         expr->getQualifierLoc(), expr->getTemplateKeywordLoc(),
         expr->getMemberDecl(), expr->getFoundDecl(), expr->getMemberNameInfo(),
@@ -141,92 +143,94 @@ class ExprClone : public StmtVisitor<ExprClone, Expr*> {
         expr->getObjectKind(), expr->isNonOdrUse());
   }
 
-  Expr* VisitCallExpr(CallExpr* expr) {
-    std::vector<Expr*> args;
+  clang::Expr* VisitCallExpr(clang::CallExpr* expr) {
+    std::vector<clang::Expr*> args;
     for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
-    return CallExpr::Create(ctx, Visit(expr->getCallee()), args,
-                            expr->getType(), expr->getValueKind(),
-                            expr->getRParenLoc(), expr->getFPFeatures(),
-                            expr->getNumArgs(), expr->getADLCallKind());
+    return clang::CallExpr::Create(ctx, Visit(expr->getCallee()), args,
+                                   expr->getType(), expr->getValueKind(),
+                                   expr->getRParenLoc(), expr->getFPFeatures(),
+                                   expr->getNumArgs(), expr->getADLCallKind());
   }
 
-  Expr* VisitUnaryOperator(UnaryOperator* expr) {
-    return UnaryOperator::Create(
+  clang::Expr* VisitUnaryOperator(clang::UnaryOperator* expr) {
+    return clang::UnaryOperator::Create(
         ctx, Visit(expr->getSubExpr()), expr->getOpcode(), expr->getType(),
         expr->getValueKind(), expr->getObjectKind(), expr->getOperatorLoc(),
         expr->canOverflow(), expr->getFPOptionsOverride());
   }
 
-  Expr* VisitBinaryOperator(BinaryOperator* expr) {
-    return BinaryOperator::Create(
+  clang::Expr* VisitBinaryOperator(clang::BinaryOperator* expr) {
+    return clang::BinaryOperator::Create(
         ctx, Visit(expr->getLHS()), Visit(expr->getRHS()), expr->getOpcode(),
         expr->getType(), expr->getValueKind(), expr->getObjectKind(),
         expr->getOperatorLoc(), expr->getFPFeatures());
   }
 
-  Expr* VisitConditionalOperator(ConditionalOperator* expr) {
-    return new (ctx) ConditionalOperator(
+  clang::Expr* VisitConditionalOperator(clang::ConditionalOperator* expr) {
+    return new (ctx) clang::ConditionalOperator(
         Visit(expr->getCond()), expr->getQuestionLoc(), Visit(expr->getLHS()),
         expr->getColonLoc(), Visit(expr->getRHS()), expr->getType(),
         expr->getValueKind(), expr->getObjectKind());
   }
 
-  Expr* VisitParenExpr(ParenExpr* expr) {
-    return new (ctx) ParenExpr(expr->getBeginLoc(), expr->getEndLoc(),
-                               Visit(expr->getSubExpr()));
+  clang::Expr* VisitParenExpr(clang::ParenExpr* expr) {
+    return new (ctx) clang::ParenExpr(expr->getBeginLoc(), expr->getEndLoc(),
+                                      Visit(expr->getSubExpr()));
   }
 
-  Expr* VisitArraySubscriptExpr(ArraySubscriptExpr* expr) {
-    return new (ctx) ArraySubscriptExpr(
+  clang::Expr* VisitArraySubscriptExpr(clang::ArraySubscriptExpr* expr) {
+    return new (ctx) clang::ArraySubscriptExpr(
         Visit(expr->getLHS()), Visit(expr->getRHS()), expr->getType(),
         expr->getValueKind(), expr->getObjectKind(), expr->getRBracketLoc());
   }
 
-  Expr* VisitInitListExpr(InitListExpr* expr) {
-    std::vector<Expr*> inits;
+  clang::Expr* VisitInitListExpr(clang::InitListExpr* expr) {
+    std::vector<clang::Expr*> inits;
     for (auto* init : expr->inits()) {
       inits.push_back(Visit(init));
     }
-    auto* cloned = new (ctx)
-        InitListExpr(ctx, expr->getLBraceLoc(), inits, expr->getRBraceLoc());
+    auto* cloned = new (ctx) clang::InitListExpr(ctx, expr->getLBraceLoc(),
+                                                 inits, expr->getRBraceLoc());
     cloned->setType(expr->getType());
     return cloned;
   }
 
-  Expr* VisitDesignatedInitUpdateExpr(DesignatedInitUpdateExpr* expr) {
-    return new (ctx) DesignatedInitUpdateExpr(
+  clang::Expr* VisitDesignatedInitUpdateExpr(
+      clang::DesignatedInitUpdateExpr* expr) {
+    return new (ctx) clang::DesignatedInitUpdateExpr(
         ctx, expr->getBeginLoc(), Visit(expr->getBase()), expr->getEndLoc());
   }
 
-  Expr* VisitCXXOperatorCallExpr(CXXOperatorCallExpr* expr) {
-    std::vector<Expr*> args;
+  clang::Expr* VisitCXXOperatorCallExpr(clang::CXXOperatorCallExpr* expr) {
+    std::vector<clang::Expr*> args;
     for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
-    return CXXOperatorCallExpr::Create(
+    return clang::CXXOperatorCallExpr::Create(
         ctx, expr->getOperator(), Visit(expr->getCallee()), args,
         expr->getType(), expr->getValueKind(), expr->getRParenLoc(),
         expr->getFPFeatures());
   }
 
-  Expr* VisitCXXMemberCallExpr(CXXMemberCallExpr* expr) {
-    std::vector<Expr*> args;
+  clang::Expr* VisitCXXMemberCallExpr(clang::CXXMemberCallExpr* expr) {
+    std::vector<clang::Expr*> args;
     for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
-    return CXXMemberCallExpr::Create(
+    return clang::CXXMemberCallExpr::Create(
         ctx, Visit(expr->getCallee()), args, expr->getType(),
         expr->getValueKind(), expr->getRParenLoc(), expr->getFPFeatures());
   }
 
-  Expr* VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* expr) {
-    std::vector<Expr*> args;
+  clang::Expr* VisitCXXTemporaryObjectExpr(
+      clang::CXXTemporaryObjectExpr* expr) {
+    std::vector<clang::Expr*> args;
     for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
-    return CXXTemporaryObjectExpr::Create(
+    return clang::CXXTemporaryObjectExpr::Create(
         ctx, expr->getConstructor(), expr->getType(), expr->getTypeSourceInfo(),
         args, expr->getParenOrBraceRange(), expr->hadMultipleCandidates(),
         expr->isListInitialization(), expr->isStdInitListInitialization(),
@@ -234,15 +238,15 @@ class ExprClone : public StmtVisitor<ExprClone, Expr*> {
   }
 
  private:
-  ASTContext& ctx;
+  clang::ASTContext& ctx;
 };
 
 }  // namespace
 
-Expr* Clone(ASTContext& ctx, const Expr* expr) {
+clang::Expr* Clone(clang::ASTContext& ctx, const clang::Expr* expr) {
   ExprClone cloner(ctx);
   // FIXME: get rid of this const cast
-  return cloner.Visit(const_cast<Expr*>(expr));
+  return cloner.Visit(const_cast<clang::Expr*>(expr));
 }
 
 }  // namespace xlscc

--- a/xls/contrib/xlscc/expr_clone.cc
+++ b/xls/contrib/xlscc/expr_clone.cc
@@ -14,6 +14,8 @@
 
 #include "xls/contrib/xlscc/expr_clone.h"
 
+#include <clang/AST/Expr.h>
+
 #include <vector>
 
 #include "clang/AST/StmtVisitor.h"
@@ -25,6 +27,45 @@ using namespace clang;
 class ExprClone : public StmtVisitor<ExprClone, Expr*> {
  public:
   explicit ExprClone(ASTContext& ctx_) : ctx(ctx_) {}
+
+  Expr* VisitIntegerLiteral(IntegerLiteral* expr) {
+    return IntegerLiteral::Create(ctx, expr->getValue(), expr->getType(),
+                                  expr->getLocation());
+  }
+
+  Expr* VisitCharacterLiteral(CharacterLiteral* expr) {
+    return new (ctx) CharacterLiteral(expr->getValue(), expr->getKind(),
+                                      expr->getType(), expr->getLocation());
+  }
+
+  Expr* VisitFloatingLiteral(FloatingLiteral* expr) {
+    return FloatingLiteral::Create(ctx, expr->getValue(), expr->isExact(),
+                                   expr->getType(), expr->getLocation());
+  }
+
+  Expr* VisitStringLiteral(StringLiteral* expr) {
+    return StringLiteral::Create(ctx, expr->getString(), expr->getKind(),
+                                 expr->isPascal(), expr->getType(),
+                                 expr->getExprLoc());
+  }
+
+  Expr* VisitUserDefinedLiteral(UserDefinedLiteral* expr) {
+    std::vector<Expr*> args;
+    for (auto* arg : expr->arguments()) {
+      args.push_back(Visit(arg));
+    }
+    return UserDefinedLiteral::Create(
+        ctx, Visit(expr->getCallee()), args, expr->getType(),
+        expr->getValueKind(), expr->getRParenLoc(), expr->getUDSuffixLoc(),
+        expr->getFPFeatures());
+  }
+
+  Expr* VisitCompoundLiteralExpr(CompoundLiteralExpr* expr) {
+    return new (ctx) CompoundLiteralExpr(
+        expr->getLParenLoc(), expr->getTypeSourceInfo(), expr->getType(),
+        expr->getValueKind(), Visit(expr->getInitializer()),
+        expr->getObjectKind());
+  }
 
   Expr* VisitDeclRefExpr(DeclRefExpr* expr) {
     TemplateArgumentListInfo template_args;
@@ -42,15 +83,154 @@ class ExprClone : public StmtVisitor<ExprClone, Expr*> {
         nullptr, expr->getValueKind(), expr->getFPFeatures());
   }
 
+  Expr* VisitCStyleCastExpr(CStyleCastExpr* expr) {
+    return CStyleCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
+        Visit(expr->getSubExpr()), nullptr, expr->getFPFeatures(),
+        expr->getTypeInfoAsWritten(), expr->getLParenLoc(),
+        expr->getRParenLoc());
+  }
+
+  Expr* VisitCXXFunctionalCastExpr(CXXFunctionalCastExpr* expr) {
+    return CXXFunctionalCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(),
+        expr->getTypeInfoAsWritten(), expr->getCastKind(),
+        Visit(expr->getSubExpr()), nullptr, expr->getFPFeatures(),
+        expr->getLParenLoc(), expr->getRParenLoc());
+  }
+
+  Expr* VisitCXXStaticCastExpr(CXXStaticCastExpr* expr) {
+    return CXXStaticCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
+        Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
+        expr->getFPFeatures(), expr->getOperatorLoc(), expr->getRParenLoc(),
+        expr->getAngleBrackets());
+  }
+
+  Expr* VisitCXXDynamicCastExpr(CXXDynamicCastExpr* expr) {
+    return CXXDynamicCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
+        Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
+        expr->getOperatorLoc(), expr->getRParenLoc(), expr->getAngleBrackets());
+  }
+
+  Expr* VisitCXXReinterpretCastExpr(CXXReinterpretCastExpr* expr) {
+    return CXXReinterpretCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(), expr->getCastKind(),
+        Visit(expr->getSubExpr()), nullptr, expr->getTypeInfoAsWritten(),
+        expr->getOperatorLoc(), expr->getRParenLoc(), expr->getAngleBrackets());
+  }
+
+  Expr* VisitCXXConstCastExpr(CXXConstCastExpr* expr) {
+    return CXXConstCastExpr::Create(
+        ctx, expr->getType(), expr->getValueKind(), Visit(expr->getSubExpr()),
+        expr->getTypeInfoAsWritten(), expr->getOperatorLoc(),
+        expr->getRParenLoc(), expr->getAngleBrackets());
+  }
+
+  Expr* VisitMemberExpr(MemberExpr* expr) {
+    TemplateArgumentListInfo template_args;
+    if (expr->hasExplicitTemplateArgs()) {
+      expr->copyTemplateArgumentsInto(template_args);
+    }
+    return MemberExpr::Create(
+        ctx, Visit(expr->getBase()), expr->isArrow(), expr->getOperatorLoc(),
+        expr->getQualifierLoc(), expr->getTemplateKeywordLoc(),
+        expr->getMemberDecl(), expr->getFoundDecl(), expr->getMemberNameInfo(),
+        &template_args, expr->getType(), expr->getValueKind(),
+        expr->getObjectKind(), expr->isNonOdrUse());
+  }
+
   Expr* VisitCallExpr(CallExpr* expr) {
     std::vector<Expr*> args;
-    for (Expr* arg : expr->arguments()) {
+    for (auto* arg : expr->arguments()) {
       args.push_back(Visit(arg));
     }
     return CallExpr::Create(ctx, Visit(expr->getCallee()), args,
                             expr->getType(), expr->getValueKind(),
                             expr->getRParenLoc(), expr->getFPFeatures(),
                             expr->getNumArgs(), expr->getADLCallKind());
+  }
+
+  Expr* VisitUnaryOperator(UnaryOperator* expr) {
+    return UnaryOperator::Create(
+        ctx, Visit(expr->getSubExpr()), expr->getOpcode(), expr->getType(),
+        expr->getValueKind(), expr->getObjectKind(), expr->getOperatorLoc(),
+        expr->canOverflow(), expr->getFPOptionsOverride());
+  }
+
+  Expr* VisitBinaryOperator(BinaryOperator* expr) {
+    return BinaryOperator::Create(
+        ctx, Visit(expr->getLHS()), Visit(expr->getRHS()), expr->getOpcode(),
+        expr->getType(), expr->getValueKind(), expr->getObjectKind(),
+        expr->getOperatorLoc(), expr->getFPFeatures());
+  }
+
+  Expr* VisitConditionalOperator(ConditionalOperator* expr) {
+    return new (ctx) ConditionalOperator(
+        Visit(expr->getCond()), expr->getQuestionLoc(), Visit(expr->getLHS()),
+        expr->getColonLoc(), Visit(expr->getRHS()), expr->getType(),
+        expr->getValueKind(), expr->getObjectKind());
+  }
+
+  Expr* VisitParenExpr(ParenExpr* expr) {
+    return new (ctx) ParenExpr(expr->getBeginLoc(), expr->getEndLoc(),
+                               Visit(expr->getSubExpr()));
+  }
+
+  Expr* VisitArraySubscriptExpr(ArraySubscriptExpr* expr) {
+    return new (ctx) ArraySubscriptExpr(
+        Visit(expr->getLHS()), Visit(expr->getRHS()), expr->getType(),
+        expr->getValueKind(), expr->getObjectKind(), expr->getRBracketLoc());
+  }
+
+  Expr* VisitInitListExpr(InitListExpr* expr) {
+    std::vector<Expr*> inits;
+    for (auto* init : expr->inits()) {
+      inits.push_back(Visit(init));
+    }
+    auto* cloned = new (ctx)
+        InitListExpr(ctx, expr->getLBraceLoc(), inits, expr->getRBraceLoc());
+    cloned->setType(expr->getType());
+    return cloned;
+  }
+
+  Expr* VisitDesignatedInitUpdateExpr(DesignatedInitUpdateExpr* expr) {
+    return new (ctx) DesignatedInitUpdateExpr(
+        ctx, expr->getBeginLoc(), Visit(expr->getBase()), expr->getEndLoc());
+  }
+
+  Expr* VisitCXXOperatorCallExpr(CXXOperatorCallExpr* expr) {
+    std::vector<Expr*> args;
+    for (auto* arg : expr->arguments()) {
+      args.push_back(Visit(arg));
+    }
+    return CXXOperatorCallExpr::Create(
+        ctx, expr->getOperator(), Visit(expr->getCallee()), args,
+        expr->getType(), expr->getValueKind(), expr->getRParenLoc(),
+        expr->getFPFeatures());
+  }
+
+  Expr* VisitCXXMemberCallExpr(CXXMemberCallExpr* expr) {
+    std::vector<Expr*> args;
+    for (auto* arg : expr->arguments()) {
+      args.push_back(Visit(arg));
+    }
+    return CXXMemberCallExpr::Create(
+        ctx, Visit(expr->getCallee()), args, expr->getType(),
+        expr->getValueKind(), expr->getRParenLoc(), expr->getFPFeatures());
+  }
+
+  Expr* VisitCXXTemporaryObjectExpr(CXXTemporaryObjectExpr* expr) {
+    std::vector<Expr*> args;
+    for (auto* arg : expr->arguments()) {
+      args.push_back(Visit(arg));
+    }
+    return CXXTemporaryObjectExpr::Create(
+        ctx, expr->getConstructor(), expr->getType(), expr->getTypeSourceInfo(),
+        args, expr->getParenOrBraceRange(), expr->hadMultipleCandidates(),
+        expr->isListInitialization(), expr->isStdInitListInitialization(),
+        expr->requiresZeroInitialization());
   }
 
  private:
@@ -61,13 +241,8 @@ class ExprClone : public StmtVisitor<ExprClone, Expr*> {
 
 Expr* Clone(ASTContext& ctx, const Expr* expr) {
   ExprClone cloner(ctx);
-  llvm::outs() << "=> Original:\n";
-  expr->dump(llvm::outs(), ctx);
   // FIXME: get rid of this const cast
-  auto* cloned = cloner.Visit(const_cast<Expr*>(expr));
-  llvm::outs() << "=> Cloned:\n";
-  cloned->dump(llvm::outs(), ctx);
-  return cloned;
+  return cloner.Visit(const_cast<Expr*>(expr));
 }
 
 }  // namespace xlscc

--- a/xls/contrib/xlscc/expr_clone.cc
+++ b/xls/contrib/xlscc/expr_clone.cc
@@ -1,0 +1,73 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/xlscc/expr_clone.h"
+
+#include <vector>
+
+#include "clang/AST/StmtVisitor.h"
+
+namespace xlscc {
+namespace {
+using namespace clang;
+
+class ExprClone : public StmtVisitor<ExprClone, Expr*> {
+ public:
+  explicit ExprClone(ASTContext& ctx_) : ctx(ctx_) {}
+
+  Expr* VisitDeclRefExpr(DeclRefExpr* expr) {
+    TemplateArgumentListInfo template_args;
+    expr->copyTemplateArgumentsInto(template_args);
+    return DeclRefExpr::Create(
+        ctx, expr->getQualifierLoc(), expr->getTemplateKeywordLoc(),
+        expr->getDecl(), expr->refersToEnclosingVariableOrCapture(),
+        expr->getNameInfo(), expr->getType(), expr->getValueKind(),
+        expr->getFoundDecl(), &template_args, expr->isNonOdrUse());
+  }
+
+  Expr* VisitImplicitCastExpr(ImplicitCastExpr* expr) {
+    return ImplicitCastExpr::Create(
+        ctx, expr->getType(), expr->getCastKind(), Visit(expr->getSubExpr()),
+        nullptr, expr->getValueKind(), expr->getFPFeatures());
+  }
+
+  Expr* VisitCallExpr(CallExpr* expr) {
+    std::vector<Expr*> args;
+    for (Expr* arg : expr->arguments()) {
+      args.push_back(Visit(arg));
+    }
+    return CallExpr::Create(ctx, Visit(expr->getCallee()), args,
+                            expr->getType(), expr->getValueKind(),
+                            expr->getRParenLoc(), expr->getFPFeatures(),
+                            expr->getNumArgs(), expr->getADLCallKind());
+  }
+
+ private:
+  ASTContext& ctx;
+};
+
+}  // namespace
+
+Expr* Clone(ASTContext& ctx, const Expr* expr) {
+  ExprClone cloner(ctx);
+  llvm::outs() << "=> Original:\n";
+  expr->dump(llvm::outs(), ctx);
+  // FIXME: get rid of this const cast
+  auto* cloned = cloner.Visit(const_cast<Expr*>(expr));
+  llvm::outs() << "=> Cloned:\n";
+  cloned->dump(llvm::outs(), ctx);
+  return cloned;
+}
+
+}  // namespace xlscc

--- a/xls/contrib/xlscc/expr_clone.h
+++ b/xls/contrib/xlscc/expr_clone.h
@@ -1,0 +1,27 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_CONTRIB_XLSCC_EXPR_CLONE_H_
+#define XLS_CONTRIB_XLSCC_EXPR_CLONE_H_
+
+namespace clang {
+  class ASTContext;
+  class Expr;
+}
+
+namespace xlscc {
+  clang::Expr* Clone(clang::ASTContext& ctx, const clang::Expr* expr);
+}  // namespace xlscc
+
+#endif  // XLS_CONTRIB_XLSCC_EXPR_CLONE_H_

--- a/xls/contrib/xlscc/expr_clone.h
+++ b/xls/contrib/xlscc/expr_clone.h
@@ -21,7 +21,7 @@ namespace clang {
 }
 
 namespace xlscc {
-  clang::Expr* Clone(clang::ASTContext& ctx, const clang::Expr* expr);
+  const clang::Expr* Clone(clang::ASTContext& ctx, const clang::Expr* expr);
 }  // namespace xlscc
 
 #endif  // XLS_CONTRIB_XLSCC_EXPR_CLONE_H_

--- a/xls/contrib/xlscc/unit_tests/BUILD
+++ b/xls/contrib/xlscc/unit_tests/BUILD
@@ -28,7 +28,7 @@ cc_library(
     name = "unit_test",
     testonly = 1,
     srcs = ["unit_test.cc"],
-    hdrs = ["unit_test.h"],
+    hdrs = ["clang_util.h", "unit_test.h"],
     deps = [
         "//xls/codegen:module_signature_cc_proto",
         "//xls/common:source_location",

--- a/xls/contrib/xlscc/unit_tests/BUILD
+++ b/xls/contrib/xlscc/unit_tests/BUILD
@@ -317,6 +317,7 @@ cc_test(
         "//xls/contrib/xlscc:cc_parser",
         "//xls/contrib/xlscc:expr_clone",
         "@googletest//:gtest",
+        "@llvm-project//clang:ast",
     ],
 )
 

--- a/xls/contrib/xlscc/unit_tests/BUILD
+++ b/xls/contrib/xlscc/unit_tests/BUILD
@@ -308,6 +308,19 @@ cc_test(
 )
 
 cc_test(
+    name = "expr_clone_test",
+    srcs = ["expr_clone_test.cc"],
+    deps = [
+        ":unit_test",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/contrib/xlscc:cc_parser",
+        "//xls/contrib/xlscc:expr_clone",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
     name = "synth_only_test",
     srcs = ["synth_only_test.cc"],
     data = [

--- a/xls/contrib/xlscc/unit_tests/clang_util.h
+++ b/xls/contrib/xlscc/unit_tests/clang_util.h
@@ -1,0 +1,71 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "clang/include/clang/AST/Decl.h"
+#include "clang/include/clang/AST/Stmt.h"
+
+template <typename ClangT>
+const ClangT* GetStmtInCompoundStmt(const clang::CompoundStmt* stmt) {
+  for (const clang::Stmt* body_st : stmt->children()) {
+    if (const clang::LabelStmt* label =
+            clang::dyn_cast<clang::LabelStmt>(body_st);
+        label != nullptr) {
+      body_st = label->getSubStmt();
+    }
+
+    const ClangT* ret;
+    if (const clang::CompoundStmt* cmpnd_stmt =
+            clang::dyn_cast<clang::CompoundStmt>(body_st);
+        cmpnd_stmt != nullptr) {
+      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
+    } else {
+      ret = clang::dyn_cast<const ClangT>(body_st);
+    }
+    if (ret != nullptr) {
+      return ret;
+    }
+  }
+
+  return nullptr;
+}
+
+template <typename ClangT>
+const ClangT* GetStmtInFunction(const clang::FunctionDecl* func) {
+  const clang::Stmt* body = func->getBody();
+  if (body == nullptr) {
+    return nullptr;
+  }
+
+  for (const clang::Stmt* body_st : body->children()) {
+    if (const clang::LabelStmt* label =
+            clang::dyn_cast<clang::LabelStmt>(body_st);
+        label != nullptr) {
+      body_st = label->getSubStmt();
+    }
+
+    const ClangT* ret;
+    if (const clang::CompoundStmt* cmpnd_stmt =
+            clang::dyn_cast<clang::CompoundStmt>(body_st);
+        cmpnd_stmt != nullptr) {
+      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
+    } else {
+      ret = clang::dyn_cast<const ClangT>(body_st);
+    }
+    if (ret != nullptr) {
+      return ret;
+    }
+  }
+
+  return nullptr;
+}

--- a/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
+++ b/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
@@ -14,17 +14,12 @@
 
 #include "xls/contrib/xlscc/expr_clone.h"
 
-#include <string>
-
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/contrib/xlscc/cc_parser.h"
 #include "xls/contrib/xlscc/unit_tests/unit_test.h"
-
-namespace {
-class ExprCloneTest : public XlsccTestBase {
- public:
-};
 
 // From cc_parser_test
 template <typename ClangT>
@@ -83,30 +78,325 @@ const ClangT* GetStmtInFunction(const clang::FunctionDecl* func) {
   return nullptr;
 }
 
-TEST_F(ExprCloneTest, CloneFunCall) {
-  xlscc::CCParser parser;
+void CheckStmtsEq(const clang::Stmt* first, const clang::Stmt* second) {
+  ASSERT_NE(first, second);
+  ASSERT_EQ(first->getStmtClass(), second->getStmtClass());
 
-  const std::string cpp_src = R"(
-    int bar() {
-      return 0;
+  auto* first_expr = clang::dyn_cast<clang::Expr>(first);
+  auto* second_expr = clang::dyn_cast<clang::Expr>(second);
+  if (first_expr && second_expr) {
+    ASSERT_EQ(first_expr->getType(), second_expr->getType());
+    ASSERT_EQ(first_expr->getValueKind(), second_expr->getValueKind());
+    ASSERT_EQ(first_expr->getObjectKind(), second_expr->getObjectKind());
+  }
+
+#define ASSERT_FIELDS_EQ(class, field)                     \
+  do {                                                     \
+    auto* first_ = clang::dyn_cast<clang::class>(first);   \
+    ASSERT_NE(first_, nullptr);                            \
+    auto* second_ = clang::dyn_cast<clang::class>(second); \
+    ASSERT_NE(second_, nullptr);                           \
+    ASSERT_EQ(first_->field(), second_->field());          \
+  } while (false)  // force trailing semicolon
+
+  switch (first->getStmtClass()) {
+    case clang::Stmt::IntegerLiteralClass:
+      ASSERT_FIELDS_EQ(IntegerLiteral, getValue);
+      break;
+    case clang::Stmt::FloatingLiteralClass:
+      ASSERT_FIELDS_EQ(FloatingLiteral, getValue);
+      ASSERT_FIELDS_EQ(FloatingLiteral, isExact);
+      break;
+    case clang::Stmt::CharacterLiteralClass:
+      ASSERT_FIELDS_EQ(CharacterLiteral, getValue);
+      break;
+    case clang::Stmt::StringLiteralClass:
+      ASSERT_FIELDS_EQ(StringLiteral, getString);
+      ASSERT_FIELDS_EQ(StringLiteral, isPascal);
+      break;
+    case clang::Stmt::UserDefinedLiteralClass:
+      ASSERT_FIELDS_EQ(UserDefinedLiteral, getUDSuffix);
+      break;
+    case clang::Stmt::DeclRefExprClass:
+      ASSERT_FIELDS_EQ(DeclRefExpr, getDecl);
+      ASSERT_FIELDS_EQ(DeclRefExpr, getFoundDecl);
+      ASSERT_FIELDS_EQ(DeclRefExpr, refersToEnclosingVariableOrCapture);
+      ASSERT_FIELDS_EQ(DeclRefExpr, isNonOdrUse);
+      break;
+    case clang::Stmt::ImplicitCastExprClass:
+      ASSERT_FIELDS_EQ(ImplicitCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CStyleCastExprClass:
+      ASSERT_FIELDS_EQ(CStyleCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CXXFunctionalCastExprClass:
+      ASSERT_FIELDS_EQ(CXXFunctionalCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CXXStaticCastExprClass:
+      ASSERT_FIELDS_EQ(CXXStaticCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CXXDynamicCastExprClass:
+      ASSERT_FIELDS_EQ(CXXDynamicCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CXXReinterpretCastExprClass:
+      ASSERT_FIELDS_EQ(CXXReinterpretCastExpr, getCastKind);
+      break;
+    case clang::Stmt::CXXConstCastExprClass:
+      ASSERT_FIELDS_EQ(CXXConstCastExpr, getCastKind);
+      break;
+    case clang::Stmt::MemberExprClass:
+      ASSERT_FIELDS_EQ(MemberExpr, isArrow);
+      ASSERT_FIELDS_EQ(MemberExpr, isNonOdrUse);
+      ASSERT_FIELDS_EQ(MemberExpr, getMemberDecl);
+      ASSERT_FIELDS_EQ(MemberExpr, getFoundDecl);
+      break;
+    case clang::Stmt::UnaryOperatorClass:
+      ASSERT_FIELDS_EQ(UnaryOperator, getOpcode);
+      ASSERT_FIELDS_EQ(UnaryOperator, canOverflow);
+      break;
+    case clang::Stmt::BinaryOperatorClass:
+      ASSERT_FIELDS_EQ(BinaryOperator, getOpcode);
+      break;
+    case clang::Stmt::CXXTemporaryObjectExprClass:
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, isElidable);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, hadMultipleCandidates);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, isListInitialization);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, isStdInitListInitialization);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, requiresZeroInitialization);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, getConstructor);
+      ASSERT_FIELDS_EQ(CXXTemporaryObjectExpr, getConstructionKind);
+      break;
+    case clang::Stmt::CompoundLiteralExprClass:
+    case clang::Stmt::CallExprClass:
+    case clang::Stmt::ConditionalOperatorClass:
+    case clang::Stmt::InitListExprClass:
+    case clang::Stmt::ParenExprClass:
+    case clang::Stmt::ArraySubscriptExprClass:
+    case clang::Stmt::CXXOperatorCallExprClass:
+    case clang::Stmt::CXXMemberCallExprClass:
+      break;
+    default:
+      FAIL() << "Unsupported Stmt";
+      break;
+  }
+
+  ASSERT_EQ(llvm::range_size(first->children()),
+            llvm::range_size(second->children()));
+  for (auto [first_child, second_child] :
+       llvm::zip(first->children(), second->children())) {
+    CheckStmtsEq(first_child, second_child);
+  }
+}
+
+namespace {
+class ExprCloneTest : public XlsccTestBase {
+ public:
+  void CloneCheckReturnExpr(const char* top_name, const char* cpp_src) {
+    xlscc::CCParser parser;
+    XLS_ASSERT_OK(ScanTempFileWithContent(cpp_src, {}, &parser, top_name));
+    XLS_ASSERT_OK_AND_ASSIGN(const auto* top_fn, parser.GetTopFunction());
+    ASSERT_NE(top_fn, nullptr);
+    auto* ret_stmt = GetStmtInFunction<clang::ReturnStmt>(top_fn);
+    ASSERT_NE(ret_stmt, nullptr);
+    auto* ret_val = ret_stmt->getRetValue();
+    ASSERT_NE(ret_val, nullptr);
+    llvm::errs() << "=> Original:\n";
+    ret_val->dump(llvm::errs(), top_fn->getASTContext());
+
+    auto* ret_val_clone = xlscc::Clone(top_fn->getASTContext(), ret_val);
+    ASSERT_NE(ret_val_clone, nullptr);
+    llvm::errs() << "=> Cloned:\n";
+    ret_val_clone->dump(llvm::errs(), top_fn->getASTContext());
+
+    CheckStmtsEq(ret_val, ret_val_clone);
+  }
+};
+
+TEST_F(ExprCloneTest, CloneIntegerLiteral) {
+  CloneCheckReturnExpr("foo", R"(int foo() {
+    return 42;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneFloatingLiteral) {
+  CloneCheckReturnExpr("foo", R"(float foo() {
+    return 3.14f;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneCharacterLiteral) {
+  CloneCheckReturnExpr("foo", R"(char foo() {
+    return 'x';
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneStringLiteral) {
+  CloneCheckReturnExpr("foo", R"(const char* foo() {
+    return "hello world";
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneUserDefinedLiteral) {
+  CloneCheckReturnExpr("foo", R"(
+    int operator ""_qux(unsigned long long);
+    int foo() {
+      return 16_qux;
     }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCompoundLiteralExpr) {
+  CloneCheckReturnExpr("foo", R"(int foo() {
+    return (int){42};
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneDeclRefExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    int foo() {
+      int x = 0;
+      return x;
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCallExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    int bar();
     int foo() {
       return bar();
     }
-  )";
+  )");
+}
 
-  XLS_ASSERT_OK(
-      ScanTempFileWithContent(cpp_src, {}, &parser, /*top_name=*/"foo"));
-  XLS_ASSERT_OK_AND_ASSIGN(const auto* top_fn, parser.GetTopFunction());
-  ASSERT_NE(top_fn, nullptr);
-  auto* ret_stmt = GetStmtInFunction<clang::ReturnStmt>(top_fn);
-  ASSERT_NE(ret_stmt, nullptr);
-  auto* ret_val = ret_stmt->getRetValue();
-  ASSERT_NE(ret_val, nullptr);
-  auto* ret_val_clone = xlscc::Clone(top_fn->getASTContext(), ret_val);
-  ASSERT_NE(ret_val_clone, nullptr);
-  // TODO: Check that the refs are the same.
-  // TODO: Verify the cloned AST somehow?
+TEST_F(ExprCloneTest, CloneCStyleCastExpr) {
+  CloneCheckReturnExpr("foo", R"(float foo() {
+    return (float) 42;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneCXXFunctionalCastExpr) {
+  CloneCheckReturnExpr("foo", R"(float foo() {
+    return float(42);
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneCXXStaticCastExpr) {
+  CloneCheckReturnExpr("foo", R"(float foo() {
+    return static_cast<float>(42);
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneCXXDynamicCastExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar {
+      virtual ~bar() = default;
+    };
+    struct baz : bar {};
+    baz* foo(bar* b) {
+      return dynamic_cast<baz*>(b);
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCXXReinterpretCastExpr) {
+  CloneCheckReturnExpr("foo", R"(float* foo(int* x) {
+    return reinterpret_cast<float*>(x);
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneCXXConstCastExpr) {
+  CloneCheckReturnExpr("foo", R"(int& foo(const int& x) {
+    return const_cast<int&>(x);
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneMemberExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar {
+      int x;
+    };
+    int foo() {
+      bar b;
+      return b.x;
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneUnaryOperator) {
+  CloneCheckReturnExpr("foo", R"(int foo() {
+    int a = 0;
+    return -a;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneBinaryOperator) {
+  CloneCheckReturnExpr("foo", R"(int foo(int a) {
+    int b = 0;
+    return a + b;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneConditionalOperator) {
+  CloneCheckReturnExpr("foo", R"(int foo(bool b) {
+    return b ? 1 : 0;
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneArraySubscriptExpr) {
+  CloneCheckReturnExpr("foo", R"(int foo(int* a, int i) {
+    return a[i];
+  })");
+}
+
+TEST_F(ExprCloneTest, CloneInitListExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar { int a, b, c; };
+    bar foo() {
+      return {1, 2, 3};
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCXXOperatorCallExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar {};
+    bar operator*(bar, bar);
+    bar foo() {
+      return bar{} * bar{};
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCXXMemberCallExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar {
+      float qux();
+    };
+    float foo() {
+      bar b;
+      return b.qux();
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneCXXTemporaryObjectExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    struct bar {};
+    bar foo() {
+      return bar();
+    }
+  )");
+}
+
+TEST_F(ExprCloneTest, CloneComplexExpr) {
+  CloneCheckReturnExpr("foo", R"(
+    int bar(int);
+    float foo(int* a, int i) {
+      int b = 0;
+      return a[i] ? (float) a[i] * (bar(b) << 1) : 3.14;
+    }
+  )");
 }
 
 }  // namespace

--- a/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
+++ b/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
@@ -19,64 +19,8 @@
 #include "gtest/gtest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/contrib/xlscc/cc_parser.h"
+#include "xls/contrib/xlscc/unit_tests/clang_util.h"
 #include "xls/contrib/xlscc/unit_tests/unit_test.h"
-
-// From cc_parser_test
-template <typename ClangT>
-const ClangT* GetStmtInCompoundStmt(const clang::CompoundStmt* stmt) {
-  for (const clang::Stmt* body_st : stmt->children()) {
-    if (const clang::LabelStmt* label =
-            clang::dyn_cast<clang::LabelStmt>(body_st);
-        label != nullptr) {
-      body_st = label->getSubStmt();
-    }
-
-    const ClangT* ret;
-    if (const clang::CompoundStmt* cmpnd_stmt =
-            clang::dyn_cast<clang::CompoundStmt>(body_st);
-        cmpnd_stmt != nullptr) {
-      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
-    } else {
-      ret = clang::dyn_cast<const ClangT>(body_st);
-    }
-    if (ret != nullptr) {
-      return ret;
-    }
-  }
-
-  return nullptr;
-}
-
-// From cc_parser_test
-template <typename ClangT>
-const ClangT* GetStmtInFunction(const clang::FunctionDecl* func) {
-  const clang::Stmt* body = func->getBody();
-  if (body == nullptr) {
-    return nullptr;
-  }
-
-  for (const clang::Stmt* body_st : body->children()) {
-    if (const clang::LabelStmt* label =
-            clang::dyn_cast<clang::LabelStmt>(body_st);
-        label != nullptr) {
-      body_st = label->getSubStmt();
-    }
-
-    const ClangT* ret;
-    if (const clang::CompoundStmt* cmpnd_stmt =
-            clang::dyn_cast<clang::CompoundStmt>(body_st);
-        cmpnd_stmt != nullptr) {
-      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
-    } else {
-      ret = clang::dyn_cast<const ClangT>(body_st);
-    }
-    if (ret != nullptr) {
-      return ret;
-    }
-  }
-
-  return nullptr;
-}
 
 void CheckStmtsEq(const clang::Stmt* first, const clang::Stmt* second) {
   ASSERT_NE(first, second);

--- a/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
+++ b/xls/contrib/xlscc/unit_tests/expr_clone_test.cc
@@ -1,0 +1,112 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/contrib/xlscc/expr_clone.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/contrib/xlscc/cc_parser.h"
+#include "xls/contrib/xlscc/unit_tests/unit_test.h"
+
+namespace {
+class ExprCloneTest : public XlsccTestBase {
+ public:
+};
+
+// From cc_parser_test
+template <typename ClangT>
+const ClangT* GetStmtInCompoundStmt(const clang::CompoundStmt* stmt) {
+  for (const clang::Stmt* body_st : stmt->children()) {
+    if (const clang::LabelStmt* label =
+            clang::dyn_cast<clang::LabelStmt>(body_st);
+        label != nullptr) {
+      body_st = label->getSubStmt();
+    }
+
+    const ClangT* ret;
+    if (const clang::CompoundStmt* cmpnd_stmt =
+            clang::dyn_cast<clang::CompoundStmt>(body_st);
+        cmpnd_stmt != nullptr) {
+      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
+    } else {
+      ret = clang::dyn_cast<const ClangT>(body_st);
+    }
+    if (ret != nullptr) {
+      return ret;
+    }
+  }
+
+  return nullptr;
+}
+
+// From cc_parser_test
+template <typename ClangT>
+const ClangT* GetStmtInFunction(const clang::FunctionDecl* func) {
+  const clang::Stmt* body = func->getBody();
+  if (body == nullptr) {
+    return nullptr;
+  }
+
+  for (const clang::Stmt* body_st : body->children()) {
+    if (const clang::LabelStmt* label =
+            clang::dyn_cast<clang::LabelStmt>(body_st);
+        label != nullptr) {
+      body_st = label->getSubStmt();
+    }
+
+    const ClangT* ret;
+    if (const clang::CompoundStmt* cmpnd_stmt =
+            clang::dyn_cast<clang::CompoundStmt>(body_st);
+        cmpnd_stmt != nullptr) {
+      ret = GetStmtInCompoundStmt<ClangT>(cmpnd_stmt);
+    } else {
+      ret = clang::dyn_cast<const ClangT>(body_st);
+    }
+    if (ret != nullptr) {
+      return ret;
+    }
+  }
+
+  return nullptr;
+}
+
+TEST_F(ExprCloneTest, CloneFunCall) {
+  xlscc::CCParser parser;
+
+  const std::string cpp_src = R"(
+    int bar() {
+      return 0;
+    }
+    int foo() {
+      return bar();
+    }
+  )";
+
+  XLS_ASSERT_OK(
+      ScanTempFileWithContent(cpp_src, {}, &parser, /*top_name=*/"foo"));
+  XLS_ASSERT_OK_AND_ASSIGN(const auto* top_fn, parser.GetTopFunction());
+  ASSERT_NE(top_fn, nullptr);
+  auto* ret_stmt = GetStmtInFunction<clang::ReturnStmt>(top_fn);
+  ASSERT_NE(ret_stmt, nullptr);
+  auto* ret_val = ret_stmt->getRetValue();
+  ASSERT_NE(ret_val, nullptr);
+  auto* ret_val_clone = xlscc::Clone(top_fn->getASTContext(), ret_val);
+  ASSERT_NE(ret_val_clone, nullptr);
+  // TODO: Check that the refs are the same.
+  // TODO: Verify the cloned AST somehow?
+}
+
+}  // namespace


### PR DESCRIPTION
This patch adds a Clang expression tree cloning utility to `xlscc`, as well as a unit test for it.

It handles most C++ expressions, with one notable exception being lambdas (as they are more complex but probably won't be needed).
It doesn't support non-standard extensions.