### PR TITLE
Add support for #[cfg(test)] attribute

### DIFF
--- a/xls/codegen/vast/translate_vast_to_dslx.cc
+++ b/xls/codegen/vast/translate_vast_to_dslx.cc
@@ -569,7 +569,7 @@ class VastToDslxTranslator {
         CreateNodeSpan(function), fn_name,
         /*parametric_bindings=*/std::vector<dslx::ParametricBinding*>(), params,
         fn_type, block, dslx::FunctionTag::kNormal,
-        /*is_public=*/true);
+        /*is_public=*/true, /*is_test_utility=*/false);
     XLS_RETURN_IF_ERROR(module().AddTop(fn, /*make_collision_error=*/nullptr));
     fn_name->set_definer(fn);
     return fn;

--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -618,6 +618,22 @@ absl::Status BytecodeInterpreter::EvalCall(const Bytecode& bytecode) {
                        GetBytecodeFn(*user_fn_data.function, data.invocation(),
                                      caller_bindings));
 
+  if (user_fn_data.function->test_only()) {
+    const Function* callee = user_fn_data.function;
+    const Function* caller = frames_.back().bf()->source_fn();
+
+    bool is_init =
+        callee->IsInProc() &&
+        callee->identifier() == (*callee->proc())->init().identifier();
+
+    // init() has no caller, so cannot be called incorrectly
+    if (!is_init && !caller->test_only()) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "Test utility function '%s' can only be called from tests",
+          callee->identifier()));
+    }
+  }
+
   // Store the _return_ PC.
   frames_.back().IncrementPc();
 

--- a/xls/dslx/bytecode/bytecode_interpreter.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter.cc
@@ -618,7 +618,7 @@ absl::Status BytecodeInterpreter::EvalCall(const Bytecode& bytecode) {
                        GetBytecodeFn(*user_fn_data.function, data.invocation(),
                                      caller_bindings));
 
-  if (user_fn_data.function->test_only()) {
+  if (user_fn_data.function->is_test_utility()) {
     const Function* callee = user_fn_data.function;
     const Function* caller = frames_.back().bf()->source_fn();
 
@@ -627,7 +627,7 @@ absl::Status BytecodeInterpreter::EvalCall(const Bytecode& bytecode) {
         callee->identifier() == (*callee->proc())->init().identifier();
 
     // init() has no caller, so cannot be called incorrectly
-    if (!is_init && !caller->test_only()) {
+    if (!is_init && !caller->is_test_utility()) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "Test utility function '%s' can only be called from tests",
           callee->identifier()));

--- a/xls/dslx/bytecode/bytecode_interpreter_test.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter_test.cc
@@ -1664,6 +1664,28 @@ fn caller(a: u32) -> u32{
   EXPECT_EQ(int_val, 400);
 }
 
+TEST_F(BytecodeInterpreterTest, NormalFunctionCallsTestUtility) {
+  constexpr std::string_view kProgram = R"(
+#[cfg(test)]
+fn callee(x: u32, y: u32) -> u32 {
+  x + y
+}
+
+fn caller() -> u32{
+  let a = u32:100;
+  let b = u32:200;
+  callee(a, b)
+})";
+
+  absl::StatusOr<InterpValue> value = Interpret(kProgram, "caller");
+  EXPECT_THAT(
+      value.status(),
+      StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          HasSubstr(
+              "Test utility function 'callee' can only be called from tests")));
+}
+
 TEST_F(BytecodeInterpreterTest, SimpleParametric) {
   constexpr std::string_view kProgram = R"(
 fn foo<N: u32>(x: uN[N]) -> uN[N] {

--- a/xls/dslx/fmt/BUILD
+++ b/xls/dslx/fmt/BUILD
@@ -73,6 +73,7 @@ cc_library(
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:ast_cloner",
         "//xls/dslx/frontend:ast_node",
+        "//xls/dslx/frontend:ast_utils",
         "//xls/dslx/frontend:comment_data",
         "//xls/dslx/frontend:module",
         "//xls/dslx/frontend:pos",

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2209,7 +2209,7 @@ DocRef Formatter::Format(const Function& n, bool is_test) {
                             arena_.MakeText("\")]"),
                             arena_.hard_line(),
                         }));
-  } else if (n.test_only() && !is_test) {
+  } else if (n.is_test_utility() && !is_test) {
     fn_pieces.push_back(
         ConcatN(arena_, {
                             arena_.MakeText("#"),
@@ -2248,7 +2248,7 @@ DocRef Formatter::Format(const ProcMember& n) {
 
 DocRef Formatter::Format(const Proc& n, bool is_test) {
   std::vector<DocRef> attribute_pieces;
-  if (n.test_only() && !is_test) {
+  if (n.is_test_utility() && !is_test) {
     attribute_pieces.push_back(
         ConcatN(arena_, {
                             arena_.MakeText("#"),

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2249,8 +2249,14 @@ DocRef Formatter::Format(const ProcMember& n) {
 DocRef Formatter::Format(const Proc& n, bool is_test) {
   std::vector<DocRef> attribute_pieces;
   if (n.test_only() && !is_test) {
-    attribute_pieces.push_back(arena_.MakeText("#[cfg(test)]"));
-    attribute_pieces.push_back(arena_.hard_line());
+    attribute_pieces.push_back(
+        ConcatN(arena_, {
+                            arena_.MakeText("#"),
+                            arena_.obracket(),
+                            arena_.MakeText(std::string(kCfgTestAttr)),
+                            arena_.cbracket(),
+                            arena_.hard_line(),
+                        }));
   }
 
   std::vector<DocRef> signature_pieces;

--- a/xls/dslx/fmt/ast_fmt.h
+++ b/xls/dslx/fmt/ast_fmt.h
@@ -41,7 +41,7 @@ class Formatter {
   // keep-sorted start
   // Each `Format` method creates a pretty-printable document from the given AST
   // node `n`.
-  DocRef Format(const Function& n);
+  DocRef Format(const Function& n, bool is_test = false);
   DocRef Format(const Expr& n);
   DocRef Format(const Let& n, bool trailing_semi);
   absl::StatusOr<DocRef> Format(const Module& n);
@@ -63,7 +63,7 @@ class Formatter {
   DocRef Format(const ModuleMember& n);
   DocRef Format(const ParametricBinding& n);
   DocRef Format(const ParametricBinding* n);
-  DocRef Format(const Proc& n);
+  DocRef Format(const Proc& n, bool is_test = false);
   DocRef Format(const ProcDef& n);
   DocRef Format(const ProcMember& n);
   DocRef Format(const QuickCheck& n);

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1820,6 +1820,15 @@ fn my_test() {
 )");
 }
 
+TEST_F(ModuleFmtTest, SimpleTestUtilityFunction) {
+  DoFmt(
+      R"(#[cfg(test)]
+fn assert_value_is_0<N: u32>(a: uN[N]) {
+    assert_eq(0, a);
+}
+)");
+}
+
 TEST_F(ModuleFmtTest, SimpleParametricInvocation) {
   DoFmt(
       R"(fn p<N: u32>(x: bits[N]) -> bits[N] { x }
@@ -2461,6 +2470,26 @@ proc tester {
     next(_: ()) {
         assert!(false, "my_fail");
         send(join(), terminator, true);
+    }
+}
+)");
+}
+
+TEST_F(ModuleFmtTest, SimpleTestUtilityProc) {
+  DoFmt(
+      R"(#[cfg(test)]
+proc TestUtilityProc {
+    req_r: chan<()> in;
+    resp_s: chan<()> out;
+
+    config(req_r: chan<()> in, resp_s: chan<()> out) { (req_r, resp_s) }
+
+    init {  }
+
+    next(state: ()) {
+        let (tok, _) = recv(join(), req_r);
+        trace_fmt!("Message from a TestUtilityProc");
+        send(tok, resp_s, ());
     }
 }
 )");

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -235,7 +235,7 @@ class FunctionFmtTest : public testing::Test {
 
     XLS_ASSIGN_OR_RETURN(
         f_, parser_->ParseFunction(Pos(), /*is_public=*/false,
-                                   /*test_only=*/false, bindings_));
+                                   /*is_test_utility=*/false, bindings_));
     Comments comments = Comments::Create(scanner_->comments());
 
     DocRef doc = Formatter(comments, arena_).Format(*f_);

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -234,7 +234,8 @@ class FunctionFmtTest : public testing::Test {
     }
 
     XLS_ASSIGN_OR_RETURN(
-        f_, parser_->ParseFunction(Pos(), /*is_public=*/false, bindings_));
+        f_, parser_->ParseFunction(Pos(), /*is_public=*/false,
+                                   /*test_only=*/false, bindings_));
     Comments comments = Comments::Create(scanner_->comments());
 
     DocRef doc = Formatter(comments, arena_).Format(*f_);

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -2197,7 +2197,10 @@ std::string Function::ToString() const {
   }
   std::string pub_str = is_public() ? "pub " : "";
   std::string annotation_str;
-  if (extern_verilog_module_.has_value()) {
+
+  if (test_only()) {
+    annotation_str = "#[cfg(test)]\n";
+  } else if (extern_verilog_module_.has_value()) {
     annotation_str = absl::StrFormat("#[extern_verilog(\"%s\")]\n",
                                      extern_verilog_module_->code_template());
   }

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -2115,7 +2115,7 @@ Function::Function(Module* owner, Span span, NameDef* name_def,
                    std::vector<ParametricBinding*> parametric_bindings,
                    std::vector<Param*> params, TypeAnnotation* return_type,
                    StatementBlock* body, FunctionTag tag, bool is_public,
-                   bool test_only)
+                   bool is_test_utility)
     : AstNode(owner),
       span_(std::move(span)),
       name_def_(name_def),
@@ -2125,7 +2125,7 @@ Function::Function(Module* owner, Span span, NameDef* name_def,
       body_(body),
       tag_(tag),
       is_public_(is_public),
-      test_only_(test_only) {
+      is_test_utility_(is_test_utility) {
   for (const ParametricBinding* pb : parametric_bindings_) {
     CHECK(parametric_keys_.insert(pb->identifier()).second)
         << "Duplicate parametric binding: " << pb->identifier();
@@ -2200,7 +2200,7 @@ std::string Function::ToString() const {
   std::string pub_str = is_public() ? "pub " : "";
   std::string annotation_str;
 
-  if (test_only()) {
+  if (is_test_utility()) {
     annotation_str = "#[cfg(test)]\n";
   } else if (extern_verilog_module_.has_value()) {
     annotation_str = absl::StrFormat("#[extern_verilog(\"%s\")]\n",

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -2201,7 +2201,7 @@ std::string Function::ToString() const {
   std::string annotation_str;
 
   if (is_test_utility()) {
-    annotation_str = "#[cfg(test)]\n";
+    annotation_str = absl::StrFormat("#[%s]\n", kCfgTestAttr);
   } else if (extern_verilog_module_.has_value()) {
     annotation_str = absl::StrFormat("#[extern_verilog(\"%s\")]\n",
                                      extern_verilog_module_->code_template());

--- a/xls/dslx/frontend/ast.cc
+++ b/xls/dslx/frontend/ast.cc
@@ -2114,7 +2114,8 @@ std::string ForLoopBase::ToStringInternal() const {
 Function::Function(Module* owner, Span span, NameDef* name_def,
                    std::vector<ParametricBinding*> parametric_bindings,
                    std::vector<Param*> params, TypeAnnotation* return_type,
-                   StatementBlock* body, FunctionTag tag, bool is_public)
+                   StatementBlock* body, FunctionTag tag, bool is_public,
+                   bool test_only)
     : AstNode(owner),
       span_(std::move(span)),
       name_def_(name_def),
@@ -2123,7 +2124,8 @@ Function::Function(Module* owner, Span span, NameDef* name_def,
       return_type_(return_type),
       body_(body),
       tag_(tag),
-      is_public_(is_public) {
+      is_public_(is_public),
+      test_only_(test_only) {
   for (const ParametricBinding* pb : parametric_bindings_) {
     CHECK(parametric_keys_.insert(pb->identifier()).second)
         << "Duplicate parametric binding: " << pb->identifier();

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -2373,6 +2373,8 @@ class Function : public AstNode {
     disable_format_ = disable_format;
   }
   bool disable_format() const { return disable_format_; }
+  void set_test_only(bool test_only) { test_only_ = test_only; }
+  bool test_only() const { return test_only_; }
 
   FunctionTag tag() const { return tag_; }
   std::optional<Proc*> proc() const { return proc_; }
@@ -2405,6 +2407,7 @@ class Function : public AstNode {
   const bool is_public_;
   std::optional<ForeignFunctionData> extern_verilog_module_;
   bool disable_format_ = false;
+  bool test_only_ = false;
 };
 
 // A lambda expression.

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -2299,7 +2299,7 @@ class Function : public AstNode {
            std::vector<ParametricBinding*> parametric_bindings,
            std::vector<Param*> params, TypeAnnotation* return_type,
            StatementBlock* body, FunctionTag tag, bool is_public,
-           bool test_only);
+           bool is_test_utility);
 
   ~Function() override;
   AstNodeKind kind() const override { return AstNodeKind::kFunction; }
@@ -2331,7 +2331,7 @@ class Function : public AstNode {
 
   bool IsParametric() const { return !parametric_bindings_.empty(); }
   bool is_public() const { return is_public_; }
-  bool test_only() const { return test_only_; }
+  bool is_test_utility() const { return is_test_utility_; }
   bool IsMethod() const;
 
   // Returns all of the parametric identifiers that must be bound by the caller
@@ -2405,7 +2405,7 @@ class Function : public AstNode {
   std::optional<Impl*> impl_;
 
   const bool is_public_;
-  const bool test_only_;
+  const bool is_test_utility_;
   std::optional<ForeignFunctionData> extern_verilog_module_;
   bool disable_format_ = false;
 };

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -141,6 +141,7 @@
 namespace xls::dslx {
 
 inline constexpr int64_t kRustSpacesPerIndent = 4;
+inline constexpr std::string_view kCfgTestAttr = "cfg(test)";
 
 // Forward decls of all leaf types.
 #define FORWARD_DECL(__type) class __type;

--- a/xls/dslx/frontend/ast.h
+++ b/xls/dslx/frontend/ast.h
@@ -2298,7 +2298,8 @@ class Function : public AstNode {
   Function(Module* owner, Span span, NameDef* name_def,
            std::vector<ParametricBinding*> parametric_bindings,
            std::vector<Param*> params, TypeAnnotation* return_type,
-           StatementBlock* body, FunctionTag tag, bool is_public);
+           StatementBlock* body, FunctionTag tag, bool is_public,
+           bool test_only);
 
   ~Function() override;
   AstNodeKind kind() const override { return AstNodeKind::kFunction; }
@@ -2330,6 +2331,7 @@ class Function : public AstNode {
 
   bool IsParametric() const { return !parametric_bindings_.empty(); }
   bool is_public() const { return is_public_; }
+  bool test_only() const { return test_only_; }
   bool IsMethod() const;
 
   // Returns all of the parametric identifiers that must be bound by the caller
@@ -2373,8 +2375,6 @@ class Function : public AstNode {
     disable_format_ = disable_format;
   }
   bool disable_format() const { return disable_format_; }
-  void set_test_only(bool test_only) { test_only_ = test_only; }
-  bool test_only() const { return test_only_; }
 
   FunctionTag tag() const { return tag_; }
   std::optional<Proc*> proc() const { return proc_; }
@@ -2405,9 +2405,9 @@ class Function : public AstNode {
   std::optional<Impl*> impl_;
 
   const bool is_public_;
+  const bool test_only_;
   std::optional<ForeignFunctionData> extern_verilog_module_;
   bool disable_format_ = false;
-  bool test_only_ = false;
 };
 
 // A lambda expression.

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -397,7 +397,8 @@ class AstCloner : public AstNodeVisitor {
         CastIfNotVerbatim<StatementBlock*>(old_to_new_.at(n->body())));
     auto new_function = module_->Make<Function>(
         n->span(), new_name_def, new_parametric_bindings, new_params,
-        new_return_type, new_body, n->tag(), n->is_public(), n->test_only());
+        new_return_type, new_body, n->tag(), n->is_public(),
+        n->is_test_utility());
     if (n->extern_verilog_module().has_value()) {
       new_function->set_extern_verilog_module(*n->extern_verilog_module());
     }

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -397,12 +397,11 @@ class AstCloner : public AstNodeVisitor {
         CastIfNotVerbatim<StatementBlock*>(old_to_new_.at(n->body())));
     auto new_function = module_->Make<Function>(
         n->span(), new_name_def, new_parametric_bindings, new_params,
-        new_return_type, new_body, n->tag(), n->is_public());
+        new_return_type, new_body, n->tag(), n->is_public(), n->test_only());
     if (n->extern_verilog_module().has_value()) {
       new_function->set_extern_verilog_module(*n->extern_verilog_module());
     }
     new_function->set_disable_format(n->disable_format());
-    new_function->set_test_only(n->test_only());
     old_to_new_[n] = new_function;
     new_name_def->set_definer(old_to_new_.at(n));
     if (n->impl().has_value()) {

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -402,6 +402,7 @@ class AstCloner : public AstNodeVisitor {
       new_function->set_extern_verilog_module(*n->extern_verilog_module());
     }
     new_function->set_disable_format(n->disable_format());
+    new_function->set_test_only(n->test_only());
     old_to_new_[n] = new_function;
     new_name_def->set_definer(old_to_new_.at(n));
     if (n->impl().has_value()) {

--- a/xls/dslx/frontend/ast_test.cc
+++ b/xls/dslx/frontend/ast_test.cc
@@ -231,9 +231,9 @@ TEST(AstTest, GetFuncParam) {
   StatementBlock* block =
       m.Make<StatementBlock>(fake_span, std::vector<Statement*>{}, true);
 
-  Function* f =
-      m.Make<Function>(fake_span, func_name_def, parametric_bindings, params,
-                       u32_type_annotation, block, FunctionTag::kNormal, false);
+  Function* f = m.Make<Function>(fake_span, func_name_def, parametric_bindings,
+                                 params, u32_type_annotation, block,
+                                 FunctionTag::kNormal, false, false);
 
   XLS_ASSERT_OK_AND_ASSIGN(Param * found_param, f->GetParamByName("p"));
   EXPECT_EQ(found_param, params[0]);

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -34,6 +34,8 @@
 
 namespace xls::dslx {
 
+inline constexpr std::string_view kCfgTestAttr = "cfg(test)";
+
 // Returns true if `callee` refers to a builtin function. If `callee` isn't a
 // NameRef, then this always returns false.
 //

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -34,8 +34,6 @@
 
 namespace xls::dslx {
 
-inline constexpr std::string_view kCfgTestAttr = "cfg(test)";
-
 // Returns true if `callee` refers to a builtin function. If `callee` isn't a
 // NameRef, then this always returns false.
 //

--- a/xls/dslx/frontend/module.h
+++ b/xls/dslx/frontend/module.h
@@ -237,6 +237,9 @@ class Module : public AstNode {
   std::vector<ProcDef*> GetProcDefs() { return GetTopWithT<ProcDef>(); }
 
   std::vector<Proc*> GetProcs() const { return GetTopWithT<Proc>(); }
+  std::vector<TestProc*> GetTestProcs() const {
+    return GetTopWithT<TestProc>();
+  }
 
   std::vector<Impl*> GetImpls() const { return GetTopWithT<Impl>(); }
 

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -220,14 +220,16 @@ absl::Status Parser::ParseErrorStatus(const Span& span,
 absl::StatusOr<Function*> Parser::ParseImplFunction(
     const Pos& start_pos, bool is_public, Bindings& bindings,
     TypeAnnotation* struct_ref) {
-  return ParseFunctionInternal(start_pos, is_public, bindings, struct_ref);
+  return ParseFunctionInternal(start_pos, is_public, /*test_only=*/false,
+                               bindings, struct_ref);
 }
 
 absl::StatusOr<Function*> Parser::ParseFunction(
-    const Pos& start_pos, bool is_public, Bindings& bindings,
+    const Pos& start_pos, bool is_public, bool test_only, Bindings& bindings,
     absl::flat_hash_map<std::string, Function*>* name_to_fn) {
-  XLS_ASSIGN_OR_RETURN(Function * f,
-                       ParseFunctionInternal(start_pos, is_public, bindings));
+  XLS_ASSIGN_OR_RETURN(
+      Function * f,
+      ParseFunctionInternal(start_pos, is_public, test_only, bindings));
   if (name_to_fn == nullptr) {
     return f;
   }
@@ -355,15 +357,17 @@ absl::StatusOr<std::unique_ptr<Module>> Parser::ParseModule(
         XLS_ASSIGN_OR_RETURN(
             Function * fn,
             ParseFunction(start_pos,
-                          /*is_public=*/true, *bindings, &name_to_fn));
+                          /*is_public=*/true, /*test_only=*/false, *bindings,
+                          &name_to_fn));
         XLS_RETURN_IF_ERROR(module_->AddTop(fn, make_collision_error));
         continue;
       }
 
       if (peek->IsKeyword(Keyword::kProc)) {
-        XLS_ASSIGN_OR_RETURN(ModuleMember proc,
-                             ParseProc(start_pos,
-                                       /*is_public=*/true, *bindings));
+        XLS_ASSIGN_OR_RETURN(
+            ModuleMember proc,
+            ParseProc(start_pos,
+                      /*is_public=*/true, /*test_only=*/false, *bindings));
         XLS_RETURN_IF_ERROR(module_->AddTop(proc, make_collision_error));
         continue;
       }
@@ -480,14 +484,16 @@ absl::StatusOr<std::unique_ptr<Module>> Parser::ParseModule(
         XLS_ASSIGN_OR_RETURN(
             Function * fn,
             ParseFunction(GetPos(),
-                          /*is_public=*/false, *bindings, &name_to_fn));
+                          /*is_public=*/false, /*test_only=*/false, *bindings,
+                          &name_to_fn));
         XLS_RETURN_IF_ERROR(module_->AddTop(fn, make_collision_error));
         break;
       }
       case Keyword::kProc: {
-        XLS_ASSIGN_OR_RETURN(ModuleMember proc,
-                             ParseProc(GetPos(),
-                                       /*is_public=*/false, *bindings));
+        XLS_ASSIGN_OR_RETURN(
+            ModuleMember proc,
+            ParseProc(GetPos(),
+                      /*is_public=*/false, /*test_only=*/false, *bindings));
         XLS_RETURN_IF_ERROR(module_->AddTop(proc, make_collision_error));
         break;
       }
@@ -730,8 +736,9 @@ Parser::ParseAttribute(absl::flat_hash_map<std::string, Function*>* name_to_fn,
   if (attribute_name == "dslx_format_disable") {
     XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kCBrack));
     XLS_ASSIGN_OR_RETURN(bool is_public, TryDropKeyword(Keyword::kPub));
-    XLS_ASSIGN_OR_RETURN(Function * fn, ParseFunction(hash_pos, is_public,
-                                                      bindings, name_to_fn));
+    XLS_ASSIGN_OR_RETURN(Function * fn,
+                         ParseFunction(hash_pos, is_public, /*test_only=*/false,
+                                       bindings, name_to_fn));
     fn->set_disable_format(true);
     return fn;
   }
@@ -753,15 +760,15 @@ Parser::ParseAttribute(absl::flat_hash_map<std::string, Function*>* name_to_fn,
 
     XLS_ASSIGN_OR_RETURN(const Token* t, PeekToken());
     if (t->IsKeyword(Keyword::kFn)) {
-      XLS_ASSIGN_OR_RETURN(Function * fn, ParseFunction(hash_pos, is_public,
-                                                        bindings, name_to_fn));
-      fn->set_test_only(true);
+      XLS_ASSIGN_OR_RETURN(
+          Function * fn, ParseFunction(hash_pos, is_public, /*test_only=*/true,
+                                       bindings, name_to_fn));
       return fn;
     } else if (t->IsKeyword(Keyword::kProc)) {
       XLS_ASSIGN_OR_RETURN(ModuleMember m,
-                           ParseProc(GetPos(), /*is_public=*/false, bindings));
+                           ParseProc(GetPos(), /*is_public=*/false,
+                                     /*test_only=*/true, bindings));
       Proc* p = std::get<Proc*>(m);
-      p->set_test_only(true);
       return p;
     } else {
       return ParseErrorStatus(
@@ -782,8 +789,8 @@ Parser::ParseAttribute(absl::flat_hash_map<std::string, Function*>* name_to_fn,
     XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kCBrack));
     XLS_ASSIGN_OR_RETURN(bool dropped_pub, TryDropKeyword(Keyword::kPub));
     XLS_ASSIGN_OR_RETURN(
-        Function * f,
-        ParseFunction(template_start, dropped_pub, bindings, name_to_fn));
+        Function * f, ParseFunction(template_start, dropped_pub,
+                                    /*test_only=*/false, bindings, name_to_fn));
     absl::StatusOr<ForeignFunctionData> parsed_ffi_annotation =
         ForeignFunctionDataCreateFromTemplate(ffi_annotation);
     if (!parsed_ffi_annotation.ok()) {
@@ -1970,8 +1977,8 @@ absl::StatusOr<Import*> Parser::ParseImport(Bindings& bindings) {
 }
 
 absl::StatusOr<Function*> Parser::ParseFunctionInternal(
-    const Pos& start_pos, bool is_public, Bindings& outer_bindings,
-    TypeAnnotation* struct_ref) {
+    const Pos& start_pos, bool is_public, bool test_only,
+    Bindings& outer_bindings, TypeAnnotation* struct_ref) {
   XLS_ASSIGN_OR_RETURN(Token fn_tok, PopKeywordOrError(Keyword::kFn));
 
   XLS_ASSIGN_OR_RETURN(NameDef * name_def, ParseNameDef(outer_bindings));
@@ -2017,7 +2024,7 @@ absl::StatusOr<Function*> Parser::ParseFunctionInternal(
   }
   Function* f = module_->Make<Function>(
       Span(start_pos, GetPos()), name_def, std::move(parametric_bindings),
-      params, return_type, body, FunctionTag::kNormal, is_public);
+      params, return_type, body, FunctionTag::kNormal, is_public, test_only);
   name_def->set_definer(f);
   return f;
 }
@@ -2054,8 +2061,8 @@ absl::StatusOr<QuickCheck*> Parser::ParseQuickCheck(
 
   XLS_RETURN_IF_ERROR(DropTokenOrError(TokenKind::kCBrack));
   XLS_ASSIGN_OR_RETURN(
-      Function * fn,
-      ParseFunction(GetPos(), /*is_public=*/false, bindings, name_to_fn));
+      Function * fn, ParseFunction(GetPos(), /*is_public=*/false,
+                                   /*test_only=*/false, bindings, name_to_fn));
   const Span quickcheck_span(hash_pos, fn->span().limit());
   return module_->Make<QuickCheck>(quickcheck_span, fn, test_cases.value());
 }
@@ -2802,7 +2809,7 @@ absl::StatusOr<Function*> Parser::ParseProcConfig(
     Bindings& outer_bindings,
     std::vector<ParametricBinding*> parametric_bindings,
     const std::vector<ProcMember*>& proc_members, std::string_view proc_name,
-    bool is_public) {
+    bool is_public, bool test_only) {
   Bindings bindings(&outer_bindings);
   XLS_ASSIGN_OR_RETURN(Token config_tok,
                        PopTokenOrError(TokenKind::kIdentifier));
@@ -2851,7 +2858,7 @@ absl::StatusOr<Function*> Parser::ParseProcConfig(
   Function* config = module_->Make<Function>(
       block->span(), name_def, std::move(parametric_bindings),
       std::move(config_params), return_type, block, FunctionTag::kProcConfig,
-      is_public);
+      is_public, test_only);
   name_def->set_definer(config);
 
   return config;
@@ -2859,7 +2866,7 @@ absl::StatusOr<Function*> Parser::ParseProcConfig(
 
 absl::StatusOr<Function*> Parser::ParseProcNext(
     Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-    std::string_view proc_name, bool is_public) {
+    std::string_view proc_name, bool is_public, bool test_only) {
   Bindings inner_bindings(&bindings);
   inner_bindings.NoteFunctionScoped();
 
@@ -2904,10 +2911,10 @@ absl::StatusOr<Function*> Parser::ParseProcNext(
   Span span(oparen.span().start(), GetPos());
   NameDef* name_def =
       module_->Make<NameDef>(span, absl::StrCat(proc_name, ".next"), nullptr);
-  Function* next =
-      module_->Make<Function>(span, name_def, std::move(parametric_bindings),
-                              std::vector<Param*>({state_param}), return_type,
-                              body, FunctionTag::kProcNext, is_public);
+  Function* next = module_->Make<Function>(
+      span, name_def, std::move(parametric_bindings),
+      std::vector<Param*>({state_param}), return_type, body,
+      FunctionTag::kProcNext, is_public, test_only);
   name_def->set_definer(next);
 
   return next;
@@ -2917,7 +2924,7 @@ absl::StatusOr<Function*> Parser::ParseProcNext(
 // type.
 absl::StatusOr<Function*> Parser::ParseProcInit(
     Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-    std::string_view proc_name, bool is_public) {
+    std::string_view proc_name, bool is_public, bool test_only) {
   Bindings inner_bindings(&bindings);
   XLS_ASSIGN_OR_RETURN(Token init_identifier, PopToken());
   if (!init_identifier.IsIdentifier("init")) {
@@ -2934,8 +2941,8 @@ absl::StatusOr<Function*> Parser::ParseProcInit(
   Span span(init_identifier.span().start(), GetPos());
   Function* init = module_->Make<Function>(
       span, name_def, std::move(parametric_bindings), std::vector<Param*>(),
-      /*return_type=*/nullptr, body, FunctionTag::kProcInit,
-      /*is_public=*/is_public);
+      /*return_type=*/nullptr, body, FunctionTag::kProcInit, is_public,
+      test_only);
   name_def->set_definer(init);
   return init;
 }
@@ -2958,6 +2965,7 @@ std::vector<StructMemberNode*> ConvertProcMembersToStructMembers(
 template <typename T>
 absl::StatusOr<ModuleMember> Parser::ParseProcLike(const Pos& start_pos,
                                                    bool is_public,
+                                                   bool test_only,
                                                    Bindings& outer_bindings,
                                                    Keyword keyword) {
   XLS_ASSIGN_OR_RETURN(Token leading_token, PopKeywordOrError(keyword));
@@ -3051,11 +3059,12 @@ absl::StatusOr<ModuleMember> Parser::ParseProcLike(const Pos& start_pos,
       // type aliases and similar. As a result, we use `proc_bindings` instead
       // of `member_bindings` as the base bindings here.
       Bindings this_bindings(&proc_bindings);
-      XLS_ASSIGN_OR_RETURN(Function * config,
-                           ParseProcConfig(this_bindings, parametric_bindings,
-                                           proc_like_body.members,
-                                           name_def->identifier(), is_public),
-                           _.With(specialize_config_name_error));
+      XLS_ASSIGN_OR_RETURN(
+          Function * config,
+          ParseProcConfig(this_bindings, parametric_bindings,
+                          proc_like_body.members, name_def->identifier(),
+                          is_public, test_only),
+          _.With(specialize_config_name_error));
 
       proc_like_body.config = config;
 
@@ -3072,9 +3081,10 @@ absl::StatusOr<ModuleMember> Parser::ParseProcLike(const Pos& start_pos,
 
       // Note: parsing of the `next()` function does have access to members,
       // unlike `config()`.
-      XLS_ASSIGN_OR_RETURN(Function * next,
-                           ParseProcNext(member_bindings, parametric_bindings,
-                                         name_def->identifier(), is_public));
+      XLS_ASSIGN_OR_RETURN(
+          Function * next,
+          ParseProcNext(member_bindings, parametric_bindings,
+                        name_def->identifier(), is_public, test_only));
       proc_like_body.next = next;
       XLS_RETURN_IF_ERROR(module_->AddTop(next, make_collision_error));
 
@@ -3087,9 +3097,10 @@ absl::StatusOr<ModuleMember> Parser::ParseProcLike(const Pos& start_pos,
     } else if (peek->IsIdentifier("init")) {
       XLS_RETURN_IF_ERROR(check_not_yet_specified(proc_like_body.init, peek));
 
-      XLS_ASSIGN_OR_RETURN(Function * init,
-                           ParseProcInit(member_bindings, parametric_bindings,
-                                         name_def->identifier(), is_public));
+      XLS_ASSIGN_OR_RETURN(
+          Function * init,
+          ParseProcInit(member_bindings, parametric_bindings,
+                        name_def->identifier(), is_public, test_only));
       proc_like_body.init = init;
       XLS_RETURN_IF_ERROR(module_->AddTop(init, make_collision_error));
 
@@ -3225,9 +3236,9 @@ absl::StatusOr<ModuleMember> Parser::ParseProcLike(const Pos& start_pos,
 }
 
 absl::StatusOr<ModuleMember> Parser::ParseProc(const Pos& start_pos,
-                                               bool is_public,
+                                               bool is_public, bool test_only,
                                                Bindings& outer_bindings) {
-  return ParseProcLike<Proc>(start_pos, is_public, outer_bindings,
+  return ParseProcLike<Proc>(start_pos, is_public, test_only, outer_bindings,
                              Keyword::kProc);
 }
 
@@ -3995,9 +4006,9 @@ absl::StatusOr<std::vector<ExprOrType>> Parser::ParseParametrics(
 
 absl::StatusOr<TestFunction*> Parser::ParseTestFunction(
     Bindings& bindings, const Span& attribute_span) {
-  XLS_ASSIGN_OR_RETURN(
-      Function * f,
-      ParseFunctionInternal(GetPos(), /*is_public=*/false, bindings));
+  XLS_ASSIGN_OR_RETURN(Function * f,
+                       ParseFunctionInternal(GetPos(), /*is_public=*/false,
+                                             /*test_only=*/false, bindings));
   XLS_RET_CHECK(f != nullptr);
   if (std::optional<ModuleMember*> member =
           module_->FindMemberWithName(f->identifier())) {
@@ -4016,8 +4027,9 @@ absl::StatusOr<TestFunction*> Parser::ParseTestFunction(
 
 absl::StatusOr<TestProc*> Parser::ParseTestProc(
     Bindings& bindings, std::optional<std::string> expected_fail_label) {
-  XLS_ASSIGN_OR_RETURN(ModuleMember m,
-                       ParseProc(GetPos(), /*is_public=*/false, bindings));
+  XLS_ASSIGN_OR_RETURN(
+      ModuleMember m,
+      ParseProc(GetPos(), /*is_public=*/false, /*test_only=*/false, bindings));
   if (!std::holds_alternative<Proc*>(m)) {
     // TODO: https://github.com/google/xls/issues/836 - Support `ProcDef` here.
     ProcDef* proc_def = std::get<ProcDef*>(m);

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -648,8 +648,9 @@ class Parser : public TokenParser {
   // #[test_proc] Expects a proc, returns TestProc*
   // #[quickcheck(...)] Expects a fn, returns QuickCheck*
   // #[sv_type(...)] Expects a TypeDefinition, returns TypeDefinition
-  absl::StatusOr<std::variant<TestFunction*, Function*, TestProc*, QuickCheck*,
-                              TypeDefinition, std::nullptr_t>>
+  // #[cfg(...)] Expects a fn, returns Function*
+  absl::StatusOr<std::variant<TestFunction*, Function*, TestProc*, Proc*,
+                              QuickCheck*, TypeDefinition, std::nullptr_t>>
   ParseAttribute(absl::flat_hash_map<std::string, Function*>* name_to_fn,
                  Bindings& bindings, const Pos& hash_pos);
 

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -121,7 +121,8 @@ class Parser : public TokenParser {
   FileTable& file_table() { return scanner().file_table(); }
 
   absl::StatusOr<Function*> ParseFunction(
-      const Pos& start_pos, bool is_public, bool test_only, Bindings& bindings,
+      const Pos& start_pos, bool is_public, bool is_test_utility,
+      Bindings& bindings,
       absl::flat_hash_map<std::string, Function*>* name_to_fn = nullptr);
 
   absl::StatusOr<Function*> ParseImplFunction(const Pos& start_pos,
@@ -132,7 +133,8 @@ class Parser : public TokenParser {
   absl::StatusOr<Lambda*> ParseLambda(Bindings& bindings);
 
   absl::StatusOr<ModuleMember> ParseProc(const Pos& start_pos, bool is_public,
-                                         bool test_only, Bindings& bindings);
+                                         bool is_test_utility,
+                                         Bindings& bindings);
 
   absl::StatusOr<std::unique_ptr<Module>> ParseModule(
       Bindings* bindings = nullptr);
@@ -602,7 +604,7 @@ class Parser : public TokenParser {
 
   // Parses a function out of the token stream.
   absl::StatusOr<Function*> ParseFunctionInternal(
-      const Pos& start_pos, bool is_public, bool test_only,
+      const Pos& start_pos, bool is_public, bool is_test_utility,
       Bindings& outer_bindings, TypeAnnotation* struct_ref = nullptr);
 
   // Parses an import statement into an `Import` AST node.
@@ -690,22 +692,23 @@ class Parser : public TokenParser {
   absl::StatusOr<Function*> ParseProcConfig(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
       const std::vector<ProcMember*>& proc_members, std::string_view proc_name,
-      bool is_public, bool test_only);
+      bool is_public, bool is_test_utility);
 
   absl::StatusOr<Function*> ParseProcNext(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-      std::string_view proc_name, bool is_public, bool test_only);
+      std::string_view proc_name, bool is_public, bool is_test_utility);
 
   absl::StatusOr<Function*> ParseProcInit(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-      std::string_view proc_name, bool is_public, bool test_only);
+      std::string_view proc_name, bool is_public, bool is_test_utility);
 
   // Parses a proc-like entity (i.e. either a Proc or a Block). This will yield
   // a node of type `T` unless the entity parsed is actually an impl-style
   // `ProcDef`.
   template <typename T>
   absl::StatusOr<ModuleMember> ParseProcLike(const Pos& start_pos,
-                                             bool is_public, bool test_only,
+                                             bool is_public,
+                                             bool is_test_utility,
                                              Bindings& outer_bindings,
                                              Keyword keyword);
 

--- a/xls/dslx/frontend/parser.h
+++ b/xls/dslx/frontend/parser.h
@@ -121,7 +121,7 @@ class Parser : public TokenParser {
   FileTable& file_table() { return scanner().file_table(); }
 
   absl::StatusOr<Function*> ParseFunction(
-      const Pos& start_pos, bool is_public, Bindings& bindings,
+      const Pos& start_pos, bool is_public, bool test_only, Bindings& bindings,
       absl::flat_hash_map<std::string, Function*>* name_to_fn = nullptr);
 
   absl::StatusOr<Function*> ParseImplFunction(const Pos& start_pos,
@@ -132,7 +132,7 @@ class Parser : public TokenParser {
   absl::StatusOr<Lambda*> ParseLambda(Bindings& bindings);
 
   absl::StatusOr<ModuleMember> ParseProc(const Pos& start_pos, bool is_public,
-                                         Bindings& bindings);
+                                         bool test_only, Bindings& bindings);
 
   absl::StatusOr<std::unique_ptr<Module>> ParseModule(
       Bindings* bindings = nullptr);
@@ -602,8 +602,8 @@ class Parser : public TokenParser {
 
   // Parses a function out of the token stream.
   absl::StatusOr<Function*> ParseFunctionInternal(
-      const Pos& start_pos, bool is_public, Bindings& outer_bindings,
-      TypeAnnotation* struct_ref = nullptr);
+      const Pos& start_pos, bool is_public, bool test_only,
+      Bindings& outer_bindings, TypeAnnotation* struct_ref = nullptr);
 
   // Parses an import statement into an `Import` AST node.
   absl::StatusOr<Import*> ParseImport(Bindings& bindings);
@@ -690,22 +690,22 @@ class Parser : public TokenParser {
   absl::StatusOr<Function*> ParseProcConfig(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
       const std::vector<ProcMember*>& proc_members, std::string_view proc_name,
-      bool is_public);
+      bool is_public, bool test_only);
 
   absl::StatusOr<Function*> ParseProcNext(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-      std::string_view proc_name, bool is_public);
+      std::string_view proc_name, bool is_public, bool test_only);
 
   absl::StatusOr<Function*> ParseProcInit(
       Bindings& bindings, std::vector<ParametricBinding*> parametric_bindings,
-      std::string_view proc_name, bool is_public);
+      std::string_view proc_name, bool is_public, bool test_only);
 
   // Parses a proc-like entity (i.e. either a Proc or a Block). This will yield
   // a node of type `T` unless the entity parsed is actually an impl-style
   // `ProcDef`.
   template <typename T>
   absl::StatusOr<ModuleMember> ParseProcLike(const Pos& start_pos,
-                                             bool is_public,
+                                             bool is_public, bool test_only,
                                              Bindings& outer_bindings,
                                              Keyword keyword);
 

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -852,7 +852,7 @@ TEST_F(ParserTest, ParseIdentityFunction) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
@@ -883,8 +883,9 @@ TEST_F(ParserTest, ParseSimpleProc) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -911,8 +912,9 @@ TEST_F(ParserTest, ParseStatelessProc) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1078,8 +1080,9 @@ TEST_F(ParserTest, ParseNextTooManyArgs) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1110,8 +1113,9 @@ TEST_F(ParserTest, ParseSimpleProcWithAlias) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1141,8 +1145,9 @@ TEST_F(ParserTest, ParseSimpleProcWithDepdenentTypeAlias) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1606,7 +1611,7 @@ TEST_F(ParserTest, ConcatFunction) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
   EXPECT_EQ(f->params().size(), 2);
 
@@ -1641,7 +1646,7 @@ fn concat(
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
   EXPECT_EQ(f->params().size(), 2);
 }
@@ -1657,7 +1662,7 @@ fn f(x: u32) -> u8 {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
@@ -1685,7 +1690,7 @@ TEST_F(ParserTest, LocalConstBinding) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
   StatementBlock* body = f->body();
   absl::Span<Statement* const> stmts = body->statements();
@@ -2888,7 +2893,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false,
+                                /*is_test_utility=*/false,
                                 /*bindings=*/bindings));
 }
 
@@ -2902,7 +2908,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false,
+                                /*is_test_utility=*/false,
                                 /*bindings=*/bindings));
 }
 
@@ -2916,8 +2923,9 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  absl::StatusOr<Function*> function = p.ParseFunction(
-      Pos(), /*is_public=*/false, /*test_only=*/false, /*bindings=*/bindings);
+  absl::StatusOr<Function*> function =
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                      /*bindings=*/bindings);
   EXPECT_THAT(function.status(),
               IsPosError("ParseError",
                          HasSubstr("Expected ':', got ',': Expect colon after "
@@ -2936,7 +2944,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false,
+                                /*is_test_utility=*/false,
                                 /*bindings=*/bindings));
 }
 
@@ -2951,7 +2960,7 @@ fn f(x: u32) -> u8 {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   StatementBlock* body = f->body();
@@ -3557,8 +3566,9 @@ TEST_F(ParserTest, ParseParametricProcWithConstAssert) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
-                               /*bindings=*/bindings);
+  auto proc =
+      parser.ParseProc(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
+                       /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -3659,7 +3669,7 @@ TEST_F(ParserTest, StubFunctionIsEmpty) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
@@ -3692,7 +3702,7 @@ TEST_F(ParserTest, GenericTypeReturn) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   const TypeAnnotation* return_type = f->return_type();
@@ -3711,7 +3721,7 @@ TEST_F(ParserTest, GenericTypeParameters) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   auto params = f->params();
@@ -3733,7 +3743,7 @@ TEST_F(ParserTest, GenericTypeParametersDifferentTypes) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   auto params = f->params();
@@ -3753,7 +3763,7 @@ TEST_F(ParserTest, GenericTypeArray) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+      p.ParseFunction(Pos(), /*is_public=*/false, /*is_test_utility=*/false,
                       /*bindings=*/bindings));
 
   const TypeAnnotation* return_type = f->return_type();

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -852,7 +852,8 @@ TEST_F(ParserTest, ParseIdentityFunction) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
   ASSERT_TRUE(block != nullptr);
@@ -882,8 +883,8 @@ TEST_F(ParserTest, ParseSimpleProc) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -910,8 +911,8 @@ TEST_F(ParserTest, ParseStatelessProc) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1077,8 +1078,8 @@ TEST_F(ParserTest, ParseNextTooManyArgs) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1109,8 +1110,8 @@ TEST_F(ParserTest, ParseSimpleProcWithAlias) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1140,8 +1141,8 @@ TEST_F(ParserTest, ParseSimpleProcWithDepdenentTypeAlias) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -1605,7 +1606,8 @@ TEST_F(ParserTest, ConcatFunction) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
   EXPECT_EQ(f->params().size(), 2);
 
   StatementBlock* block = f->body();
@@ -1639,7 +1641,8 @@ fn concat(
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
   EXPECT_EQ(f->params().size(), 2);
 }
 
@@ -1654,7 +1657,8 @@ fn f(x: u32) -> u8 {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
   absl::Span<Statement* const> stmts = block->statements();
@@ -1681,7 +1685,8 @@ TEST_F(ParserTest, LocalConstBinding) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
   StatementBlock* body = f->body();
   absl::Span<Statement* const> stmts = body->statements();
   ASSERT_EQ(stmts.size(), 2);
@@ -2883,8 +2888,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                                /*bindings=*/bindings));
 }
 
 TEST_F(ParserTest, TupleArrayCast) {
@@ -2897,8 +2902,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                                /*bindings=*/bindings));
 }
 
 TEST_F(ParserTest, InvalidParenthetical) {
@@ -2911,8 +2916,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  absl::StatusOr<Function*> function =
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  absl::StatusOr<Function*> function = p.ParseFunction(
+      Pos(), /*is_public=*/false, /*test_only=*/false, /*bindings=*/bindings);
   EXPECT_THAT(function.status(),
               IsPosError("ParseError",
                          HasSubstr("Expected ':', got ',': Expect colon after "
@@ -2931,8 +2936,8 @@ fn f() -> u8 {
   Scanner s(file_table_, Fileno(0), std::string(text));
   Parser p("test", &s);
   Bindings bindings;
-  XLS_ASSERT_OK(
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+  XLS_ASSERT_OK(p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                                /*bindings=*/bindings));
 }
 
 TEST_F(ParserTest, TupleIndex) {
@@ -2946,7 +2951,8 @@ fn f(x: u32) -> u8 {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   StatementBlock* body = f->body();
   absl::Span<Statement* const> stmts = body->statements();
@@ -3551,8 +3557,8 @@ TEST_F(ParserTest, ParseParametricProcWithConstAssert) {
   Scanner s{file_table_, Fileno(0), std::string{text}};
   Parser parser{"test", &s};
   Bindings bindings;
-  auto proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, /*bindings=*/bindings);
+  auto proc = parser.ParseProc(Pos(), /*is_public=*/false, /*test_only=*/false,
+                               /*bindings=*/bindings);
   if (!proc.ok()) {
     UniformContentFilesystem vfs(text);
     TryPrintError(proc.status(), file_table_, vfs);
@@ -3653,7 +3659,8 @@ TEST_F(ParserTest, StubFunctionIsEmpty) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   StatementBlock* block = f->body();
   absl::Span<Statement* const> stmts = block->statements();
@@ -3685,7 +3692,8 @@ TEST_F(ParserTest, GenericTypeReturn) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   const TypeAnnotation* return_type = f->return_type();
   const TypeVariableTypeAnnotation* tvta =
@@ -3703,7 +3711,8 @@ TEST_F(ParserTest, GenericTypeParameters) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   auto params = f->params();
   EXPECT_EQ(params.size(), 2);
@@ -3724,7 +3733,8 @@ TEST_F(ParserTest, GenericTypeParametersDifferentTypes) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   auto params = f->params();
   EXPECT_EQ(params.size(), 2);
@@ -3743,7 +3753,8 @@ TEST_F(ParserTest, GenericTypeArray) {
   Bindings bindings;
   XLS_ASSERT_OK_AND_ASSIGN(
       Function * f,
-      p.ParseFunction(Pos(), /*is_public=*/false, /*bindings=*/bindings));
+      p.ParseFunction(Pos(), /*is_public=*/false, /*test_only=*/false,
+                      /*bindings=*/bindings));
 
   const TypeAnnotation* return_type = f->return_type();
   const ArrayTypeAnnotation* array_type =

--- a/xls/dslx/frontend/proc.cc
+++ b/xls/dslx/frontend/proc.cc
@@ -109,6 +109,7 @@ std::vector<AstNode*> ProcLike::GetChildren(bool want_types) const {
 }
 
 std::string ProcLike::ToString() const {
+  std::string attr_str = test_only() ? "#[cfg(test)]\n" : "";
   std::string pub_str = is_public() ? "pub " : "";
   std::string parametric_str;
   if (!parametric_bindings().empty()) {
@@ -136,13 +137,13 @@ std::string ProcLike::ToString() const {
   std::string init_str = Indent(
       absl::StrCat("init ", init().body()->ToString()), kRustSpacesPerIndent);
 
-  constexpr std::string_view kTemplate = R"(%sproc %s%s {
+  constexpr std::string_view kTemplate = R"(%s%sproc %s%s {
 %s%s
 %s
 %s
 })";
   return absl::StrFormat(
-      kTemplate, pub_str, name_def()->identifier(), parametric_str,
+      kTemplate, attr_str, pub_str, name_def()->identifier(), parametric_str,
       Indent(stmts_str, kRustSpacesPerIndent),
       Indent(config().ToUndecoratedString("config"), kRustSpacesPerIndent),
       init_str,

--- a/xls/dslx/frontend/proc.cc
+++ b/xls/dslx/frontend/proc.cc
@@ -109,7 +109,7 @@ std::vector<AstNode*> ProcLike::GetChildren(bool want_types) const {
 }
 
 std::string ProcLike::ToString() const {
-  std::string attr_str = test_only() ? "#[cfg(test)]\n" : "";
+  std::string attr_str = is_test_utility() ? "#[cfg(test)]\n" : "";
   std::string pub_str = is_public() ? "pub " : "";
   std::string parametric_str;
   if (!parametric_bindings().empty()) {

--- a/xls/dslx/frontend/proc.cc
+++ b/xls/dslx/frontend/proc.cc
@@ -109,7 +109,10 @@ std::vector<AstNode*> ProcLike::GetChildren(bool want_types) const {
 }
 
 std::string ProcLike::ToString() const {
-  std::string attr_str = is_test_utility() ? "#[cfg(test)]\n" : "";
+  std::string attr_str;
+  if (is_test_utility()) {
+    attr_str = absl::StrFormat("#[%s]\n", kCfgTestAttr);
+  }
   std::string pub_str = is_public() ? "pub " : "";
   std::string parametric_str;
   if (!parametric_bindings().empty()) {

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -120,6 +120,16 @@ class ProcLike : public AstNode {
   }
   bool IsParametric() const { return !parametric_bindings_.empty(); }
   bool is_public() const { return is_public_; }
+  void set_test_only(bool test_only) {
+    body_.config->set_test_only(test_only);
+    body_.init->set_test_only(test_only);
+    body_.next->set_test_only(test_only);
+  }
+  bool test_only() const {
+    CHECK((body_.init->test_only() == body_.config->test_only()) &&
+          (body_.config->test_only() == body_.next->test_only()));
+    return body_.init->test_only();
+  }
 
   Function& config() const { return *body_.config; }
   Function& next() const { return *body_.next; }

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -120,10 +120,10 @@ class ProcLike : public AstNode {
   }
   bool IsParametric() const { return !parametric_bindings_.empty(); }
   bool is_public() const { return is_public_; }
-  bool test_only() const {
-    CHECK((body_.init->test_only() == body_.config->test_only()) &&
-          (body_.config->test_only() == body_.next->test_only()));
-    return body_.init->test_only();
+  bool is_test_utility() const {
+    CHECK((body_.init->is_test_utility() == body_.config->is_test_utility()) &&
+          (body_.config->is_test_utility() == body_.next->is_test_utility()));
+    return body_.init->is_test_utility();
   }
 
   Function& config() const { return *body_.config; }

--- a/xls/dslx/frontend/proc.h
+++ b/xls/dslx/frontend/proc.h
@@ -120,11 +120,6 @@ class ProcLike : public AstNode {
   }
   bool IsParametric() const { return !parametric_bindings_.empty(); }
   bool is_public() const { return is_public_; }
-  void set_test_only(bool test_only) {
-    body_.config->set_test_only(test_only);
-    body_.init->set_test_only(test_only);
-    body_.next->set_test_only(test_only);
-  }
   bool test_only() const {
     CHECK((body_.init->test_only() == body_.config->test_only()) &&
           (body_.config->test_only() == body_.next->test_only()));

--- a/xls/dslx/frontend/proc_test_utils.cc
+++ b/xls/dslx/frontend/proc_test_utils.cc
@@ -40,8 +40,8 @@ std::pair<Module, Proc*> CreateEmptyProc(FileTable& file_table,
   Scanner s(file_table, Fileno(0), absl::StrFormat(code_template, name));
   Parser parser{"test", &s};
   Bindings bindings;
-  absl::StatusOr<ModuleMember> proc =
-      parser.ParseProc(Pos(), /*is_public=*/false, bindings);
+  absl::StatusOr<ModuleMember> proc = parser.ParseProc(
+      Pos(), /*is_public=*/false, /*test_only=*/false, bindings);
   CHECK(proc.ok());
   CHECK(std::holds_alternative<Proc*>(*proc));
   return {std::move(parser.module()), std::get<Proc*>(*proc)};

--- a/xls/dslx/frontend/proc_test_utils.cc
+++ b/xls/dslx/frontend/proc_test_utils.cc
@@ -41,7 +41,7 @@ std::pair<Module, Proc*> CreateEmptyProc(FileTable& file_table,
   Parser parser{"test", &s};
   Bindings bindings;
   absl::StatusOr<ModuleMember> proc = parser.ParseProc(
-      Pos(), /*is_public=*/false, /*test_only=*/false, bindings);
+      Pos(), /*is_public=*/false, /*is_test_utility=*/false, bindings);
   CHECK(proc.ok());
   CHECK(std::holds_alternative<Proc*>(*proc));
   return {std::move(parser.module()), std::get<Proc*>(*proc)};

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -484,7 +484,7 @@ absl::StatusOr<std::vector<Proc*>> GetTopLevelProcs(Module* module,
   absl::flat_hash_set<Spawn*> spawns;
   auto collect_spawns_from_proc =
       [&spawns](Proc* proc, bool include_tests) -> absl::Status {
-    if (proc->test_only() && !include_tests) {
+    if (proc->is_test_utility() && !include_tests) {
       return absl::OkStatus();
     }
     XLS_RET_CHECK(proc != nullptr);
@@ -755,7 +755,7 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrder(Module* module,
     }
 
     // Skip converting functions used in tests unless requested
-    if (f->test_only() && !include_tests) {
+    if (f->is_test_utility() && !include_tests) {
       return absl::OkStatus();
     }
 
@@ -815,7 +815,7 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrder(Module* module,
   // Get the order for each top level proc.
   for (Proc* proc : top_level_procs) {
     // Skip converting procs used in tests unless requested
-    if (proc->test_only() && !include_tests) {
+    if (proc->is_test_utility() && !include_tests) {
       continue;
     }
 

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -479,14 +479,28 @@ static absl::StatusOr<std::vector<Spawn*>> GetSpawns(Proc& p) {
 }
 
 absl::StatusOr<std::vector<Proc*>> GetTopLevelProcs(Module* module,
-                                                    TypeInfo* type_info) {
+                                                    TypeInfo* type_info,
+                                                    bool include_tests) {
   absl::flat_hash_set<Spawn*> spawns;
-
-  std::vector<Proc*> procs;
-  for (Proc* proc : module->GetProcs()) {
+  auto collect_spawns_from_proc =
+      [&spawns](Proc* proc, bool include_tests) -> absl::Status {
+    if (proc->test_only() && !include_tests) {
+      return absl::OkStatus();
+    }
     XLS_RET_CHECK(proc != nullptr);
     XLS_ASSIGN_OR_RETURN(std::vector<Spawn*> this_spawns, GetSpawns(*proc));
     spawns.insert(this_spawns.begin(), this_spawns.end());
+    return absl::OkStatus();
+  };
+  for (Proc* proc : module->GetProcs()) {
+    XLS_RETURN_IF_ERROR(collect_spawns_from_proc(proc, include_tests));
+  }
+  if (include_tests) {
+    for (TestProc* test_proc : module->GetTestProcs()) {
+      XLS_RET_CHECK(test_proc != nullptr);
+      XLS_RETURN_IF_ERROR(
+          collect_spawns_from_proc(test_proc->proc(), include_tests));
+    }
   }
 
   absl::flat_hash_set<Proc*> spawned;
@@ -506,7 +520,7 @@ absl::StatusOr<std::vector<Proc*>> GetTopLevelProcs(Module* module,
 
   // All non-parametric procs that are not spawned are top level.
   std::vector<Proc*> results;
-  for (Proc* proc : module->GetProcs()) {
+  auto add_if_top_level_proc = [&results, &spawned](Proc* proc) {
     if (!proc->IsParametric() && !spawned.contains(proc) &&
         absl::c_all_of(proc->config().params(),
                        [&](const Param* param) -> bool {
@@ -516,6 +530,14 @@ absl::StatusOr<std::vector<Proc*>> GetTopLevelProcs(Module* module,
                        })) {
       // Proc is not parametric and not spawned, thus top level.
       results.push_back(proc);
+    }
+  };
+  for (Proc* proc : module->GetProcs()) {
+    add_if_top_level_proc(proc);
+  }
+  if (include_tests) {
+    for (TestProc* test_proc : module->GetTestProcs()) {
+      add_if_top_level_proc(test_proc->proc());
     }
   }
 
@@ -732,6 +754,11 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrder(Module* module,
       return absl::OkStatus();
     }
 
+    // Skip converting functions used in tests unless requested
+    if (f->test_only() && !include_tests) {
+      return absl::OkStatus();
+    }
+
     return AddToReady(f, /*invocation=*/nullptr, module, type_info,
                       ParametricEnv(), &ready, {});
   };
@@ -783,10 +810,15 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrder(Module* module,
 
   // Collect the top level procs.
   XLS_ASSIGN_OR_RETURN(std::vector<Proc*> top_level_procs,
-                       GetTopLevelProcs(module, type_info));
+                       GetTopLevelProcs(module, type_info, include_tests));
 
   // Get the order for each top level proc.
   for (Proc* proc : top_level_procs) {
+    // Skip converting procs used in tests unless requested
+    if (proc->test_only() && !include_tests) {
+      continue;
+    }
+
     XLS_ASSIGN_OR_RETURN(TypeInfo * proc_ti,
                          type_info->GetTopLevelProcTypeInfo(proc));
 

--- a/xls/dslx/ir_convert/extract_conversion_order.h
+++ b/xls/dslx/ir_convert/extract_conversion_order.h
@@ -167,7 +167,8 @@ absl::StatusOr<std::vector<ConversionRecord>> GetOrderForEntry(
 // Given that there is no invocation of ProcA and ProcB, they (ProcA and ProcB)
 // are the top level procs.
 absl::StatusOr<std::vector<Proc*>> GetTopLevelProcs(Module* module,
-                                                    TypeInfo* type_info);
+                                                    TypeInfo* type_info,
+                                                    bool include_tests = false);
 
 }  // namespace xls::dslx
 

--- a/xls/dslx/ir_convert/ir_converter.cc
+++ b/xls/dslx/ir_convert/ir_converter.cc
@@ -186,7 +186,7 @@ absl::Status ConvertOneFunctionInternal(PackageData& package_data,
   }
 
   Function* f = record.f();
-  if (f->test_only() && !options.convert_tests) {
+  if (f->is_test_utility() && !options.convert_tests) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Tried to convert a %s used in tests, but test conversion is disabled",
         f->IsInProc()
@@ -512,7 +512,7 @@ absl::Status ConvertOneFunctionIntoPackage(Module* module,
 
   std::optional<Function*> fn_or = module->GetFunction(entry_function_name);
   if (fn_or.has_value()) {
-    if (fn_or.value()->test_only() && !options.convert_tests) {
+    if (fn_or.value()->is_test_utility() && !options.convert_tests) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "IR conversion of tests is disabled, but conversion of a test "
           "utility function \"%s\" from module %s was requested.",

--- a/xls/dslx/ir_convert/ir_converter.cc
+++ b/xls/dslx/ir_convert/ir_converter.cc
@@ -186,6 +186,15 @@ absl::Status ConvertOneFunctionInternal(PackageData& package_data,
   }
 
   Function* f = record.f();
+  if (f->test_only() && !options.convert_tests) {
+    return absl::InvalidArgumentError(absl::StrFormat(
+        "Tried to convert a %s used in tests, but test conversion is disabled",
+        f->IsInProc()
+            ? absl::StrFormat("proc '%s'",
+                              f->proc().value()->name_def()->identifier())
+            : absl::StrFormat("function '%s'", f->identifier())));
+  }
+
   if (f->tag() == FunctionTag::kProcConfig) {
     XLS_RET_CHECK(!options.lower_to_proc_scoped_channels)
         << "Should not process config or init methods if "
@@ -489,10 +498,43 @@ absl::Status ConvertOneFunctionIntoPackage(Module* module,
                                            const ParametricEnv* parametric_env,
                                            const ConvertOptions& options,
                                            PackageConversionData* conv) {
+  absl::StatusOr<TestFunction*> test_fn = module->GetTest(entry_function_name);
+  if (test_fn.ok()) {
+    if (!options.convert_tests) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "IR conversion of tests is disabled, but conversion of a test "
+          "function \"%s\" from module %s was requested.",
+          entry_function_name, module->name()));
+    }
+    return ConvertOneFunctionIntoPackageInternal(&(*test_fn)->fn(), import_data,
+                                                 parametric_env, options, conv);
+  }
+
   std::optional<Function*> fn_or = module->GetFunction(entry_function_name);
   if (fn_or.has_value()) {
-    return ConvertOneFunctionIntoPackageInternal(fn_or.value(), import_data,
+    if (fn_or.value()->test_only() && !options.convert_tests) {
+      return absl::InvalidArgumentError(absl::StrFormat(
+          "IR conversion of tests is disabled, but conversion of a test "
+          "utility function \"%s\" from module %s was requested.",
+          entry_function_name, module->name()));
+    }
+
+    return ConvertOneFunctionIntoPackageInternal(*fn_or, import_data,
                                                  parametric_env, options, conv);
+  }
+
+  absl::StatusOr<TestProc*> test_proc =
+      module->GetTestProc(entry_function_name);
+  if (test_proc.ok()) {
+    XLS_RETURN_IF_ERROR(CheckAcceptableTopProc((*test_proc)->proc()));
+    if (!options.convert_tests) {
+      return absl::InvalidArgumentError(
+          absl::StrFormat("IR conversion of tests is disabled, but conversion "
+                          "of a test proc \"%s\" from module %s was requested.",
+                          entry_function_name, module->name()));
+    }
+    return ConvertOneFunctionIntoPackageInternal(
+        (*test_proc)->proc(), import_data, parametric_env, options, conv);
   }
 
   absl::StatusOr<Proc*> proc =
@@ -501,22 +543,6 @@ absl::Status ConvertOneFunctionIntoPackage(Module* module,
     XLS_RETURN_IF_ERROR(CheckAcceptableTopProc(*proc));
     return ConvertOneFunctionIntoPackageInternal(*proc, import_data,
                                                  parametric_env, options, conv);
-  }
-
-  if (options.convert_tests) {
-    absl::StatusOr<TestFunction*> test_fn =
-        module->GetTest(entry_function_name);
-    if (test_fn.ok()) {
-      return ConvertOneFunctionIntoPackageInternal(
-          &(*test_fn)->fn(), import_data, parametric_env, options, conv);
-    }
-    absl::StatusOr<TestProc*> test_proc =
-        module->GetTestProc(entry_function_name);
-    if (test_proc.ok()) {
-      XLS_RETURN_IF_ERROR(CheckAcceptableTopProc((*test_proc)->proc()));
-      return ConvertOneFunctionIntoPackageInternal(
-          (*test_proc)->proc(), import_data, parametric_env, options, conv);
-    }
   }
 
   return absl::InvalidArgumentError(

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertWithTests.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertWithTests.ir
@@ -1,0 +1,103 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+chan test_module__terminator(bits[1], id=0, kind=streaming, ops=send_only, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+chan test_module__tester_req((), id=1, kind=streaming, ops=send_receive, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+chan test_module__tester_resp((), id=2, kind=streaming, ops=send_receive, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+chan test_module__user_req((), id=3, kind=streaming, ops=send_receive, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+chan test_module__user_resp((), id=4, kind=streaming, ops=send_receive, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+
+fn __itok__test_module__test_utility_function(__token: token id=1, __activated: bits[1] id=2) -> (token, ()) {
+  trace.3: token = trace(__token, __activated, format="Message from a test utility function", data_operands=[], id=3)
+  after_all.5: token = after_all(trace.3, id=5)
+  tuple.4: () = tuple(id=4)
+  ret tuple.6: (token, ()) = tuple(after_all.5, tuple.4, id=6)
+}
+
+fn __itok__test_module__normal_function(__token: token id=7, __activated: bits[1] id=8) -> (token, ()) {
+  trace.9: token = trace(__token, __activated, format="Message from a normal function", data_operands=[], id=9)
+  after_all.11: token = after_all(trace.9, id=11)
+  tuple.10: () = tuple(id=10)
+  ret tuple.12: (token, ()) = tuple(after_all.11, tuple.10, id=12)
+}
+
+fn __itok__test_module__test_func(__token: token id=13, __activated: bits[1] id=14) -> (token, ()) {
+  invoke.15: (token, ()) = invoke(__token, __activated, to_apply=__itok__test_module__test_utility_function, id=15)
+  invoke.18: (token, ()) = invoke(__token, __activated, to_apply=__itok__test_module__normal_function, id=18)
+  tuple_index.16: token = tuple_index(invoke.15, index=0, id=16)
+  tuple_index.19: token = tuple_index(invoke.18, index=0, id=19)
+  trace.21: token = trace(__token, __activated, format="Message from a test function", data_operands=[], id=21)
+  after_all.23: token = after_all(tuple_index.16, tuple_index.19, trace.21, id=23)
+  tuple.22: () = tuple(id=22)
+  tuple_index.17: () = tuple_index(invoke.15, index=1, id=17)
+  tuple_index.20: () = tuple_index(invoke.18, index=1, id=20)
+  ret tuple.24: (token, ()) = tuple(after_all.23, tuple.22, id=24)
+}
+
+fn __test_module__TestUtilityProc.init() -> () {
+  ret tuple.25: () = tuple(id=25)
+}
+
+fn __test_module__NormalProc.init() -> () {
+  ret tuple.26: () = tuple(id=26)
+}
+
+proc __test_module__TestProc_0_next(__state: (), init={()}) {
+  after_all.41: token = after_all(id=41)
+  literal.29: bits[1] = literal(value=1, id=29)
+  after_all.33: token = after_all(id=33)
+  receive.42: (token, ()) = receive(after_all.41, predicate=literal.29, channel=test_module__user_resp, id=42)
+  after_all.30: token = after_all(id=30)
+  tuple.31: () = tuple(id=31)
+  receive.34: (token, ()) = receive(after_all.33, predicate=literal.29, channel=test_module__tester_resp, id=34)
+  after_all.38: token = after_all(id=38)
+  tuple.39: () = tuple(id=39)
+  __token: token = literal(value=token, id=27)
+  tok__3: token = tuple_index(receive.42, index=0, id=44)
+  literal.47: bits[1] = literal(value=1, id=47)
+  __state: () = state_read(state_element=__state, id=28)
+  tuple.49: () = tuple(id=49)
+  tok: token = send(after_all.30, tuple.31, predicate=literal.29, channel=test_module__tester_req, id=32)
+  tuple_index.35: token = tuple_index(receive.34, index=0, id=35)
+  tok__1: token = tuple_index(receive.34, index=0, id=36)
+  tuple_index.37: () = tuple_index(receive.34, index=1, id=37)
+  tok__2: token = send(after_all.38, tuple.39, predicate=literal.29, channel=test_module__user_req, id=40)
+  tuple_index.43: token = tuple_index(receive.42, index=0, id=43)
+  tuple_index.45: () = tuple_index(receive.42, index=1, id=45)
+  trace.46: token = trace(__token, literal.29, format="Message from a TestProc", data_operands=[], id=46)
+  send.48: token = send(tok__3, literal.47, predicate=literal.29, channel=test_module__terminator, id=48)
+  next_value.50: () = next_value(param=__state, value=tuple.49, id=50)
+}
+
+proc __test_module__TestProc__TestUtilityProc_0_next(__state: (), init={()}) {
+  after_all.54: token = after_all(id=54)
+  literal.53: bits[1] = literal(value=1, id=53)
+  receive.55: (token, ()) = receive(after_all.54, predicate=literal.53, channel=test_module__tester_req, id=55)
+  __token: token = literal(value=token, id=51)
+  tok: token = tuple_index(receive.55, index=0, id=57)
+  tuple.60: () = tuple(id=60)
+  __state: () = state_read(state_element=__state, id=52)
+  tuple.62: () = tuple(id=62)
+  tuple_index.56: token = tuple_index(receive.55, index=0, id=56)
+  tuple_index.58: () = tuple_index(receive.55, index=1, id=58)
+  trace.59: token = trace(__token, literal.53, format="Message from a TestUtilityProc", data_operands=[], id=59)
+  send.61: token = send(tok, tuple.60, predicate=literal.53, channel=test_module__tester_resp, id=61)
+  next_value.63: () = next_value(param=__state, value=tuple.62, id=63)
+}
+
+proc __test_module__TestProc__NormalProc_0_next(__state: (), init={()}) {
+  after_all.67: token = after_all(id=67)
+  literal.66: bits[1] = literal(value=1, id=66)
+  receive.68: (token, ()) = receive(after_all.67, predicate=literal.66, channel=test_module__user_req, id=68)
+  __token: token = literal(value=token, id=64)
+  tok: token = tuple_index(receive.68, index=0, id=70)
+  tuple.73: () = tuple(id=73)
+  __state: () = state_read(state_element=__state, id=65)
+  tuple.75: () = tuple(id=75)
+  tuple_index.69: token = tuple_index(receive.68, index=0, id=69)
+  tuple_index.71: () = tuple_index(receive.68, index=1, id=71)
+  trace.72: token = trace(__token, literal.66, format="Message from a NormalProc", data_operands=[], id=72)
+  send.74: token = send(tok, tuple.73, predicate=literal.66, channel=test_module__user_resp, id=74)
+  next_value.76: () = next_value(param=__state, value=tuple.75, id=76)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertWithoutTests.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertWithoutTests.ir
@@ -1,0 +1,36 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+chan test_module__req_r((), id=0, kind=streaming, ops=receive_only, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+chan test_module__resp_s((), id=1, kind=streaming, ops=send_only, flow_control=ready_valid, strictness=proven_mutually_exclusive)
+
+fn __itok__test_module__normal_function(__token: token id=1, __activated: bits[1] id=2) -> (token, ()) {
+  trace.3: token = trace(__token, __activated, format="Message from a normal function", data_operands=[], id=3)
+  after_all.5: token = after_all(trace.3, id=5)
+  tuple.4: () = tuple(id=4)
+  ret tuple.6: (token, ()) = tuple(after_all.5, tuple.4, id=6)
+}
+
+fn __test_module__normal_function() -> () {
+  after_all.20: token = after_all(id=20)
+  literal.21: bits[1] = literal(value=1, id=21)
+  invoke.22: (token, ()) = invoke(after_all.20, literal.21, to_apply=__itok__test_module__normal_function, id=22)
+  ret tuple_index.23: () = tuple_index(invoke.22, index=1, id=23)
+}
+
+proc __test_module__NormalProc_0_next(__state: (), init={()}) {
+  after_all.10: token = after_all(id=10)
+  literal.9: bits[1] = literal(value=1, id=9)
+  receive.11: (token, ()) = receive(after_all.10, predicate=literal.9, channel=test_module__req_r, id=11)
+  __token: token = literal(value=token, id=7)
+  tok: token = tuple_index(receive.11, index=0, id=13)
+  tuple.16: () = tuple(id=16)
+  __state: () = state_read(state_element=__state, id=8)
+  tuple.18: () = tuple(id=18)
+  tuple_index.12: token = tuple_index(receive.11, index=0, id=12)
+  tuple_index.14: () = tuple_index(receive.11, index=1, id=14)
+  trace.15: token = trace(__token, literal.9, format="Message from a NormalProc", data_operands=[], id=15)
+  send.17: token = send(tok, tuple.16, predicate=literal.9, channel=test_module__resp_s, id=17)
+  next_value.19: () = next_value(param=__state, value=tuple.18, id=19)
+}

--- a/xls/dslx/type_system/deduce_utils_test.cc
+++ b/xls/dslx/type_system/deduce_utils_test.cc
@@ -85,17 +85,17 @@ TEST(ProcConfigIrConverterTest, ResolveProcNameRef) {
       Span::Fake(), config_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcConfig, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcConfig, /*is_public=*/true, /*is_test_utility=*/false);
   Function* next = module.Make<Function>(
       Span::Fake(), next_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcNext, /*is_public=*/true, /*is_test_utility=*/false);
   Function* init = module.Make<Function>(
       Span::Fake(), init_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcNext, /*is_public=*/true, /*is_test_utility=*/false);
   const std::vector<ParametricBinding*> bindings;
   const ProcLikeBody proc_body{
       .stmts = {},
@@ -153,17 +153,17 @@ TEST(ProcConfigIrConverterTest, ResolveProcColonRef) {
       Span::Fake(), config_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcConfig, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcConfig, /*is_public=*/true, /*is_test_utility=*/false);
   Function* next = import_module->Make<Function>(
       Span::Fake(), next_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcNext, /*is_public=*/true, /*is_test_utility=*/false);
   Function* init = import_module->Make<Function>(
       Span::Fake(), init_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcInit, /*is_public=*/true, /*test_only=*/false);
+      FunctionTag::kProcInit, /*is_public=*/true, /*is_test_utility=*/false);
   std::vector<ProcMember*> members;
   std::vector<ParametricBinding*> bindings;
   ProcLikeBody proc_body = {

--- a/xls/dslx/type_system/deduce_utils_test.cc
+++ b/xls/dslx/type_system/deduce_utils_test.cc
@@ -85,17 +85,17 @@ TEST(ProcConfigIrConverterTest, ResolveProcNameRef) {
       Span::Fake(), config_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcConfig, /*is_public=*/true);
+      FunctionTag::kProcConfig, /*is_public=*/true, /*test_only=*/false);
   Function* next = module.Make<Function>(
       Span::Fake(), next_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true);
+      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
   Function* init = module.Make<Function>(
       Span::Fake(), init_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true);
+      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
   const std::vector<ParametricBinding*> bindings;
   const ProcLikeBody proc_body{
       .stmts = {},
@@ -153,17 +153,17 @@ TEST(ProcConfigIrConverterTest, ResolveProcColonRef) {
       Span::Fake(), config_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcConfig, /*is_public=*/true);
+      FunctionTag::kProcConfig, /*is_public=*/true, /*test_only=*/false);
   Function* next = import_module->Make<Function>(
       Span::Fake(), next_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcNext, /*is_public=*/true);
+      FunctionTag::kProcNext, /*is_public=*/true, /*test_only=*/false);
   Function* init = import_module->Make<Function>(
       Span::Fake(), init_name_def,
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(), return_type, block,
-      FunctionTag::kProcInit, /*is_public=*/true);
+      FunctionTag::kProcInit, /*is_public=*/true, /*test_only=*/false);
   std::vector<ProcMember*> members;
   std::vector<ParametricBinding*> bindings;
   ProcLikeBody proc_body = {

--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -2970,7 +2970,8 @@ absl::StatusOr<AnnotatedFunction> AstGenerator::GenerateFunction(
       /*parametric_bindings=*/parametric_bindings,
       /*params=*/params,
       /*return_type=*/retval.type, block, FunctionTag::kNormal,
-      /*is_public=*/false);
+      /*is_public=*/false,
+      /*test_only=*/false);
   name_def->set_definer(f);
 
   return AnnotatedFunction{.function = f,
@@ -3036,7 +3037,8 @@ absl::StatusOr<Function*> AstGenerator::GenerateProcConfigFunction(
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/params,
       /*return_type=*/ret_tuple_type, block, FunctionTag::kProcConfig,
-      /*is_public=*/false);
+      /*is_public=*/false,
+      /*test_only=*/false);
   name_def->set_definer(f);
   return f;
 }
@@ -3073,7 +3075,8 @@ absl::StatusOr<AnnotatedFunction> AstGenerator::GenerateProcNextFunction(
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/params,
       /*return_type=*/retval.type, block, FunctionTag::kProcNext,
-      /*is_public=*/false);
+      /*is_public=*/false,
+      /*test_only=*/false);
   name_def->set_definer(f);
 
   return AnnotatedFunction{.function = f,
@@ -3098,7 +3101,8 @@ absl::StatusOr<Function*> AstGenerator::GenerateProcInitFunction(
       /*parametric_bindings=*/std::vector<ParametricBinding*>(),
       /*params=*/std::vector<Param*>(),
       /*return_type=*/return_type, b, FunctionTag::kProcInit,
-      /*is_public=*/false);
+      /*is_public=*/false,
+      /*test_only=*/false);
   name_def->set_definer(f);
   return f;
 }


### PR DESCRIPTION
# Description

This commit adds a `#[cfg(test)]` attribute that you can use to mark functions or procs that are only meant for testing. When marked this way, they won't be lowered to IR.  The original request in #1524 was just for functions, but I applied the same idea to procs as well.

# Implementation details

This feature uses a `test_only` flag in the `Function` class to mark functions and procs that are only used for tests. When converting code to IR, functions and procs  marked as test-only are skipped, unless the `convert_tests` option is enabled. This allows test helpers to be included in the IR if needed.

IR conversion now provides clearer error messages. If a test-only function or proc is selected for conversion without the `convert_tests` option, a dedicated error is shown. Same happens when a test-only function is called from a regular function or proc and IR is being dumped.

In DSLX, the interpreter will fail if a test-only function is called from a regular one. This check is not yet in place for procs, as communication between regular and test-only procs involves more complexity, but I can add it too if needed.

Resolves https://github.com/google/xls/issues/1524