### PR TITLE
Move NOLINT comment to a place recognized by clang-tidy

### DIFF
--- a/xls/contrib/xlscc/tracked_bvalue.h
+++ b/xls/contrib/xlscc/tracked_bvalue.h
@@ -62,8 +62,8 @@ class TrackedBValue {
       : bval_(bval.bval_), sequence_number_(sNextSequenceNumber++) {
     record();
   }
-  TrackedBValue(
-      const xls::BValue& native_bval)  // NOLINT(google-explicit-constructor)
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  TrackedBValue(const xls::BValue& native_bval)
       : bval_(native_bval), sequence_number_(sNextSequenceNumber++) {
     record();
   }


### PR DESCRIPTION
If a function is formatted over multiple lines, just adding a NOLINT at the end of the function declaration does not seem to work; switching to NOLINTNEXTLINE and putting in front.