### PR TITLE
Mark a globally visible constexpr as inline constexpr

### DIFF
--- a/xls/dslx/frontend/builtin_stubs_utils.h
+++ b/xls/dslx/frontend/builtin_stubs_utils.h
@@ -24,7 +24,7 @@
 
 namespace xls::dslx {
 
-constexpr std::string_view kBuiltinStubsModuleName = "<builtin_stubs>";
+inline constexpr std::string_view kBuiltinStubsModuleName = "<builtin_stubs>";
 
 absl::StatusOr<std::filesystem::path> BuiltinStubsPath();
 


### PR DESCRIPTION
Otherwise clang complains that it is not used right there in the header.