### PR TITLE
Mark constructors explicit if needed or excempt from lint.

### DIFF
--- a/xls/contrib/xlscc/tracked_bvalue.h
+++ b/xls/contrib/xlscc/tracked_bvalue.h
@@ -62,7 +62,7 @@ class TrackedBValue {
       : bval_(bval.bval_), sequence_number_(sNextSequenceNumber++) {
     record();
   }
-  TrackedBValue(const xls::BValue& native_bval)
+  TrackedBValue(const xls::BValue& native_bval)  // NOLINT(google-explicit-constructor)
       : bval_(native_bval), sequence_number_(sNextSequenceNumber++) {
     record();
   }
@@ -91,7 +91,9 @@ class TrackedBValue {
     unrecord();
     bval_ = xls::BValue();
   }
-  operator xls::BValue() const { return bval_; }
+  operator xls::BValue() const {  // NOLINT(google-explicit-constructor)
+    return bval_;
+  }
   bool valid() const { return bval_.valid(); }
   xls::Node* node() const { return bval_.node(); }
   std::string ToString() const { return bval_.ToString(); }

--- a/xls/fuzzer/ir_fuzzer/stringify_program_pass.h
+++ b/xls/fuzzer/ir_fuzzer/stringify_program_pass.h
@@ -29,7 +29,7 @@ namespace xls {
 // as effective for debugging.
 class StringifyProgramPass : public IrFuzzVisitor {
  public:
-  StringifyProgramPass(FuzzProgramProto* fuzz_program)
+  explicit StringifyProgramPass(FuzzProgramProto* fuzz_program)
       : fuzz_program_(fuzz_program) {}
 
   std::string StringifyProgram();


### PR DESCRIPTION
Found by clang-tidy `google-explicit-constructor` rule.