### PR TITLE
Use `inline constexpr` for toplevel constants in headers.

### DIFF
--- a/xls/dslx/cpp_transpiler/cpp_type_generator.cc
+++ b/xls/dslx/cpp_transpiler/cpp_type_generator.cc
@@ -85,14 +85,15 @@ class EnumCppTypeGenerator : public CppTypeGenerator {
               absl::StrAppendFormat(out, "  %s = %s,", ev.name, ev.value_str);
             }));
     std::string num_elements_def =
-        absl::StrFormat("constexpr int64_t k%sNumElements = %d;", cpp_type(),
-                        enum_values_.size());
-    std::string width_def = absl::StrFormat("constexpr int64_t k%sWidth = %d;",
-                                            cpp_type(), dslx_bit_count());
+        absl::StrFormat("inline constexpr int64_t k%sNumElements = %d;",
+                        cpp_type(), enum_values_.size());
+    std::string width_def =
+        absl::StrFormat("inline constexpr int64_t k%sWidth = %d;", cpp_type(),
+                        dslx_bit_count());
 
     std::string_view enum_cpp_type = cpp_type();
     std::string enum_values_list_def = absl::StrFormat(
-        "constexpr std::array<%s, %d> k%sValues = {\n%s\n};", cpp_type(),
+        "inline constexpr std::array<%s, %d> k%sValues = {\n%s\n};", cpp_type(),
         enum_values_.size(), cpp_type(),
         absl::StrJoin(enum_values_, ",\n",
                       [enum_cpp_type](std::string* out, const EnumValue& ev) {
@@ -100,7 +101,8 @@ class EnumCppTypeGenerator : public CppTypeGenerator {
                                               ev.name);
                       }));
     std::string enum_names_list_def = absl::StrFormat(
-        "constexpr std::array<std::string_view, %d> k%sNames = {\n%s\n};",
+        "inline constexpr std::array<std::string_view, %d> k%sNames = "
+        "{\n%s\n};",
         enum_values_.size(), cpp_type(),
         absl::StrJoin(enum_values_, ",\n",
                       [](std::string* out, const EnumValue& ev) {
@@ -338,8 +340,9 @@ class TypeAliasCppTypeGenerator : public CppTypeGenerator {
         absl::StrFormat("using %s = %s;", cpp_type(), emitter_->cpp_type()));
     std::optional<int64_t> width = emitter_->GetBitCountIfBitVector();
     if (width.has_value()) {
-      hdr_pieces.push_back(absl::StrFormat("constexpr int64_t k%sWidth = %d;",
-                                           cpp_type(), width.value()));
+      hdr_pieces.push_back(
+          absl::StrFormat("inline constexpr int64_t k%sWidth = %d;", cpp_type(),
+                          width.value()));
     }
     hdr_pieces.push_back(verify_src.header);
     hdr_pieces.push_back(to_string_src.header);

--- a/xls/dslx/cpp_transpiler/testdata/BasicEnums.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/BasicEnums.htxt
@@ -17,15 +17,15 @@ enum class MyEnum : uint32_t {
   kC = 42,
   kE = 4294967295,
 };
-constexpr int64_t kMyEnumNumElements = 4;
-constexpr int64_t kMyEnumWidth = 32;
-constexpr std::array<MyEnum, 4> kMyEnumValues = {
+inline constexpr int64_t kMyEnumNumElements = 4;
+inline constexpr int64_t kMyEnumWidth = 32;
+inline constexpr std::array<MyEnum, 4> kMyEnumValues = {
   MyEnum::kA,
   MyEnum::kB,
   MyEnum::kC,
   MyEnum::kE
 };
-constexpr std::array<std::string_view, 4> kMyEnumNames = {
+inline constexpr std::array<std::string_view, 4> kMyEnumNames = {
   "A",
   "B",
   "C",

--- a/xls/dslx/cpp_transpiler/testdata/BasicTypedefs.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/BasicTypedefs.htxt
@@ -14,7 +14,7 @@
 namespace robs::secret::space {
 
 using MyType = uint8_t;
-constexpr int64_t kMyTypeWidth = 6;
+inline constexpr int64_t kMyTypeWidth = 6;
 absl::Status VerifyMyType(MyType value);
 std::string MyTypeToString(MyType value, int64_t indent = 0);
 std::string MyTypeToDslxString(MyType value, int64_t indent = 0);
@@ -22,7 +22,7 @@ absl::StatusOr<::xls::Value> MyTypeToValue(MyType input);
 absl::StatusOr<MyType> MyTypeFromValue(const ::xls::Value& value);
 
 using MySignedType = int8_t;
-constexpr int64_t kMySignedTypeWidth = 8;
+inline constexpr int64_t kMySignedTypeWidth = 8;
 absl::Status VerifyMySignedType(MySignedType value);
 std::string MySignedTypeToString(MySignedType value, int64_t indent = 0);
 std::string MySignedTypeToDslxString(MySignedType value, int64_t indent = 0);
@@ -30,7 +30,7 @@ absl::StatusOr<::xls::Value> MySignedTypeToValue(MySignedType input);
 absl::StatusOr<MySignedType> MySignedTypeFromValue(const ::xls::Value& value);
 
 using MyThirdType = int16_t;
-constexpr int64_t kMyThirdTypeWidth = 9;
+inline constexpr int64_t kMyThirdTypeWidth = 9;
 absl::Status VerifyMyThirdType(MyThirdType value);
 std::string MyThirdTypeToString(MyThirdType value, int64_t indent = 0);
 std::string MyThirdTypeToDslxString(MyThirdType value, int64_t indent = 0);
@@ -66,7 +66,7 @@ absl::StatusOr<::xls::Value> MyArrayType4ToValue(const MyArrayType4& input);
 absl::StatusOr<MyArrayType4> MyArrayType4FromValue(const ::xls::Value& value);
 
 using MyArrayType5 = bool;
-constexpr int64_t kMyArrayType5Width = 1;
+inline constexpr int64_t kMyArrayType5Width = 1;
 absl::Status VerifyMyArrayType5(MyArrayType5 value);
 std::string MyArrayType5ToString(MyArrayType5 value, int64_t indent = 0);
 std::string MyArrayType5ToDslxString(MyArrayType5 value, int64_t indent = 0);

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithConstexprValues.htxt
@@ -16,14 +16,14 @@ enum class MyEnum : uint32_t {
   kB = 17,
   kC = 289,
 };
-constexpr int64_t kMyEnumNumElements = 3;
-constexpr int64_t kMyEnumWidth = 32;
-constexpr std::array<MyEnum, 3> kMyEnumValues = {
+inline constexpr int64_t kMyEnumNumElements = 3;
+inline constexpr int64_t kMyEnumWidth = 32;
+inline constexpr std::array<MyEnum, 3> kMyEnumValues = {
   MyEnum::kA,
   MyEnum::kB,
   MyEnum::kC
 };
-constexpr std::array<std::string_view, 3> kMyEnumNames = {
+inline constexpr std::array<std::string_view, 3> kMyEnumNames = {
   "A",
   "B",
   "C"

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithS64.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithS64.htxt
@@ -16,14 +16,14 @@ enum class MyEnum : int64_t {
   kMID = 4611686018427387904,
   kMAX = 9223372036854775807,
 };
-constexpr int64_t kMyEnumNumElements = 3;
-constexpr int64_t kMyEnumWidth = 64;
-constexpr std::array<MyEnum, 3> kMyEnumValues = {
+inline constexpr int64_t kMyEnumNumElements = 3;
+inline constexpr int64_t kMyEnumWidth = 64;
+inline constexpr std::array<MyEnum, 3> kMyEnumValues = {
   MyEnum::kMIN,
   MyEnum::kMID,
   MyEnum::kMAX
 };
-constexpr std::array<std::string_view, 3> kMyEnumNames = {
+inline constexpr std::array<std::string_view, 3> kMyEnumNames = {
   "MIN",
   "MID",
   "MAX"

--- a/xls/dslx/cpp_transpiler/testdata/EnumWithU64.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/EnumWithU64.htxt
@@ -16,14 +16,14 @@ enum class MyEnum : uint64_t {
   kMID = 9223372036854775808,
   kMAX = 18446744073709551615,
 };
-constexpr int64_t kMyEnumNumElements = 3;
-constexpr int64_t kMyEnumWidth = 64;
-constexpr std::array<MyEnum, 3> kMyEnumValues = {
+inline constexpr int64_t kMyEnumNumElements = 3;
+inline constexpr int64_t kMyEnumWidth = 64;
+inline constexpr std::array<MyEnum, 3> kMyEnumValues = {
   MyEnum::kMIN,
   MyEnum::kMID,
   MyEnum::kMAX
 };
-constexpr std::array<std::string_view, 3> kMyEnumNames = {
+inline constexpr std::array<std::string_view, 3> kMyEnumNames = {
   "MIN",
   "MID",
   "MAX"

--- a/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.htxt
+++ b/xls/dslx/cpp_transpiler/testdata/HandlesAbsolutePaths.htxt
@@ -17,15 +17,15 @@ enum class MyEnum : uint64_t {
   kC = 42,
   kE = 4294967295,
 };
-constexpr int64_t kMyEnumNumElements = 4;
-constexpr int64_t kMyEnumWidth = 34;
-constexpr std::array<MyEnum, 4> kMyEnumValues = {
+inline constexpr int64_t kMyEnumNumElements = 4;
+inline constexpr int64_t kMyEnumWidth = 34;
+inline constexpr std::array<MyEnum, 4> kMyEnumValues = {
   MyEnum::kA,
   MyEnum::kB,
   MyEnum::kC,
   MyEnum::kE
 };
-constexpr std::array<std::string_view, 4> kMyEnumNames = {
+inline constexpr std::array<std::string_view, 4> kMyEnumNames = {
   "A",
   "B",
   "C",

--- a/xls/dslx/frontend/BUILD
+++ b/xls/dslx/frontend/BUILD
@@ -670,7 +670,7 @@ genrule(
     cmd = """(
       echo "#pragma once"
       echo "#include <string_view>"
-      echo 'static inline constexpr std::string_view kBuiltinStubs = R"stubs('
+      echo 'inline constexpr std::string_view kBuiltinStubs = R"stubs('
       cat $<
       echo ')stubs";'
     ) > $@""",


### PR DESCRIPTION
This way, they won't be reported as unused values warnings.