### PR TITLE
[codegen] flag to avoid inserting "invariant assertions" via codegen passes

### DIFF
--- a/docs_src/codegen_options.md
+++ b/docs_src/codegen_options.md
@@ -497,6 +497,13 @@ response-receive are scheduled to match the RAM's latency.
     false may reduce the resource/area utilization, but may also result in
     mismatches between IR-level evaluation and Verilog simulation.
 
+-   `--add_invariant_assertions` (default: true) controls whether runtime
+    assertions are emitted in the generated RTL to check IR-level invariants
+    (such as one-hot selectors for one-hot selects). Disabling this flag omits
+    these assertions from the output, which may be desirable for production
+    builds or when such checks are not needed; e.g. auto-generated assertions can
+    sometimes interfere with coverage closure metrics.
+
 -   `--array_index_bounds_checking`: With this option set, an out of bounds
     array access returns the maximal index element in the array. If this option
     is not set, the result relies on the semantics of out-of-bounds array access

--- a/xls/codegen/BUILD
+++ b/xls/codegen/BUILD
@@ -2118,3 +2118,27 @@ diff_test(
     file1 = ":assertions_comb_no_ifdef_guards.sv",
     file2 = "testdata/assertions_comb_no_ifdef_guards.svtxt",
 )
+
+cc_test(
+    name = "priority_select_reduction_pass_test",
+    srcs = ["priority_select_reduction_pass_test.cc"],
+    deps = [
+        ":block_conversion",
+        ":codegen_options",
+        ":codegen_pass",
+        ":codegen_pass_pipeline",
+        ":priority_select_reduction_pass",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/common/status:ret_check",
+        "//xls/common/status:status_macros",
+        "//xls/ir",
+        "//xls/ir:bits",
+        "//xls/ir:function_builder",
+        "//xls/ir:ir_matcher",
+        "//xls/passes:pass_base",
+        "@com_google_absl//absl/status:statusor",
+        "@com_google_absl//absl/strings",
+        "@googletest//:gtest",
+    ],
+)

--- a/xls/codegen/block_conversion.cc
+++ b/xls/codegen/block_conversion.cc
@@ -662,8 +662,9 @@ absl::StatusOr<CodegenContext> PackageToPipelinedBlocks(
   // Run codegen passes as appropriate
   {
     MarkChannelFifosPass mark_chans;
-    CodegenPassOptions cg_options;
-    cg_options.codegen_options = options;
+    const CodegenPassOptions cg_options = {
+        .codegen_options = options,
+    };
     PassResults results;
     XLS_RETURN_IF_ERROR(
         mark_chans.Run(package, cg_options, &results, context).status());

--- a/xls/codegen/block_generator_test.cc
+++ b/xls/codegen/block_generator_test.cc
@@ -25,8 +25,6 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -37,6 +35,8 @@
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/strings/str_split.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -2356,9 +2356,9 @@ TEST_P(ZeroWidthBlockGeneratorTest, ZeroWidthRecvChannel) {
   OptimizationContext opt_context;
   std::unique_ptr<CodegenPass> passes = CreateCodegenPassPipeline(opt_context);
   PassResults results;
-  CodegenPassOptions codegen_pass_options{.codegen_options = options,
-                                          .schedule = schedule,
-                                          .delay_estimator = estimator};
+  const CodegenPassOptions codegen_pass_options{.codegen_options = options,
+                                                .schedule = schedule,
+                                                .delay_estimator = estimator};
   XLS_ASSERT_OK(passes->Run(&package, codegen_pass_options, &results, context));
 
   XLS_ASSERT_OK_AND_ASSIGN(std::string verilog,
@@ -2401,9 +2401,10 @@ TEST_P(ZeroWidthBlockGeneratorTest, ZeroWidthSendChannel) {
   OptimizationContext opt_context;
   std::unique_ptr<CodegenPass> passes = CreateCodegenPassPipeline(opt_context);
   PassResults results;
-  CodegenPassOptions codegen_pass_options{.codegen_options = options,
-                                          .schedule = schedule,
-                                          .delay_estimator = estimator};
+  const CodegenPassOptions codegen_pass_options = {
+      .codegen_options = options,
+      .schedule = schedule,
+      .delay_estimator = estimator};
   XLS_ASSERT_OK(passes->Run(&package, codegen_pass_options, &results, context));
 
   XLS_ASSERT_OK_AND_ASSIGN(std::string verilog,

--- a/xls/codegen/block_inlining_pass_test.cc
+++ b/xls/codegen/block_inlining_pass_test.cc
@@ -19,10 +19,10 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status_matchers.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/common/status/matchers.h"
 #include "xls/interpreter/block_evaluator.h"
@@ -87,7 +87,7 @@ TEST_F(BlockInliningPassTest, InlineBlocks) {
   BlockInliningPass bip;
   CodegenContext context(top);
   PassResults results;
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ASSERT_THAT(bip.Run(p.get(), opt, &results, context),
               absl_testing::IsOkAndHolds(true));
 
@@ -165,7 +165,7 @@ TEST_F(BlockInliningPassTest, InlineBlocksWithReg) {
   BlockInliningPass bip;
   CodegenContext context(top);
   PassResults results;
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ASSERT_THAT(bip.Run(p.get(), opt, &results, context),
               absl_testing::IsOkAndHolds(true));
 
@@ -250,7 +250,7 @@ TEST_F(BlockInliningPassTest, InlineBlocksWithFifo) {
   BlockInliningPass bip;
   CodegenContext context(top);
   PassResults results;
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ASSERT_THAT(bip.Run(p.get(), opt, &results, context),
               absl_testing::IsOkAndHolds(true));
 
@@ -324,7 +324,7 @@ TEST_F(BlockInliningPassTest, InlineBlocksWithExtern) {
   BlockInliningPass bip;
   CodegenContext context(top);
   PassResults results;
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ASSERT_THAT(bip.Run(p.get(), opt, &results, context),
               absl_testing::IsOkAndHolds(true));
 

--- a/xls/codegen/codegen_options.cc
+++ b/xls/codegen/codegen_options.cc
@@ -222,4 +222,9 @@ CodegenOptions& CodegenOptions::register_merge_strategy(
   return *this;
 }
 
+CodegenOptions& CodegenOptions::add_invariant_assertions(bool value) {
+  add_invariant_assertions_ = value;
+  return *this;
+}
+
 }  // namespace xls::verilog

--- a/xls/codegen/codegen_options.h
+++ b/xls/codegen/codegen_options.h
@@ -352,6 +352,10 @@ class CodegenOptions {
     return randomize_order_seed_;
   }
 
+  // Control whether runtime invariant asserts are emitted.
+  CodegenOptions& add_invariant_assertions(bool value);
+  bool add_invariant_assertions() const { return add_invariant_assertions_; }
+
  private:
   std::optional<std::string> entry_;
   std::optional<std::string> module_name_;
@@ -377,6 +381,7 @@ class CodegenOptions {
   std::string streaming_channel_valid_suffix_ = "_vld";
   bool array_index_bounds_checking_ = true;
   bool gate_recvs_ = true;
+  bool add_invariant_assertions_ = true;
   std::vector<RamConfiguration> ram_configurations_;
   int64_t max_trace_verbosity_ = 0;
   RegisterMergeStrategy register_merge_strategy_ =

--- a/xls/codegen/codegen_pass.h
+++ b/xls/codegen/codegen_pass.h
@@ -66,11 +66,9 @@ struct CodegenPassOptions : public PassOptionsBase {
   // to implement proc state members.
   ChannelConfig state_channel_config = ChannelConfig{};
 
-  // If true (default), codegen passes may insert runtime assertions which
-  // check that IR-level invariants hold in the generated RTL. One example is
-  // verifying that the selector for a one-hot select is truly one-hot at
-  // runtime.  Setting this to false disables the emission of such assertions.
-  bool add_invariant_assertions = true;
+  bool AddInvariantAssertions() const {
+    return codegen_options.add_invariant_assertions();
+  }
 };
 
 using Stage = int64_t;

--- a/xls/codegen/codegen_pass.h
+++ b/xls/codegen/codegen_pass.h
@@ -65,6 +65,12 @@ struct CodegenPassOptions : public PassOptionsBase {
   // The config to use for loopback channels that are fabricated during codegen
   // to implement proc state members.
   ChannelConfig state_channel_config = ChannelConfig{};
+
+  // If true (default), codegen passes may insert runtime assertions which
+  // check that IR-level invariants hold in the generated RTL. One example is
+  // verifying that the selector for a one-hot select is truly one-hot at
+  // runtime.  Setting this to false disables the emission of such assertions.
+  bool add_invariant_assertions = true;
 };
 
 using Stage = int64_t;

--- a/xls/codegen/combinational_generator.cc
+++ b/xls/codegen/combinational_generator.cc
@@ -44,11 +44,10 @@ absl::StatusOr<CodegenResult> GenerateCombinationalModule(
   XLS_ASSIGN_OR_RETURN(CodegenContext context,
                        FunctionBaseToCombinationalBlock(module, options));
 
-  CodegenPassOptions codegen_pass_options;
-  codegen_pass_options.codegen_options = options;
-  codegen_pass_options.delay_estimator = delay_estimator;
-  codegen_pass_options.add_invariant_assertions =
-      options.add_invariant_assertions();
+  const CodegenPassOptions codegen_pass_options = {
+      .codegen_options = options,
+      .delay_estimator = delay_estimator,
+  };
 
   PassResults results;
   OptimizationContext opt_context;

--- a/xls/codegen/combinational_generator.cc
+++ b/xls/codegen/combinational_generator.cc
@@ -47,6 +47,8 @@ absl::StatusOr<CodegenResult> GenerateCombinationalModule(
   CodegenPassOptions codegen_pass_options;
   codegen_pass_options.codegen_options = options;
   codegen_pass_options.delay_estimator = delay_estimator;
+  codegen_pass_options.add_invariant_assertions =
+      options.add_invariant_assertions();
 
   PassResults results;
   OptimizationContext opt_context;

--- a/xls/codegen/conversion_utils.cc
+++ b/xls/codegen/conversion_utils.cc
@@ -31,6 +31,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
+#include "re2/re2.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/register_legalization_pass.h"
@@ -55,7 +56,6 @@
 #include "xls/passes/dce_pass.h"
 #include "xls/passes/optimization_pass.h"
 #include "xls/passes/pass_base.h"
-#include "re2/re2.h"
 
 namespace xls::verilog {
 
@@ -385,7 +385,7 @@ absl::Status RemoveDeadTokenNodes(Block* block, CodegenContext& context) {
       dce_pass.RunOnFunctionBase(block, options, &results, opt_context)
           .status());
 
-  CodegenPassOptions codegen_options;
+  const CodegenPassOptions codegen_options;
   RegisterLegalizationPass reg_legalization_pass;
   XLS_RETURN_IF_ERROR(
       reg_legalization_pass

--- a/xls/codegen/mark_channel_fifos_pass_test.cc
+++ b/xls/codegen/mark_channel_fifos_pass_test.cc
@@ -17,13 +17,13 @@
 #include <initializer_list>
 #include <utility>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "xls/common/fuzzing/fuzztest.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
+#include "xls/common/fuzzing/fuzztest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
@@ -60,11 +60,13 @@ class MarkChannelFifosPassTest : public IrTestBase {
     XLS_ASSIGN_OR_RETURN(Block * b, bb.Build());
     MarkChannelFifosPass mcfp;
     CodegenContext context(b);
-    CodegenPassOptions opt;
-    opt.codegen_options.flop_inputs(input_flops)
-        .flop_outputs(output_flops)
-        .flop_inputs_kind(input_kind)
-        .flop_outputs_kind(output_kind);
+    const CodegenPassOptions opt = {
+        .codegen_options = CodegenOptions()
+                               .flop_inputs(input_flops)
+                               .flop_outputs(output_flops)
+                               .flop_inputs_kind(input_kind)
+                               .flop_outputs_kind(output_kind),
+    };
     PassResults res;
 
     XLS_RETURN_IF_ERROR(mcfp.Run(&pkg, opt, &res, context).status());
@@ -322,11 +324,13 @@ void IgnoresManuallySet(bool input_flops, CodegenOptions::IOKind input_kind,
   XLS_ASSERT_OK_AND_ASSIGN(Block * b, bb.Build());
   MarkChannelFifosPass mcfp;
   CodegenContext context(b);
-  CodegenPassOptions opt;
-  opt.codegen_options.flop_inputs(input_flops)
-      .flop_outputs(output_flops)
-      .flop_inputs_kind(input_kind)
-      .flop_outputs_kind(output_kind);
+  const CodegenPassOptions opt = {
+      .codegen_options = CodegenOptions()
+                             .flop_inputs(input_flops)
+                             .flop_outputs(output_flops)
+                             .flop_inputs_kind(input_kind)
+                             .flop_outputs_kind(output_kind),
+  };
   PassResults res;
 
   EXPECT_THAT(mcfp.Run(&pkg, opt, &res, context),
@@ -350,11 +354,13 @@ void IgnoresNonStreaming(bool input_flops, CodegenOptions::IOKind input_kind,
   XLS_ASSERT_OK_AND_ASSIGN(Block * b, bb.Build());
   MarkChannelFifosPass mcfp;
   CodegenContext context(b);
-  CodegenPassOptions opt;
-  opt.codegen_options.flop_inputs(input_flops)
-      .flop_outputs(output_flops)
-      .flop_inputs_kind(input_kind)
-      .flop_outputs_kind(output_kind);
+  const CodegenPassOptions opt = {
+      .codegen_options = CodegenOptions()
+                             .flop_inputs(input_flops)
+                             .flop_outputs(output_flops)
+                             .flop_inputs_kind(input_kind)
+                             .flop_outputs_kind(output_kind),
+  };
   PassResults res;
 
   EXPECT_THAT(mcfp.Run(&pkg, opt, &res, context),

--- a/xls/codegen/maybe_materialize_fifos_pass_test.cc
+++ b/xls/codegen/maybe_materialize_fifos_pass_test.cc
@@ -21,17 +21,17 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include "xls/common/fuzzing/fuzztest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status_matchers.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/fifo_model_test_utils.h"
+#include "xls/common/fuzzing/fuzztest.h"
 #include "xls/common/status/matchers.h"
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
@@ -84,11 +84,19 @@ class MaterializeFifosPassTestHelper {
 
     MaybeMaterializeFifosPass mfp;
     CodegenContext context(wrapper);
-    CodegenPassOptions opt;
-    opt.codegen_options.reset(reset_name, /*asynchronous=*/false,
-                              /*active_low=*/false, /*reset_data_path=*/false);
-    opt.codegen_options.set_fifo_module("");
-    opt.codegen_options.set_nodata_fifo_module("");
+    const CodegenPassOptions opt = {
+        .codegen_options = CodegenOptions()
+                               .reset(reset_name, /*asynchronous=*/false,
+                                      /*active_low=*/false,
+                                      /*reset_data_path=*/false)
+                               .set_fifo_module("")
+                               .set_nodata_fifo_module("")
+                               .reset(reset_name, /*asynchronous=*/false,
+                                      /*active_low=*/false,
+                                      /*reset_data_path=*/false)
+                               .set_fifo_module("")
+                               .set_nodata_fifo_module(""),
+    };
     PassResults res;
     XLS_ASSIGN_OR_RETURN(auto changed, mfp.Run(p, opt, &res, context));
     XLS_RET_CHECK(changed);

--- a/xls/codegen/name_legalization_pass_test.cc
+++ b/xls/codegen/name_legalization_pass_test.cc
@@ -17,10 +17,10 @@
 #include <string>
 #include <string_view>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_generator.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -60,8 +60,9 @@ absl::StatusOr<bool> RunLegalizationPass(Block* block,
   CodegenContext context(block);
   CodegenOptions codegen_options;
   codegen_options.use_system_verilog(use_system_verilog);
-  CodegenPassOptions options;
-  options.codegen_options = codegen_options;
+  const CodegenPassOptions options = {
+      .codegen_options = codegen_options,
+  };
   return NameLegalizationPass().Run(block->package(), options, &results,
                                     context);
 }

--- a/xls/codegen/passes_ng/stage_conversion_pass_pipeline_test.cc
+++ b/xls/codegen/passes_ng/stage_conversion_pass_pipeline_test.cc
@@ -20,12 +20,12 @@
 #include <string_view>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/log/check.h"
 #include "absl/log/log.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/passes_ng/stage_conversion.h"
@@ -103,11 +103,13 @@ TEST_P(SweepPipelineStagesFixture, TrivialPipelinedFunction) {
   CodegenContext context;
   context.AssociateSchedule(f, schedule);
 
-  CodegenPassOptions pass_options;
-  pass_options.codegen_options =
-      CodegenOptions().flop_inputs(false).flop_outputs(true).clock_name("clk");
-  pass_options.schedule = schedule;
-  pass_options.delay_estimator = &delay_estimator;
+  const CodegenPassOptions pass_options = {
+      .codegen_options =
+          CodegenOptions().flop_inputs(false).flop_outputs(true).clock_name(
+              "clk"),
+      .schedule = schedule,
+      .delay_estimator = &delay_estimator,
+  };
   PassResults results;
   OptimizationContext opt_context;
 

--- a/xls/codegen/pipeline_generator.cc
+++ b/xls/codegen/pipeline_generator.cc
@@ -57,6 +57,7 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
   pass_options.codegen_options = options;
   pass_options.schedule = schedule;
   pass_options.delay_estimator = delay_estimator;
+  pass_options.add_invariant_assertions = options.add_invariant_assertions();
 
   // Convert to block and add in pipe stages according to schedule.
   XLS_ASSIGN_OR_RETURN(CodegenContext context,
@@ -118,6 +119,7 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
   CodegenPassOptions pass_options;
   pass_options.codegen_options = options;
   pass_options.delay_estimator = delay_estimator;
+  pass_options.add_invariant_assertions = options.add_invariant_assertions();
 
   // Convert to block and add in pipe stages according to schedule.
   XLS_ASSIGN_OR_RETURN(CodegenContext context,

--- a/xls/codegen/pipeline_generator.cc
+++ b/xls/codegen/pipeline_generator.cc
@@ -53,11 +53,13 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
   XLS_VLOG_LINES(2, module->DumpIr());
   XLS_VLOG_LINES(2, schedule.ToString());
 
-  CodegenPassOptions pass_options;
-  pass_options.codegen_options = options;
-  pass_options.schedule = schedule;
-  pass_options.delay_estimator = delay_estimator;
-  pass_options.add_invariant_assertions = options.add_invariant_assertions();
+  // Note: this is mutated below so cannot be const. It would be nice to
+  // refactor this so it could be.
+  CodegenPassOptions pass_options = {
+      .codegen_options = options,
+      .schedule = schedule,
+      .delay_estimator = delay_estimator,
+  };
 
   // Convert to block and add in pipe stages according to schedule.
   XLS_ASSIGN_OR_RETURN(CodegenContext context,
@@ -116,10 +118,12 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
     }
   }
 
-  CodegenPassOptions pass_options;
-  pass_options.codegen_options = options;
-  pass_options.delay_estimator = delay_estimator;
-  pass_options.add_invariant_assertions = options.add_invariant_assertions();
+  // Note: this is mutated below so cannot be const. It would be nice to
+  // refactor this so it could be.
+  CodegenPassOptions pass_options = {
+      .codegen_options = options,
+      .delay_estimator = delay_estimator,
+  };
 
   // Convert to block and add in pipe stages according to schedule.
   XLS_ASSIGN_OR_RETURN(CodegenContext context,

--- a/xls/codegen/priority_select_reduction_pass.cc
+++ b/xls/codegen/priority_select_reduction_pass.cc
@@ -97,17 +97,20 @@ absl::StatusOr<bool> PrioritySelectReductionPass::RunInternal(
       XLS_ASSIGN_OR_RETURN(Node * tkn,
                            sel->function_base()->MakeNode<xls::Literal>(
                                sel->loc(), Value::Token()));
-      XLS_ASSIGN_OR_RETURN(
-          Node * one_hot_assert,
-          sel->function_base()->MakeNode<Assert>(
-              sel->loc(), tkn, selector_is_one_hot,
-              absl::StrFormat(
-                  "Selector %s was expected to be one-hot, and is not.",
-                  selector->GetName()),
-              /*label=*/
-              SanitizeVerilogIdentifier(
-                  absl::StrCat(sel->GetName(), "_selector_one_hot_A")),
-              /*original_label=*/std::nullopt));
+      Node* one_hot_assert = nullptr;
+      if (options.add_invariant_assertions) {
+        XLS_ASSIGN_OR_RETURN(
+            one_hot_assert,
+            sel->function_base()->MakeNode<Assert>(
+                sel->loc(), tkn, selector_is_one_hot,
+                absl::StrFormat(
+                    "Selector %s was expected to be one-hot, and is not.",
+                    selector->GetName()),
+                /*label=*/
+                SanitizeVerilogIdentifier(absl::StrCat(
+                    "__xls_invariant_", sel->GetName(), "_selector_one_hot_A")),
+                /*original_label=*/std::nullopt));
+      }
       XLS_ASSIGN_OR_RETURN(
           Node * new_sel,
           sel->ReplaceUsesWithNew<OneHotSelect>(selector, sel->cases()));
@@ -121,7 +124,9 @@ absl::StatusOr<bool> PrioritySelectReductionPass::RunInternal(
         node_to_stage_map[one_hot_original_bits] = stage;
         node_to_stage_map[selector_is_one_hot] = stage;
         node_to_stage_map[tkn] = stage;
-        node_to_stage_map[one_hot_assert] = stage;
+        if (options.add_invariant_assertions && one_hot_assert != nullptr) {
+          node_to_stage_map[one_hot_assert] = stage;
+        }
         node_to_stage_map[new_sel] = stage;
       }
       changed = true;

--- a/xls/codegen/priority_select_reduction_pass.cc
+++ b/xls/codegen/priority_select_reduction_pass.cc
@@ -98,7 +98,7 @@ absl::StatusOr<bool> PrioritySelectReductionPass::RunInternal(
                            sel->function_base()->MakeNode<xls::Literal>(
                                sel->loc(), Value::Token()));
       Node* one_hot_assert = nullptr;
-      if (options.add_invariant_assertions) {
+      if (options.AddInvariantAssertions()) {
         XLS_ASSIGN_OR_RETURN(
             one_hot_assert,
             sel->function_base()->MakeNode<Assert>(
@@ -124,7 +124,7 @@ absl::StatusOr<bool> PrioritySelectReductionPass::RunInternal(
         node_to_stage_map[one_hot_original_bits] = stage;
         node_to_stage_map[selector_is_one_hot] = stage;
         node_to_stage_map[tkn] = stage;
-        if (options.add_invariant_assertions && one_hot_assert != nullptr) {
+        if (options.AddInvariantAssertions() && one_hot_assert != nullptr) {
           node_to_stage_map[one_hot_assert] = stage;
         }
         node_to_stage_map[new_sel] = stage;

--- a/xls/codegen/priority_select_reduction_pass_test.cc
+++ b/xls/codegen/priority_select_reduction_pass_test.cc
@@ -56,13 +56,14 @@ TEST_P(PrioritySelectReductionPassTest, AssertEmissionMatchesFlag) {
   FunctionBase* top = package->GetTop().value();
 
   // Run the code-gen pipeline with/without invariant assertions enabled.
-  CodegenOptions cg_opts;
+  const CodegenOptions cg_opts =
+      CodegenOptions().add_invariant_assertions(enable_asserts);
   XLS_ASSERT_OK_AND_ASSIGN(CodegenContext context,
                            FunctionBaseToCombinationalBlock(top, cg_opts));
 
-  CodegenPassOptions pass_opts;
-  pass_opts.codegen_options = cg_opts;
-  pass_opts.add_invariant_assertions = enable_asserts;
+  const CodegenPassOptions pass_opts = {
+      .codegen_options = cg_opts,
+  };
 
   OptimizationContext opt_ctx;
   PassResults results;

--- a/xls/codegen/priority_select_reduction_pass_test.cc
+++ b/xls/codegen/priority_select_reduction_pass_test.cc
@@ -1,0 +1,96 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/codegen/priority_select_reduction_pass.h"
+
+#include <memory>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/codegen/block_conversion.h"
+#include "xls/codegen/codegen_options.h"
+#include "xls/codegen/codegen_pass.h"
+#include "xls/codegen/codegen_pass_pipeline.h"
+#include "xls/common/status/matchers.h"
+#include "xls/common/status/ret_check.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/function_builder.h"
+#include "xls/ir/ir_matcher.h"
+#include "xls/ir/package.h"
+
+namespace m = xls::op_matchers;
+
+namespace xls::verilog {
+namespace {
+using ::absl_testing::IsOkAndHolds;
+
+// Helper which builds a simple function containing a priority-select that the
+// reduction pass can transform. Returns the newly-created package.
+static absl::StatusOr<std::unique_ptr<Package>> BuildPkgWithPrioritySelect() {
+  auto package = std::make_unique<Package>("test_pkg");
+
+  FunctionBuilder fb("f", package.get());
+  // Selector is constant one-hot 0b01 so the pass can prove properties.
+  BValue selector = fb.Literal(xls::UBits(1, 2));
+  BValue case0 = fb.Literal(xls::UBits(11, 32));
+  BValue case1 = fb.Literal(xls::UBits(22, 32));
+  BValue def = fb.Literal(xls::UBits(0, 32));
+  BValue prio = fb.PrioritySelect(selector, {case0, case1}, def);
+  XLS_RETURN_IF_ERROR(fb.BuildWithReturnValue(prio).status());
+  XLS_RETURN_IF_ERROR(package->SetTopByName("f"));
+  return package;
+}
+
+void RunPassAndCheck(bool enable_asserts, bool expect_assert) {
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> package,
+                           BuildPkgWithPrioritySelect());
+  FunctionBase* top = package->GetTop().value();
+  CodegenOptions cg_opts;  // Minimal options.
+
+  XLS_ASSERT_OK_AND_ASSIGN(CodegenContext context,
+                           FunctionBaseToCombinationalBlock(top, cg_opts));
+
+  CodegenPassOptions pass_opts;
+  pass_opts.codegen_options = cg_opts;
+  pass_opts.add_invariant_assertions = enable_asserts;
+
+  OptimizationContext opt_ctx;
+  PassResults results;
+  XLS_ASSERT_OK(CreateCodegenPassPipeline(opt_ctx)
+                    ->Run(package.get(), pass_opts, &results, context)
+                    .status());
+
+  XLS_ASSERT_OK_AND_ASSIGN(Block * block, package->GetBlock("f"));
+  bool found_assert = false;
+  for (Node* n : block->nodes()) {
+    if (n->Is<Assert>()) {
+      found_assert = true;
+      break;
+    }
+  }
+  EXPECT_EQ(found_assert, expect_assert);
+}
+
+TEST(PrioritySelectReductionPassTest, AssertsInsertedWhenEnabled) {
+  RunPassAndCheck(/*enable_asserts=*/true, /*expect_assert=*/true);
+}
+
+TEST(PrioritySelectReductionPassTest, AssertsOmittedWhenDisabled) {
+  RunPassAndCheck(/*enable_asserts=*/false, /*expect_assert=*/false);
+}
+
+}  // namespace
+}  // namespace xls::verilog

--- a/xls/codegen/ram_rewrite_pass_test.cc
+++ b/xls/codegen/ram_rewrite_pass_test.cc
@@ -26,8 +26,6 @@
 #include <variant>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
@@ -38,6 +36,8 @@
 #include "absl/strings/str_replace.h"
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -328,8 +328,8 @@ class RamRewritePassTest
 
 TEST_P(RamRewritePassTest, PortsUpdated) {
   auto& param = std::get<0>(GetParam());
-  CodegenOptions codegen_options = GetCodegenOptions();
-  CodegenPassOptions pass_options{
+  const CodegenOptions codegen_options = GetCodegenOptions();
+  const CodegenPassOptions pass_options{
       .codegen_options = codegen_options,
   };
 
@@ -463,8 +463,8 @@ TEST_P(RamRewritePassTest, ModuleSignatureUpdated) {
   }
 
   auto& param = std::get<0>(GetParam());
-  CodegenOptions codegen_options = GetCodegenOptions();
-  CodegenPassOptions pass_options{
+  const CodegenOptions codegen_options = GetCodegenOptions();
+  const CodegenPassOptions pass_options{
       .codegen_options = codegen_options,
   };
 
@@ -657,8 +657,8 @@ TEST_P(RamRewritePassTest, ModuleSignatureUpdated) {
 
 TEST_P(RamRewritePassTest, WriteCompletionRemoved) {
   auto& param = std::get<0>(GetParam());
-  CodegenOptions codegen_options = GetCodegenOptions();
-  CodegenPassOptions pass_options{
+  const CodegenOptions codegen_options = GetCodegenOptions();
+  const CodegenPassOptions pass_options{
       .codegen_options = codegen_options,
   };
 
@@ -1063,17 +1063,18 @@ absl::StatusOr<Block*> MakeBlockAndRunPasses(Package* package,
         absl::StrFormat("Unrecognized ram_kind %s.", ram_kind));
   }
 
-  CodegenOptions codegen_options;
-  codegen_options.flop_inputs(false)
-      .flop_outputs(false)
-      .clock_name("clk")
-      .reset("rst", false, false, false)
-      .streaming_channel_data_suffix("_data")
-      .streaming_channel_valid_suffix("_valid")
-      .streaming_channel_ready_suffix("_ready")
-      .module_name("pipelined_proc")
-      .ram_configurations(ram_configurations);
-  CodegenPassOptions pass_options{
+  const CodegenOptions codegen_options =
+      CodegenOptions()
+          .flop_inputs(false)
+          .flop_outputs(false)
+          .clock_name("clk")
+          .reset("rst", false, false, false)
+          .streaming_channel_data_suffix("_data")
+          .streaming_channel_valid_suffix("_valid")
+          .streaming_channel_ready_suffix("_ready")
+          .module_name("pipelined_proc")
+          .ram_configurations(ram_configurations);
+  const CodegenPassOptions pass_options{
       .codegen_options = codegen_options,
   };
 

--- a/xls/codegen/register_chaining_analysis_test.cc
+++ b/xls/codegen/register_chaining_analysis_test.cc
@@ -19,11 +19,11 @@
 #include <optional>
 #include <string_view>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/algorithm/container.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/concurrent_stage_groups.h"
 #include "xls/common/status/matchers.h"
@@ -786,7 +786,7 @@ TEST_F(RegisterChainingAnalysisTest, BasicSelectMutexList) {
   XLS_ASSERT_OK_AND_ASSIGN((const std::array<RegisterData, kRegCnt> datas),
                            CreateStraightShot<kRegCnt>(p.get()));
 
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 1);
   csg.MarkMutuallyExclusive(1, 2);
   csg.MarkMutuallyExclusive(1, 3);
@@ -826,7 +826,7 @@ TEST_F(RegisterChainingAnalysisTest, SplitMutexRegion) {
   EXPECT_THAT(datas, ElementsAre(Reg("reg_A"), Reg("reg_B"), Reg("reg_C"),
                                  Reg("reg_D"), Reg("reg_E"), Reg("reg_F")));
 
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 1);
   csg.MarkMutuallyExclusive(0, 1);
   csg.MarkMutuallyExclusive(0, 2);
@@ -867,7 +867,7 @@ TEST_F(RegisterChainingAnalysisTest, MutexTouchesEnd) {
   // NB can combine registers 'D, 'E', & 'F.
   XLS_ASSERT_OK_AND_ASSIGN((const std::array<RegisterData, kRegCnt> registers),
                            CreateStraightShot<kRegCnt>(p.get()));
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 1);
   csg.MarkMutuallyExclusive(3, 4);
   csg.MarkMutuallyExclusive(3, 5);
@@ -906,7 +906,7 @@ TEST_F(RegisterChainingAnalysisTest, LoopbackMutex) {
   // NB can combine registers 'A, 'B' & 'C
   XLS_ASSERT_OK_AND_ASSIGN((const std::array<RegisterData, kRegCnt> registers),
                            CreateLoopback<kRegCnt>(p.get()));
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 1);
   csg.MarkMutuallyExclusive(0, 1);
   csg.MarkMutuallyExclusive(0, 2);
@@ -946,7 +946,7 @@ TEST_F(RegisterChainingAnalysisTest, MutexTouchesStart) {
   // NB can registers 'A, 'B' & 'C
   XLS_ASSERT_OK_AND_ASSIGN((const std::array<RegisterData, kRegCnt> datas),
                            CreateStraightShot<kRegCnt>(p.get()));
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 1);
   csg.MarkMutuallyExclusive(0, 1);
   csg.MarkMutuallyExclusive(0, 2);
@@ -1009,7 +1009,7 @@ TEST_F(RegisterChainingAnalysisTest, OverlappingFullyUsedMutexRegions) {
       (const std::array<RegisterData, kRegCnt> datas_late),
       CreateStraightShot<kRegCnt>(bb, /*start_stage=*/3, /*prefix=*/"late_"));
   XLS_ASSERT_OK(bb.Build().status());
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 3 + 1);
   MarkAllPairs(csg, 0, 6);
   MarkAllPairs(csg, 3, 9);
@@ -1080,7 +1080,7 @@ TEST_F(RegisterChainingAnalysisTest, OverlappingMutexRegions) {
       (const std::array<RegisterData, kRegCnt> datas_late),
       CreateStraightShot<kRegCnt>(bb, /*start_stage=*/3, /*prefix=*/"late_"));
   XLS_ASSERT_OK(bb.Build().status());
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(kRegCnt + 3 + 1);
   MarkAllPairs(csg, 0, 4);
   MarkAllPairs(csg, 3, 6);
@@ -1222,7 +1222,7 @@ TEST_F(RegisterChainingAnalysisTest, MutexLoopbackContinues) {
       .write_stage = 5,
   };
 
-  CodegenPassOptions opt;
+  const CodegenPassOptions opt;
   ConcurrentStageGroups csg(7);
   MarkAllPairs(csg, 0, 4);
 

--- a/xls/codegen/side_effect_condition_pass_test.cc
+++ b/xls/codegen/side_effect_condition_pass_test.cc
@@ -21,14 +21,14 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_split.h"
 #include "absl/types/span.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 #include "xls/codegen/block_conversion.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
@@ -139,8 +139,10 @@ class SideEffectConditionPassTest
         CodegenContext context,
         FunctionBaseToPipelinedBlock(schedule, codegen_options, top));
     PassResults results;
-    CodegenPassOptions codegen_pass_options{.codegen_options = codegen_options,
-                                            .schedule = schedule};
+    const CodegenPassOptions codegen_pass_options = {
+        .codegen_options = codegen_options,
+        .schedule = schedule,
+    };
     return GetCodegenPass(GetParam(), optimization_context)
         ->Run(p, codegen_pass_options, &results, context);
   }
@@ -198,12 +200,14 @@ TEST_F(SideEffectConditionPassTest, UnchangedIfCombinationalFunction) {
   XLS_ASSERT_OK_AND_ASSIGN(Function * top,
                            fb.BuildWithReturnValue(fb.Tuple({assertion, sum})));
   ASSERT_NE(top, nullptr);
-  CodegenOptions codegen_options;
+  const CodegenOptions codegen_options;
   XLS_ASSERT_OK_AND_ASSIGN(
       CodegenContext context,
       FunctionBaseToCombinationalBlock(top, codegen_options));
   PassResults results;
-  CodegenPassOptions codegen_pass_options{.codegen_options = codegen_options};
+  const CodegenPassOptions codegen_pass_options = {
+      .codegen_options = codegen_options,
+  };
   OptimizationContext opt_context;
   EXPECT_THAT(
       GetCodegenPass(CodegenPassType::kSideEffectConditionPassOnly, opt_context)
@@ -241,7 +245,8 @@ TEST_P(SideEffectConditionPassTest, CombinationalProc) {
       CodegenContext context,
       FunctionBaseToCombinationalBlock(top, codegen_options));
   PassResults results;
-  CodegenPassOptions codegen_pass_options{.codegen_options = codegen_options};
+  const CodegenPassOptions codegen_pass_options{.codegen_options =
+                                                    codegen_options};
   OptimizationContext opt_context;
   EXPECT_THAT(GetCodegenPass(GetParam(), opt_context)
                   ->Run(&package, codegen_pass_options, &results, context),

--- a/xls/codegen/trace_verbosity_pass_test.cc
+++ b/xls/codegen/trace_verbosity_pass_test.cc
@@ -16,9 +16,9 @@
 
 #include <cstdint>
 
+#include "absl/status/statusor.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "absl/status/statusor.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/common/status/matchers.h"
 #include "xls/ir/bits.h"
@@ -44,8 +44,10 @@ namespace m = ::xls::op_matchers;
 absl::StatusOr<bool> RunTraceVerbosityPass(Block* block,
                                            int64_t max_trace_verbosity = 0) {
   PassResults results;
-  verilog::CodegenPassOptions options;
-  options.codegen_options.set_max_trace_verbosity(max_trace_verbosity);
+  const verilog::CodegenPassOptions options = {
+      .codegen_options = verilog::CodegenOptions().set_max_trace_verbosity(
+          max_trace_verbosity),
+  };
   verilog::CodegenContext context(block);
   return verilog::TraceVerbosityPass().Run(block->package(), options, &results,
                                            context);

--- a/xls/codegen/unified_generator.cc
+++ b/xls/codegen/unified_generator.cc
@@ -66,9 +66,12 @@ absl::StatusOr<CodegenResult> GenerateModuleText(
   XLS_ASSIGN_OR_RETURN(CodegenContext codegen_context,
                        CreateBlocksFor(schedules, options, package));
 
-  CodegenPassOptions pass_options;
-  pass_options.codegen_options = options;
-  pass_options.delay_estimator = delay_estimator;
+  // Note: this is mutated below so cannot be const. It would be nice to
+  // refactor this so it could be.
+  CodegenPassOptions pass_options = {
+      .codegen_options = options,
+      .delay_estimator = delay_estimator,
+  };
 
   PassResults results;
   OptimizationContext opt_context;

--- a/xls/jit/block_jit.cc
+++ b/xls/jit/block_jit.cc
@@ -224,7 +224,7 @@ absl::StatusOr<ElaborationJitData> CloneElaborationPackage(
   XLS_ASSIGN_OR_RETURN(Block * cloned_top, jit_package->GetBlock(top_name));
   verilog::CodegenContext codegen_context(cloned_top);
   PassResults results;
-  verilog::CodegenPassOptions opts{
+  const verilog::CodegenPassOptions opts{
       .codegen_options =
           verilog::CodegenOptions()
               .reset(FifoInstantiation::kResetPortName, /*asynchronous=*/false,

--- a/xls/tools/codegen.cc
+++ b/xls/tools/codegen.cc
@@ -309,6 +309,14 @@ absl::StatusOr<verilog::CodegenOptions> CodegenOptionsFromProto(
     options.flop_single_value_channels(p.flop_single_value_channels());
     options.add_idle_output(p.add_idle_output());
 
+    // Set invariant assertion emission regardless of generator kind.  Proto3
+    // returns the default (false) when the field is unset, so if the field is
+    // not present we emit assertions by default via the CodegenOptions default
+    // of `true`.
+    if (p.has_add_invariant_assertions()) {
+      options.add_invariant_assertions(p.add_invariant_assertions());
+    }
+
     if (!p.reset().empty()) {
       options.reset(p.reset(), p.reset_asynchronous(), p.reset_active_low(),
                     p.reset_data_path());
@@ -325,6 +333,14 @@ absl::StatusOr<verilog::CodegenOptions> CodegenOptionsFromProto(
 
   if (!p.output_port_name().empty()) {
     options.output_port_name(p.output_port_name());
+  }
+
+  // Set invariant assertion emission regardless of generator kind.  Proto3
+  // returns the default (false) when the field is unset, so if the field is
+  // not present we emit assertions by default via the CodegenOptions default
+  // of `true`.
+  if (p.has_add_invariant_assertions()) {
+    options.add_invariant_assertions(p.add_invariant_assertions());
   }
 
   options.use_system_verilog(p.use_system_verilog());

--- a/xls/tools/codegen_flags.cc
+++ b/xls/tools/codegen_flags.cc
@@ -166,6 +166,10 @@ ABSL_FLAG(bool, array_index_bounds_checking, true,
 ABSL_FLAG(int64_t, max_trace_verbosity, 0,
           "Maximum verbosity for traces. Traces with higher verbosity are "
           "stripped from codegen output. 0 by default.");
+ABSL_FLAG(bool, add_invariant_assertions, true,
+          "If true, codegen will insert runtime assertions which check that "
+          "certain IR-level invariants hold (e.g., one-hot selector "
+          "invariants). Disable to omit these assertions.");
 ABSL_FLAG(std::string, codegen_options_proto, "",
           "Path to a protobuf containing all codegen args.");
 ABSL_FLAG(std::optional<std::string>, codegen_options_used_textproto_file,
@@ -348,6 +352,7 @@ static absl::StatusOr<bool> SetOptionsFromFlags(CodegenFlagsProto& proto) {
   POPULATE_FLAG(streaming_channel_valid_suffix);
   POPULATE_FLAG(streaming_channel_ready_suffix);
   POPULATE_REPEATED_FLAG(ram_configurations);
+  POPULATE_FLAG(add_invariant_assertions);
 
   // Optimizations
   POPULATE_FLAG(gate_recvs);

--- a/xls/tools/codegen_flags.h
+++ b/xls/tools/codegen_flags.h
@@ -37,6 +37,10 @@ ABSL_DECLARE_FLAG(std::optional<std::string>,
 ABSL_DECLARE_FLAG(std::string, block_metrics_path);
 ABSL_DECLARE_FLAG(int64_t, max_trace_verbosity);
 
+// Enables or disables insertion of runtime invariant assertions during
+// codegen (e.g., one-hot selector checks).  Enabled by default.
+ABSL_DECLARE_FLAG(bool, add_invariant_assertions);
+
 namespace xls {
 
 // Populates the codegen flags proto from the ABSL flags library values.

--- a/xls/tools/codegen_flags.proto
+++ b/xls/tools/codegen_flags.proto
@@ -95,4 +95,8 @@ message CodegenFlagsProto {
   // empty, will use a default order. This can be useful for creating multiple
   // equivalent Verilog outputs to exercise the rest of the synthesis pipeline.
   repeated int32 randomize_order_seed = 38;
+
+  // If false, runtime invariant assertions (e.g. one-hot selector checks)
+  // are omitted from generated RTL.  Default is true.
+  optional bool add_invariant_assertions = 42;
 }


### PR DESCRIPTION
Sometimes passes want to add in assertions for properties they "believe they have proven to be true but would like additional validation for at simulation-time".

We put these assertions behind a flag because they can slow down assert-condition coverage closure.