### PR TITLE
[ir] strict verification for comparison operations

### DIFF
--- a/xls/jit/function_jit_test.cc
+++ b/xls/jit/function_jit_test.cc
@@ -899,11 +899,9 @@ TEST(FunctionJitTest, TokenCompareError) {
 
   b.Eq(p0, p0);
 
-  XLS_ASSERT_OK_AND_ASSIGN(Function * f, b.Build());
-
-  EXPECT_THAT(FunctionJit::Create(f),
+  EXPECT_THAT(b.Build(),
               StatusIs(absl::StatusCode::kInvalidArgument,
-                       HasSubstr("Tokens are incomparable")));
+                       HasSubstr("cannot be Token type for this operation")));
 }
 
 // Make sure the token comparison error is still reported when the token is


### PR DESCRIPTION
* non-equality cmp comparisons (ult, slt, etc.) now strictly require `bits` type operands, aligning verifier with `ir_semantics.md`
*  equality comparisons (eq, ne) now disallow `Token` type operands in the verifier