### PR TITLE
 Allow if without else in DSLX

### DIFF
--- a/xls/dslx/diagnostics/maybe_explain_error_test.cc
+++ b/xls/dslx/diagnostics/maybe_explain_error_test.cc
@@ -110,5 +110,19 @@ TEST(MaybeExplainErrorTest,
       "note that conditional block @ test.x:2:26-4:6 had a trailing semicolon");
 }
 
+TEST(MaybeExplainErrorTest,
+     ExplainIfConditionalWithoutElseReturnsMismatchingType) {
+  constexpr std::string_view kProgram = R"(fn f() {
+    if true {
+        u32:42
+    }
+}
+)";
+  TypecheckAndExplain(kProgram,
+                      "note that if expression without else from @ "
+                      "test.x:2:13-4:6 evaluates to (). Consider adding an "
+                      "else block that evaluates to the expected type");
+}
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -2069,7 +2069,7 @@ class Conditional : public Expr {
  public:
   Conditional(Module* owner, Span span, Expr* test, StatementBlock* consequent,
               std::variant<StatementBlock*, Conditional*> alternate,
-              bool in_parens = false);
+              bool in_parens = false, bool has_else = true);
 
   ~Conditional() override;
 
@@ -2097,10 +2097,11 @@ class Conditional : public Expr {
     return alternate_;
   }
 
+  bool HasElse() const { return has_else_; }
+
   bool HasElseIf() const {
     return std::holds_alternative<Conditional*>(alternate());
   }
-
   // Returns whether the blocks inside of this (potentially laddered)
   // conditional have multiple statements.
   bool HasMultiStatementBlocks() const;
@@ -2119,6 +2120,7 @@ class Conditional : public Expr {
   Expr* test_;
   StatementBlock* consequent_;
   std::variant<StatementBlock*, Conditional*> alternate_;
+  bool has_else_;
 };
 
 // Represents a member in a parametric binding list.

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -921,7 +921,7 @@ class AstCloner : public AstNodeVisitor {
     old_to_new_[n] = module_->Make<Conditional>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->test())),
         down_cast<StatementBlock*>(old_to_new_.at(n->consequent())),
-        new_alternate, n->in_parens());
+        new_alternate, n->in_parens(), n->HasElse());
     return absl::OkStatus();
   }
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -2564,6 +2564,8 @@ TEST_F(ParserTest, ForFreevars) {
                              absl::flat_hash_set<std::string>{"j", "range"}));
 }
 
+TEST_F(ParserTest, IfWithoutElse) { RoundTripExpr("if true {}"); }
+
 TEST_F(ParserTest, EmptyTernary) { RoundTripExpr("if true {} else {}"); }
 
 TEST_F(ParserTest, TernaryConditional) {

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1311,6 +1311,16 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
         stderr,
     )
 
+  def test_if_without_else_returning_mismatching_type(self):
+    stderr = self._run(
+        "xls/dslx/tests/errors/if_without_else_returning_mismatching_type.x"
+    )
+    self.assertIn("XlsTypeError:", stderr)
+    self.assertIn(
+        "uN[32] vs (): Conditional consequent type (in the 'then' clause) did "
+        "not match alternative type (in the 'else' clause)",
+        stderr,
+    )
 
 if __name__ == '__main__':
   test_base.main()

--- a/xls/dslx/tests/errors/if_without_else_returning_mismatching_type.x
+++ b/xls/dslx/tests/errors/if_without_else_returning_mismatching_type.x
@@ -1,0 +1,17 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn f(predicate: bool) {
+  if predicate { u32:0 }
+}


### PR DESCRIPTION
This PR addresses the changes requested in #1980, enabling the use of `if` expressions without requiring an `else` branch. Additionally, it provides more detailed error messages for failing cases, helping users better understand potential issues with their code. The error message is taken from the rust compiler and resembles the one posted in the issue description (https://github.com/google/xls/issues/1980#issue-2899942121)

Here is an example of the error message, which provides explanation to the user:

* Incorrect DSLX code:
```rust
fn if_without_else_incorrect (predicate: bool) {
    if (predicate) {
        trace_fmt!("This is if with else (if branch)")
    }
}

#[test]
fn test_if_without_else_incorrect() {
    assert_eq(if_without_else_incorrect(true), ());
    assert_eq(if_without_else_incorrect(false), ());
}
```
* Error message:
```
xls/examples/if_no_else.x:42:5-45:1
0040:
0041:   fn if_without_else_incorrect (predicate: bool) {
0042:       if (predicate) {
       _____^
0043: |         trace_fmt!("This is if with else (if branch)")
0044: |     }
0045: | }
      |^ XlsTypeError: token vs (): Conditional consequent type (in the 'then' clause) did not match alternative type (in the 'else' clause); note that if expression without else from @ xls/examples/if_no_else.x:42:20-44:6 evaluates to (). Consider adding an else block that evaluates to the expected type.
0046:
0047:   #[test]
Error parsing and type checking DSLX source file: xls/examples/if_no_else.x
Target //xls/examples:if_no_else_dslx_test failed to build
```

Resolves #1980 
FYI @richmckeever 


