### PR TITLE
[DSLX; std] implement msbs & lsbs

### DIFF
--- a/docs_src/dslx_std.md
+++ b/docs_src/dslx_std.md
@@ -932,6 +932,22 @@ pub fn msb<N: u32>(x: uN[N]) -> u1
 
 Extracts the MSb (Most Significant bit) from the value `x` and returns it.
 
+#### `std::lsbs`
+
+```dslx-snippet
+pub fn lsbs<R: u32, N: u32>(x: uN[N]) -> uN[R]
+```
+
+Returns the R LSbs of x. `x` must be at least R bits wide.
+
+#### `std::msbs`
+
+```dslx-snippet
+pub fn msbs<R: u32, N: u32>(x: uN[N]) -> uN[R]
+```
+
+Returns the R MSbs of x. `x` must be at least R bits wide.
+
 #### `std::keep_lsbs`
 
 ```dslx-snippet

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -403,6 +403,66 @@ fn msbs_test() {
     assert_eq(msbs<u32:3>(u5:30), u3:7);
 }
 
+// Splits bits into (N most significant bits, the remaining least significant
+// bits).
+//
+// This function ensures that all bits of the argument are used.
+pub fn split_msbs<N: u32, X: u32, Z: u32 = {X - N}, FROM_START: s32 = {Z as s32}>
+    (x: bits[X]) -> (bits[N], bits[Z]) {
+    // Can't split more bits than exist
+    const_assert!(N <= X);
+
+    let msbs = x[FROM_START:];
+    let lsbs = x[0:FROM_START];
+    (msbs, lsbs)
+}
+
+#[test]
+fn test_split_msbs() {
+    assert_eq(split_msbs<u32:0>(u5:0b10101), (uN[0]:0, u5:0b10101));
+    assert_eq(split_msbs<u32:1>(u5:0b10101), (u1:0b1, u4:0b0101));
+    assert_eq(split_msbs<u32:2>(u5:0b10101), (u2:0b10, u3:0b101));
+    assert_eq(split_msbs<u32:3>(u5:0b10101), (u3:0b101, u2:0b01));
+    assert_eq(split_msbs<u32:4>(u5:0b10101), (u4:0b1010, u1:0b1));
+    assert_eq(split_msbs<u32:5>(u5:0b10101), (u5:0b10101, uN[0]:0));
+}
+
+#[quickcheck(exhaustive)]
+fn prop_split_msbs(n: uN[4], o: uN[3]) -> bool {
+    let (n2, o2) = split_msbs<4>(n ++ o);
+    n == n2 && o == o2
+}
+
+// Splits bits into (the remaining most significant bits, N least significant
+// bits).
+//
+// This function ensures that all bits of the argument are used.
+pub fn split_lsbs<N: u32, X: u32, Y: u32 = {X - N}, FROM_START: s32 = {N as s32}>
+    (x: bits[X]) -> (bits[Y], bits[N]) {
+    // Can't split more bits than exist
+    const_assert!(N <= X);
+
+    let msbs = x[FROM_START:];
+    let lsbs = x[0:FROM_START];
+    (msbs, lsbs)
+}
+
+#[test]
+fn test_split_lsbs() {
+    assert_eq(split_lsbs<u32:5>(u5:0b10101), (uN[0]:0, u5:0b10101));
+    assert_eq(split_lsbs<u32:4>(u5:0b10101), (u1:0b1, u4:0b0101));
+    assert_eq(split_lsbs<u32:3>(u5:0b10101), (u2:0b10, u3:0b101));
+    assert_eq(split_lsbs<u32:2>(u5:0b10101), (u3:0b101, u2:0b01));
+    assert_eq(split_lsbs<u32:1>(u5:0b10101), (u4:0b1010, u1:0b1));
+    assert_eq(split_lsbs<u32:0>(u5:0b10101), (u5:0b10101, uN[0]:0));
+}
+
+#[quickcheck(exhaustive)]
+fn prop_split_lsbs(n: uN[4], o: uN[3]) -> bool {
+    let (n2, o2) = split_lsbs<3>(n ++ o);
+    n == n2 && o == o2
+}
+
 // Returns the absolute value of x as a signed number.
 pub fn abs<BITS: u32>(x: sN[BITS]) -> sN[BITS] { if x < sN[BITS]:0 { -x } else { x } }
 
@@ -1280,66 +1340,6 @@ fn test_vslice() {
     assert_eq(vslice<u32:3, u32:0>(u8:0xab), u4:0xb);
     assert_eq(vslice<u32:7, u32:4>(u8:0xab), u4:0xa);
     assert_eq(vslice<u32:0, u32:0>(u8:0xab), u1:1);
-}
-
-// Splits bits into (N most significant bits, the remaining least significant
-// bits).
-//
-// This function ensures that all bits of the argument are used.
-pub fn split_msbs<N: u32, X: u32, Z: u32 = {X - N}, FROM_START: s32 = {Z as s32}>
-    (x: bits[X]) -> (bits[N], bits[Z]) {
-    // Can't split more bits than exist
-    const_assert!(N <= X);
-
-    let msbs = x[FROM_START:];
-    let lsbs = x[0:FROM_START];
-    (msbs, lsbs)
-}
-
-#[test]
-fn test_split_msbs() {
-    assert_eq(split_msbs<u32:0>(u5:0b10101), (uN[0]:0, u5:0b10101));
-    assert_eq(split_msbs<u32:1>(u5:0b10101), (u1:0b1, u4:0b0101));
-    assert_eq(split_msbs<u32:2>(u5:0b10101), (u2:0b10, u3:0b101));
-    assert_eq(split_msbs<u32:3>(u5:0b10101), (u3:0b101, u2:0b01));
-    assert_eq(split_msbs<u32:4>(u5:0b10101), (u4:0b1010, u1:0b1));
-    assert_eq(split_msbs<u32:5>(u5:0b10101), (u5:0b10101, uN[0]:0));
-}
-
-#[quickcheck(exhaustive)]
-fn prop_split_msbs(n: uN[4], o: uN[3]) -> bool {
-    let (n2, o2) = split_msbs<4>(n ++ o);
-    n == n2 && o == o2
-}
-
-// Splits bits into (the remaining most significant bits, N least significant
-// bits).
-//
-// This function ensures that all bits of the argument are used.
-pub fn split_lsbs<N: u32, X: u32, Y: u32 = {X - N}, FROM_START: s32 = {N as s32}>
-    (x: bits[X]) -> (bits[Y], bits[N]) {
-    // Can't split more bits than exist
-    const_assert!(N <= X);
-
-    let msbs = x[FROM_START:];
-    let lsbs = x[0:FROM_START];
-    (msbs, lsbs)
-}
-
-#[test]
-fn test_split_lsbs() {
-    assert_eq(split_lsbs<u32:5>(u5:0b10101), (uN[0]:0, u5:0b10101));
-    assert_eq(split_lsbs<u32:4>(u5:0b10101), (u1:0b1, u4:0b0101));
-    assert_eq(split_lsbs<u32:3>(u5:0b10101), (u2:0b10, u3:0b101));
-    assert_eq(split_lsbs<u32:2>(u5:0b10101), (u3:0b101, u2:0b01));
-    assert_eq(split_lsbs<u32:1>(u5:0b10101), (u4:0b1010, u1:0b1));
-    assert_eq(split_lsbs<u32:0>(u5:0b10101), (u5:0b10101, uN[0]:0));
-}
-
-#[quickcheck(exhaustive)]
-fn prop_split_lsbs(n: uN[4], o: uN[3]) -> bool {
-    let (n2, o2) = split_lsbs<3>(n ++ o);
-    n == n2 && o == o2
 }
 
 // Deprecated functions, to be removed in favor of sizeof() which is

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -374,6 +374,35 @@ fn msb_test() {
     assert_eq(u1:1, msb(s2:0b11));
 }
 
+
+// Returns the R LSbs of x.
+// `x` must be at least R bits wide.
+pub fn lsbs<R: u32, N: u32>(x: uN[N]) -> uN[R] {
+  const_assert!(N >= R);
+  x[0 +: uN[R]]
+}
+
+#[test]
+fn lsbs_test() {
+    assert_eq(lsbs<u32:1>(u2:1), u1:1);
+    assert_eq(lsbs<u32:2>(u3:5), u2:1);
+    assert_eq(lsbs<u32:3>(u5:30), u3:6);
+}
+
+// Returns the R MSbs of x.
+// `x` must be at least R bits wide.
+pub fn msbs<R: u32, N: u32>(x: uN[N]) -> uN[R] {
+  const_assert!(N >= R);
+  x[(N - R) +: uN[R]]
+}
+
+#[test]
+fn msbs_test() {
+    assert_eq(msbs<u32:1>(u2:1), u1:0);
+    assert_eq(msbs<u32:2>(u3:5), u2:2);
+    assert_eq(msbs<u32:3>(u5:30), u3:7);
+}
+
 // Returns the absolute value of x as a signed number.
 pub fn abs<BITS: u32>(x: sN[BITS]) -> sN[BITS] { if x < sN[BITS]:0 { -x } else { x } }
 

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -403,36 +403,6 @@ fn msbs_test() {
     assert_eq(msbs<u32:3>(u5:30), u3:7);
 }
 
-// Splits bits into (N most significant bits, the remaining least significant
-// bits).
-//
-// This function ensures that all bits of the argument are used.
-pub fn split_msbs<N: u32, X: u32, Z: u32 = {X - N}, FROM_START: s32 = {Z as s32}>
-    (x: bits[X]) -> (bits[N], bits[Z]) {
-    // Can't split more bits than exist
-    const_assert!(N <= X);
-
-    let msbs = x[FROM_START:];
-    let lsbs = x[0:FROM_START];
-    (msbs, lsbs)
-}
-
-#[test]
-fn test_split_msbs() {
-    assert_eq(split_msbs<u32:0>(u5:0b10101), (uN[0]:0, u5:0b10101));
-    assert_eq(split_msbs<u32:1>(u5:0b10101), (u1:0b1, u4:0b0101));
-    assert_eq(split_msbs<u32:2>(u5:0b10101), (u2:0b10, u3:0b101));
-    assert_eq(split_msbs<u32:3>(u5:0b10101), (u3:0b101, u2:0b01));
-    assert_eq(split_msbs<u32:4>(u5:0b10101), (u4:0b1010, u1:0b1));
-    assert_eq(split_msbs<u32:5>(u5:0b10101), (u5:0b10101, uN[0]:0));
-}
-
-#[quickcheck(exhaustive)]
-fn prop_split_msbs(n: uN[4], o: uN[3]) -> bool {
-    let (n2, o2) = split_msbs<4>(n ++ o);
-    n == n2 && o == o2
-}
-
 // Splits bits into (the remaining most significant bits, N least significant
 // bits).
 //
@@ -460,6 +430,36 @@ fn test_split_lsbs() {
 #[quickcheck(exhaustive)]
 fn prop_split_lsbs(n: uN[4], o: uN[3]) -> bool {
     let (n2, o2) = split_lsbs<3>(n ++ o);
+    n == n2 && o == o2
+}
+
+// Splits bits into (N most significant bits, the remaining least significant
+// bits).
+//
+// This function ensures that all bits of the argument are used.
+pub fn split_msbs<N: u32, X: u32, Z: u32 = {X - N}, FROM_START: s32 = {Z as s32}>
+    (x: bits[X]) -> (bits[N], bits[Z]) {
+    // Can't split more bits than exist
+    const_assert!(N <= X);
+
+    let msbs = x[FROM_START:];
+    let lsbs = x[0:FROM_START];
+    (msbs, lsbs)
+}
+
+#[test]
+fn test_split_msbs() {
+    assert_eq(split_msbs<u32:0>(u5:0b10101), (uN[0]:0, u5:0b10101));
+    assert_eq(split_msbs<u32:1>(u5:0b10101), (u1:0b1, u4:0b0101));
+    assert_eq(split_msbs<u32:2>(u5:0b10101), (u2:0b10, u3:0b101));
+    assert_eq(split_msbs<u32:3>(u5:0b10101), (u3:0b101, u2:0b01));
+    assert_eq(split_msbs<u32:4>(u5:0b10101), (u4:0b1010, u1:0b1));
+    assert_eq(split_msbs<u32:5>(u5:0b10101), (u5:0b10101, uN[0]:0));
+}
+
+#[quickcheck(exhaustive)]
+fn prop_split_msbs(n: uN[4], o: uN[3]) -> bool {
+    let (n2, o2) = split_msbs<4>(n ++ o);
     n == n2 && o == o2
 }
 

--- a/xls/dslx/stdlib/std.x
+++ b/xls/dslx/stdlib/std.x
@@ -429,7 +429,7 @@ fn test_split_lsbs() {
 
 #[quickcheck(exhaustive)]
 fn prop_split_lsbs(n: uN[4], o: uN[3]) -> bool {
-    let (n2, o2) = split_lsbs<3>(n ++ o);
+    let (n2, o2) = split_lsbs<u32:3>(n ++ o);
     n == n2 && o == o2
 }
 
@@ -459,7 +459,7 @@ fn test_split_msbs() {
 
 #[quickcheck(exhaustive)]
 fn prop_split_msbs(n: uN[4], o: uN[3]) -> bool {
-    let (n2, o2) = split_msbs<4>(n ++ o);
+    let (n2, o2) = split_msbs<u32:4>(n ++ o);
     n == n2 && o == o2
 }
 


### PR DESCRIPTION
- document new functions in dslx_std.md
- fix: annotate literal with type (how did this work before?)
- move split_msbs & split_lsbs up, just after msbs
  - move split_lsbs before split_msbs, to match lsb & msb ordering
