### PR TITLE
Change forward declaration of a `struct` (was `class`)

### DIFF
--- a/xls/dslx/type_system_v2/type_system_tracer.h
+++ b/xls/dslx/type_system_v2/type_system_tracer.h
@@ -31,7 +31,7 @@
 namespace xls::dslx {
 
 class TypeSystemTracerImpl;
-class TypeSystemTraceImpl;
+struct TypeSystemTraceImpl;
 class NoopTracer;
 
 // An object that represents the scope of a trace record. These objects are


### PR DESCRIPTION
Forward-declaring a `struct` type as `class` might or might not work.