### PR TITLE
Avoid implicit constructors.

### DIFF
--- a/xls/codegen/passes_ng/stage_to_block_conversion.h
+++ b/xls/codegen/passes_ng/stage_to_block_conversion.h
@@ -45,7 +45,7 @@ class BlockChannelMetadata {
  public:
   // Creates a new metadata object that can associate a channel interface
   // (in a stage proc) with slots and an adapter in a block.
-  BlockChannelMetadata(const ChannelInterface* ABSL_NONNULL channel_interface)
+  explicit BlockChannelMetadata(const ChannelInterface* ABSL_NONNULL channel_interface)
       : channel_interface_(channel_interface) {}
 
   // Returns the channel interface associated with this set of slots

--- a/xls/common/status/status_or_ref.h
+++ b/xls/common/status/status_or_ref.h
@@ -63,7 +63,7 @@ class [[nodiscard]] StatusOrRef {
   // Conversion constructors
   template <typename U>
     requires(std::is_base_of_v<T, U>)
-  StatusOrRef(StatusOrRef<U>&& other ABSL_ATTRIBUTE_LIFETIME_BOUND)
+  explicit StatusOrRef(StatusOrRef<U>&& other ABSL_ATTRIBUTE_LIFETIME_BOUND)
       : value_(std::move(other.value_)) {}
   template <typename U>
     requires(std::is_base_of_v<T, U>)
@@ -72,9 +72,9 @@ class [[nodiscard]] StatusOrRef {
     return *this;
   }
   // conversion to base status-or.
-  operator InnerStatusOr() && { return std::move(value_); }
-  operator InnerStatusOr() & { return value_; }
-  operator InnerStatusOr() const& { return value_; }
+  explicit operator InnerStatusOr() && { return std::move(value_); }
+  explicit operator InnerStatusOr() & { return value_; }
+  explicit operator InnerStatusOr() const& { return value_; }
 
   bool ok() const { return value_.ok(); }
 

--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -439,7 +439,7 @@ absl::StatusOr<ChannelTypeProto> ToProto(const ChannelType& channel_type,
 
 class ToProtoVisitor : public TypeVisitor {
  public:
-  ToProtoVisitor(const FileTable& file_table) : file_table_(file_table) {}
+  explicit ToProtoVisitor(const FileTable& file_table) : file_table_(file_table) {}
 
   absl::Status HandleBits(const BitsType& type) override {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_bits_type(),

--- a/xls/passes/inlining_pass.h
+++ b/xls/passes/inlining_pass.h
@@ -33,7 +33,7 @@ class InliningPass : public OptimizationPass {
     kLeafOnly,
   };
   static constexpr std::string_view kName = "inlining";
-  InliningPass(InlineDepth depth = InlineDepth::kFull)
+  explicit InliningPass(InlineDepth depth = InlineDepth::kFull)
       : OptimizationPass(kName, "Inlines invocations"), depth_(depth) {}
 
   // Inline a single invoke instruction. Provided for test and utility

--- a/xls/passes/lazy_dag_cache.h
+++ b/xls/passes/lazy_dag_cache.h
@@ -77,7 +77,7 @@ class LazyDagCache {
         const Key& key, absl::Span<const Value* const> input_values) const = 0;
   };
 
-  LazyDagCache<Key, Value>(DagProvider* provider) : provider_(provider) {}
+  explicit LazyDagCache<Key, Value>(DagProvider* provider) : provider_(provider) {}
 
   LazyDagCache<Key, Value>(DagProvider* provider,
                            const LazyDagCache<Key, Value>& other)

--- a/xls/passes/optimization_pass.h
+++ b/xls/passes/optimization_pass.h
@@ -240,7 +240,7 @@ class OptimizationContext {
 
   class InvalidatingVector : public ChangeListener {
    public:
-    InvalidatingVector(FunctionBase* f, std::vector<Node*> value = {})
+    explicit InvalidatingVector(FunctionBase* f, std::vector<Node*> value = {})
         : f_(f), storage_(std::move(value)) {
       f_->RegisterChangeListener(this);
     }

--- a/xls/passes/pass_test_helpers.h
+++ b/xls/passes/pass_test_helpers.h
@@ -28,7 +28,7 @@ template <typename Inner>
 class RecordIfPassChanged : public OptimizationPass {
  public:
   template <typename... Args>
-  RecordIfPassChanged(bool* ABSL_NONNULL changed, Args... args)
+  explicit RecordIfPassChanged(bool* ABSL_NONNULL changed, Args... args)
       : OptimizationPass("temp_sort_name", "temp_long_name"),
         changed_(changed),
         inner_(std::forward<Args>(args)...) {

--- a/xls/passes/proc_state_bits_shattering_pass.cc
+++ b/xls/passes/proc_state_bits_shattering_pass.cc
@@ -46,7 +46,7 @@ namespace {
 
 class TuplifyFlatStateElement : public Proc::StateElementTransformer {
  public:
-  TuplifyFlatStateElement(std::vector<int64_t> split_ends)
+  explicit TuplifyFlatStateElement(std::vector<int64_t> split_ends)
       : split_ends_(std::move(split_ends)) {}
 
   absl::StatusOr<Node*> TransformStateRead(Proc* proc,

--- a/xls/passes/resource_sharing_pass.cc
+++ b/xls/passes/resource_sharing_pass.cc
@@ -170,7 +170,7 @@ class NaryFoldingAction : public FoldingAction {
       const absl::flat_hash_set<std::pair<Node *, uint32_t>> &from, Node *to,
       Node *select, uint32_t to_case_number);
 
-  NaryFoldingAction(const std::vector<BinaryFoldingAction *> &edges);
+  explicit NaryFoldingAction(const std::vector<BinaryFoldingAction *> &edges);
 
   absl::flat_hash_set<std::pair<Node *, uint32_t>> GetFrom() const;
 


### PR DESCRIPTION
Essentially the result of

```
xls/dev_tools/run-clang-tidy-cached.sh --checks="-*,google-explicit-constructor" --fix
```