### PR TITLE
[dslx:fmt] Print human readable positional (scan/parse) errors

### DIFF
--- a/xls/common/exit_status.cc
+++ b/xls/common/exit_status.cc
@@ -26,7 +26,7 @@ int ExitStatus(const absl::Status& status, bool log_on_error) {
     return EXIT_SUCCESS;
   }
   if (log_on_error) {
-    std::cerr << "Error: " << status;
+    std::cerr << "Error: " << status << "\n";
   }
   return EXIT_FAILURE;
 }


### PR DESCRIPTION
If dslx_fmt encounters a positional error in parsing the module print it in human-readable form.