### PR TITLE
[dslx] Add an out-of-tree interpreter test to regression test the usecase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,5 @@ repos:
     rev: v3.3.4
     hooks:
       - id: pylint
-        files: ^xls/dev_tools/check_.*.py$
-        args: [
-          --rcfile=.pylintrc
-        ]
+        files: ^(xls/dev_tools/check_.*\.py|xls/dslx/interpreter_test\.py)$
+        args: [--rcfile=.pylintrc]

--- a/xls/dslx/interpreter_test.py
+++ b/xls/dslx/interpreter_test.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for the DSLX interpreter.
 
 Note that generally we want DSLX test to be in `xls/dslx/tests`, but this can
@@ -155,9 +154,9 @@ class InterpreterTest(test_base.TestCase):
     """)
     # warnings-as-errors off because we have a useless match expression just to
     # trigger the type error.
-    stderr = self._parse_and_test(
-        program, warnings_as_errors=False, want_error=True
-    )
+    stderr = self._parse_and_test(program,
+                                  warnings_as_errors=False,
+                                  want_error=True)
     self.assertIn(
         'Match pattern is not exhaustive',
         stderr,
@@ -285,9 +284,9 @@ class InterpreterTest(test_base.TestCase):
       main()
     }
     """
-    stderr = self._parse_and_test(
-        program, want_error=False, alsologtostderr=True
-    )
+    stderr = self._parse_and_test(program,
+                                  want_error=False,
+                                  alsologtostderr=True)
     self.assertIn('Hello world!', stderr)
     self.assertIn('x is 240, 0xf0 in hex and 0b1111_0000 in binary', stderr)
 
@@ -352,9 +351,8 @@ class InterpreterTest(test_base.TestCase):
     result = subp.run(cmd, stderr=subp.PIPE, encoding='utf-8', check=False)
     print(result.stderr)
     self.assertRegex(result.stderr, r'a as hex: \[\s+MyStruct\s+{\s+x: 0x2a')
-    self.assertRegex(
-        result.stderr, r'a as bin: \[\s+MyStruct\s+{\s+x: 0b10_1010'
-    )
+    self.assertRegex(result.stderr,
+                     r'a as bin: \[\s+MyStruct\s+{\s+x: 0b10_1010')
 
   def test_trace_fmt_array_of_enum(self):
     """Tests we can trace-format an array of enum values."""
@@ -373,9 +371,9 @@ class InterpreterTest(test_base.TestCase):
       main()
     }
     """
-    stderr = self._parse_and_test(
-        program, want_error=False, alsologtostderr=True
-    )
+    stderr = self._parse_and_test(program,
+                                  want_error=False,
+                                  alsologtostderr=True)
     self.assertRegex(stderr, r'MyEnum::ONE\s+// u2:1')
     self.assertRegex(stderr, r'MyEnum::TWO\s+// u2:2')
 
@@ -392,9 +390,9 @@ class InterpreterTest(test_base.TestCase):
       main()
     }
     """
-    stderr = self._parse_and_test(
-        program, want_error=False, alsologtostderr=True
-    )
+    stderr = self._parse_and_test(program,
+                                  want_error=False,
+                                  alsologtostderr=True)
     self.assertIn(r'a: [', stderr)
     self.assertIn(r'0x1', stderr)
     self.assertIn(r'0x2', stderr)
@@ -416,9 +414,9 @@ class InterpreterTest(test_base.TestCase):
       main()
     }
     """
-    stderr = self._parse_and_test(
-        program, want_error=False, alsologtostderr=True
-    )
+    stderr = self._parse_and_test(program,
+                                  want_error=False,
+                                  alsologtostderr=True)
     self.assertIn('t: (', stderr)
     self.assertIn('MyEnum::ONE', stderr)
     self.assertIn('MyEnum::TWO', stderr)
@@ -555,9 +553,9 @@ class InterpreterTest(test_base.TestCase):
       assert_eq(u32:20, u32:30)
     }
     """)
-    stderr = self._parse_and_test(
-        program, want_error=True, extra_flags=('--format_preference=hex',)
-    )
+    stderr = self._parse_and_test(program,
+                                  want_error=True,
+                                  extra_flags=('--format_preference=hex',))
     self.assertIn('lhs: u32:0x14', stderr)
     self.assertIn('rhs: u32:0x1e', stderr)
 
@@ -680,13 +678,11 @@ class InterpreterTest(test_base.TestCase):
       root = ET.fromstring(xml_got)
       self.assertLen(
           root.findall(
-              ".//testcase[@name='test_failing'][@result='completed']"
-          ),
+              ".//testcase[@name='test_failing'][@result='completed']"),
           1,
       )
-      self.assertLen(
-          root.findall(".//testcase[@name='test_failing']/failure"), 1
-      )
+      self.assertLen(root.findall(".//testcase[@name='test_failing']/failure"),
+                     1)
       self.assertLen(
           root.findall(".//testcase[@name='test_passing'][@result='filtered']"),
           1,
@@ -713,17 +709,15 @@ class InterpreterTest(test_base.TestCase):
       root = ET.fromstring(xml_got)
       self.assertLen(
           root.findall(
-              ".//testcase[@name='test_passing'][@result='completed']"
-          ),
+              ".//testcase[@name='test_passing'][@result='completed']"),
           1,
       )
       self.assertLen(
           root.findall(".//testcase[@name='test_failing'][@result='filtered']"),
           1,
       )
-      self.assertLen(
-          root.findall(".//testcase[@name='test_failing']/failure"), 0
-      )
+      self.assertLen(root.findall(".//testcase[@name='test_failing']/failure"),
+                     0)
       self.assertLen(root.findall('.//failure'), 0)
 
   def test_flag_based_test_filter(self):
@@ -752,11 +746,9 @@ class InterpreterTest(test_base.TestCase):
       root = ET.fromstring(xml_got)
       print('root:', root)
       self.assertLen(
-          root.findall(".//testcase[@name='test_two'][@result='completed']"), 1
-      )
+          root.findall(".//testcase[@name='test_two'][@result='completed']"), 1)
       self.assertLen(
-          root.findall(".//testcase[@name='test_one'][@result='filtered']"), 1
-      )
+          root.findall(".//testcase[@name='test_one'][@result='filtered']"), 1)
       self.assertLen(root.findall('.//failure'), 0)
 
   def test_both_test_filters_errors(self):
@@ -815,7 +807,11 @@ class OutOfTreeInterpreterTest(test_base.TestCase):
     """
     temp_file = self.create_tempfile(content=program)
     # Note: we have to supply `env` to avoid the Python testbridge setting seeping in.
-    p = subp.run([self.interpreter_path.full_path, temp_file.full_path], stdout=subp.PIPE, stderr=subp.PIPE, encoding='utf-8', env={})
+    p = subp.run([self.interpreter_path.full_path, temp_file.full_path],
+                 stdout=subp.PIPE,
+                 stderr=subp.PIPE,
+                 encoding='utf-8',
+                 env={})
     self.assertEqual(p.returncode, 0)
     self.assertIn('1 test(s) ran; 0 failed; 0 skipped', p.stderr)
 
@@ -826,7 +822,14 @@ class OutOfTreeInterpreterTest(test_base.TestCase):
     """
     temp_file = self.create_tempfile(content=program)
     # Note: we have to supply `env` to avoid the Python testbridge setting seeping in.
-    p = subp.run([self.interpreter_path.full_path, temp_file.full_path, "--type_inference_v2"], stdout=subp.PIPE, stderr=subp.PIPE, encoding='utf-8', env={})
+    p = subp.run([
+        self.interpreter_path.full_path, temp_file.full_path,
+        "--type_inference_v2"
+    ],
+                 stdout=subp.PIPE,
+                 stderr=subp.PIPE,
+                 encoding='utf-8',
+                 env={})
     print('p:', p)
     self.assertEqual(p.returncode, 0)
     self.assertIn('1 test(s) ran; 0 failed; 0 skipped', p.stderr)
@@ -839,7 +842,11 @@ class OutOfTreeInterpreterTest(test_base.TestCase):
     """
     temp_file = self.create_tempfile(content=program)
     # Note: we have to supply `env` to avoid the Python testbridge setting seeping in.
-    p = subp.run([self.interpreter_path.full_path, temp_file.full_path], stdout=subp.PIPE, stderr=subp.PIPE, encoding='utf-8', env={})
+    p = subp.run([self.interpreter_path.full_path, temp_file.full_path],
+                 stdout=subp.PIPE,
+                 stderr=subp.PIPE,
+                 encoding='utf-8',
+                 env={})
     print('p:', p)
     self.assertEqual(p.returncode, 0)
     self.assertIn('1 test(s) ran; 0 failed; 0 skipped', p.stderr)


### PR DESCRIPTION
Ran `$ python3 -m yapf --style="{based_on_style: google, indent_width: 2}" -i xls/dslx/interpreter_test.py` to try to get style compliant