### PR TITLE
[dslx:stdlib] Add comprehensive apfloat cmp testing via bfloat16

### DIFF
--- a/xls/dev_tools/check_cpp_includes.py
+++ b/xls/dev_tools/check_cpp_includes.py
@@ -28,6 +28,7 @@ ALLOWED_INCLUDE_STARTS = frozenset([
     'gmock/',
     'gtest/',
     'benchmark/',
+    'Eigen/',
     'llvm/',
     'fuzztest/',
     'verible/',

--- a/xls/dslx/stdlib/apfloat.x
+++ b/xls/dslx/stdlib/apfloat.x
@@ -2358,26 +2358,30 @@ fn test_fp_eq_2() {
 // Always returns false if x or y is NaN.
 pub fn gt_2<EXP_SZ: u32, FRACTION_SZ: u32>
     (x: APFloat<EXP_SZ, FRACTION_SZ>, y: APFloat<EXP_SZ, FRACTION_SZ>) -> bool {
-    // Flush denormals.
-    let x = subnormals_to_zero(x);
-    let y = subnormals_to_zero(y);
+    if eq_2(x, y) {
+        false
+    } else {
+        // Flush denormals.
+        let x = subnormals_to_zero(x);
+        let y = subnormals_to_zero(y);
 
-    let gt_exp = x.bexp > y.bexp;
-    let eq_exp = x.bexp == y.bexp;
-    let gt_fraction = x.fraction > y.fraction;
-    let abs_gt = gt_exp || (eq_exp && gt_fraction);
-    let result = match (x.sign, y.sign) {
-        // Both positive.
-        (u1:0, u1:0) => abs_gt,
-        // x positive, y negative.
-        (u1:0, u1:1) => u1:1,
-        // x negative, y positive.
-        (u1:1, u1:0) => u1:0,
-        // Both negative.
-        _ => !abs_gt && !eq_2(x, y),
-    };
+        let gt_exp = x.bexp > y.bexp;
+        let eq_exp = x.bexp == y.bexp;
+        let gt_fraction = x.fraction > y.fraction;
+        let abs_gt = gt_exp || (eq_exp && gt_fraction);
+        let result = match (x.sign, y.sign) {
+            // Both positive.
+            (u1:0, u1:0) => abs_gt,
+            // x positive, y negative.
+            (u1:0, u1:1) => true,
+            // x negative, y positive.
+            (u1:1, u1:0) => false,
+            // Both negative.
+            _ => !abs_gt && !eq_2(x, y),
+        };
 
-    if !(is_nan(x) || is_nan(y)) { result } else { u1:0 }
+        if !(is_nan(x) || is_nan(y)) { result } else { false }
+    }
 }
 
 #[test]
@@ -2563,7 +2567,7 @@ fn test_fp_lte_2() {
 // Always returns false if x or y is NaN.
 pub fn lt_2<EXP_SZ: u32, FRACTION_SZ: u32>
     (x: APFloat<EXP_SZ, FRACTION_SZ>, y: APFloat<EXP_SZ, FRACTION_SZ>) -> bool {
-    if !(is_nan(x) || is_nan(y)) { !gte_2(x, y) } else { u1:0 }
+    if !(is_nan(x) || is_nan(y)) { !gte_2(x, y) } else { false }
 }
 
 #[test]

--- a/xls/dslx/stdlib/tests/BUILD
+++ b/xls/dslx/stdlib/tests/BUILD
@@ -468,3 +468,51 @@ cc_test(
         "@com_google_absl//absl/status",
     ],
 )
+
+# bfloat16 comparison tests
+BFLOAT16_CMP_TOPS = [
+    "eq_2",
+    "gt_2",
+    "gte_2",
+    "lt_2",
+    "lte_2",
+]
+
+[
+    xls_dslx_opt_ir(
+        name = "bfloat16_" + top,
+        srcs = ["//xls/dslx/stdlib:bfloat16.x"],
+        dslx_top = top,
+    )
+    for top in BFLOAT16_CMP_TOPS
+]
+
+[
+    cc_xls_ir_jit_wrapper(
+        name = "bfloat16_" + top + "_jit_wrapper",
+        src = ":bfloat16_" + top,
+        jit_wrapper_args = {
+            "class_name": "Bfloat16" + top.replace("_", " ").title().replace(" ", ""),
+            "function": top,
+            "namespace": "xls::dslx",
+        },
+    )
+    for top in BFLOAT16_CMP_TOPS
+]
+
+cc_test(
+    name = "bfloat16_cmp_test",
+    srcs = ["bfloat16_cmp_test.cc"],
+    deps = [
+        "//xls/common:xls_gunit_main",
+        "//xls/common/status:matchers",
+        "//xls/ir:bits",
+        "//xls/ir:value",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/random",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/status:statusor",
+        "@eigen//:eigen3",
+        "@googletest//:gtest",
+    ] + [":bfloat16_" + top + "_jit_wrapper" for top in BFLOAT16_CMP_TOPS],
+)

--- a/xls/dslx/stdlib/tests/bfloat16_cmp_test.cc
+++ b/xls/dslx/stdlib/tests/bfloat16_cmp_test.cc
@@ -1,0 +1,246 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <string>
+#include <variant>
+#include <vector>
+#include <cmath>
+
+#include "gtest/gtest.h"
+#include "absl/log/log.h"
+#include "absl/random/random.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "Eigen/Core"
+#include "xls/common/status/matchers.h"
+#include "xls/dslx/stdlib/tests/bfloat16_eq_2_jit_wrapper.h"
+#include "xls/dslx/stdlib/tests/bfloat16_gt_2_jit_wrapper.h"
+#include "xls/dslx/stdlib/tests/bfloat16_gte_2_jit_wrapper.h"
+#include "xls/dslx/stdlib/tests/bfloat16_lt_2_jit_wrapper.h"
+#include "xls/dslx/stdlib/tests/bfloat16_lte_2_jit_wrapper.h"
+#include "xls/ir/bits.h"
+#include "xls/ir/value.h"
+
+namespace xls::dslx {
+namespace {
+
+// Flushes subnormal bfloat16 values to zero, preserving the sign.
+uint16_t FlushSubnormal(uint16_t u) {
+  Eigen::bfloat16 bf = Eigen::numext::bit_cast<Eigen::bfloat16>(u);
+  if (std::fpclassify(static_cast<float>(bf)) == FP_SUBNORMAL) {
+    if (std::signbit(static_cast<float>(bf))) {
+      return Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(-0.0f));
+    }
+    return Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(0.0f));
+  }
+  return u;
+}
+
+// Helper to convert a u16 into a bfloat16 tuple value.
+Value U16ToBfloat16Tuple(uint16_t val) {
+  bool sign = (val >> 15) & 1;
+  uint8_t exp = (val >> 7) & 0xff;
+  uint8_t frac = val & 0x7f;
+  return Value::Tuple({Value(UBits(sign, 1)), Value(UBits(exp, 8)),
+                       Value(UBits(frac, 7))});
+}
+
+enum class CmpOp { kEq, kGt, kGte, kLt, kLte };
+
+std::string CmpOpToString(CmpOp op) {
+  switch (op) {
+    case CmpOp::kEq:
+      return "==";
+    case CmpOp::kGt:
+      return ">";
+    case CmpOp::kGte:
+      return ">=";
+    case CmpOp::kLt:
+      return "<";
+    case CmpOp::kLte:
+      return "<=";
+  }
+  LOG(FATAL) << "Invalid CmpOp";
+}
+
+using JitVariant =
+    std::variant<std::unique_ptr<Bfloat16Eq2>, std::unique_ptr<Bfloat16Gt2>,
+                 std::unique_ptr<Bfloat16Gte2>, std::unique_ptr<Bfloat16Lt2>,
+                 std::unique_ptr<Bfloat16Lte2>>;
+
+absl::StatusOr<JitVariant> CreateJit(CmpOp op) {
+  switch (op) {
+    case CmpOp::kEq:
+      return Bfloat16Eq2::Create();
+    case CmpOp::kGt:
+      return Bfloat16Gt2::Create();
+    case CmpOp::kGte:
+      return Bfloat16Gte2::Create();
+    case CmpOp::kLt:
+      return Bfloat16Lt2::Create();
+    case CmpOp::kLte:
+      return Bfloat16Lte2::Create();
+  }
+  LOG(FATAL) << "Invalid CmpOp";
+}
+
+bool EvalOp(CmpOp op, float a, float b) {
+  switch (op) {
+    case CmpOp::kEq:
+      return a == b;
+    case CmpOp::kGt:
+      return a > b;
+    case CmpOp::kGte:
+      return a >= b;
+    case CmpOp::kLt:
+      return a < b;
+    case CmpOp::kLte:
+      return a <= b;
+  }
+  LOG(FATAL) << "Invalid CmpOp";
+}
+
+std::vector<uint16_t> GetInterestingBfloat16Values() {
+  return {
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(0.0f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(-0.0f)),
+      Eigen::numext::bit_cast<uint16_t>(
+          std::numeric_limits<Eigen::bfloat16>::min()),
+      Eigen::numext::bit_cast<uint16_t>(
+          -std::numeric_limits<Eigen::bfloat16>::min()),
+      Eigen::numext::bit_cast<uint16_t>(
+          std::numeric_limits<Eigen::bfloat16>::max()),
+      Eigen::numext::bit_cast<uint16_t>(
+          std::numeric_limits<Eigen::bfloat16>::lowest()),
+      Eigen::numext::bit_cast<uint16_t>(
+          std::numeric_limits<Eigen::bfloat16>::infinity()),
+      Eigen::numext::bit_cast<uint16_t>(
+          -std::numeric_limits<Eigen::bfloat16>::infinity()),
+      Eigen::numext::bit_cast<uint16_t>(
+          std::numeric_limits<Eigen::bfloat16>::quiet_NaN()),
+      Eigen::numext::bit_cast<uint16_t>(
+          -std::numeric_limits<Eigen::bfloat16>::quiet_NaN()),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(1.0f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(-1.0f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(2.0f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(-2.0f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(0.5f)),
+      Eigen::numext::bit_cast<uint16_t>(Eigen::bfloat16(-0.5f)),
+  };
+}
+
+class Bfloat16CmpTest : public ::testing::TestWithParam<CmpOp> {};
+
+TEST_P(Bfloat16CmpTest, ExhaustiveVsInterestingValues) {
+  CmpOp op = GetParam();
+  XLS_ASSERT_OK_AND_ASSIGN(JitVariant jit_variant, CreateJit(op));
+
+  auto do_test = [&](uint16_t u16_a, uint16_t u16_b) {
+    // The DSLX bfloat16 operations flush subnormals to zero, so we must also do
+    // so in our reference implementation.
+    Eigen::bfloat16 bf_a =
+        Eigen::numext::bit_cast<Eigen::bfloat16>(FlushSubnormal(u16_a));
+    Eigen::bfloat16 bf_b =
+        Eigen::numext::bit_cast<Eigen::bfloat16>(FlushSubnormal(u16_b));
+
+    XLS_ASSERT_OK_AND_ASSIGN(
+        Value xls_value,
+        std::visit(
+            [&](auto& jit) {
+              return jit->Run(U16ToBfloat16Tuple(u16_a),
+                              U16ToBfloat16Tuple(u16_b));
+            },
+            jit_variant));
+    XLS_ASSERT_OK_AND_ASSIGN(bool xls_result, xls_value.bits().ToBool());
+
+    bool eigen_result =
+        EvalOp(op, static_cast<float>(bf_a), static_cast<float>(bf_b));
+    EXPECT_EQ(xls_result, eigen_result)
+        << u16_a << " " << CmpOpToString(op) << " " << u16_b << " ("
+        << static_cast<float>(bf_a) << " vs " << static_cast<float>(bf_b)
+        << ")";
+  };
+
+  const std::vector<uint16_t> interesting_values = GetInterestingBfloat16Values();
+  for (uint32_t i = 0; i <= std::numeric_limits<uint16_t>::max(); ++i) {
+    uint16_t u16_a = i;
+    // Test against interesting values.
+    for (uint16_t u16_b : interesting_values) {
+      do_test(u16_a, u16_b);
+      do_test(u16_b, u16_a);
+    }
+
+    // Test against self.
+    do_test(u16_a, u16_a);
+  }
+}
+
+TEST_P(Bfloat16CmpTest, Random) {
+  CmpOp op = GetParam();
+  XLS_ASSERT_OK_AND_ASSIGN(JitVariant jit_variant, CreateJit(op));
+
+  absl::BitGen bitgen;
+  constexpr int kNumSamples = 1024 * 1024;
+  for (int i = 0; i < kNumSamples; ++i) {
+    uint16_t u16_a = absl::Uniform<uint16_t>(bitgen);
+    uint16_t u16_b = absl::Uniform<uint16_t>(bitgen);
+    // The DSLX bfloat16 operations flush subnormals to zero, so we must also do
+    // so in our reference implementation.
+    Eigen::bfloat16 bf_a =
+        Eigen::numext::bit_cast<Eigen::bfloat16>(FlushSubnormal(u16_a));
+    Eigen::bfloat16 bf_b =
+        Eigen::numext::bit_cast<Eigen::bfloat16>(FlushSubnormal(u16_b));
+
+    XLS_ASSERT_OK_AND_ASSIGN(
+        Value xls_value,
+        std::visit([&](auto& jit) {
+          return jit->Run(U16ToBfloat16Tuple(u16_a), U16ToBfloat16Tuple(u16_b));
+        }, jit_variant));
+    XLS_ASSERT_OK_AND_ASSIGN(bool xls_result, xls_value.bits().ToBool());
+
+    bool eigen_result =
+        EvalOp(op, static_cast<float>(bf_a), static_cast<float>(bf_b));
+    EXPECT_EQ(xls_result, eigen_result)
+        << u16_a << " " << CmpOpToString(op) << " " << u16_b << " ("
+        << static_cast<float>(bf_a) << " vs " << static_cast<float>(bf_b)
+        << ")";
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Bfloat16CmpTests, Bfloat16CmpTest,
+    ::testing::Values(CmpOp::kEq, CmpOp::kGt, CmpOp::kGte, CmpOp::kLt,
+                      CmpOp::kLte),
+    [](const ::testing::TestParamInfo<CmpOp>& info) {
+      switch (info.param) {
+        case CmpOp::kEq:
+          return "Eq";
+        case CmpOp::kGt:
+          return "Gt";
+        case CmpOp::kGte:
+          return "Gte";
+        case CmpOp::kLt:
+          return "Lt";
+        case CmpOp::kLte:
+          return "Lte";
+      }
+      LOG(FATAL) << "Unknown CmpOp";
+    });
+
+}  // namespace
+}  // namespace xls::dslx

--- a/xls/ir/bits.cc
+++ b/xls/ir/bits.cc
@@ -264,6 +264,14 @@ absl::StatusOr<int64_t> Bits::UnsignedToInt64() const {
   return static_cast<int64_t>(bitmap_.GetWord(0));
 }
 
+absl::StatusOr<bool> Bits::ToBool() const {
+  if (bit_count() != 1) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Cannot convert Bits of width %d to bool", bit_count()));
+  }
+  return Get(0);
+}
+
 Bits Bits::Slice(int64_t start, int64_t width) && {
   CHECK_GE(width, 0);
   CHECK_LE(start + width, bit_count())

--- a/xls/ir/bits.h
+++ b/xls/ir/bits.h
@@ -209,6 +209,10 @@ class Bits {
   absl::StatusOr<int64_t> ToInt64() const;
   absl::StatusOr<int64_t> UnsignedToInt64() const;
 
+  // Converts the value of a single-bit Bits object to a boolean. Returns an
+  // error if the width is not 1.
+  absl::StatusOr<bool> ToBool() const;
+
   // Extracts the "word_number"th u64 from this value, as in Bitmap::GetWord.
   // (Zero-bit values get 0 by convention.)
   absl::StatusOr<uint64_t> WordToUint64(int64_t word_number) const;


### PR DESCRIPTION
Fixes `+0 > -0`, it used to give `true` and now appropriately gives `false` -- this fixes google/xls#2448

Adds a missing `Bits::ToBool()` helper analogous to `ToUint64()`

Adds more comprehensive testing vs the Eigen bfloat16 implementation:

* exhaustive 16-bit vs interesting
* 2**20 randomized