### PR TITLE
Expose `test_filter` option from interpreter_main in build rules

### DIFF
--- a/xls/build_rules/xls_dslx_rules.bzl
+++ b/xls/build_rules/xls_dslx_rules.bzl
@@ -109,6 +109,7 @@ def _get_dslx_test_cmdline(ctx, src, all_srcs, append_cmd_line_args = True):
         "enable_warnings",
         "max_ticks",
         "format_preference",
+        "test_filter"
     )
 
     dslx_test_args = dict(_dslx_test_args)


### PR DESCRIPTION
This commits exposes the `test_filter` option of the `interpreter_main` in the build rules:
https://github.com/google/xls/blob/f69d07cf2ded54a7dd41ad07eeaca0823b5e8d51/xls/dslx/interpreter_main.cc#L69

This enables creating DSLX test targets that run only a specific test case:
```
xls_dslx_test(
    name = "my_proc_dslx_test",
    library = ":my_proc_dslx",
    dslx_test_args = {
        "test_filter": "MyProcTest",
    },
)
```

FYI @proppy