### PR TITLE
In if (), don't assign to variables that are not used later.

### DIFF
--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -1088,7 +1088,7 @@ absl::StatusOr<TypeRefOrAnnotation> Parser::ParseTypeRef(Bindings& bindings,
       bindings.ResolveNodeOrError(*tok.GetValue(), tok.span(), file_table()));
   if (std::holds_alternative<NameDef*>(type_def)) {
     NameDef* name_def = std::get<NameDef*>(type_def);
-    if (auto gta = dynamic_cast<GenericTypeAnnotation*>(name_def->definer())) {
+    if (dynamic_cast<GenericTypeAnnotation*>(name_def->definer())) {
       VLOG(5) << "ParseTypeRef ResolveNode to GenericTypeAnnotation: "
               << name_def->definer()->ToString();
 

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -1592,7 +1592,7 @@ absl::StatusOr<BValue> FunctionConverter::HandleForBody(
 // Returns whether `node` is a range expression, which is either a `Range` node
 // or an `Invocation` node with a callee of the builtin `range`.
 static bool IsRangeExpr(AstNode* node) {
-  if (auto* range = dynamic_cast<Range*>(node)) {
+  if (dynamic_cast<Range*>(node)) {
     return true;
   }
   if (auto* invocation = dynamic_cast<Invocation*>(node)) {

--- a/xls/dslx/ir_convert/ir_conversion_utils.cc
+++ b/xls/dslx/ir_convert/ir_conversion_utils.cc
@@ -70,8 +70,7 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
       XLS_ASSIGN_OR_RETURN(int64_t element_count,
                            ResolveDimToInt(t.size(), bindings_));
 
-      if (const auto* bc =
-              dynamic_cast<const BitsConstructorType*>(&t.element_type())) {
+      if (dynamic_cast<const BitsConstructorType*>(&t.element_type())) {
         retval_ = package_->GetBitsType(element_count);
         return absl::OkStatus();
       }


### PR DESCRIPTION
Fixing compilation warnings.