### PR TITLE
Make sure the Python interpreter can be found.

### DIFF
--- a/xls/build_rules/xls_ir_rules.bzl
+++ b/xls/build_rules/xls_ir_rules.bzl
@@ -1194,6 +1194,7 @@ def _xls_ir_cc_library_impl(ctx):
         mnemonic = "GenerateAotWrapper",
         progress_message = "AOT Wrapping %s" % src.ir_file.short_path,
         toolchain = None,
+        use_default_shell_env = True,
     )
 
     ctx.actions.run_shell(

--- a/xls/build_rules/xls_jit_wrapper_rules.bzl
+++ b/xls/build_rules/xls_jit_wrapper_rules.bzl
@@ -185,6 +185,7 @@ def _xls_ir_jit_wrapper_impl(ctx):
         mnemonic = "IRJITWrapper",
         progress_message = "Building JIT wrapper for source file: %s" % (src.ir_file.path),
         toolchain = None,
+        use_default_shell_env = True,
     )
     return [
         JitWrapperInfo(


### PR DESCRIPTION
Some rules use Python from the system but with assumptions that don't work on systems with diferent paths such as NixOS or BSD. Make sure it can be found by using the `use_default_shell_env` option.