### PR TITLE
Allow #[test_proc] to expect specific assertion failures

### DIFF
--- a/docs_src/tutorials/how_to_use_procs.md
+++ b/docs_src/tutorials/how_to_use_procs.md
@@ -217,6 +217,12 @@ test proc is very similar to a normal proc with the following changes:
     output channel for terminating interpretation. When the test is complete,
     the proc should send the test's status (`true` on success, `false` on
     failure) on that channel (commonly called the "terminator" channel).
+*   The `#[test_proc]` attribute also supports an optional `expected_fail`
+    parameter. This allows writing tests that are expected to fail due to
+    a specific `assert!` or `fail!` condition. The value must match the label
+    on the failing assertion. If a failure with the matching label occurs,
+    the test is treated as successful, and if no such failure happens,
+    the test is treated as failed.
 
 A skeletal example:
 

--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -1486,10 +1486,14 @@ absl::Status BytecodeInterpreter::RunBuiltinFn(const Bytecode& bytecode,
     case Builtin::kFail: {
       XLS_ASSIGN_OR_RETURN(InterpValue value, Pop());
       std::string message{value.ToString()};
+      XLS_ASSIGN_OR_RETURN(InterpValue label, Pop());
+      XLS_ASSIGN_OR_RETURN(std::string label_as_string,
+                           InterpValueAsString(label));
       if (proc_id().has_value()) {
         message += absl::StrFormat(" (called from %s)", proc_id()->ToString());
       }
-      return FailureErrorStatus(bytecode.source_span(), message, file_table());
+      return FailureErrorStatusForAssertion(
+          bytecode.source_span(), label_as_string, message, file_table());
     }
     case Builtin::kAssert: {
       XLS_ASSIGN_OR_RETURN(InterpValue label, Pop());
@@ -1503,8 +1507,8 @@ absl::Status BytecodeInterpreter::RunBuiltinFn(const Bytecode& bytecode,
           message +=
               absl::StrFormat(" (called from %s)", proc_id()->ToString());
         }
-        return FailureErrorStatus(bytecode.source_span(), message,
-                                  file_table());
+        return FailureErrorStatusForAssertion(
+            bytecode.source_span(), label_as_string, message, file_table());
       }
 
       stack_.Push(InterpValue::MakeUnit());

--- a/xls/dslx/errors.h
+++ b/xls/dslx/errors.h
@@ -39,6 +39,13 @@ absl::Status ArgCountMismatchErrorStatus(const Span& span,
 absl::Status FailureErrorStatus(const Span& span, std::string_view message,
                                 const FileTable& file_table);
 
+// Variant of `FailureErrorStatus` for  when interpretation of a design
+// fails on assertion.
+absl::Status FailureErrorStatusForAssertion(const Span& span,
+                                            std::string_view label,
+                                            std::string_view message,
+                                            const FileTable& file_table);
+
 // Returned when proof of a property fails.
 absl::Status ProofErrorStatus(const Span& span, std::string_view message,
                               const FileTable& file_table);
@@ -142,6 +149,11 @@ absl::Status RangeStartGreaterThanEndErrorStatus(const Span& span,
 absl::Status RangeTooLargeErrorStatus(const Span& span, const Range* range,
                                       const InterpValue& size,
                                       const FileTable& file_table);
+
+// Extracts the assertion label from an error message.
+// Intended for use with errors returned by `FailureErrorStatusForAssertion()`.
+std::optional<std::string> GetAssertionLabelFromError(
+    const absl::Status& status);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2445,7 +2445,13 @@ DocRef Formatter::Format(const TestFunction& n) {
 
 DocRef Formatter::Format(const TestProc& n) {
   std::vector<DocRef> pieces;
-  pieces.push_back(arena_.MakeText("#[test_proc]"));
+  if (n.expected_fail_label().has_value()) {
+    pieces.push_back(arena_.MakeText(
+        absl::StrFormat("#[test_proc(expected_fail_label=\"%s\")]",
+                        n.expected_fail_label().value())));
+  } else {
+    pieces.push_back(arena_.MakeText("#[test_proc]"));
+  }
   pieces.push_back(arena_.hard_line());
   pieces.push_back(Format(*n.proc()));
   return ConcatN(arena_, pieces);

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -2448,6 +2448,24 @@ proc p_test {
 )");
 }
 
+TEST_F(ModuleFmtTest, SimpleTestProcWithExpectedFailLabelAttribute) {
+  DoFmt(
+      R"(#[test_proc(expected_fail_label="my_fail")]
+proc tester {
+    terminator: chan<bool> out;
+
+    config(terminator: chan<bool> out) { (terminator,) }
+
+    init {  }
+
+    next(_: ()) {
+        assert!(false, "my_fail");
+        send(join(), terminator, true);
+    }
+}
+)");
+}
+
 TEST_F(ModuleFmtTest, MatchLongWildcardArmExpression) {
   DoFmt(
       R"(import float32;

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -947,8 +947,8 @@ class AstCloner : public AstNodeVisitor {
   absl::Status HandleTestProc(const TestProc* n) override {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
-    old_to_new_[n] =
-        module_->Make<TestProc>(down_cast<Proc*>(old_to_new_.at(n->proc())));
+    old_to_new_[n] = module_->Make<TestProc>(
+        down_cast<Proc*>(old_to_new_.at(n->proc())), n->expected_fail_label());
     return absl::OkStatus();
   }
 

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -815,8 +815,29 @@ Parser::ParseAttribute(absl::flat_hash_map<std::string, Function*>* name_to_fn,
         peek->span(), absl::StrCat("Invalid test type: ", peek->ToString()));
   }
   if (attribute_name == "test_proc") {
+    std::optional<std::string> expected_fail_label = std::nullopt;
+    XLS_ASSIGN_OR_RETURN(const Token* peek, PeekToken());
+    if (peek->kind() == TokenKind::kOParen) {
+      XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kOParen));
+      XLS_ASSIGN_OR_RETURN(Token parameter_name,
+                           PopTokenOrError(TokenKind::kIdentifier));
+
+      if (parameter_name.GetStringValue() == "expected_fail_label") {
+        XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kEquals));
+        XLS_ASSIGN_OR_RETURN(Token parameter_value,
+                             PopTokenOrError(TokenKind::kString));
+        expected_fail_label = parameter_value.GetStringValue();
+      } else {
+        return ParseErrorStatus(
+            attribute_tok.span(),
+            absl::StrFormat(
+                "Unknown parameter name in the #[test_proc] attribute: '%s'",
+                parameter_name.ToString()));
+      }
+      XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kCParen));
+    }
     XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kCBrack));
-    return ParseTestProc(bindings);
+    return ParseTestProc(bindings, expected_fail_label);
   }
   return ParseErrorStatus(
       attribute_tok.span(),
@@ -3965,7 +3986,8 @@ absl::StatusOr<TestFunction*> Parser::ParseTestFunction(
   return tf;
 }
 
-absl::StatusOr<TestProc*> Parser::ParseTestProc(Bindings& bindings) {
+absl::StatusOr<TestProc*> Parser::ParseTestProc(
+    Bindings& bindings, std::optional<std::string> expected_fail_label) {
   XLS_ASSIGN_OR_RETURN(ModuleMember m,
                        ParseProc(GetPos(), /*is_public=*/false, bindings));
   if (!std::holds_alternative<Proc*>(m)) {
@@ -3987,7 +4009,7 @@ absl::StatusOr<TestProc*> Parser::ParseTestProc(Bindings& bindings) {
   }
 
   // Verify no state or config args
-  return module_->Make<TestProc>(p);
+  return module_->Make<TestProc>(p, expected_fail_label);
 }
 
 const Span& GetSpan(

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -619,7 +619,8 @@ class Parser : public TokenParser {
   absl::StatusOr<TestFunction*> ParseTestFunction(Bindings& bindings,
                                                   const Span& attribute_span);
 
-  absl::StatusOr<TestProc*> ParseTestProc(Bindings& bindings);
+  absl::StatusOr<TestProc*> ParseTestProc(
+      Bindings& bindings, std::optional<std::string> expected_fail_label);
 
   // Parses a constant definition (e.g. at the top level of a module). Token
   // cursor should be over the `const` keyword.

--- a/xls/dslx/frontend/proc.cc
+++ b/xls/dslx/frontend/proc.cc
@@ -154,6 +154,10 @@ std::string ProcLike::ToString() const {
 TestProc::~TestProc() = default;
 
 std::string TestProc::ToString() const {
+  if (expected_fail_label_.has_value()) {
+    return absl::StrFormat("#[test_proc(expected_fail_label=\"%s\")]\n%s",
+                           *expected_fail_label_, proc_->ToString());
+  }
   return absl::StrFormat("#[test_proc]\n%s", proc_->ToString());
 }
 

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -203,7 +203,11 @@ class TestProc : public AstNode {
  public:
   static std::string_view GetDebugTypeName() { return "test proc"; }
 
-  TestProc(Module* owner, Proc* proc) : AstNode(owner), proc_(proc) {}
+  TestProc(Module* owner, Proc* proc,
+           std::optional<std::string> expected_fail_label = std::nullopt)
+      : AstNode(owner),
+        proc_(proc),
+        expected_fail_label_(expected_fail_label) {}
   ~TestProc() override;
 
   AstNodeKind kind() const override { return AstNodeKind::kTestProc; }
@@ -221,9 +225,13 @@ class TestProc : public AstNode {
   std::optional<Span> GetSpan() const override { return proc_->span(); }
 
   const std::string& identifier() const { return proc_->identifier(); }
+  std::optional<std::string> expected_fail_label() const {
+    return expected_fail_label_;
+  }
 
  private:
   Proc* proc_;
+  std::optional<std::string> expected_fail_label_;
 };
 
 }  // namespace xls::dslx


### PR DESCRIPTION
This commit introduces the ability to specify that a test proc is expected to fail on a particular `assert!` or `fail!` in the DSLX interpreter. The `#[test_proc]` attribute accepts an optional `expected_fail` parameter. with the label marking the failure. If a failure occurs with the matching label, the test is treated as successful.

The choice to implement this as an attribute, rather than a built-in, as discussed in https://github.com/google/xls/issues/1071#issuecomment-1642453871 was motivated by cases where there's no clear location to “catch” the failure. For example, a test that spawns a proc containing only a single `fail!` statement.

The functionality is implemented by storing the `expected_fail` value in the `TestProc` object. When an `assert!` or `fail!` is handled in the DSLX interpreter, the label of the failure is attached to the error using an `absl::Status` payload. This is then compared in `RunDslxTestProc` against the stored label in the `TestProc`.

Resolves #1071
