### PR TITLE
[cleanup] Switch uses of L and LL suffixes to be explicitly typed for x-platform portability

### DIFF
--- a/xls/common/math_util_test.cc
+++ b/xls/common/math_util_test.cc
@@ -184,7 +184,8 @@ TEST(MathUtil, CeilOfRatioInt64) { TestCeilOfRatioSigned<int64_t>(); }
 TEST(MathUtil, CeilOfRatioDenomMinusOneIsIncorrect) {
   // Here we demonstrate why not to use CeilOfRatioDenomMinusOne: It does not
   // work with negative values.
-  TestThatCeilOfRatioDenomMinusOneIsIncorrect(-1LL, -2LL, -1LL);
+  TestThatCeilOfRatioDenomMinusOneIsIncorrect(int64_t{-1}, int64_t{-2},
+                                              int64_t{-1});
 
   // This would also fail if given kint64max because of signed integer overflow.
 }

--- a/xls/data_structures/binary_decision_diagram_test.cc
+++ b/xls/data_structures/binary_decision_diagram_test.cc
@@ -233,7 +233,7 @@ TEST(BinaryDecisionDiagramTest, Parity) {
                     bdd.And(bdd.Not(parity), variables[i]));
 
     if (i < 30) {
-      EXPECT_EQ(bdd.path_count(parity), 1LL << (i + 1));
+      EXPECT_EQ(bdd.path_count(parity), int64_t{1} << (i + 1));
     } else {
       EXPECT_EQ(bdd.path_count(parity), std::numeric_limits<int32_t>::max());
     }

--- a/xls/dslx/bytecode/bytecode_interpreter_test.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter_test.cc
@@ -1082,7 +1082,7 @@ fn do_and() -> u32 {
   XLS_ASSERT_OK_AND_ASSIGN(InterpValue value, Interpret(kProgram, "do_and"));
   XLS_ASSERT_OK_AND_ASSIGN(Bits bits, value.GetBits());
   XLS_ASSERT_OK_AND_ASSIGN(uint64_t int_val, bits.ToUint64());
-  EXPECT_EQ(int_val, 0xa5a5a5a5ll);
+  EXPECT_EQ(int_val, uint64_t{0xa5a5a5a5});
 }
 
 TEST_F(BytecodeInterpreterTest, BinopConcat) {
@@ -1096,7 +1096,7 @@ fn do_concat() -> u64 {
   XLS_ASSERT_OK_AND_ASSIGN(InterpValue value, Interpret(kProgram, "do_concat"));
   XLS_ASSERT_OK_AND_ASSIGN(Bits bits, value.GetBits());
   XLS_ASSERT_OK_AND_ASSIGN(uint64_t int_val, bits.ToUint64());
-  EXPECT_EQ(int_val, 0xa5a5a5a5ffffffffll);
+  EXPECT_EQ(int_val, uint64_t{0xa5a5a5a5ffffffff});
 }
 
 TEST_F(BytecodeInterpreterTest, BinopDiv) {

--- a/xls/dslx/stdlib/tests/umul_with_overflow_long_test.cc
+++ b/xls/dslx/stdlib/tests/umul_with_overflow_long_test.cc
@@ -86,9 +86,9 @@ TEST_P(UmulSweepOverflowTest, Umul212118Sweep) {
 
 INSTANTIATE_TEST_SUITE_P(
     Umul212118ExhaustiveTest, UmulSweepOverflowTest,
-    testing::Combine(testing::Range(0l, 0x40000l,
-                                    0x100l),  // From [0x0, 0x3ffff]
-                     testing::Values(0x100l)),
+    testing::Combine(testing::Range(int64_t{0}, int64_t{0x40000},
+                                    int64_t{0x100}),  // From [0x0, 0x3ffff]
+                     testing::Values(int64_t{0x100})),
     UmulSweepOverflowTest::PrintToStringParamName);
 
 // Expand a 16 bit integer to 32 bits, inserting a zero between each bit.
@@ -162,9 +162,9 @@ TEST_P(UmulSweepOverflowTest, Umul353218SweepPartial) {
 
 INSTANTIATE_TEST_SUITE_P(
     Umul353218SweepPartial, UmulSweepOverflowTest,
-    testing::Combine(testing::Range(0l, 0x40000l,
-                                    0x100l),  // From [0x0, 0x3ffff]
-                     testing::Values(0x100l)),
+    testing::Combine(testing::Range(int64_t{0}, int64_t{0x40000},
+                                    int64_t{0x100}),  // From [0x0, 0x3ffff]
+                     testing::Values(int64_t{0x100})),
     UmulSweepOverflowTest::PrintToStringParamName);
 
 }  // namespace

--- a/xls/dslx/type_system/deduce_utils.cc
+++ b/xls/dslx/type_system/deduce_utils.cc
@@ -740,8 +740,8 @@ absl::StatusOr<StartAndWidth> ResolveBitSliceIndices(
     limit += bit_count;
   }
 
-  limit = std::clamp(limit, 0L, bit_count);
-  start = std::clamp(start, 0L, limit);
+  limit = std::clamp(limit, int64_t{0}, bit_count);
+  start = std::clamp(start, int64_t{0}, limit);
   return StartAndWidth{.start = start, .width = limit - start};
 }
 

--- a/xls/estimators/delay_model/delay_estimator.cc
+++ b/xls/estimators/delay_model/delay_estimator.cc
@@ -108,14 +108,14 @@ namespace {
     XLS_ASSIGN_OR_RETURN(
         double base_effort,
         netlist::logical_effort::GetLogicalEffort(kind, operand_count));
-    return std::ceil(invert ? base_effort + 1LL : base_effort);
+    return std::ceil(invert ? base_effort + int64_t{1} : base_effort);
   };
   auto get_logical_effort = [node](netlist::CellKind kind,
                                    bool invert) -> absl::StatusOr<int64_t> {
     XLS_ASSIGN_OR_RETURN(double base_effort,
                          netlist::logical_effort::GetLogicalEffort(
                              kind, node->operands().size()));
-    return std::ceil(invert ? base_effort + 1LL : base_effort);
+    return std::ceil(invert ? base_effort + int64_t{1} : base_effort);
   };
   auto get_reduction_logical_effort =
       [node](netlist::CellKind kind, bool invert) -> absl::StatusOr<int64_t> {
@@ -126,7 +126,7 @@ namespace {
     XLS_ASSIGN_OR_RETURN(
         double base_effort,
         netlist::logical_effort::GetLogicalEffort(kind, bit_count));
-    return std::ceil(invert ? base_effort + 1LL : base_effort);
+    return std::ceil(invert ? base_effort + int64_t{1} : base_effort);
   };
   switch (node->op()) {
     // TODO(leary): 2019-09-24 Collect real numbers for these.

--- a/xls/ir/function_builder.cc
+++ b/xls/ir/function_builder.cc
@@ -727,7 +727,7 @@ BValue BuilderBase::Decode(BValue arg, std::optional<int64_t> width,
   }
   return AddNode<xls::Decode>(
       loc, arg.node(),
-      /*width=*/width.has_value() ? *width : (1LL << arg_width), name);
+      /*width=*/width.has_value() ? *width : (int64_t{1} << arg_width), name);
 }
 
 BValue BuilderBase::Shra(BValue operand, BValue amount, const SourceInfo& loc,

--- a/xls/ir/verify_node.cc
+++ b/xls/ir/verify_node.cc
@@ -408,7 +408,8 @@ class NodeChecker : public DfsVisitor {
     // The width of the decode output must be less than or equal to
     // 2**input_width.
     const int64_t operand_width = decode->operand(0)->BitCountOrDie();
-    if (operand_width < 63 && (decode->width() > (1LL << operand_width))) {
+    if (operand_width < 63 &&
+        (decode->width() > (int64_t{1} << operand_width))) {
       return absl::InternalError(absl::StrFormat(
           "Decode output width (%d) greater than 2**${operand width} "
           "where operand width is %d",

--- a/xls/passes/resource_sharing_pass.cc
+++ b/xls/passes/resource_sharing_pass.cc
@@ -1293,7 +1293,8 @@ absl::StatusOr<bool> PerformFoldingActions(
     // - Step 2: Replace the operands of the @to_node to use the results of the
     //           new selectors computed at Step 1.
     VLOG(3) << "    Step 2: update the target of the folding transformation";
-    for (int64_t op_id = 0LL; op_id < to_node->operand_count(); op_id++) {
+    for (int64_t op_id = int64_t{0}; op_id < to_node->operand_count();
+         op_id++) {
       XLS_RETURN_IF_ERROR(
           to_node->ReplaceOperandNumber(op_id, new_operands[op_id], true));
     }

--- a/xls/tests/basic_ir_ops_test.cc
+++ b/xls/tests/basic_ir_ops_test.cc
@@ -395,8 +395,8 @@ top fn main(x: bits[8]) -> bits[27] {
 
   RunAndExpectEq({{"x", 0}}, 1, text);
   RunAndExpectEq({{"x", 1}}, 2, text);
-  RunAndExpectEq({{"x", 17}}, (1LL << 17), text);
-  RunAndExpectEq({{"x", 26}}, (1LL << 26), text);
+  RunAndExpectEq({{"x", 17}}, (int64_t{1} << 17), text);
+  RunAndExpectEq({{"x", 26}}, (int64_t{1} << 26), text);
   RunAndExpectEq({{"x", 27}}, 0, text);
   RunAndExpectEq({{"x", 123}}, 0, text);
   RunAndExpectEq({{"x", 255}}, 0, text);


### PR DESCRIPTION
This was breaking the OS X build on integrate from upstream.

I think the recommendation in the style guide is to avoid integer type suffxes but they can easily creep in since there's not a tidy for them.