### PR TITLE
Prevent clang-tidy from suggesting needed headers to be removed.

### DIFF
--- a/xls/codegen/codegen_util.cc
+++ b/xls/codegen/codegen_util.cc
@@ -21,10 +21,10 @@
 #include "absl/status/statusor.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/ir/block.h"
-#include "xls/ir/function.h"
+#include "xls/ir/function.h"  // IWYU pragma: keep
 #include "xls/ir/function_base.h"
 #include "xls/ir/package.h"
-#include "xls/ir/proc.h"
+#include "xls/ir/proc.h"  // IWYU pragma: keep
 
 namespace xls {
 

--- a/xls/contrib/mlir/util/identifier.cc
+++ b/xls/contrib/mlir/util/identifier.cc
@@ -16,7 +16,7 @@
 
 #include <string>
 
-#include "llvm/include/llvm/ADT/StringRef.h"
+#include "llvm/include/llvm/ADT/StringRef.h"  // IWYU pragma: keep
 #include "mlir/include/mlir/Support/LLVM.h"
 #include "xls/codegen/vast/vast.h"
 


### PR DESCRIPTION
It seems to be confused on some of these.