### PR TITLE
Make sure the editor finds the location of the stdlib: canonicalize p…

### DIFF
--- a/xls/dslx/lsp/dslx_ls.cc
+++ b/xls/dslx/lsp/dslx_ls.cc
@@ -177,7 +177,7 @@ absl::Status RealMain() {
     dslx_path_uris.push_back(LspUri::FromFilesystemPath(path));
   }
 
-  const LspUri stdlib_uri = LspUri::FromFilesystemPath(stdlib_path);
+  const LspUri stdlib_uri = LspUri::FromFilesystemPath(stdlib_realpath);
 
   // Adapter that interfaces between dslx parsing and LSP
   LanguageServerAdapter language_server_adapter(stdlib_uri, dslx_path_uris);


### PR DESCRIPTION
…ath.

Typically, the stdlib is not relative to the current location, so the editor won't find that if not provided.
Make sure we send URIs to the editor as fully-qualified path.