### PR TITLE
[cleanup] Make a comment on BitCountOrDie in Node.

### DIFF
--- a/xls/ir/node.h
+++ b/xls/ir/node.h
@@ -94,6 +94,12 @@ class Node {
 
   Type* GetType() const { return type_; }
 
+  // Precondition: this node's result type must be known to be a `BitsType`.
+  //
+  // Convenience helper for getting the bit count of the result type. Many
+  // operations produce bits-typed outputs, so this is a useful helper even
+  // though it is not properly polymorphic. It must only be called on nodes that
+  // we are sure are producing bits-typed results.
   int64_t BitCountOrDie() const {
     return GetType()->AsBitsOrDie()->bit_count();
   }


### PR DESCRIPTION
Per review discussion in https://github.com/google/xls/pull/2251 the `BitCountOrDie` method on Node assumes the result type for the node is `BitsType` which is convenient as we have a lot of things like that, but it also obscures the assumption cases where the result may not be `BitsType`.

Put a good comment at least to indicate the precondition and upside/downside.

cc @proppy 