### PR TITLE
Use std::string in OptOptions

### DIFF
--- a/xls/public/runtime_build_actions.cc
+++ b/xls/public/runtime_build_actions.cc
@@ -106,7 +106,7 @@ absl::StatusOr<std::string> OptimizeIr(std::string_view ir,
                                        std::string_view top) {
   const tools::OptOptions options = {
       .opt_level = xls::kMaxOptLevel,
-      .top = top,
+      .top = std::string(top),
   };
   return tools::OptimizeIrForTop(ir, options);
 }

--- a/xls/tools/opt.h
+++ b/xls/tools/opt.h
@@ -38,7 +38,7 @@ namespace xls::tools {
 // this consolidated library).
 struct OptOptions {
   int64_t opt_level = xls::kMaxOptLevel;
-  std::string_view top;
+  std::string top;
   std::string ir_dump_path = "";
   std::optional<std::string> ir_path = std::nullopt;
   std::vector<std::string> skip_passes;
@@ -52,8 +52,8 @@ struct OptOptions {
   std::string area_model = "v";
   // Custom registry to use to get default pipeline and compound passes.
   std::optional<OptimizationPipelineProto> custom_registry = std::nullopt;
-  std::variant<std::nullopt_t, std::string_view, PassPipelineProto>
-      pass_pipeline = std::nullopt;
+  std::variant<std::nullopt_t, std::string, PassPipelineProto> pass_pipeline =
+      std::nullopt;
   std::optional<int64_t> bisect_limit;
   bool debug_optimizations = false;
 };

--- a/xls/tools/opt_main.cc
+++ b/xls/tools/opt_main.cc
@@ -256,8 +256,8 @@ absl::Status RealMain(std::string_view input_path) {
       absl::GetFlag(FLAGS_pipeline_textproto);
   std::optional<std::string> pipeline_binproto =
       absl::GetFlag(FLAGS_pipeline_proto);
-  std::variant<std::nullopt_t, std::string_view, PassPipelineProto>
-      pass_pipeline = std::nullopt;
+  std::variant<std::nullopt_t, std::string, PassPipelineProto> pass_pipeline =
+      std::nullopt;
   std::optional<OptimizationPipelineProto> custom_registry = std::nullopt;
   if (pipeline_textproto && pipeline_binproto) {
     return absl::InvalidArgumentError(


### PR DESCRIPTION
using std::string_view is prone to memory bugs.
Since using std::string does not incur much performance penalty, swiching to std::string.