### PR TITLE
[dslx:type_system] Improve message for constexpr overshifting

### DIFF
--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -345,7 +345,7 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
   def test_over_shift(self):
     stderr = self._run('xls/dslx/tests/errors/over_shift_amount.x')
     self.assertIn(
-        'Shift amount is larger than shift value bit width of', stderr
+        'Shifting a 4-bit value (`uN[4]`) by a constexpr shift of 5 exceeds its bit width.', stderr
     )
 
   def test_colon_ref_of_type_alias(self):

--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -597,12 +597,13 @@ static absl::StatusOr<std::unique_ptr<Type>> DeduceShift(const Binop* node,
     const TypeDim& lhs_size = lhs_bits_like->size;
     CHECK(!lhs_size.IsParametric()) << "Shift amount type not inferred.";
     XLS_ASSIGN_OR_RETURN(int64_t lhs_bit_count, lhs_size.GetAsInt64());
-    if (lhs_bit_count < number_value.value()) {
+    int64_t value = static_cast<int64_t>(number_value.value());
+    if (lhs_bit_count < value) {
       return TypeInferenceErrorStatus(
           node->rhs()->span(), rhs.get(),
-          absl::StrFormat(
-              "Shift amount is larger than shift value bit width of %d.",
-              lhs_bit_count),
+          absl::StrFormat("Shifting a %d-bit value (`%s`) by a constexpr shift "
+                          "of %d exceeds its bit width.",
+                          lhs_bit_count, lhs->ToString(), value),
           ctx->file_table());
     }
   }

--- a/xls/dslx/type_system_v2/typecheck_module_v2_test.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2_test.cc
@@ -3703,15 +3703,17 @@ TEST(TypecheckV2Test,
 }
 
 TEST(TypecheckV2Test, GlobalConstantEqualsLShiftOfLiteralsSizeTooSmall) {
-  EXPECT_THAT("const X = u2:3 << 4;",
-              TypecheckFails(HasSubstr(
-                  "Shift amount is larger than shift value bit width of 2.")));
+  EXPECT_THAT(
+      "const X = u2:3 << 4;",
+      TypecheckFails(HasSubstr("Shifting a 2-bit value (`uN[2]`) by a "
+                               "constexpr shift of 4 exceeds its bit width.")));
 }
 
 TEST(TypecheckV2Test, GlobalConstantEqualsRShiftOfLiteralsSizeTooSmall) {
-  EXPECT_THAT("const X = u1:1 >> 4;",
-              TypecheckFails(HasSubstr(
-                  "Shift amount is larger than shift value bit width of 1.")));
+  EXPECT_THAT(
+      "const X = u1:1 >> 4;",
+      TypecheckFails(HasSubstr("Shifting a 1-bit value (`uN[1]`) by a "
+                               "constexpr shift of 4 exceeds its bit width.")));
 }
 
 TEST(TypecheckV2Test, GlobalConstantEqualsLShiftOfLiteralsMismatchedType) {

--- a/xls/dslx/type_system_v2/validate_concrete_type.cc
+++ b/xls/dslx/type_system_v2/validate_concrete_type.cc
@@ -359,9 +359,9 @@ class TypeValidator : public AstNodeVisitorWithDefault {
       if (lhs_bits_count < number_value) {
         return TypeInferenceErrorStatus(
             binop.rhs()->span(), rhs_type,
-            absl::StrFormat(
-                "Shift amount is larger than shift value bit width of %d.",
-                lhs_bits_count),
+            absl::StrFormat("Shifting a %d-bit value (`%s`) by a constexpr "
+                            "shift of %d exceeds its bit width.",
+                            lhs_bits_count, lhs_type->ToString(), number_value),
             file_table_);
       }
     }


### PR DESCRIPTION
Previously:

- it would say the bitwidth (but not the type) of the subject
- and it would not say the shift amount, which when it was a `const` symbol meant you had to go look it up

Now both are provided immediately in the error message.