### PR TITLE
Optimize duplicate operands in XOR operations.

### DIFF
--- a/xls/passes/BUILD
+++ b/xls/passes/BUILD
@@ -3575,6 +3575,7 @@ xls_pass(
         "//xls/ir:op",
         "//xls/ir:value",
         "//xls/ir:value_utils",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",


### PR DESCRIPTION
If a value appears as an operand to a XOR an even number of times, the operands are removed. If the value appears an odd number of times the operands are replaced with a single instance of the value.