### PR TITLE
Improvements to ZSTD Decoder: 

### DIFF
--- a/xls/modules/zstd/huffman_ctrl.x
+++ b/xls/modules/zstd/huffman_ctrl.x
@@ -342,9 +342,9 @@ pub proc HuffmanControlAndSequence<AXI_ADDR_W: u32, AXI_DATA_W: u32> {
             let stream_sizes = jump_table_raw.data[0:48] as u16[3];
             let total_streams_size = ctrl.len - tree_description_size;
             let stream_sizes = uN[AXI_ADDR_W][4]:[
-                stream_sizes[0] as uN[AXI_ADDR_W],
-                stream_sizes[1] as uN[AXI_ADDR_W],
                 stream_sizes[2] as uN[AXI_ADDR_W],
+                stream_sizes[1] as uN[AXI_ADDR_W],
+                stream_sizes[0] as uN[AXI_ADDR_W],
                 total_streams_size - JUMP_TABLE_SIZE as uN[AXI_ADDR_W] - (stream_sizes[0] + stream_sizes[1] + stream_sizes[2]) as uN[AXI_ADDR_W]
             ];
 

--- a/xls/modules/zstd/huffman_ctrl.x
+++ b/xls/modules/zstd/huffman_ctrl.x
@@ -617,14 +617,14 @@ proc HuffmanControlAndSequence_test {
 
         const TEST_STREAM_ADDR = uN[TEST_AXI_ADDR_W][4]:[
             ctrl.base_addr + JUMP_TABLE_SIZE,
+            ctrl.base_addr + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x1,
             ctrl.base_addr + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x3,
-            ctrl.base_addr + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x5,
             ctrl.base_addr + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x6,
         ];
         const TEST_STREAM_LENGTH = uN[TEST_AXI_ADDR_W][4]:[
-            uN[TEST_AXI_ADDR_W]:0x3,
-            uN[TEST_AXI_ADDR_W]:0x2,
             uN[TEST_AXI_ADDR_W]:0x1,
+            uN[TEST_AXI_ADDR_W]:0x2,
+            uN[TEST_AXI_ADDR_W]:0x3,
             uN[TEST_AXI_ADDR_W]:0x3,
         ];
 
@@ -692,14 +692,14 @@ proc HuffmanControlAndSequence_test {
 
         const TEST_STREAM_ADDR = uN[TEST_AXI_ADDR_W][4]:[
             ctrl.base_addr + tree_description_size + JUMP_TABLE_SIZE,
+            ctrl.base_addr + tree_description_size + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x1,
             ctrl.base_addr + tree_description_size + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x3,
-            ctrl.base_addr + tree_description_size + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x5,
             ctrl.base_addr + tree_description_size + JUMP_TABLE_SIZE + uN[TEST_AXI_ADDR_W]:0x6,
         ];
         const TEST_STREAM_LENGTH = uN[TEST_AXI_ADDR_W][4]:[
-            uN[TEST_AXI_ADDR_W]:0x3,
-            uN[TEST_AXI_ADDR_W]:0x2,
             uN[TEST_AXI_ADDR_W]:0x1,
+            uN[TEST_AXI_ADDR_W]:0x2,
+            uN[TEST_AXI_ADDR_W]:0x3,
             uN[TEST_AXI_ADDR_W]:0x1F,
         ];
 

--- a/xls/modules/zstd/huffman_decoder.x
+++ b/xls/modules/zstd/huffman_decoder.x
@@ -326,11 +326,11 @@ pub proc HuffmanDecoder {
             zero!<common::LitData>()
         };
 
-        let done = (state.data_len == uN[BUFF_W_LOG2]:0) && (state.fsm == FSM::DECODE);
+        let done = (state.data_len == uN[BUFF_W_LOG2]:0) && (state.fsm == FSM::DECODE) && state.data_last;
         let decoded_literals = common::LiteralsDataWithSync{
             data: data,
             length: state.decoded_literals_len as common::LitLength,
-            last: done && state.last_stream && state.data_last,
+            last: done && state.last_stream,
             id: state.id,
             literals_last: state.literals_last,
         };

--- a/xls/modules/zstd/huffman_weights_dec.x
+++ b/xls/modules/zstd/huffman_weights_dec.x
@@ -824,7 +824,7 @@ pub proc HuffmanFseDecoder<
                 } else { state }
             },
             FSM::FILL_ZEROS => {
-                if state.current_iteration >= u8:0x7F {
+                if state.current_iteration > u8:0x7F {
                     State {
                         fsm: FSM::SEND_FINISH,
                         ..state


### PR DESCRIPTION
These changes fix:

- off by one error in huffman weights decoding end condition that caused temporary buffers not to be zeroed at the last bytes
- endianness in reading multi-stream stream sizes
- end condition in huffman decoding so that only the last packet of the last stream is marked as "last" when passing data to the literals buffer