### PR TITLE
Use `final` where possible unless `override` is needed.

### DIFF
--- a/docs_src/optimizations/optimizations.md
+++ b/docs_src/optimizations/optimizations.md
@@ -35,7 +35,7 @@ class DeadCodeEliminationPass : public OptimizationFunctionBasePass {
  public:
   DeadCodeEliminationPass()
       : OptimizationFunctionBasePass("dce", "Dead Code Elimination") {}
-  ~DeadCodeEliminationPass() override {}
+  ~DeadCodeEliminationPass() final {}
 
  protected:
   // Iterate all nodes, mark and eliminate the unvisited nodes.
@@ -214,7 +214,7 @@ transformation and accordingly the pass is derived from
 class CsePass : public OptimizationFunctionBasePass {
  public:
   CsePass() : OptimizationFunctionBasePass("cse", "Common subexpression elimination") {}
-  ~CsePass() override {}
+  ~CsePass() final {}
 
  protected:
   absl::StatusOr<bool> RunOnFunctionBaseInternal(

--- a/xls/codegen/block_conversion_test.cc
+++ b/xls/codegen/block_conversion_test.cc
@@ -1544,7 +1544,7 @@ proc my_proc(tkn: token, st: (), init={token, ()}) {
 class SimplePipelinedProcTest : public ProcConversionTestFixture {
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     // Simple streaming one input and one output pipeline.
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
@@ -2095,7 +2095,7 @@ class SimpleRunningCounterProcTestSweepFixture
 
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     // Simple streaming one input and one output pipeline.
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
@@ -2289,7 +2289,7 @@ INSTANTIATE_TEST_SUITE_P(
 class MultiInputPipelinedProcTest : public ProcConversionTestFixture {
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     // Simple streaming one input and one output pipeline.
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
@@ -3060,7 +3060,7 @@ TEST_F(MultiInputPipelinedProcTest, IdleSignalNoFlops) {
 class MultiInputWithStatePipelinedProcTest : public ProcConversionTestFixture {
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     // Simple streaming one input and one output pipeline.
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
@@ -3345,7 +3345,7 @@ TEST_F(BlockConversionTest, BlockWithNonMutuallyExclusiveSends) {
 class MultiIOWithStatePipelinedProcTest : public ProcConversionTestFixture {
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
 
@@ -4236,7 +4236,7 @@ TEST_F(ProcConversionTestFixture, TwoReceivesTwoSendsRandomScheduler) {
 class NonblockingReceivesProcTest : public ProcConversionTestFixture {
  protected:
   absl::StatusOr<std::unique_ptr<Package>> BuildBlockInPackage(
-      int64_t stage_count, const CodegenOptions& options) override {
+      int64_t stage_count, const CodegenOptions& options) final {
     auto package_ptr = std::make_unique<Package>(TestName());
     Package& package = *package_ptr;
 
@@ -5454,13 +5454,13 @@ proc slow_counter(counter: bits[32], odd_iteration: bits[1], init={0, 0}) {
                           5, 5, std::nullopt, 6, 6, std::nullopt, 7, 7))));
 }
 
-class AddPredicate : public Proc::StateElementTransformer {
+class AddPredicate final : public Proc::StateElementTransformer {
  public:
   explicit AddPredicate(Node* predicate) : predicate_(predicate) {}
-  ~AddPredicate() override = default;
+  ~AddPredicate() final = default;
 
   absl::StatusOr<std::optional<Node*>> TransformReadPredicate(
-      Proc* proc, StateRead* old_state_read) override {
+      Proc* proc, StateRead* old_state_read) final {
     return predicate_;
   }
 

--- a/xls/codegen/block_generator_test.cc
+++ b/xls/codegen/block_generator_test.cc
@@ -2304,7 +2304,7 @@ class ZeroWidthBlockGeneratorTest
   }
   std::filesystem::path GoldenFilePath(
       std::string_view test_file_name,
-      const std::filesystem::path& testdata_dir) override {
+      const std::filesystem::path& testdata_dir) final {
     // We suffix the golden reference files with "txt" on top of the extension
     // just to indicate they're compiler byproduct comparison points and not
     // Verilog files that have been written by hand.

--- a/xls/codegen/block_inlining_pass.cc
+++ b/xls/codegen/block_inlining_pass.cc
@@ -50,7 +50,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
   reg_map() const {
     return reg_map_;
   }
-  absl::Status DefaultHandler(const ElaboratedNode& n) override {
+  absl::Status DefaultHandler(const ElaboratedNode& n) final {
     std::vector<Node*> new_ops;
     new_ops.reserve(n.node->operand_count());
     for (Node* op : n.node->operands()) {
@@ -65,7 +65,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
 
   // NB Call order is InstantiationInput -> Input
   absl::Status HandleInstantiationInput(InstantiationInput* ii,
-                                        BlockInstance* instance) override {
+                                        BlockInstance* instance) final {
     if (ii->instantiation()->kind() != InstantiationKind::kBlock) {
       // Copy a new instantiation
       XLS_ASSIGN_OR_RETURN(
@@ -101,7 +101,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
   }
 
   absl::Status HandleInputPort(InputPort* port,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     if (!instance->parent_instance()) {
       // Top block, no linking of ports required.
       XLS_ASSIGN_OR_RETURN(
@@ -125,7 +125,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
 
   // NB Call order is Output -> InstantiationOutput
   absl::Status HandleOutputPort(OutputPort* port,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     if (!instance->parent_instance()) {
       // Top block, no linking of ports required.
       XLS_ASSIGN_OR_RETURN(
@@ -146,7 +146,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
   }
 
   absl::Status HandleInstantiationOutput(InstantiationOutput* ii,
-                                         BlockInstance* instance) override {
+                                         BlockInstance* instance) final {
     if (ii->instantiation()->kind() != InstantiationKind::kBlock) {
       // Copy a new instantiation
       XLS_ASSIGN_OR_RETURN(
@@ -179,7 +179,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
   }
 
   absl::Status HandleRegisterRead(RegisterRead* rr,
-                                  BlockInstance* instance) override {
+                                  BlockInstance* instance) final {
     XLS_ASSIGN_OR_RETURN(Register * new_reg,
                          GetCopiedRegister(rr->GetRegister(), instance));
     XLS_ASSIGN_OR_RETURN(Node * new_node,
@@ -190,7 +190,7 @@ class InlineVisitor : public ElaboratedBlockDfsVisitorWithDefault {
   }
 
   absl::Status HandleRegisterWrite(RegisterWrite* rw,
-                                   BlockInstance* instance) override {
+                                   BlockInstance* instance) final {
     XLS_ASSIGN_OR_RETURN(Register * new_reg,
                          GetCopiedRegister(rw->GetRegister(), instance));
     Node* new_data = old_to_new_[{.node = rw->data(), .instance = instance}];

--- a/xls/codegen/passes_ng/passes_ng_test_fixtures.h
+++ b/xls/codegen/passes_ng/passes_ng_test_fixtures.h
@@ -368,7 +368,7 @@ class SweepPipelineStagesFixture : public BlockConversionTestFixture,
 // Simple pipelined function test fixture.
 class SweepTrivialPipelinedFunctionFixture : public SweepPipelineStagesFixture {
  public:
-  CodegenOptions codegen_options() override {
+  CodegenOptions codegen_options() final {
     return SweepPipelineStagesFixture::codegen_options()
         .flop_inputs(false)
         .flop_outputs(true)

--- a/xls/codegen/passes_ng/state_to_channel_conversion_pass_test.cc
+++ b/xls/codegen/passes_ng/state_to_channel_conversion_pass_test.cc
@@ -84,7 +84,7 @@ class StateChannelConversionTest
     : public IrTestBase,
       public testing::WithParamInterface<TestParam> {
  public:
-  void SetUp() override { package_ = CreatePackage(); }
+  void SetUp() final { package_ = CreatePackage(); }
 
   std::unique_ptr<Package> package_;
 };
@@ -268,7 +268,7 @@ class CounterProcWithMaxHelper : public CounterProcHelper {
     return absl::OkStatus();
   }
 
-  void NextRound() override {
+  void NextRound() final {
     // New data out.
     EXPECT_THAT(Tick(),
                 IsOkAndHolds(TickResult{
@@ -308,7 +308,7 @@ class CounterProcWithMaxHelper : public CounterProcHelper {
  protected:
   absl::StatusOr<Proc*> BuildProc(ProcBuilder& pb, Channel* out_channel,
                                   uint32_t start_value,
-                                  uint32_t delta_each_round) override {
+                                  uint32_t delta_each_round) final {
     BValue enable = pb.StateElement("enable", Value(UBits(1, 1)));
     BValue counter = pb.StateElement(kCounterStateElementName,
                                      Value(UBits(start_value, 32)), enable);

--- a/xls/common/status/status_builder_test.cc
+++ b/xls/common/status/status_builder_test.cc
@@ -62,7 +62,7 @@ class StringSink : public absl::LogSink {
  public:
   StringSink() = default;
 
-  void Send(const absl::LogEntry& entry) override {
+  void Send(const absl::LogEntry& entry) final {
     absl::StrAppend(&message_, entry.source_basename(), ":",
                     entry.source_line(), " - ", entry.text_message());
   }

--- a/xls/common/status/status_macros_test.cc
+++ b/xls/common/status/status_macros_test.cc
@@ -468,7 +468,7 @@ class ReturnIfErrorLoop : public ReturnLoop<absl::Status> {
       : ReturnLoop(std::move(return_value)) {}
 
  private:
-  absl::Status LoopAgain(size_t* ops) override {
+  absl::Status LoopAgain(size_t* ops) final {
     --*ops;
     XLS_RETURN_IF_ERROR(Loop(ops));
     return absl::OkStatus();
@@ -481,7 +481,7 @@ class ReturnIfErrorWithAnnotateLoop : public ReturnLoop<absl::Status> {
       : ReturnLoop(std::move(return_value)) {}
 
  private:
-  absl::Status LoopAgain(size_t* ops) override {
+  absl::Status LoopAgain(size_t* ops) final {
     --*ops;
     XLS_RETURN_IF_ERROR(Loop(ops))
         << "The quick brown fox jumped over the lazy dog.";
@@ -495,7 +495,7 @@ class AssignOrReturnLoop : public ReturnLoop<absl::StatusOr<int>> {
       : ReturnLoop(std::move(return_value)) {}
 
  private:
-  ReturnType LoopAgain(size_t* ops) override {
+  ReturnType LoopAgain(size_t* ops) final {
     --*ops;
     XLS_ASSIGN_OR_RETURN(int result, Loop(ops));
     return result;
@@ -510,7 +510,7 @@ class AssignOrReturnAnnotateLoop : public ReturnLoop<absl::StatusOr<int>> {
       : ReturnLoop(std::move(return_value)) {}
 
  private:
-  ReturnType LoopAgain(size_t* ops) override {
+  ReturnType LoopAgain(size_t* ops) final {
     --*ops;
     XLS_ASSIGN_OR_RETURN(int result, Loop(ops),
                          _ << "The quick brown fox jumped over the lazy dog.");

--- a/xls/common/stopwatch.cc
+++ b/xls/common/stopwatch.cc
@@ -45,11 +45,11 @@ steady_clock_t::duration ToSteadyDuration(absl::Duration d) {
 
 class RealTimeSteadyClock final : public SteadyClock {
  public:
-  ~RealTimeSteadyClock() override {
+  ~RealTimeSteadyClock() final {
     LOG(FATAL) << "RealTimeSteadyClock should never be destroyed";
   }
 
-  SteadyTime Now() override { return SteadyTime::Now(); }
+  SteadyTime Now() final { return SteadyTime::Now(); }
 };
 
 }  // namespace

--- a/xls/common/timeout_support.cc
+++ b/xls/common/timeout_support.cc
@@ -26,7 +26,7 @@
 namespace xls {
 
 namespace {
-class Cleaner : public TimeoutCleaner {
+class Cleaner final : public TimeoutCleaner {
  public:
   explicit Cleaner(absl::Duration duration)
       : duration_(duration), barrier_(2), thr_(Cleaner::StartThread, this) {
@@ -34,7 +34,7 @@ class Cleaner : public TimeoutCleaner {
     barrier_.Block();
   }
 
-  ~Cleaner() override {
+  ~Cleaner() final {
     notify_.Notify();
     thr_.join();
   }

--- a/xls/contrib/ice40/null_io_strategy.h
+++ b/xls/contrib/ice40/null_io_strategy.h
@@ -28,17 +28,17 @@ namespace verilog {
 
 // An IO strategy used for testing which transparently passes the byte-wise
 // input and output interfaces up through the top-level module.
-class NullIOStrategy : public IOStrategy {
+class NullIOStrategy final : public IOStrategy {
  public:
-  ~NullIOStrategy() override = default;
+  ~NullIOStrategy() final = default;
 
   absl::Status AddTopLevelDependencies(LogicRef* clk, Reset reset,
-                                       Module* m) override;
+                                       Module* m) final;
 
   absl::Status InstantiateIOBlocks(Input input, Output output,
-                                   Module* m) override;
+                                   Module* m) final;
 
-  absl::StatusOr<std::vector<VerilogInclude>> GetIncludes() override {
+  absl::StatusOr<std::vector<VerilogInclude>> GetIncludes() final {
     return std::vector<VerilogInclude>();
   }
 

--- a/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h
+++ b/xls/contrib/integrator/integration_algorithms/basic_integration_algorithm.h
@@ -78,15 +78,15 @@ class BasicIntegrationAlgorithm
   }
 
   // Initialize member fields.
-  absl::Status Initialize() override;
+  absl::Status Initialize() final;
 
   // Returns a function that integrates the functions in source_functions_.
   // Runs after Initialize.
-  absl::StatusOr<std::unique_ptr<IntegrationFunction>> Run() override;
+  absl::StatusOr<std::unique_ptr<IntegrationFunction>> Run() final;
 
   // Get the IntegrationOptions::Algorithm value corresponding to
   // this algoirthm.
-  IntegrationOptions::Algorithm get_corresponding_algorithm_option() override {
+  IntegrationOptions::Algorithm get_corresponding_algorithm_option() final {
     return IntegrationOptions::Algorithm::kBasicIntegrationAlgorithm;
   }
 

--- a/xls/contrib/mlir/transforms/arith_to_xls.cc
+++ b/xls/contrib/mlir/transforms/arith_to_xls.cc
@@ -120,7 +120,7 @@ static Type boolLike(Operation* op) {
 
 class ArithToXlsPass : public impl::ArithToXlsPassBase<ArithToXlsPass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     getOperation()->walk([&](Operation* op) {
       if (auto interface = dyn_cast<XlsRegionOpInterface>(op)) {
         if (interface.isSupportedRegion()) {

--- a/xls/contrib/mlir/transforms/array_to_bits.cc
+++ b/xls/contrib/mlir/transforms/array_to_bits.cc
@@ -397,7 +397,7 @@ class LegalizeArrayConcatPattern : public OpConversionPattern<ArrayConcatOp> {
 
 class ArrayToBitsPass : public impl::ArrayToBitsPassBase<ArrayToBitsPass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     TensorTypeConverter typeConverter;
     ConversionTarget target(getContext());
     target.addDynamicallyLegalOp<ChanOp>(

--- a/xls/contrib/mlir/transforms/expand_macro_ops.cc
+++ b/xls/contrib/mlir/transforms/expand_macro_ops.cc
@@ -59,7 +59,7 @@ class ArrayUpdateSliceOpRewrite : public OpRewritePattern<ArrayUpdateSliceOp> {
 class ExpandMacroOpsPass
     : public impl::ExpandMacroOpsPassBase<ExpandMacroOpsPass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     getOperation()->walk([&](Operation* op) {
       if (auto interface = dyn_cast<XlsRegionOpInterface>(op)) {
         if (interface.isSupportedRegion()) {

--- a/xls/contrib/mlir/transforms/index_type_conversion.cc
+++ b/xls/contrib/mlir/transforms/index_type_conversion.cc
@@ -260,7 +260,7 @@ class IndexTypeConversionPass
  public:
   using IndexTypeConversionPassBase::IndexTypeConversionPassBase;
 
-  void runOnOperation() override {
+  void runOnOperation() final {
     MLIRContext &ctx = getContext();
     IndexTypeConverter typeConverter(ctx, indexTypeBitWidth);
     ConversionTarget target(ctx);

--- a/xls/contrib/mlir/transforms/lower_counted_for.cc
+++ b/xls/contrib/mlir/transforms/lower_counted_for.cc
@@ -289,7 +289,7 @@ class ForToCountedForRewrite : public OpConversionPattern<ForOp> {
 class LowerCountedForPass
     : public impl::LowerCountedForPassBase<LowerCountedForPass> {
  private:
-  void runOnOperation() override {
+  void runOnOperation() final {
     // See comment in ForToCountedForRewrite for why we do this.
     DenseSet<StringRef> addedSymbols;
     SymbolTable symbolTable(getOperation());

--- a/xls/contrib/mlir/transforms/optimize_spawns.cc
+++ b/xls/contrib/mlir/transforms/optimize_spawns.cc
@@ -133,7 +133,7 @@ void RemoveUnusedArguments(SprocOp sproc) {
 class OptimizeSpawnsPass
     : public impl::OptimizeSpawnsPassBase<OptimizeSpawnsPass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     RewritePatternSet patterns(&getContext());
     patterns.add<SendOfBlockingReceiveOp>(&getContext());
     if (failed(applyPatternsGreedily(getOperation().getNext(),

--- a/xls/contrib/mlir/transforms/procify_loops.cc
+++ b/xls/contrib/mlir/transforms/procify_loops.cc
@@ -42,7 +42,7 @@ class ProcifyLoopsPass : public impl::ProcifyLoopsPassBase<ProcifyLoopsPass> {
  public:
   using ProcifyLoopsPassBase::ProcifyLoopsPassBase;
 
-  void runOnOperation() override {
+  void runOnOperation() final {
     ModuleOp module = getOperation();
     SymbolTable symbolTable(module);
     // We need to transform in pre-order, but MLIR's walkers require that if we

--- a/xls/contrib/mlir/transforms/scalarize.cc
+++ b/xls/contrib/mlir/transforms/scalarize.cc
@@ -816,7 +816,7 @@ class LegalizeCallDslxPattern : public OpConversionPattern<CallDslxOp> {
 
 class ScalarizePass : public impl::ScalarizePassBase<ScalarizePass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     getOperation()->walk([&](Operation* op) {
       if (auto interface = dyn_cast<XlsRegionOpInterface>(op)) {
         if (interface.isSupportedRegion()) {

--- a/xls/contrib/mlir/transforms/scf_to_xls.cc
+++ b/xls/contrib/mlir/transforms/scf_to_xls.cc
@@ -289,7 +289,7 @@ class PredicateRewriter {
 class ScfToXlsConversionPass
     : public impl::ScfToXlsPassBase<ScfToXlsConversionPass> {
  public:
-  void runOnOperation() override {
+  void runOnOperation() final {
     getOperation()->walk([&](XlsRegionOpInterface interface) {
       if (interface.isSupportedRegion()) {
         runOnOperation(interface);

--- a/xls/contrib/mlir/util/extraction_utils.cc
+++ b/xls/contrib/mlir/util/extraction_utils.cc
@@ -187,7 +187,7 @@ struct TestExtractAsTopLevelModulePass
   StringRef getDescription() const final {
     return "Extracts the function in 'test.name' as a top level module.";
   }
-  void runOnOperation() override {
+  void runOnOperation() final {
     auto attr =
         cast<StringAttr>(getOperation()->getDiscardableAttr("test.name"));
     llvm::outs() << "Testing : " << attr << "\n";

--- a/xls/contrib/mlir/util/proc_utils.cc
+++ b/xls/contrib/mlir/util/proc_utils.cc
@@ -477,7 +477,7 @@ struct TestConvertForOpToSprocCallPass
   void getDependentDialects(DialectRegistry& registry) const override {
     registry.insert<xls::XlsDialect>();
   }
-  void runOnOperation() override {
+  void runOnOperation() final {
     // We need to transform in pre-order, but MLIR's walkers require that if we
     // erase forOp we must interrupt the walk. So we run the walk to fixpoint.
     SymbolTable symbolTable(getOperation());

--- a/xls/contrib/xlscc/cc_parser.cc
+++ b/xls/contrib/xlscc/cc_parser.cc
@@ -824,7 +824,7 @@ class HlsNoTuplePragmaHandler : public HlsArgsPragmaHandler {
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
                     clang::Token& firstToken,
-                    const std::vector<clang::Token>& toks) override {
+                    const std::vector<clang::Token>& toks) final {
     const clang::PresumedLoc presumed_loc =
         PP.getSourceManager().getPresumedLoc(Introducer.Loc);
 
@@ -848,7 +848,7 @@ class HlsSyntheticIntPragmaHandler : public HlsArgsPragmaHandler {
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
                     clang::Token& firstToken,
-                    const std::vector<clang::Token>& toks) override {
+                    const std::vector<clang::Token>& toks) final {
     const clang::PresumedLoc presumed_loc =
         PP.getSourceManager().getPresumedLoc(Introducer.Loc);
 
@@ -873,7 +873,7 @@ class HlsTopPragmaHandler : public HlsArgsPragmaHandler {
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
                     clang::Token& firstToken,
-                    const std::vector<clang::Token>& toks) override {
+                    const std::vector<clang::Token>& toks) final {
     GenerateAnnotation(PP, clang::PragmaHandler::getName(), firstToken,
                        /*arguments=*/{});
   }
@@ -890,7 +890,7 @@ class HlsAllowDefaultPadPragmaHandler : public HlsArgsPragmaHandler {
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
                     clang::Token& firstToken,
-                    const std::vector<clang::Token>& toks) override {
+                    const std::vector<clang::Token>& toks) final {
     GenerateAnnotation(PP, "hls_array_allow_default_pad", firstToken,
                        /*arguments=*/{});
   }
@@ -909,7 +909,7 @@ class HlsDesignPragmaHandler : public HlsArgsPragmaHandler {
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
                     clang::Token& firstToken,
-                    const std::vector<clang::Token>& toks) override {
+                    const std::vector<clang::Token>& toks) final {
     const clang::Token& tok = toks.at(0);
 
     if (tok.is(clang::tok::identifier)) {
@@ -939,7 +939,7 @@ class HlsPipelineInitIntervalPragmaHandler : public clang::PragmaHandler {
       : clang::PragmaHandler("hls_pipeline_init_interval") {}
 
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
-                    clang::Token& firstToken) override {
+                    clang::Token& firstToken) final {
     std::vector<clang::Token> toks;
     PP.LexTokensUntilEOF(&toks);
     GenerateAnnotation(PP, "hls_pipeline_init_interval", firstToken, toks);
@@ -954,7 +954,7 @@ class HlsUnrollPragmaHandler : public clang::PragmaHandler {
  public:
   explicit HlsUnrollPragmaHandler() : clang::PragmaHandler("hls_unroll") {}
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
-                    clang::Token& firstToken) override {
+                    clang::Token& firstToken) final {
     std::vector<clang::Token> toks;
     PP.LexTokensUntilEOF(&toks);
     GenerateAnnotation(PP, "hls_unroll", firstToken, toks);
@@ -968,7 +968,7 @@ static clang::PragmaHandlerRegistry::Add<HlsUnrollPragmaHandler>
 class UnknownPragmaHandler : public clang::PragmaHandler {
  public:
   void HandlePragma(clang::Preprocessor& PP, clang::PragmaIntroducer Introducer,
-                    clang::Token& firstToken) override {
+                    clang::Token& firstToken) final {
     const std::string& name = firstToken.getIdentifierInfo()->getName().str();
     static const auto* non_hls_names = new absl::flat_hash_set<std::string>(
         {"top", "design", "pipeline_init_interval", "array_allow_default_pad",
@@ -995,7 +995,7 @@ class LibToolASTConsumer : public clang::ASTConsumer {
   explicit LibToolASTConsumer(clang::CompilerInstance& CI, CCParser& parser)
       : visitor_(new LibToolVisitor(CI, parser)) {}
 
-  void HandleTranslationUnit(clang::ASTContext& Context) override {
+  void HandleTranslationUnit(clang::ASTContext& Context) final {
     visitor_->TraverseDecl(Context.getTranslationUnitDecl());
   }
 
@@ -1005,14 +1005,14 @@ class LibToolASTConsumer : public clang::ASTConsumer {
 class LibToolFrontendAction : public clang::ASTFrontendAction {
  public:
   explicit LibToolFrontendAction(CCParser& parser) : parser_(parser) {}
-  void EndSourceFileAction() override;
+  void EndSourceFileAction() final;
   std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(
-      clang::CompilerInstance& CI, clang::StringRef /*file*/) override {
+      clang::CompilerInstance& CI, clang::StringRef /*file*/) final {
     compiler_instance_ = &CI;
     return std::unique_ptr<clang::ASTConsumer>(
         new LibToolASTConsumer(CI, parser_));
   }
-  void ExecuteAction() override { clang::ASTFrontendAction::ExecuteAction(); }
+  void ExecuteAction() final { clang::ASTFrontendAction::ExecuteAction(); }
 
  private:
   CCParser& parser_;
@@ -1026,7 +1026,7 @@ class DiagnosticInterceptor : public clang::TextDiagnosticPrinter {
       : clang::TextDiagnosticPrinter(os, *diags, OwnsOutputStream),
         parser_(translator) {}
   void HandleDiagnostic(clang::DiagnosticsEngine::Level level,
-                        const clang::Diagnostic& info) override {
+                        const clang::Diagnostic& info) final {
     // Print the message
     clang::TextDiagnosticPrinter::HandleDiagnostic(level, info);
 

--- a/xls/dev_tools/booleanifier.cc
+++ b/xls/dev_tools/booleanifier.cc
@@ -115,7 +115,7 @@ class BooleanifierNodeEvaluator : public AbstractNodeEvaluator<BitEvaluator> {
         params_(params) {}
 
   // Select the appropriate elements.
-  absl::Status HandleArrayIndex(ArrayIndex* index) override {
+  absl::Status HandleArrayIndex(ArrayIndex* index) final {
     XLS_ASSIGN_OR_RETURN(std::vector<BitEvaluator::Span> indexes,
                          GetValueList(index->indices()));
     XLS_ASSIGN_OR_RETURN(LeafTypeTreeView<LeafValueT> array,
@@ -137,7 +137,7 @@ class BooleanifierNodeEvaluator : public AbstractNodeEvaluator<BitEvaluator> {
   }
 
   // select the appropriate slice.
-  absl::Status HandleArraySlice(ArraySlice* slice) override {
+  absl::Status HandleArraySlice(ArraySlice* slice) final {
     XLS_ASSIGN_OR_RETURN(LeafTypeTreeView<LeafValueT> array,
                          GetCompoundValue(slice->array()));
     XLS_ASSIGN_OR_RETURN(ArrayType * array_type, slice->GetType()->AsArray());
@@ -189,7 +189,7 @@ class BooleanifierNodeEvaluator : public AbstractNodeEvaluator<BitEvaluator> {
     return SetValue(slice, std::move(result));
   }
 
-  absl::Status HandleArrayUpdate(ArrayUpdate* update) override {
+  absl::Status HandleArrayUpdate(ArrayUpdate* update) final {
     XLS_ASSIGN_OR_RETURN(std::vector<BitEvaluator::Span> indexes,
                          GetValueList(update->indices()));
     XLS_ASSIGN_OR_RETURN(LeafTypeTreeView<LeafValueT> array,
@@ -218,7 +218,7 @@ class BooleanifierNodeEvaluator : public AbstractNodeEvaluator<BitEvaluator> {
     return SetValue(update, std::move(result));
   }
 
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     XLS_ASSIGN_OR_RETURN(LeafTypeTree<LeafValueT> result,
                          UnpackParam(params_.at(param->name())));
     return SetValue(param, std::move(result));

--- a/xls/dslx/bytecode/bytecode_interpreter_test.cc
+++ b/xls/dslx/bytecode/bytecode_interpreter_test.cc
@@ -70,7 +70,7 @@ using ::testing::HasSubstr;
 
 class BytecodeInterpreterTest : public ::testing::Test {
  public:
-  void SetUp() override { import_data_.emplace(CreateImportDataForTest()); }
+  void SetUp() final { import_data_.emplace(CreateImportDataForTest()); }
 
  protected:
   std::optional<ImportData> import_data_;

--- a/xls/dslx/bytecode/proc_hierarchy_interpreter_test.cc
+++ b/xls/dslx/bytecode/proc_hierarchy_interpreter_test.cc
@@ -66,7 +66,7 @@ using ::testing::HasSubstr;
 
 class ProcHierarchyInterpreterTest : public ::testing::Test {
  public:
-  void SetUp() override { import_data_.emplace(CreateImportDataForTest()); }
+  void SetUp() final { import_data_.emplace(CreateImportDataForTest()); }
 
   absl::StatusOr<TestProc*> ParseAndGetTestProc(
       std::string_view program, std::string_view test_proc_name) {

--- a/xls/dslx/constexpr_evaluator.h
+++ b/xls/dslx/constexpr_evaluator.h
@@ -39,7 +39,7 @@ namespace xls::dslx {
 // conversion, at which point we don't want to be collecting warnings since we
 // expect to have flagged all warnings (e.g. rollovers) in the type checking
 // phase.
-class ConstexprEvaluator : public xls::dslx::ExprVisitor {
+class ConstexprEvaluator final : public xls::dslx::ExprVisitor {
  public:
   // Evaluates the given expression to determine if it's constexpr or not, and
   // updates `type_info` accordingly. Returns success as long as no error
@@ -64,42 +64,42 @@ class ConstexprEvaluator : public xls::dslx::ExprVisitor {
   //    `u32[4]:[0, 1, ...]`. The type is needed to determine the number of
   //    elements to fill in.
   // In all other cases, `type` can be nullptr.
-  ~ConstexprEvaluator() override = default;
+  ~ConstexprEvaluator() final = default;
 
-  absl::Status HandleAllOnesMacro(const AllOnesMacro* expr) override;
-  absl::Status HandleArray(const Array* expr) override;
-  absl::Status HandleAttr(const Attr* expr) override;
-  absl::Status HandleBinop(const Binop* expr) override;
-  absl::Status HandleCast(const Cast* expr) override;
-  absl::Status HandleChannelDecl(const ChannelDecl* expr) override;
-  absl::Status HandleColonRef(const ColonRef* expr) override;
-  absl::Status HandleConditional(const Conditional* expr) override;
-  absl::Status HandleFor(const For* expr) override;
-  absl::Status HandleFormatMacro(const FormatMacro* expr) override {
+  absl::Status HandleAllOnesMacro(const AllOnesMacro* expr) final;
+  absl::Status HandleArray(const Array* expr) final;
+  absl::Status HandleAttr(const Attr* expr) final;
+  absl::Status HandleBinop(const Binop* expr) final;
+  absl::Status HandleCast(const Cast* expr) final;
+  absl::Status HandleChannelDecl(const ChannelDecl* expr) final;
+  absl::Status HandleColonRef(const ColonRef* expr) final;
+  absl::Status HandleConditional(const Conditional* expr) final;
+  absl::Status HandleFor(const For* expr) final;
+  absl::Status HandleFormatMacro(const FormatMacro* expr) final {
     return absl::OkStatus();
   }
-  absl::Status HandleFunctionRef(const FunctionRef* expr) override;
-  absl::Status HandleIndex(const Index* expr) override;
-  absl::Status HandleInvocation(const Invocation* expr) override;
-  absl::Status HandleLambda(const Lambda* expr) override;
-  absl::Status HandleMatch(const Match* expr) override;
-  absl::Status HandleNameRef(const NameRef* expr) override;
-  absl::Status HandleNumber(const Number* expr) override;
-  absl::Status HandleRange(const Range* expr) override;
-  absl::Status HandleSpawn(const Spawn* expr) override {
+  absl::Status HandleFunctionRef(const FunctionRef* expr) final;
+  absl::Status HandleIndex(const Index* expr) final;
+  absl::Status HandleInvocation(const Invocation* expr) final;
+  absl::Status HandleLambda(const Lambda* expr) final;
+  absl::Status HandleMatch(const Match* expr) final;
+  absl::Status HandleNameRef(const NameRef* expr) final;
+  absl::Status HandleNumber(const Number* expr) final;
+  absl::Status HandleRange(const Range* expr) final;
+  absl::Status HandleSpawn(const Spawn* expr) final {
     return absl::OkStatus();
   }
   absl::Status HandleSplatStructInstance(
-      const SplatStructInstance* expr) override;
-  absl::Status HandleStatementBlock(const StatementBlock* expr) override;
-  absl::Status HandleString(const String* expr) override;
-  absl::Status HandleStructInstance(const StructInstance* expr) override;
-  absl::Status HandleTupleIndex(const TupleIndex* expr) override;
-  absl::Status HandleUnop(const Unop* expr) override;
-  absl::Status HandleUnrollFor(const UnrollFor* expr) override;
-  absl::Status HandleVerbatimNode(const VerbatimNode* node) override;
-  absl::Status HandleXlsTuple(const XlsTuple* expr) override;
-  absl::Status HandleZeroMacro(const ZeroMacro* expr) override;
+      const SplatStructInstance* expr) final;
+  absl::Status HandleStatementBlock(const StatementBlock* expr) final;
+  absl::Status HandleString(const String* expr) final;
+  absl::Status HandleStructInstance(const StructInstance* expr) final;
+  absl::Status HandleTupleIndex(const TupleIndex* expr) final;
+  absl::Status HandleUnop(const Unop* expr) final;
+  absl::Status HandleUnrollFor(const UnrollFor* expr) final;
+  absl::Status HandleVerbatimNode(const VerbatimNode* node) final;
+  absl::Status HandleXlsTuple(const XlsTuple* expr) final;
+  absl::Status HandleZeroMacro(const ZeroMacro* expr) final;
 
  private:
   absl::Status HandleExternRef(const NameRef* name_ref, const NameDef* name_def,

--- a/xls/dslx/diagnostics/format_type_mismatch.cc
+++ b/xls/dslx/diagnostics/format_type_mismatch.cc
@@ -64,7 +64,7 @@ class Callbacks : public ZipTypesCallbacks {
  public:
   explicit Callbacks(MismatchData& mismatches) : mismatches_(mismatches) {}
 
-  absl::Status NoteAggregateStart(const AggregatePair& aggregates) override {
+  absl::Status NoteAggregateStart(const AggregatePair& aggregates) final {
     return absl::visit(
         Visitor{
             [&](std::pair<const TupleType*, const TupleType*>) {
@@ -101,7 +101,7 @@ class Callbacks : public ZipTypesCallbacks {
         aggregates);
   }
 
-  absl::Status NoteAggregateNext(const AggregatePair& aggregates) override {
+  absl::Status NoteAggregateNext(const AggregatePair& aggregates) final {
     return absl::visit(
         Visitor{
             [&](auto p) { return absl::OkStatus(); },
@@ -117,7 +117,7 @@ class Callbacks : public ZipTypesCallbacks {
         aggregates);
   }
 
-  absl::Status NoteAggregateEnd(const AggregatePair& aggregates) override {
+  absl::Status NoteAggregateEnd(const AggregatePair& aggregates) final {
     return absl::visit(
         Visitor{
             [&](std::pair<const TupleType*, const TupleType*>) {
@@ -158,7 +158,7 @@ class Callbacks : public ZipTypesCallbacks {
 
   absl::Status NoteMatchedLeafType(const Type& lhs, const Type* lhs_parent,
                                    const Type& rhs,
-                                   const Type* rhs_parent) override {
+                                   const Type* rhs_parent) final {
     match_count_++;
     BeforeType(lhs, lhs_parent, rhs, rhs_parent);
     AddMatched(lhs.ToString(), &colorized_lhs_);
@@ -168,7 +168,7 @@ class Callbacks : public ZipTypesCallbacks {
 
   absl::Status NoteTypeMismatch(const Type& lhs, const Type* lhs_parent,
                                 const Type& rhs,
-                                const Type* rhs_parent) override {
+                                const Type* rhs_parent) final {
     if (auto* lhs_tuple = dynamic_cast<const TupleType*>(&lhs)) {
       if (auto* rhs_tuple = dynamic_cast<const TupleType*>(&rhs)) {
         XLS_RET_CHECK_NE(lhs_tuple->size(), rhs_tuple->size());

--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1792,15 +1792,15 @@ DocRef Fmt(const NameDefTree& n, Comments& comments, DocArena& arena) {
   return ConcatNGroup(arena, pieces);
 }
 
-class FmtExprVisitor : public ExprVisitor {
+class FmtExprVisitor final : public ExprVisitor {
  public:
   FmtExprVisitor(DocArena& arena, Comments& comments)
       : arena_(arena), comments_(comments) {}
 
-  ~FmtExprVisitor() override = default;
+  ~FmtExprVisitor() final = default;
 
 #define DEFINE_HANDLER(__type)                               \
-  absl::Status Handle##__type(const __type* expr) override { \
+  absl::Status Handle##__type(const __type* expr) final { \
     result_ = Fmt(*expr, comments_, arena_);                 \
     return absl::OkStatus();                                 \
   }

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -52,7 +52,7 @@ class AstCloner : public AstNodeVisitor {
     return module_.has_value() ? *module_ : n->owner();
   }
 
-  absl::Status HandleArray(const Array* n) override {
+  absl::Status HandleArray(const Array* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<Expr*> new_members;
@@ -72,7 +72,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleArrayTypeAnnotation(
-      const ArrayTypeAnnotation* n) override {
+      const ArrayTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     old_to_new_[n] = module(n)->Make<ArrayTypeAnnotation>(
@@ -82,7 +82,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSelfTypeAnnotation(const SelfTypeAnnotation* n) override {
+  absl::Status HandleSelfTypeAnnotation(const SelfTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     if (!old_to_new_.contains(n->struct_ref())) {
@@ -95,7 +95,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAttr(const Attr* n) override {
+  absl::Status HandleAttr(const Attr* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     // We must've seen the NameDef here, so we don't need to visit it.
@@ -105,7 +105,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleBinop(const Binop* n) override {
+  absl::Status HandleBinop(const Binop* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<Binop>(
         n->span(), n->binop_kind(), down_cast<Expr*>(old_to_new_.at(n->lhs())),
@@ -114,7 +114,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStatementBlock(const StatementBlock* n) override {
+  absl::Status HandleStatementBlock(const StatementBlock* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     std::vector<Statement*> new_statements;
     new_statements.reserve(n->statements().size());
@@ -140,14 +140,14 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstAssert(const ConstAssert* n) override {
+  absl::Status HandleConstAssert(const ConstAssert* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<ConstAssert>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->arg())));
     return absl::OkStatus();
   }
 
-  absl::Status HandleStatement(const Statement* n) override {
+  absl::Status HandleStatement(const Statement* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     XLS_ASSIGN_OR_RETURN(
         auto new_wrapped,
@@ -156,7 +156,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleBuiltinNameDef(const BuiltinNameDef* n) override {
+  absl::Status HandleBuiltinNameDef(const BuiltinNameDef* n) final {
     if (!old_to_new_.contains(n)) {
       old_to_new_[n] = module(n)->GetOrCreateBuiltinNameDef(n->identifier());
     }
@@ -164,7 +164,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleBuiltinTypeAnnotation(
-      const BuiltinTypeAnnotation* n) override {
+      const BuiltinTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->builtin_name_def()));
     old_to_new_[n] = module(n)->Make<BuiltinTypeAnnotation>(
         n->span(), n->builtin_type(),
@@ -172,7 +172,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleCast(const Cast* n) override {
+  absl::Status HandleCast(const Cast* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<Cast>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->expr())),
@@ -181,7 +181,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleChannelDecl(const ChannelDecl* n) override {
+  absl::Status HandleChannelDecl(const ChannelDecl* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::optional<std::vector<Expr*>> new_dims;
@@ -214,7 +214,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleChannelTypeAnnotation(
-      const ChannelTypeAnnotation* n) override {
+      const ChannelTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::optional<std::vector<Expr*>> new_dims;
@@ -234,7 +234,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleColonRef(const ColonRef* n) override {
+  absl::Status HandleColonRef(const ColonRef* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     ColonRef::Subject new_subject = absl::visit(
@@ -259,7 +259,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstantDef(const ConstantDef* n) override {
+  absl::Status HandleConstantDef(const ConstantDef* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     TypeAnnotation* new_type_annotation = nullptr;
     if (n->type_annotation() != nullptr) {
@@ -273,7 +273,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleEnumDef(const EnumDef* n) override {
+  absl::Status HandleEnumDef(const EnumDef* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     NameDef* new_name_def = down_cast<NameDef*>(old_to_new_.at(n->name_def()));
@@ -302,7 +302,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleFor(const For* n) override {
+  absl::Status HandleFor(const For* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->names()));
@@ -324,7 +324,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleFormatMacro(const FormatMacro* n) override {
+  absl::Status HandleFormatMacro(const FormatMacro* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<Expr*> new_args;
@@ -345,7 +345,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleFunctionRef(const FunctionRef* n) override {
+  absl::Status HandleFunctionRef(const FunctionRef* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<FunctionRef>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->callee())),
@@ -353,7 +353,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleZeroMacro(const ZeroMacro* n) override {
+  absl::Status HandleZeroMacro(const ZeroMacro* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     ExprOrType new_eot = ToExprOrType(old_to_new_.at(ToAstNode(n->type())));
@@ -362,7 +362,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAllOnesMacro(const AllOnesMacro* n) override {
+  absl::Status HandleAllOnesMacro(const AllOnesMacro* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     ExprOrType new_eot = ToExprOrType(old_to_new_.at(ToAstNode(n->type())));
@@ -371,7 +371,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleFunction(const Function* n) override {
+  absl::Status HandleFunction(const Function* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     XLS_ASSIGN_OR_RETURN(
         NameDef * new_name_def,
@@ -416,7 +416,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleImport(const Import* n) override {
+  absl::Status HandleImport(const Import* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     old_to_new_[n] = module(n)->Make<Import>(
@@ -425,7 +425,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleUse(const Use* n) override {
+  absl::Status HandleUse(const Use* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     const UseTreeEntry* old_root = &n->root();
@@ -435,7 +435,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleUseTreeEntry(const UseTreeEntry* n) override {
+  absl::Status HandleUseTreeEntry(const UseTreeEntry* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     using PayloadT = std::variant<UseInteriorEntry, NameDef*>;
@@ -460,7 +460,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleIndex(const Index* n) override {
+  absl::Status HandleIndex(const Index* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     IndexRhs new_rhs =
@@ -475,7 +475,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleInvocation(const Invocation* n) override {
+  absl::Status HandleInvocation(const Invocation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<Expr*> new_args;
@@ -499,11 +499,11 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleLambda(const Lambda* n) override {
+  absl::Status HandleLambda(const Lambda* n) final {
     return absl::UnimplementedError("lambdas not yet supported");
   }
 
-  absl::Status HandleLet(const Let* n) override {
+  absl::Status HandleLet(const Let* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     TypeAnnotation* new_type = nullptr;
@@ -518,7 +518,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMatch(const Match* n) override {
+  absl::Status HandleMatch(const Match* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<MatchArm*> new_arms;
@@ -533,7 +533,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMatchArm(const MatchArm* n) override {
+  absl::Status HandleMatchArm(const MatchArm* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<NameDefTree*> new_patterns;
@@ -558,7 +558,7 @@ class AstCloner : public AstNodeVisitor {
     return down_cast<T>(replacement);
   }
 
-  absl::Status HandleModule(const Module* n) override {
+  absl::Status HandleModule(const Module* n) final {
     for (const ModuleMember member : n->top()) {
       ModuleMember new_member;
       XLS_RETURN_IF_ERROR(absl::visit(
@@ -578,7 +578,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNameDef(const NameDef* n) override {
+  absl::Status HandleNameDef(const NameDef* n) final {
     if (!old_to_new_.contains(n)) {
       // We need to set the definer in the definer itself, not here, to avoid
       // looping (Function -> NameDef -> Function -> NameDef -> ...).
@@ -589,7 +589,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNameDefTree(const NameDefTree* n) override {
+  absl::Status HandleNameDefTree(const NameDefTree* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     if (n->is_leaf()) {
@@ -610,7 +610,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNameRef(const NameRef* n) override {
+  absl::Status HandleNameRef(const NameRef* n) final {
     // If it's a ref to a cloned def, then point it to the cloned def.
     // Otherwise, it may be a ref to a def that is outside the scope being
     // cloned.
@@ -626,7 +626,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNumber(const Number* n) override {
+  absl::Status HandleNumber(const Number* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     TypeAnnotation* new_type = nullptr;
@@ -639,7 +639,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleParam(const Param* n) override {
+  absl::Status HandleParam(const Param* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<Param>(
         down_cast<NameDef*>(old_to_new_.at(n->name_def())),
@@ -647,7 +647,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleProcMember(const ProcMember* n) override {
+  absl::Status HandleProcMember(const ProcMember* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<ProcMember>(
         down_cast<NameDef*>(old_to_new_.at(n->name_def())),
@@ -655,7 +655,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleParametricBinding(const ParametricBinding* n) override {
+  absl::Status HandleParametricBinding(const ParametricBinding* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     Expr* new_expr = nullptr;
@@ -669,7 +669,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleProc(const Proc* n) override {
+  absl::Status HandleProc(const Proc* n) final {
     if (old_to_new_.contains(n)) {
       // If we've already cloned this proc, just return it.
       return absl::OkStatus();
@@ -713,7 +713,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleQuickCheck(const QuickCheck* n) override {
+  absl::Status HandleQuickCheck(const QuickCheck* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<QuickCheck>(
         n->GetSpan().value(), down_cast<Function*>(old_to_new_.at(n->fn())),
@@ -721,7 +721,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleRange(const Range* n) override {
+  absl::Status HandleRange(const Range* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<Range>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->start())),
@@ -730,7 +730,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSlice(const Slice* n) override {
+  absl::Status HandleSlice(const Slice* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     Expr* new_start = n->start() == nullptr
@@ -745,7 +745,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSpawn(const Spawn* n) override {
+  absl::Status HandleSpawn(const Spawn* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->callee()));
     old_to_new_[n] = module(n)->Make<Spawn>(
@@ -757,7 +757,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleSplatStructInstance(
-      const SplatStructInstance* n) override {
+      const SplatStructInstance* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     // Have to explicitly visit struct ref, since it's not a child.
@@ -780,7 +780,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleString(const String* n) override {
+  absl::Status HandleString(const String* n) final {
     old_to_new_[n] =
         module(n)->Make<String>(n->span(), n->text(), n->in_parens());
     return absl::OkStatus();
@@ -844,7 +844,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStructDef(const StructDef* n) override {
+  absl::Status HandleStructDef(const StructDef* n) final {
     absl::Status status = HandleStructDefBaseInternal(n);
     if (status.ok()) {
       AstNode* new_node = old_to_new_.at(n);
@@ -858,11 +858,11 @@ class AstCloner : public AstNodeVisitor {
     return status;
   }
 
-  absl::Status HandleProcDef(const ProcDef* n) override {
+  absl::Status HandleProcDef(const ProcDef* n) final {
     return HandleStructDefBaseInternal(n);
   }
 
-  absl::Status HandleImpl(const Impl* n) override {
+  absl::Status HandleImpl(const Impl* n) final {
     // To avoid infinite loops between impl -> function -> struct -> impl, use a
     // placeholder for children (members and struct def) and add afterward.
     Impl* new_impl = module(n)->Make<Impl>(
@@ -894,7 +894,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStructMemberNode(const StructMemberNode* n) override {
+  absl::Status HandleStructMemberNode(const StructMemberNode* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     StructMemberNode* new_struct_member = module(n)->Make<StructMemberNode>(
         n->span(), down_cast<NameDef*>(old_to_new_.at(n->name_def())),
@@ -903,7 +903,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStructInstance(const StructInstance* n) override {
+  absl::Status HandleStructInstance(const StructInstance* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     // Have to explicitly visit struct ref, since it's not a child.
@@ -925,7 +925,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConditional(const Conditional* n) override {
+  absl::Status HandleConditional(const Conditional* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::variant<StatementBlock*, Conditional*> new_alternate;
@@ -945,7 +945,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTestFunction(const TestFunction* n) override {
+  absl::Status HandleTestFunction(const TestFunction* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(&n->fn()));
@@ -954,7 +954,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTestProc(const TestProc* n) override {
+  absl::Status HandleTestProc(const TestProc* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     old_to_new_[n] = module(n)->Make<TestProc>(
@@ -962,7 +962,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTupleIndex(const TupleIndex* n) override {
+  absl::Status HandleTupleIndex(const TupleIndex* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<TupleIndex>(
         n->span(), down_cast<Expr*>(old_to_new_.at(n->lhs())),
@@ -971,7 +971,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleTupleTypeAnnotation(
-      const TupleTypeAnnotation* n) override {
+      const TupleTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<TypeAnnotation*> new_members;
@@ -984,7 +984,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTypeAlias(const TypeAlias* n) override {
+  absl::Status HandleTypeAlias(const TypeAlias* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     NameDef* new_name_def = down_cast<NameDef*>(old_to_new_.at(&n->name_def()));
@@ -1000,7 +1000,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTypeRef(const TypeRef* n) override {
+  absl::Status HandleTypeRef(const TypeRef* n) final {
     TypeDefinition new_type_definition = n->type_definition();
 
     // A TypeRef doesn't own its referenced type definition, so we have to
@@ -1018,7 +1018,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleTypeRefTypeAnnotation(
-      const TypeRefTypeAnnotation* n) override {
+      const TypeRefTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<TypeRefTypeAnnotation>(
         n->span(), down_cast<TypeRef*>(old_to_new_.at(n->type_ref())),
@@ -1027,7 +1027,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleTypeVariableTypeAnnotation(
-      const TypeVariableTypeAnnotation* n) override {
+      const TypeVariableTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->type_variable()));
     old_to_new_[n] = module(n)->Make<TypeVariableTypeAnnotation>(
         down_cast<const NameRef*>(old_to_new_[n->type_variable()]));
@@ -1035,7 +1035,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleMemberTypeAnnotation(
-      const MemberTypeAnnotation* n) override {
+      const MemberTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->struct_type()));
     old_to_new_[n] = module(n)->Make<MemberTypeAnnotation>(
         down_cast<const TypeAnnotation*>(old_to_new_[n->struct_type()]),
@@ -1044,7 +1044,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleElementTypeAnnotation(
-      const ElementTypeAnnotation* n) override {
+      const ElementTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->container_type()));
     if (n->tuple_index().has_value()) {
       XLS_RETURN_IF_ERROR(ReplaceOrVisit(*n->tuple_index()));
@@ -1059,7 +1059,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleSliceTypeAnnotation(
-      const SliceTypeAnnotation* n) override {
+      const SliceTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->source_type()));
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(ToAstNode(n->slice())));
     AstNode* new_slice_node = old_to_new_[ToAstNode(n->slice())];
@@ -1076,7 +1076,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleFunctionTypeAnnotation(
-      const FunctionTypeAnnotation* n) override {
+      const FunctionTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->return_type()));
     std::vector<const TypeAnnotation*> param_types;
     param_types.reserve(n->param_types().size());
@@ -1092,7 +1092,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleReturnTypeAnnotation(
-      const ReturnTypeAnnotation* n) override {
+      const ReturnTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->function_type()));
     old_to_new_[n] = module(n)->Make<ReturnTypeAnnotation>(
         down_cast<TypeAnnotation*>(old_to_new_[n->function_type()]));
@@ -1100,7 +1100,7 @@ class AstCloner : public AstNodeVisitor {
   }
 
   absl::Status HandleParamTypeAnnotation(
-      const ParamTypeAnnotation* n) override {
+      const ParamTypeAnnotation* n) final {
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(n->function_type()));
     old_to_new_[n] = module(n)->Make<ParamTypeAnnotation>(
         down_cast<TypeAnnotation*>(old_to_new_[n->function_type()]),
@@ -1108,12 +1108,12 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation* n) override {
+  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation* n) final {
     old_to_new_[n] = module(n)->Make<AnyTypeAnnotation>(n->multiple());
     return absl::OkStatus();
   }
 
-  absl::Status HandleUnop(const Unop* n) override {
+  absl::Status HandleUnop(const Unop* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] =
         module(n)->Make<Unop>(n->span(), n->unop_kind(),
@@ -1122,7 +1122,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleUnrollFor(const UnrollFor* n) override {
+  absl::Status HandleUnrollFor(const UnrollFor* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     auto new_type_annotation =
@@ -1138,7 +1138,7 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleWidthSlice(const WidthSlice* n) override {
+  absl::Status HandleWidthSlice(const WidthSlice* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
     old_to_new_[n] = module(n)->Make<WidthSlice>(
         n->GetSpan().value(), down_cast<Expr*>(old_to_new_.at(n->start())),
@@ -1146,17 +1146,17 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleWildcardPattern(const WildcardPattern* n) override {
+  absl::Status HandleWildcardPattern(const WildcardPattern* n) final {
     old_to_new_[n] = module(n)->Make<WildcardPattern>(n->span());
     return absl::OkStatus();
   }
 
-  absl::Status HandleRestOfTuple(const RestOfTuple* n) override {
+  absl::Status HandleRestOfTuple(const RestOfTuple* n) final {
     old_to_new_[n] = module(n)->Make<RestOfTuple>(n->span());
     return absl::OkStatus();
   }
 
-  absl::Status HandleXlsTuple(const XlsTuple* n) override {
+  absl::Status HandleXlsTuple(const XlsTuple* n) final {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     std::vector<Expr*> members;
@@ -1170,13 +1170,13 @@ class AstCloner : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleVerbatimNode(const VerbatimNode* n) override {
+  absl::Status HandleVerbatimNode(const VerbatimNode* n) final {
     old_to_new_[n] = module(n)->Make<VerbatimNode>(n->span(), n->text());
     return absl::OkStatus();
   }
 
   absl::Status HandleGenericTypeAnnotation(
-      const GenericTypeAnnotation* n) override {
+      const GenericTypeAnnotation* n) final {
     old_to_new_[n] = module(n)->Make<GenericTypeAnnotation>(n->span());
     return absl::OkStatus();
   }

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -469,7 +469,7 @@ absl::StatusOr<std::vector<AstNode*>> CollectUnder(AstNode* root,
     explicit CollectVisitor(std::vector<AstNode*>& nodes) : nodes_(nodes) {}
 
 #define DECLARE_HANDLER(__type)                           \
-  absl::Status Handle##__type(const __type* n) override { \
+  absl::Status Handle##__type(const __type* n) final { \
     nodes_.push_back(const_cast<__type*>(n));             \
     return absl::OkStatus();                              \
   }

--- a/xls/dslx/frontend/proc_id_test.cc
+++ b/xls/dslx/frontend/proc_id_test.cc
@@ -31,7 +31,7 @@ namespace {
 
 class ProcIdTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     auto [foo_module, foo_proc] = CreateEmptyProc(file_table_, "Foo");
     auto [bar_module, bar_proc] = CreateEmptyProc(file_table_, "Bar");
     auto [baz_module, baz_proc] = CreateEmptyProc(file_table_, "Baz");

--- a/xls/dslx/frontend/zip_ast.cc
+++ b/xls/dslx/frontend/zip_ast.cc
@@ -42,7 +42,7 @@ class ZipVisitor : public AstNodeVisitorWithDefault {
   ZipAstOptions& options() { return options_; }
 
 #define DECLARE_HANDLER(__type)                           \
-  absl::Status Handle##__type(const __type* n) override { \
+  absl::Status Handle##__type(const __type* n) final { \
     return Handle<__type>(n);                             \
   }
   XLS_DSLX_AST_NODE_EACH(DECLARE_HANDLER)

--- a/xls/dslx/frontend/zip_ast_test.cc
+++ b/xls/dslx/frontend/zip_ast_test.cc
@@ -61,7 +61,7 @@ class ZipAstTest : public ::testing::Test {
 
 class Collector : public AstNodeVisitorWithDefault {
  public:
-  absl::Status DefaultHandler(const AstNode* node) override {
+  absl::Status DefaultHandler(const AstNode* node) final {
     nodes_.push_back(node);
     return absl::OkStatus();
   }

--- a/xls/dslx/interp_value.cc
+++ b/xls/dslx/interp_value.cc
@@ -345,26 +345,26 @@ absl::StatusOr<std::string> InterpValue::ToFormattedString(
           include_type_prefix_(include_type_prefix),
           indentation_(indentation) {}
 
-    absl::Status HandleStruct(const ValueFormatDescriptor& d) override {
+    absl::Status HandleStruct(const ValueFormatDescriptor& d) final {
       XLS_ASSIGN_OR_RETURN(
           result_, v_.ToStructString(d, include_type_prefix_, indentation_));
       return absl::OkStatus();
     }
-    absl::Status HandleArray(const ValueFormatDescriptor& d) override {
+    absl::Status HandleArray(const ValueFormatDescriptor& d) final {
       XLS_ASSIGN_OR_RETURN(
           result_, v_.ToArrayString(d, include_type_prefix_, indentation_));
       return absl::OkStatus();
     }
-    absl::Status HandleEnum(const ValueFormatDescriptor& d) override {
+    absl::Status HandleEnum(const ValueFormatDescriptor& d) final {
       XLS_ASSIGN_OR_RETURN(result_, v_.ToEnumString(d));
       return absl::OkStatus();
     }
-    absl::Status HandleTuple(const ValueFormatDescriptor& d) override {
+    absl::Status HandleTuple(const ValueFormatDescriptor& d) final {
       XLS_ASSIGN_OR_RETURN(
           result_, v_.ToTupleString(d, include_type_prefix_, indentation_));
       return absl::OkStatus();
     }
-    absl::Status HandleLeafValue(const ValueFormatDescriptor& d) override {
+    absl::Status HandleLeafValue(const ValueFormatDescriptor& d) final {
       result_ =
           v_.ToString(/*humanize=*/!include_type_prefix_, d.leaf_format());
       return absl::OkStatus();

--- a/xls/dslx/ir_convert/channel_scope_test.cc
+++ b/xls/dslx/ir_convert/channel_scope_test.cc
@@ -55,7 +55,7 @@ constexpr std::string_view kPackageName = "the_package";
 
 class ChannelScopeTest : public ::testing::Test {
  public:
-  void SetUp() override {
+  void SetUp() final {
     conv_.package = std::make_unique<Package>(kPackageName);
     import_data_ = std::make_unique<ImportData>(CreateImportDataForTest());
     module_ = std::make_unique<Module>("test", /*fs_path=*/std::nullopt,

--- a/xls/dslx/ir_convert/convert_format_macro.cc
+++ b/xls/dslx/ir_convert/convert_format_macro.cc
@@ -116,26 +116,26 @@ absl::Status FlattenEnum(const ValueFormatDescriptor& efd, const BValue& v,
   return absl::OkStatus();
 }
 
-class FlattenVisitor : public ValueFormatVisitor {
+class FlattenVisitor final : public ValueFormatVisitor {
  public:
   FlattenVisitor(BValue ir_value, ConvertContext& ctx)
       : ir_value_(ir_value), ctx_(ctx) {}
 
-  ~FlattenVisitor() override = default;
+  ~FlattenVisitor() final = default;
 
-  absl::Status HandleArray(const ValueFormatDescriptor& d) override {
+  absl::Status HandleArray(const ValueFormatDescriptor& d) final {
     return FlattenArray(d, ir_value_, ctx_);
   }
-  absl::Status HandleStruct(const ValueFormatDescriptor& d) override {
+  absl::Status HandleStruct(const ValueFormatDescriptor& d) final {
     return FlattenStruct(d, ir_value_, ctx_);
   }
-  absl::Status HandleEnum(const ValueFormatDescriptor& d) override {
+  absl::Status HandleEnum(const ValueFormatDescriptor& d) final {
     return FlattenEnum(d, ir_value_, ctx_);
   }
-  absl::Status HandleTuple(const ValueFormatDescriptor& d) override {
+  absl::Status HandleTuple(const ValueFormatDescriptor& d) final {
     return FlattenTuple(d, ir_value_, ctx_);
   }
-  absl::Status HandleLeafValue(const ValueFormatDescriptor& d) override {
+  absl::Status HandleLeafValue(const ValueFormatDescriptor& d) final {
     ctx_.fmt_steps.push_back(d.leaf_format());
     ctx_.ir_args.push_back(ir_value_);
     return absl::OkStatus();

--- a/xls/dslx/ir_convert/extract_conversion_order.cc
+++ b/xls/dslx/ir_convert/extract_conversion_order.cc
@@ -163,7 +163,7 @@ std::string ConversionRecord::ToString() const {
 }
 
 // Collects all Invocation nodes below the visited node.
-class InvocationVisitor : public ExprVisitor {
+class InvocationVisitor final : public ExprVisitor {
  public:
   InvocationVisitor(Module* module, TypeInfo* type_info,
                     const ParametricEnv& bindings,
@@ -175,7 +175,7 @@ class InvocationVisitor : public ExprVisitor {
     CHECK_EQ(type_info_->module(), module_);
   }
 
-  ~InvocationVisitor() override = default;
+  ~InvocationVisitor() final = default;
 
   const FileTable& file_table() const { return *module_->file_table(); }
 
@@ -187,23 +187,23 @@ class InvocationVisitor : public ExprVisitor {
     TypeInfo* type_info = nullptr;
   };
 
-  absl::Status HandleArray(const Array* expr) override {
+  absl::Status HandleArray(const Array* expr) final {
     for (const Expr* element : expr->members()) {
       XLS_RETURN_IF_ERROR(element->AcceptExpr(this));
     }
     return absl::OkStatus();
   }
 
-  absl::Status HandleAttr(const Attr* expr) override {
+  absl::Status HandleAttr(const Attr* expr) final {
     return expr->lhs()->AcceptExpr(this);
   }
 
-  absl::Status HandleBinop(const Binop* expr) override {
+  absl::Status HandleBinop(const Binop* expr) final {
     XLS_RETURN_IF_ERROR(expr->lhs()->AcceptExpr(this));
     return expr->rhs()->AcceptExpr(this);
   }
 
-  absl::Status HandleStatementBlock(const StatementBlock* expr) override {
+  absl::Status HandleStatementBlock(const StatementBlock* expr) final {
     for (Statement* stmt : expr->statements()) {
       XLS_RETURN_IF_ERROR(
           absl::visit(Visitor{
@@ -227,17 +227,17 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleCast(const Cast* expr) override {
+  absl::Status HandleCast(const Cast* expr) final {
     return expr->expr()->AcceptExpr(this);
   }
 
-  absl::Status HandleFor(const For* expr) override {
+  absl::Status HandleFor(const For* expr) final {
     XLS_RETURN_IF_ERROR(expr->init()->AcceptExpr(this));
     XLS_RETURN_IF_ERROR(expr->iterable()->AcceptExpr(this));
     return expr->body()->AcceptExpr(this);
   }
 
-  absl::Status HandleUnrollFor(const UnrollFor* expr) override {
+  absl::Status HandleUnrollFor(const UnrollFor* expr) final {
     std::optional<const Expr*> unrolled =
         type_info_->GetUnrolledLoop(expr, bindings_);
     if (unrolled.has_value()) {
@@ -246,26 +246,26 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleFormatMacro(const FormatMacro* expr) override {
+  absl::Status HandleFormatMacro(const FormatMacro* expr) final {
     for (const Expr* arg : expr->args()) {
       XLS_RETURN_IF_ERROR(arg->AcceptExpr(this));
     }
     return absl::OkStatus();
   }
 
-  absl::Status HandleFunctionRef(const FunctionRef* expr) override {
+  absl::Status HandleFunctionRef(const FunctionRef* expr) final {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAllOnesMacro(const AllOnesMacro* expr) override {
+  absl::Status HandleAllOnesMacro(const AllOnesMacro* expr) final {
     return absl::OkStatus();
   }
 
-  absl::Status HandleZeroMacro(const ZeroMacro* expr) override {
+  absl::Status HandleZeroMacro(const ZeroMacro* expr) final {
     return absl::OkStatus();
   }
 
-  absl::Status HandleIndex(const Index* expr) override {
+  absl::Status HandleIndex(const Index* expr) final {
     XLS_RETURN_IF_ERROR(expr->lhs()->AcceptExpr(this));
     // WidthSlice and Slice alternatives only contain constant values and so
     // don't need to be traversed.
@@ -275,7 +275,7 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleInvocation(const Invocation* node) override {
+  absl::Status HandleInvocation(const Invocation* node) final {
     std::optional<CalleeInfo> callee_info;
     for (const Expr* arg : node->args()) {
       XLS_RETURN_IF_ERROR(arg->AcceptExpr(this));
@@ -365,7 +365,7 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleLambda(const Lambda* expr) override {
+  absl::Status HandleLambda(const Lambda* expr) final {
     return absl::UnimplementedError("lambdas not yet supported");
   }
 
@@ -374,7 +374,7 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMatch(const Match* expr) override {
+  absl::Status HandleMatch(const Match* expr) final {
     XLS_RETURN_IF_ERROR(expr->matched()->AcceptExpr(this));
     for (const MatchArm* arm : expr->arms()) {
       XLS_RETURN_IF_ERROR(arm->expr()->AcceptExpr(this));
@@ -382,12 +382,12 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleRange(const Range* expr) override {
+  absl::Status HandleRange(const Range* expr) final {
     XLS_RETURN_IF_ERROR(expr->start()->AcceptExpr(this));
     return expr->end()->AcceptExpr(this);
   }
 
-  absl::Status HandleSpawn(const Spawn* expr) override {
+  absl::Status HandleSpawn(const Spawn* expr) final {
     XLS_RETURN_IF_ERROR(expr->callee()->AcceptExpr(this));
     XLS_RETURN_IF_ERROR(expr->config()->AcceptExpr(this));
     XLS_RETURN_IF_ERROR(expr->next()->AcceptExpr(this));
@@ -395,7 +395,7 @@ class InvocationVisitor : public ExprVisitor {
   }
 
   absl::Status HandleSplatStructInstance(
-      const SplatStructInstance* expr) override {
+      const SplatStructInstance* expr) final {
     XLS_RETURN_IF_ERROR(expr->splatted()->AcceptExpr(this));
     for (const auto& member : expr->members()) {
       XLS_RETURN_IF_ERROR(member.second->AcceptExpr(this));
@@ -403,33 +403,33 @@ class InvocationVisitor : public ExprVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStructInstance(const StructInstance* expr) override {
+  absl::Status HandleStructInstance(const StructInstance* expr) final {
     for (const auto& member : expr->GetUnorderedMembers()) {
       XLS_RETURN_IF_ERROR(member.second->AcceptExpr(this));
     }
     return absl::OkStatus();
   }
 
-  absl::Status HandleConditional(const Conditional* expr) override {
+  absl::Status HandleConditional(const Conditional* expr) final {
     XLS_RETURN_IF_ERROR(expr->test()->AcceptExpr(this));
     XLS_RETURN_IF_ERROR(expr->consequent()->AcceptExpr(this));
     return ToExprNode(expr->alternate())->AcceptExpr(this);
   }
 
-  absl::Status HandleTupleIndex(const TupleIndex* expr) override {
+  absl::Status HandleTupleIndex(const TupleIndex* expr) final {
     return expr->lhs()->AcceptExpr(this);
   }
 
-  absl::Status HandleUnop(const Unop* expr) override {
+  absl::Status HandleUnop(const Unop* expr) final {
     return expr->operand()->AcceptExpr(this);
   }
 
-  absl::Status HandleVerbatimNode(const VerbatimNode* node) override {
+  absl::Status HandleVerbatimNode(const VerbatimNode* node) final {
     return absl::Status(absl::StatusCode::kUnimplemented,
                         "Should not convert VerbatimNode");
   }
 
-  absl::Status HandleXlsTuple(const XlsTuple* expr) override {
+  absl::Status HandleXlsTuple(const XlsTuple* expr) final {
     for (const Expr* member : expr->members()) {
       XLS_RETURN_IF_ERROR(member->AcceptExpr(this));
     }
@@ -439,7 +439,7 @@ class InvocationVisitor : public ExprVisitor {
   // Null handlers (we're not using ExprVisitorWithDefault to guard against
   // accidental omissions).
 #define DEFAULT_HANDLE(TYPE) \
-  absl::Status Handle##TYPE(const TYPE*) override { return absl::OkStatus(); }
+  absl::Status Handle##TYPE(const TYPE*) final { return absl::OkStatus(); }
 
   // No ColonRef handling (ColonRef invocations are handled in HandleInvocation;
   // all other ColonRefs are to constant values, which don't need their deriving

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -324,7 +324,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstAssert(const ConstAssert* node) override {
+  absl::Status HandleConstAssert(const ConstAssert* node) final {
     // No need to IR-convert these, because they're checked by the typechecker.
     return absl::OkStatus();
   }
@@ -332,7 +332,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   // A macro used for AST types where we want to visit all children, then call
   // the FunctionConverter handler (i.e. postorder traversal).
 #define TRAVERSE_DISPATCH(__type)                            \
-  absl::Status Handle##__type(const __type* node) override { \
+  absl::Status Handle##__type(const __type* node) final { \
     XLS_RETURN_IF_ERROR(VisitChildren(node));                \
     return converter_->Handle##__type(node);                 \
   }
@@ -349,7 +349,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   // A macro used for AST types where we don't want to visit any children, just
   // call the FunctionConverter handler.
 #define NO_TRAVERSE_DISPATCH(__type)                         \
-  absl::Status Handle##__type(const __type* node) override { \
+  absl::Status Handle##__type(const __type* node) final { \
     return converter_->Handle##__type(node);                 \
   }
 
@@ -363,7 +363,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   // A macro used for AST types where we don't want to visit any children, just
   // call the FunctionConverter handler.
 #define NO_TRAVERSE_DISPATCH_VISIT(__type)                   \
-  absl::Status Handle##__type(const __type* node) override { \
+  absl::Status Handle##__type(const __type* node) final { \
     return converter_->Handle##__type(node);                 \
   }
 
@@ -392,7 +392,7 @@ class FunctionConverterVisitor : public AstNodeVisitor {
   // A macro used for AST types that we never expect to visit (if we do we
   // provide an error message noting it was unexpected).
 #define INVALID(__type)                                      \
-  absl::Status Handle##__type(const __type* node) override { \
+  absl::Status Handle##__type(const __type* node) final { \
     return Invalid(node);                                    \
   }
 

--- a/xls/dslx/ir_convert/get_conversion_records.cc
+++ b/xls/dslx/ir_convert/get_conversion_records.cc
@@ -57,7 +57,7 @@ class ConversionRecordVisitor : public AstNodeVisitorWithDefault {
         proc_id_factory_(proc_id_factory),
         top_(top) {}
 
-  absl::Status HandleFunction(const Function* f) override {
+  absl::Status HandleFunction(const Function* f) final {
     if (f->tag() == FunctionTag::kProcInit ||
         f->tag() == FunctionTag::kProcConfig) {
       // Don't include init or config, since they will always be converted while
@@ -139,20 +139,20 @@ class ConversionRecordVisitor : public AstNodeVisitorWithDefault {
     return DefaultHandler(f);
   }
 
-  absl::Status HandleTestFunction(const TestFunction* tf) override {
+  absl::Status HandleTestFunction(const TestFunction* tf) final {
     if (!include_tests_) {
       return absl::OkStatus();
     }
     return DefaultHandler(tf);
   }
 
-  absl::Status HandleQuickCheck(const QuickCheck* qc) override {
+  absl::Status HandleQuickCheck(const QuickCheck* qc) final {
     Function* f = qc->fn();
     XLS_RET_CHECK(!f->IsParametric()) << f->ToString();
     return DefaultHandler(qc);
   }
 
-  absl::Status HandleProc(const Proc* p) override {
+  absl::Status HandleProc(const Proc* p) final {
     // Do not process children, because we'll process the `next` function
     // as a top-level function in the module.
     // TODO: https://github.com/google/xls/issues/1029 - remove module-level
@@ -160,13 +160,13 @@ class ConversionRecordVisitor : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTestProc(const TestProc* tp) override {
+  absl::Status HandleTestProc(const TestProc* tp) final {
     // Do not process children, because we'll process the next function
     // as a top-level function in the module.
     return absl::OkStatus();
   }
 
-  absl::Status DefaultHandler(const AstNode* node) override {
+  absl::Status DefaultHandler(const AstNode* node) final {
     for (auto child : node->GetChildren(false)) {
       XLS_RETURN_IF_ERROR(child->Accept(this));
     }

--- a/xls/dslx/ir_convert/ir_conversion_utils.cc
+++ b/xls/dslx/ir_convert/ir_conversion_utils.cc
@@ -66,7 +66,7 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
     Visitor(const ParametricEnv& bindings, Package* package)
         : bindings_(bindings), package_(package) {}
 
-    absl::Status HandleArray(const ArrayType& t) override {
+    absl::Status HandleArray(const ArrayType& t) final {
       XLS_ASSIGN_OR_RETURN(int64_t element_count,
                            ResolveDimToInt(t.size(), bindings_));
 
@@ -84,22 +84,22 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
       retval_ = result;
       return absl::OkStatus();
     }
-    absl::Status HandleBits(const BitsType& t) override {
+    absl::Status HandleBits(const BitsType& t) final {
       XLS_ASSIGN_OR_RETURN(int64_t bit_count,
                            ResolveDimToInt(t.size(), bindings_));
       retval_ = package_->GetBitsType(bit_count);
       return absl::OkStatus();
     }
-    absl::Status HandleEnum(const EnumType& t) override {
+    absl::Status HandleEnum(const EnumType& t) final {
       XLS_ASSIGN_OR_RETURN(int64_t bit_count, t.size().GetAsInt64());
       retval_ = package_->GetBitsType(bit_count);
       return absl::OkStatus();
     }
-    absl::Status HandleToken(const TokenType& t) override {
+    absl::Status HandleToken(const TokenType& t) final {
       retval_ = package_->GetTokenType();
       return absl::OkStatus();
     }
-    absl::Status HandleStruct(const StructType& t) override {
+    absl::Status HandleStruct(const StructType& t) final {
       std::vector<xls::Type*> members;
       members.reserve(t.members().size());
       for (const std::unique_ptr<Type>& m : t.members()) {
@@ -110,13 +110,13 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
       retval_ = package_->GetTupleType(members);
       return absl::OkStatus();
     }
-    absl::Status HandleProc(const ProcType& t) override {
+    absl::Status HandleProc(const ProcType& t) final {
       // TODO: https://github.com/google/xls/issues/836 - Support this.
       return absl::UnimplementedError(absl::StrCat(
           "IR lowering for impl-style procs is not yet supported: ",
           t.ToString()));
     }
-    absl::Status HandleTuple(const TupleType& t) override {
+    absl::Status HandleTuple(const TupleType& t) final {
       std::vector<xls::Type*> members;
       members.reserve(t.members().size());
       for (const std::unique_ptr<Type>& m : t.members()) {
@@ -127,27 +127,27 @@ absl::StatusOr<xls::Type*> TypeToIr(Package* package, const Type& type,
       retval_ = package_->GetTupleType(members);
       return absl::OkStatus();
     }
-    absl::Status HandleFunction(const FunctionType& t) override {
+    absl::Status HandleFunction(const FunctionType& t) final {
       return absl::UnimplementedError(absl::StrCat(
           "Cannot convert function type to XLS IR type: ", t.ToString()));
     }
-    absl::Status HandleChannel(const ChannelType& t) override {
+    absl::Status HandleChannel(const ChannelType& t) final {
       return absl::UnimplementedError(absl::StrCat(
           "Cannot convert channel type to XLS IR type: ", t.ToString()));
     }
-    absl::Status HandleBitsConstructor(const BitsConstructorType& t) override {
+    absl::Status HandleBitsConstructor(const BitsConstructorType& t) final {
       return absl::UnimplementedError(
           absl::StrCat("Cannot convert bits-constructor type to XLS IR type: ",
                        t.ToString()));
     }
     // Note: this is a bit of a kluge, we just turn metatypes into their
     // corresponding (unwrapped) IR type.
-    absl::Status HandleMeta(const MetaType& t) override {
+    absl::Status HandleMeta(const MetaType& t) final {
       XLS_ASSIGN_OR_RETURN(retval_,
                            TypeToIr(package_, *t.wrapped(), bindings_));
       return absl::OkStatus();
     }
-    absl::Status HandleModule(const ModuleType& t) override {
+    absl::Status HandleModule(const ModuleType& t) final {
       return absl::UnimplementedError(absl::StrCat(
           "Cannot convert module type to XLS IR type: ", t.ToString()));
     }

--- a/xls/dslx/lsp/language_server_adapter.cc
+++ b/xls/dslx/lsp/language_server_adapter.cc
@@ -112,7 +112,7 @@ class LanguageServerFilesystem : public VirtualizableFilesystem {
   explicit LanguageServerFilesystem(LanguageServerAdapter& parent)
       : parent_(parent) {}
 
-  absl::Status FileExists(const std::filesystem::path& path) override {
+  absl::Status FileExists(const std::filesystem::path& path) final {
     LspUri uri(verible::lsp::PathToLSPUri(path.c_str()));
     auto it = parent_.vfs_contents().find(uri);
     if (it == parent_.vfs_contents().end()) {
@@ -123,7 +123,7 @@ class LanguageServerFilesystem : public VirtualizableFilesystem {
   }
 
   absl::StatusOr<std::string> GetFileContents(
-      const std::filesystem::path& path) override {
+      const std::filesystem::path& path) final {
     // First we check if it exists in the virtual layer.
     LspUri uri(verible::lsp::PathToLSPUri(path.c_str()));
     auto it = parent_.vfs_contents().find(uri);
@@ -134,7 +134,7 @@ class LanguageServerFilesystem : public VirtualizableFilesystem {
     return it->second;
   }
 
-  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override {
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() final {
     XLS_ASSIGN_OR_RETURN(std::filesystem::path current,
                          xls::GetCurrentDirectory());
     return verible::lsp::PathToLSPUri(current.c_str());

--- a/xls/dslx/make_value_format_descriptor.cc
+++ b/xls/dslx/make_value_format_descriptor.cc
@@ -96,7 +96,7 @@ absl::StatusOr<ValueFormatDescriptor> MakeValueFormatDescriptor(
     explicit Visitor(FormatPreference field_preference)
         : field_preference_(field_preference) {}
 
-    absl::Status HandleArray(const ArrayType& t) override {
+    absl::Status HandleArray(const ArrayType& t) final {
       if (IsBitsLike(t)) {
         result_ = ValueFormatDescriptor::MakeLeafValue(field_preference_);
         return absl::OkStatus();
@@ -105,51 +105,51 @@ absl::StatusOr<ValueFormatDescriptor> MakeValueFormatDescriptor(
                            MakeArrayFormatDescriptor(t, field_preference_));
       return absl::OkStatus();
     }
-    absl::Status HandleStruct(const StructType& t) override {
+    absl::Status HandleStruct(const StructType& t) final {
       XLS_ASSIGN_OR_RETURN(result_,
                            MakeStructFormatDescriptor(t, field_preference_));
       return absl::OkStatus();
     }
-    absl::Status HandleProc(const ProcType& t) override {
+    absl::Status HandleProc(const ProcType& t) final {
       XLS_ASSIGN_OR_RETURN(result_,
                            MakeStructFormatDescriptor(t, field_preference_));
       return absl::OkStatus();
     }
-    absl::Status HandleTuple(const TupleType& t) override {
+    absl::Status HandleTuple(const TupleType& t) final {
       XLS_ASSIGN_OR_RETURN(result_,
                            MakeTupleFormatDescriptor(t, field_preference_));
       return absl::OkStatus();
     }
-    absl::Status HandleEnum(const EnumType& t) override {
+    absl::Status HandleEnum(const EnumType& t) final {
       XLS_ASSIGN_OR_RETURN(result_,
                            MakeEnumFormatDescriptor(t, field_preference_));
       return absl::OkStatus();
     }
-    absl::Status HandleBits(const BitsType& t) override {
+    absl::Status HandleBits(const BitsType& t) final {
       result_ = ValueFormatDescriptor::MakeLeafValue(field_preference_);
       return absl::OkStatus();
     }
-    absl::Status HandleFunction(const FunctionType& t) override {
+    absl::Status HandleFunction(const FunctionType& t) final {
       return absl::InvalidArgumentError("Cannot format a function type; got: " +
                                         t.ToString());
     }
-    absl::Status HandleToken(const TokenType& t) override {
+    absl::Status HandleToken(const TokenType& t) final {
       return absl::InvalidArgumentError("Cannot format a token type; got: " +
                                         t.ToString());
     }
-    absl::Status HandleChannel(const ChannelType& t) override {
+    absl::Status HandleChannel(const ChannelType& t) final {
       return absl::InvalidArgumentError("Cannot format a channel type; got: " +
                                         t.ToString());
     }
-    absl::Status HandleMeta(const MetaType& t) override {
+    absl::Status HandleMeta(const MetaType& t) final {
       return absl::InvalidArgumentError("Cannot format a metatype; got: " +
                                         t.ToString());
     }
-    absl::Status HandleBitsConstructor(const BitsConstructorType& t) override {
+    absl::Status HandleBitsConstructor(const BitsConstructorType& t) final {
       return absl::InvalidArgumentError(
           "Cannot format a bits constructor; got: " + t.ToString());
     }
-    absl::Status HandleModule(const ModuleType& t) override {
+    absl::Status HandleModule(const ModuleType& t) final {
       return absl::InvalidArgumentError("Cannot format a module type; got: " +
                                         t.ToString());
     }

--- a/xls/dslx/run_routines/ir_test_runner.cc
+++ b/xls/dslx/run_routines/ir_test_runner.cc
@@ -148,7 +148,7 @@ class IrRunner : public AbstractParsedTestRunner {
 
   absl::StatusOr<RunResult> RunTestProc(
       std::string_view name,
-      const BytecodeInterpreterOptions& options) override {
+      const BytecodeInterpreterOptions& options) final {
     if (options.trace_channels()) {
       LOG(WARNING) << "Unable to trace channels with IR testing";
     }
@@ -174,7 +174,7 @@ class IrRunner : public AbstractParsedTestRunner {
 
   absl::StatusOr<RunResult> RunTestFunction(
       std::string_view name,
-      const BytecodeInterpreterOptions& options) override {
+      const BytecodeInterpreterOptions& options) final {
     auto* func_package = packages_.at(name).get();
     XLS_ASSIGN_OR_RETURN(xls::Function * f, func_package->GetTopAsFunction());
     XLS_RET_CHECK(f->GetType()->return_type()->IsTuple()) << f->GetType();

--- a/xls/dslx/type_system/deduce.cc
+++ b/xls/dslx/type_system/deduce.cc
@@ -1310,24 +1310,24 @@ static absl::Status Unify(NameDefTree* name_def_tree, const Type& other,
 
 static absl::Status ValidateMatchable(const Type& type, const Span& span,
                                       const FileTable& file_table) {
-  class MatchableTypeVisitor : public TypeVisitor {
+  class MatchableTypeVisitor final : public TypeVisitor {
    public:
     MatchableTypeVisitor(const Span& span, const FileTable& file_table)
         : span_(span), file_table_(file_table) {}
-    ~MatchableTypeVisitor() override = default;
-    absl::Status HandleBits(const BitsType& type) override {
+    ~MatchableTypeVisitor() final = default;
+    absl::Status HandleBits(const BitsType& type) final {
       return absl::OkStatus();
     }
-    absl::Status HandleEnum(const EnumType& type) override {
+    absl::Status HandleEnum(const EnumType& type) final {
       return absl::OkStatus();
     }
-    absl::Status HandleTuple(const TupleType& type) override {
+    absl::Status HandleTuple(const TupleType& type) final {
       for (const auto& member : type.members()) {
         XLS_RETURN_IF_ERROR(member->Accept(*this));
       }
       return absl::OkStatus();
     }
-    absl::Status HandleArray(const ArrayType& type) override {
+    absl::Status HandleArray(const ArrayType& type) final {
       std::optional<BitsLikeProperties> bits_like = GetBitsLike(type);
       if (bits_like.has_value()) {
         return absl::OkStatus();
@@ -1337,29 +1337,29 @@ static absl::Status ValidateMatchable(const Type& type, const Span& span,
     // Note: this should not be directly observable outside of the array type
     // element.
     absl::Status HandleBitsConstructor(
-        const BitsConstructorType& type) override {
+        const BitsConstructorType& type) final {
       return Error(type);
     }
     // -- these types are not matchable
-    absl::Status HandleMeta(const MetaType& type) override {
+    absl::Status HandleMeta(const MetaType& type) final {
       return Error(type);
     }
-    absl::Status HandleFunction(const FunctionType& type) override {
+    absl::Status HandleFunction(const FunctionType& type) final {
       return Error(type);
     }
-    absl::Status HandleChannel(const ChannelType& type) override {
+    absl::Status HandleChannel(const ChannelType& type) final {
       return Error(type);
     }
-    absl::Status HandleToken(const TokenType& type) override {
+    absl::Status HandleToken(const TokenType& type) final {
       return Error(type);
     }
-    absl::Status HandleStruct(const StructType& type) override {
+    absl::Status HandleStruct(const StructType& type) final {
       return Error(type);
     }
-    absl::Status HandleProc(const ProcType& type) override {
+    absl::Status HandleProc(const ProcType& type) final {
       return Error(type);
     }
-    absl::Status HandleModule(const ModuleType& type) override {
+    absl::Status HandleModule(const ModuleType& type) final {
       return Error(type);
     }
 
@@ -2040,7 +2040,7 @@ class DeduceVisitor : public AstNodeVisitor {
   explicit DeduceVisitor(DeduceCtx* ctx) : ctx_(ctx) {}
 
 #define DEDUCE_DISPATCH(__type, __rule)                   \
-  absl::Status Handle##__type(const __type* n) override { \
+  absl::Status Handle##__type(const __type* n) final { \
     result_ = __rule(n, ctx_);                            \
     return result_.status();                              \
   }
@@ -2096,80 +2096,80 @@ class DeduceVisitor : public AstNodeVisitor {
   // Unhandled nodes for deduction, either they are custom visited or not
   // visited "automatically" in the traversal process (e.g. top level module
   // members).
-  absl::Status HandleProc(const Proc* n) override { return Fatal(n); }
-  absl::Status HandleSlice(const Slice* n) override { return Fatal(n); }
-  absl::Status HandleImport(const Import* n) override { return Fatal(n); }
-  absl::Status HandleUse(const Use* n) override { return Fatal(n); }
-  absl::Status HandleFunction(const Function* n) override { return Fatal(n); }
-  absl::Status HandleQuickCheck(const QuickCheck* n) override {
+  absl::Status HandleProc(const Proc* n) final { return Fatal(n); }
+  absl::Status HandleSlice(const Slice* n) final { return Fatal(n); }
+  absl::Status HandleImport(const Import* n) final { return Fatal(n); }
+  absl::Status HandleUse(const Use* n) final { return Fatal(n); }
+  absl::Status HandleFunction(const Function* n) final { return Fatal(n); }
+  absl::Status HandleQuickCheck(const QuickCheck* n) final {
     return Fatal(n);
   }
-  absl::Status HandleTestFunction(const TestFunction* n) override {
+  absl::Status HandleTestFunction(const TestFunction* n) final {
     return Fatal(n);
   }
-  absl::Status HandleTestProc(const TestProc* n) override { return Fatal(n); }
-  absl::Status HandleModule(const Module* n) override { return Fatal(n); }
-  absl::Status HandleWidthSlice(const WidthSlice* n) override {
+  absl::Status HandleTestProc(const TestProc* n) final { return Fatal(n); }
+  absl::Status HandleModule(const Module* n) final { return Fatal(n); }
+  absl::Status HandleWidthSlice(const WidthSlice* n) final {
     return Fatal(n);
   }
-  absl::Status HandleNameDefTree(const NameDefTree* n) override {
+  absl::Status HandleNameDefTree(const NameDefTree* n) final {
     return Fatal(n);
   }
-  absl::Status HandleNameDef(const NameDef* n) override { return Fatal(n); }
-  absl::Status HandleStructMemberNode(const StructMemberNode* n) override {
+  absl::Status HandleNameDef(const NameDef* n) final { return Fatal(n); }
+  absl::Status HandleStructMemberNode(const StructMemberNode* n) final {
     return Fatal(n);
   }
-  absl::Status HandleBuiltinNameDef(const BuiltinNameDef* n) override {
+  absl::Status HandleBuiltinNameDef(const BuiltinNameDef* n) final {
     return Fatal(n);
   }
-  absl::Status HandleParametricBinding(const ParametricBinding* n) override {
+  absl::Status HandleParametricBinding(const ParametricBinding* n) final {
     return Fatal(n);
   }
-  absl::Status HandleWildcardPattern(const WildcardPattern* n) override {
+  absl::Status HandleWildcardPattern(const WildcardPattern* n) final {
     return Fatal(n);
   }
-  absl::Status HandleRestOfTuple(const RestOfTuple* n) override {
+  absl::Status HandleRestOfTuple(const RestOfTuple* n) final {
     return Fatal(n);
   }
-  absl::Status HandleVerbatimNode(const VerbatimNode* n) override {
+  absl::Status HandleVerbatimNode(const VerbatimNode* n) final {
     return Fatal(n);
   }
 
   // All of these annotation types are created by `type_system_v2`, so there
   // should be none of them when using `type_system` for inference.
   absl::Status HandleTypeVariableTypeAnnotation(
-      const TypeVariableTypeAnnotation* n) override {
+      const TypeVariableTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleMemberTypeAnnotation(
-      const MemberTypeAnnotation* n) override {
+      const MemberTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleElementTypeAnnotation(
-      const ElementTypeAnnotation* n) override {
+      const ElementTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleSliceTypeAnnotation(
-      const SliceTypeAnnotation* n) override {
+      const SliceTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleFunctionTypeAnnotation(
-      const FunctionTypeAnnotation* n) override {
+      const FunctionTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleReturnTypeAnnotation(
-      const ReturnTypeAnnotation* n) override {
+      const ReturnTypeAnnotation* n) final {
     return Fatal(n);
   }
   absl::Status HandleParamTypeAnnotation(
-      const ParamTypeAnnotation* n) override {
+      const ParamTypeAnnotation* n) final {
     return Fatal(n);
   }
-  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation* n) override {
+  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation* n) final {
     return Fatal(n);
   }
 
-  absl::Status HandleFunctionRef(const FunctionRef* n) override {
+  absl::Status HandleFunctionRef(const FunctionRef* n) final {
     XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> callee_type,
                          ctx_->Deduce(n->callee()));
     if (!callee_type->IsFunction()) {
@@ -2183,7 +2183,7 @@ class DeduceVisitor : public AstNodeVisitor {
   }
 
   absl::Status HandleGenericTypeAnnotation(
-      const GenericTypeAnnotation* n) override {
+      const GenericTypeAnnotation* n) final {
     return Fatal(n);
   }
 

--- a/xls/dslx/type_system/deduce_utils.cc
+++ b/xls/dslx/type_system/deduce_utils.cc
@@ -70,45 +70,45 @@ class FormatMacroArgumentValidator : public TypeVisitor {
   FormatMacroArgumentValidator(const FileTable& file_table, const Span& span)
       : file_table_(file_table), span_(span) {}
 
-  absl::Status HandleArray(const ArrayType& t) override {
+  absl::Status HandleArray(const ArrayType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleBits(const BitsType& t) override {
+  absl::Status HandleBits(const BitsType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleEnum(const EnumType& t) override {
+  absl::Status HandleEnum(const EnumType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleToken(const TokenType& t) override {
+  absl::Status HandleToken(const TokenType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleStruct(const StructType& t) override {
+  absl::Status HandleStruct(const StructType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleProc(const ProcType& t) override {
+  absl::Status HandleProc(const ProcType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleTuple(const TupleType& t) override {
+  absl::Status HandleTuple(const TupleType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleBitsConstructor(const BitsConstructorType& t) override {
+  absl::Status HandleBitsConstructor(const BitsConstructorType& t) final {
     return absl::OkStatus();
   }
-  absl::Status HandleFunction(const FunctionType& t) override {
+  absl::Status HandleFunction(const FunctionType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t, ": Cannot format an expression with function type",
         file_table_);
   }
-  absl::Status HandleChannel(const ChannelType& t) override {
+  absl::Status HandleChannel(const ChannelType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t, ": Cannot format an expression with channel type",
         file_table_);
   }
-  absl::Status HandleMeta(const MetaType& t) override {
+  absl::Status HandleMeta(const MetaType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t, ": Cannot format an expression with meta type", file_table_);
   }
-  absl::Status HandleModule(const ModuleType& t) override {
+  absl::Status HandleModule(const ModuleType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t, ": Cannot format an expression with module type",
         file_table_);

--- a/xls/dslx/type_system/parametric_instantiator_internal.h
+++ b/xls/dslx/type_system/parametric_instantiator_internal.h
@@ -174,9 +174,9 @@ class FunctionInstantiator : public ParametricInstantiator {
   //
   // Instantiates the parameters of function_type_ according to the presented
   // args_' types.
-  absl::StatusOr<TypeAndParametricEnv> Instantiate() override;
+  absl::StatusOr<TypeAndParametricEnv> Instantiate() final;
 
-  std::string_view GetKindName() override { return "function"; }
+  std::string_view GetKindName() final { return "function"; }
 
  private:
   FunctionInstantiator(
@@ -209,9 +209,9 @@ class StructInstantiator : public ParametricInstantiator {
       absl::Span<const ParametricBinding* absl_nonnull const>
           parametric_bindings);
 
-  absl::StatusOr<TypeAndParametricEnv> Instantiate() override;
+  absl::StatusOr<TypeAndParametricEnv> Instantiate() final;
 
-  std::string_view GetKindName() override { return "struct"; }
+  std::string_view GetKindName() final { return "struct"; }
 
  private:
   StructInstantiator(Span span, const StructType& struct_type,

--- a/xls/dslx/type_system/type.h
+++ b/xls/dslx/type_system/type.h
@@ -437,12 +437,12 @@ inline std::ostream& operator<<(std::ostream& os, const Type& t) {
 // For example, if you do `deduce(u32)` where `u32` is the builtin type
 // annotation, it will tell you "this thing is a type" and contain "the type is
 // u32".
-class MetaType : public Type {
+class MetaType final : public Type {
  public:
   explicit MetaType(std::unique_ptr<Type> wrapped)
       : wrapped_(std::move(wrapped)) {}
 
-  ~MetaType() override;
+  ~MetaType() final;
 
   absl::Status Accept(TypeVisitor& v) const override {
     return v.HandleMeta(*this);
@@ -503,9 +503,9 @@ class MetaType : public Type {
 // it cannot be distinguished or parameterized in any way from other token type
 // instances (unless you compare by pointer, of course, which is an
 // implementation detail and not part of the Type API).
-class TokenType : public Type {
+class TokenType final : public Type {
  public:
-  ~TokenType() override;
+  ~TokenType() final;
 
   absl::Status Accept(TypeVisitor& v) const override {
     return v.HandleToken(*this);
@@ -867,11 +867,11 @@ class EnumType : public Type {
 //    xN
 //
 // Note that the last one has parametric signedness.
-class BitsConstructorType : public Type {
+class BitsConstructorType final : public Type {
  public:
   explicit BitsConstructorType(TypeDim is_signed);
 
-  ~BitsConstructorType() override;
+  ~BitsConstructorType() final;
 
   absl::Status Accept(TypeVisitor& v) const override;
   absl::StatusOr<std::unique_ptr<Type>> MapSize(const MapFn& f) const override;
@@ -897,10 +897,10 @@ class BitsConstructorType : public Type {
 // Represents an existential type for a given module's identity. This
 // representation allows us to place the type of a module-reference AST node
 // into the type information mapping.
-class ModuleType : public Type {
+class ModuleType final : public Type {
  public:
   explicit ModuleType(const Module& module) : module_(module) {}
-  ~ModuleType() override;
+  ~ModuleType() final;
 
   absl::Status Accept(TypeVisitor& v) const override;
   absl::StatusOr<std::unique_ptr<Type>> MapSize(const MapFn& f) const override;
@@ -944,7 +944,7 @@ class ModuleType : public Type {
 // Note that there are related helpers IsUBits() and IsSBits() for concisely
 // testing whether a `Type` is an unsigned or signed BitsType,
 // respectively.
-class BitsType : public Type {
+class BitsType final : public Type {
  public:
   static std::string GetDebugName() { return "BitsType"; }
 
@@ -968,7 +968,7 @@ class BitsType : public Type {
 
   BitsType(bool is_signed, TypeDim size);
 
-  ~BitsType() override = default;
+  ~BitsType() final = default;
 
   absl::Status Accept(TypeVisitor& v) const override {
     return v.HandleBits(*this);

--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -442,61 +442,61 @@ class ToProtoVisitor : public TypeVisitor {
   explicit ToProtoVisitor(const FileTable& file_table)
       : file_table_(file_table) {}
 
-  absl::Status HandleBits(const BitsType& type) override {
+  absl::Status HandleBits(const BitsType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_bits_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleBitsConstructor(const BitsConstructorType& type) override {
+  absl::Status HandleBitsConstructor(const BitsConstructorType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_bits_constructor_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleFunction(const FunctionType& type) override {
+  absl::Status HandleFunction(const FunctionType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_fn_type(), ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleTuple(const TupleType& type) override {
+  absl::Status HandleTuple(const TupleType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_tuple_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleArray(const ArrayType& type) override {
+  absl::Status HandleArray(const ArrayType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_array_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleStruct(const StructType& type) override {
+  absl::Status HandleStruct(const StructType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_struct_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleProc(const ProcType& type) override {
+  absl::Status HandleProc(const ProcType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_proc_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleEnum(const EnumType& type) override {
+  absl::Status HandleEnum(const EnumType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_enum_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleMeta(const MetaType& type) override {
+  absl::Status HandleMeta(const MetaType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_meta_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleToken(const TokenType& type) override {
+  absl::Status HandleToken(const TokenType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_token_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleChannel(const ChannelType& type) override {
+  absl::Status HandleChannel(const ChannelType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_channel_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();
   }
-  absl::Status HandleModule(const ModuleType& type) override {
+  absl::Status HandleModule(const ModuleType& type) final {
     XLS_ASSIGN_OR_RETURN(*proto_.mutable_module_type(),
                          ToProto(type, file_table_));
     return absl::OkStatus();

--- a/xls/dslx/type_system/type_zero_value.cc
+++ b/xls/dslx/type_system/type_zero_value.cc
@@ -165,42 +165,42 @@ class MakeValueVisitor : public TypeVisitor {
         span_(span),
         value_name_(value_name) {}
 
-  absl::Status HandleEnum(const EnumType& t) override {
+  absl::Status HandleEnum(const EnumType& t) final {
     XLS_ASSIGN_OR_RETURN(result_, leaf_type_fn_(t, import_data_, span_));
     return absl::OkStatus();
   }
 
-  absl::Status HandleBits(const BitsType& t) override {
+  absl::Status HandleBits(const BitsType& t) final {
     XLS_ASSIGN_OR_RETURN(result_, leaf_type_fn_(t, import_data_, span_));
     return absl::OkStatus();
   }
 
-  absl::Status HandleFunction(const FunctionType& t) override {
+  absl::Status HandleFunction(const FunctionType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of function type.", value_name_),
         file_table());
   }
-  absl::Status HandleChannel(const ChannelType& t) override {
+  absl::Status HandleChannel(const ChannelType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of channel type.", value_name_),
         file_table());
   }
-  absl::Status HandleToken(const TokenType& t) override {
+  absl::Status HandleToken(const TokenType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of token type.", value_name_),
         file_table());
   }
-  absl::Status HandleBitsConstructor(const BitsConstructorType& t) override {
+  absl::Status HandleBitsConstructor(const BitsConstructorType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of bits-constructor type.",
                         value_name_),
         file_table());
   }
-  absl::Status HandleStruct(const StructType& t) override {
+  absl::Status HandleStruct(const StructType& t) final {
     std::vector<InterpValue> elems;
     for (const auto& member : t.members()) {
       XLS_RETURN_IF_ERROR(member->Accept(*this));
@@ -210,14 +210,14 @@ class MakeValueVisitor : public TypeVisitor {
     result_ = InterpValue::MakeTuple(std::move(elems));
     return absl::OkStatus();
   }
-  absl::Status HandleProc(const ProcType& t) override {
+  absl::Status HandleProc(const ProcType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of proc type.", value_name_),
         file_table());
   }
 
-  absl::Status HandleTuple(const TupleType& t) override {
+  absl::Status HandleTuple(const TupleType& t) final {
     std::vector<InterpValue> elems;
     for (const auto& m : t.members()) {
       XLS_RETURN_IF_ERROR(m->Accept(*this));
@@ -228,7 +228,7 @@ class MakeValueVisitor : public TypeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArray(const ArrayType& t) override {
+  absl::Status HandleArray(const ArrayType& t) final {
     std::optional<BitsLikeProperties> bits_like = GetBitsLike(t);
     if (bits_like.has_value()) {
       return HandleBitsLike(bits_like.value());
@@ -243,14 +243,14 @@ class MakeValueVisitor : public TypeVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMeta(const MetaType& t) override {
+  absl::Status HandleMeta(const MetaType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of a meta-type.", value_name_),
         file_table());
   }
 
-  absl::Status HandleModule(const ModuleType& t) override {
+  absl::Status HandleModule(const ModuleType& t) final {
     return TypeInferenceErrorStatus(
         span_, &t,
         absl::StrFormat("Cannot make a %s of a module type.", value_name_),

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -3111,31 +3111,31 @@ TEST_P(TypecheckBothVersionsTest, NumbersAreConstexpr) {
    public:
     explicit IsConstVisitor(TypeInfo* type_info) : type_info_(type_info) {}
 
-    absl::Status HandleFunction(const Function* node) override {
+    absl::Status HandleFunction(const Function* node) final {
       XLS_RETURN_IF_ERROR(node->body()->Accept(this));
       return absl::OkStatus();
     }
 
-    absl::Status HandleStatementBlock(const StatementBlock* node) override {
+    absl::Status HandleStatementBlock(const StatementBlock* node) final {
       for (auto child : node->GetChildren(/*want_types=*/false)) {
         XLS_RETURN_IF_ERROR(child->Accept(this));
       }
       return absl::OkStatus();
     }
 
-    absl::Status HandleStatement(const Statement* node) override {
+    absl::Status HandleStatement(const Statement* node) final {
       for (auto child : node->GetChildren(/*want_types=*/false)) {
         XLS_RETURN_IF_ERROR(child->Accept(this));
       }
       return absl::OkStatus();
     }
 
-    absl::Status HandleLet(const Let* node) override {
+    absl::Status HandleLet(const Let* node) final {
       XLS_RETURN_IF_ERROR(node->rhs()->Accept(this));
       return absl::OkStatus();
     }
 
-    absl::Status HandleNumber(const Number* node) override {
+    absl::Status HandleNumber(const Number* node) final {
       if (type_info_->GetConstExpr(node).ok()) {
         constexpr_numbers_seen_++;
       } else {

--- a/xls/dslx/type_system/zip_types.cc
+++ b/xls/dslx/type_system/zip_types.cc
@@ -33,7 +33,7 @@ absl::Status ZipTypesWithParents(const Type& lhs, const Type& rhs,
 // calling ZipTypes -- we inherit TypeVisitor because we need to learn the
 // actual type of the generic `Type` on the left hand side and then compare that
 // to what we see on the right hand side at each step.
-class ZipTypeVisitor : public TypeVisitor {
+class ZipTypeVisitor final : public TypeVisitor {
  public:
   explicit ZipTypeVisitor(const Type& rhs, const Type* lhs_parent,
                           const Type* rhs_parent, ZipTypesCallbacks& callbacks)
@@ -42,38 +42,38 @@ class ZipTypeVisitor : public TypeVisitor {
         rhs_parent_(rhs_parent),
         callbacks_(callbacks) {}
 
-  ~ZipTypeVisitor() override = default;
+  ~ZipTypeVisitor() final = default;
 
   // -- various non-aggregate types
 
-  absl::Status HandleEnum(const EnumType& lhs) override {
+  absl::Status HandleEnum(const EnumType& lhs) final {
     return HandleNonAggregate(lhs);
   }
-  absl::Status HandleBits(const BitsType& lhs) override {
+  absl::Status HandleBits(const BitsType& lhs) final {
     return HandleNonAggregate(lhs);
   }
-  absl::Status HandleBitsConstructor(const BitsConstructorType& lhs) override {
+  absl::Status HandleBitsConstructor(const BitsConstructorType& lhs) final {
     return HandleNonAggregate(lhs);
   }
-  absl::Status HandleToken(const TokenType& lhs) override {
+  absl::Status HandleToken(const TokenType& lhs) final {
     return HandleNonAggregate(lhs);
   }
 
   // -- types that contain other types
 
-  absl::Status HandleTuple(const TupleType& lhs) override {
+  absl::Status HandleTuple(const TupleType& lhs) final {
     if (auto* rhs = dynamic_cast<const TupleType*>(&rhs_)) {
       return HandleTupleLike(lhs, *rhs);
     }
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
-  absl::Status HandleStruct(const StructType& lhs) override {
+  absl::Status HandleStruct(const StructType& lhs) final {
     return HandleStructTypeBase<StructType>(lhs);
   }
-  absl::Status HandleProc(const ProcType& lhs) override {
+  absl::Status HandleProc(const ProcType& lhs) final {
     return HandleStructTypeBase<ProcType>(lhs);
   }
-  absl::Status HandleArray(const ArrayType& lhs) override {
+  absl::Status HandleArray(const ArrayType& lhs) final {
     if (auto* rhs = dynamic_cast<const ArrayType*>(&rhs_)) {
       if (lhs.size() != rhs->size()) {
         return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
@@ -87,7 +87,7 @@ class ZipTypeVisitor : public TypeVisitor {
     }
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
-  absl::Status HandleChannel(const ChannelType& lhs) override {
+  absl::Status HandleChannel(const ChannelType& lhs) final {
     if (auto* rhs = dynamic_cast<const ChannelType*>(&rhs_)) {
       // If channel directions don't match, capture the full channel strings.
       if (lhs.direction() != rhs->direction()) {
@@ -102,7 +102,7 @@ class ZipTypeVisitor : public TypeVisitor {
     }
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
-  absl::Status HandleFunction(const FunctionType& lhs) override {
+  absl::Status HandleFunction(const FunctionType& lhs) final {
     if (auto* rhs = dynamic_cast<const FunctionType*>(&rhs_)) {
       AggregatePair aggregates = std::make_pair(&lhs, rhs);
       XLS_RETURN_IF_ERROR(callbacks_.NoteAggregateStart(aggregates));
@@ -116,7 +116,7 @@ class ZipTypeVisitor : public TypeVisitor {
     }
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
-  absl::Status HandleMeta(const MetaType& lhs) override {
+  absl::Status HandleMeta(const MetaType& lhs) final {
     if (auto* rhs = dynamic_cast<const MetaType*>(&rhs_)) {
       AggregatePair aggregates = std::make_pair(&lhs, rhs);
       XLS_RETURN_IF_ERROR(callbacks_.NoteAggregateStart(aggregates));
@@ -168,7 +168,7 @@ class ZipTypeVisitor : public TypeVisitor {
     return callbacks_.NoteTypeMismatch(lhs, lhs_parent_, rhs_, rhs_parent_);
   }
 
-  absl::Status HandleModule(const ModuleType& lhs) override {
+  absl::Status HandleModule(const ModuleType& lhs) final {
     return absl::InvalidArgumentError("Cannot zip module types; got: " +
                                       lhs.ToString());
   }

--- a/xls/dslx/type_system/zip_types_test.cc
+++ b/xls/dslx/type_system/zip_types_test.cc
@@ -89,23 +89,23 @@ std::ostream& operator<<(std::ostream& os, const CallbackData& data) {
 
 // Trivial implementation of the callbacks abstract interface that just collects
 // events as they are triggered in an underlying vector.
-class ZipTypesCallbacksCollector : public ZipTypesCallbacks {
+class ZipTypesCallbacksCollector final : public ZipTypesCallbacks {
  public:
-  ~ZipTypesCallbacksCollector() override = default;
+  ~ZipTypesCallbacksCollector() final = default;
 
-  absl::Status NoteAggregateStart(const AggregatePair& pair) override {
+  absl::Status NoteAggregateStart(const AggregatePair& pair) final {
     data_.push_back(CallbackData{.kind = CallbackKind::kAggregateStart,
                                  .aggregates = pair});
     return absl::OkStatus();
   }
-  absl::Status NoteAggregateEnd(const AggregatePair& pair) override {
+  absl::Status NoteAggregateEnd(const AggregatePair& pair) final {
     data_.push_back(
         CallbackData{.kind = CallbackKind::kAggregateEnd, .aggregates = pair});
     return absl::OkStatus();
   }
   absl::Status NoteMatchedLeafType(const Type& lhs, const Type* lhs_parent,
                                    const Type& rhs,
-                                   const Type* rhs_parent) override {
+                                   const Type* rhs_parent) final {
     data_.push_back(CallbackData{.kind = CallbackKind::kMatchedLeaf,
                                  .lhs = &lhs,
                                  .lhs_parent = lhs_parent,
@@ -115,7 +115,7 @@ class ZipTypesCallbacksCollector : public ZipTypesCallbacks {
   }
   absl::Status NoteTypeMismatch(const Type& lhs, const Type* lhs_parent,
                                 const Type& rhs,
-                                const Type* rhs_parent) override {
+                                const Type* rhs_parent) final {
     data_.push_back(CallbackData{.kind = CallbackKind::kMismatch,
                                  .lhs = &lhs,
                                  .lhs_parent = lhs_parent,

--- a/xls/dslx/type_system_v2/evaluator.cc
+++ b/xls/dslx/type_system_v2/evaluator.cc
@@ -55,7 +55,7 @@ class EvaluatorImpl : public Evaluator {
 
   absl::StatusOr<bool> EvaluateBoolOrExpr(
       std::optional<const ParametricContext*> parametric_context,
-      std::variant<bool, const Expr*> value_or_expr) override {
+      std::variant<bool, const Expr*> value_or_expr) final {
     if (std::holds_alternative<bool>(value_or_expr)) {
       return std::get<bool>(value_or_expr);
     }
@@ -83,20 +83,20 @@ class EvaluatorImpl : public Evaluator {
 
   absl::StatusOr<int64_t> EvaluateU32OrExpr(
       std::optional<const ParametricContext*> parametric_context,
-      std::variant<int64_t, const Expr*> value_or_expr) override {
+      std::variant<int64_t, const Expr*> value_or_expr) final {
     return Evaluate32BitIntOrExpr(parametric_context, value_or_expr,
                                   /*is_signed=*/false);
   }
 
   absl::StatusOr<int64_t> EvaluateS32OrExpr(
       std::optional<const ParametricContext*> parametric_context,
-      std::variant<int64_t, const Expr*> value_or_expr) override {
+      std::variant<int64_t, const Expr*> value_or_expr) final {
     return Evaluate32BitIntOrExpr(parametric_context, value_or_expr,
                                   /*is_signed=*/true);
   }
 
   absl::StatusOr<InterpValue> Evaluate(
-      const ParametricContextScopedExpr& scoped_expr) override {
+      const ParametricContextScopedExpr& scoped_expr) final {
     VLOG(7) << "Evaluate: " << scoped_expr.expr()->ToString()
             << " with owner: " << scoped_expr.expr()->owner()->name()
             << " in module: " << module_.name()
@@ -120,7 +120,7 @@ class EvaluatorImpl : public Evaluator {
   absl::StatusOr<InterpValue> Evaluate(
       std::optional<const ParametricContext*> parametric_context,
       TypeInfo* type_info, const TypeAnnotation* type_annotation,
-      const Expr* expr) override {
+      const Expr* expr) final {
     TypeSystemTrace trace = tracer_.TraceEvaluate(parametric_context, expr);
 
     // This is the type of the parametric binding we are talking about, which is

--- a/xls/dslx/type_system_v2/fast_concretizer.cc
+++ b/xls/dslx/type_system_v2/fast_concretizer.cc
@@ -45,7 +45,7 @@ class FastConcretizerImpl : public FastConcretizer,
       : file_table_(file_table) {}
 
   absl::StatusOr<std::unique_ptr<Type>> Concretize(
-      const TypeAnnotation* annotation) override {
+      const TypeAnnotation* annotation) final {
     absl::StatusOr<SignednessAndBitCountResult> signedness_and_bit_count =
         GetSignednessAndBitCount(annotation);
     if (signedness_and_bit_count.ok()) {
@@ -63,7 +63,7 @@ class FastConcretizerImpl : public FastConcretizer,
   }
 
   absl::Status HandleArrayTypeAnnotation(
-      const ArrayTypeAnnotation* array_type) override {
+      const ArrayTypeAnnotation* array_type) final {
     XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> element_type,
                          Concretize(array_type->element_type()));
     XLS_ASSIGN_OR_RETURN(uint32_t dim, GetU32(array_type->dim()));
@@ -73,7 +73,7 @@ class FastConcretizerImpl : public FastConcretizer,
   }
 
   absl::Status HandleTupleTypeAnnotation(
-      const TupleTypeAnnotation* tuple_type) override {
+      const TupleTypeAnnotation* tuple_type) final {
     std::vector<std::unique_ptr<Type>> member_types;
     member_types.reserve(tuple_type->members().size());
     for (const TypeAnnotation* member : tuple_type->members()) {
@@ -86,7 +86,7 @@ class FastConcretizerImpl : public FastConcretizer,
   }
 
   absl::Status HandleFunctionTypeAnnotation(
-      const FunctionTypeAnnotation* function_type) override {
+      const FunctionTypeAnnotation* function_type) final {
     XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> return_type,
                          Concretize(function_type->return_type()));
     std::vector<std::unique_ptr<Type>> param_types;
@@ -100,7 +100,7 @@ class FastConcretizerImpl : public FastConcretizer,
     return absl::OkStatus();
   }
 
-  absl::Status DefaultHandler(const AstNode*) override {
+  absl::Status DefaultHandler(const AstNode*) final {
     return absl::UnimplementedError("Node is not handled by fast concretizer.");
   }
 

--- a/xls/dslx/type_system_v2/fast_concretizer_test.cc
+++ b/xls/dslx/type_system_v2/fast_concretizer_test.cc
@@ -40,7 +40,7 @@ using ::testing::Not;
 
 class FastConcretizerTest : public ::testing::Test {
  public:
-  void SetUp() override {
+  void SetUp() final {
     module_ =
         std::make_unique<Module>("test", /*fs_path=*/std::nullopt, file_table_);
     concretizer_ = FastConcretizer::Create(file_table_);

--- a/xls/dslx/type_system_v2/flatten_in_type_order.cc
+++ b/xls/dslx/type_system_v2/flatten_in_type_order.cc
@@ -38,14 +38,14 @@ class Flattener : public AstNodeVisitorWithDefault {
         root_(root),
         include_parametric_entities_(include_parametric_entities) {}
 
-  absl::Status HandleFunction(const Function* node) override {
+  absl::Status HandleFunction(const Function* node) final {
     if (!include_parametric_entities_ && node->IsParametric()) {
       return absl::OkStatus();
     }
     return DefaultHandler(node);
   }
 
-  absl::Status HandleProc(const Proc* node) override {
+  absl::Status HandleProc(const Proc* node) final {
     if (!include_parametric_entities_ && node->IsParametric()) {
       return absl::OkStatus();
     }
@@ -64,7 +64,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleImpl(const Impl* node) override {
+  absl::Status HandleImpl(const Impl* node) final {
     XLS_ASSIGN_OR_RETURN(std::optional<const StructDefBase*> def,
                          GetStructOrProcDef(node->struct_ref(), import_data_));
     XLS_RET_CHECK(def.has_value());
@@ -74,7 +74,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return DefaultHandler(node);
   }
 
-  absl::Status HandleStructInstance(const StructInstance* node) override {
+  absl::Status HandleStructInstance(const StructInstance* node) final {
     nodes_.push_back(node);
     XLS_RETURN_IF_ERROR(node->struct_ref()->Accept(this));
     for (const auto& [_, member] : node->GetUnorderedMembers()) {
@@ -83,7 +83,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleInvocation(const Invocation* node) override {
+  absl::Status HandleInvocation(const Invocation* node) final {
     // Do the equivalent `DefaultHandler`, but exclude most of the arguments.
     // We exclude the arguments because when an argument should
     // be converted depends on whether its type is determining or determined by
@@ -97,7 +97,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleLet(const Let* node) override {
+  absl::Status HandleLet(const Let* node) final {
     if (node->type_annotation() != nullptr) {
       XLS_RETURN_IF_ERROR(node->type_annotation()->Accept(this));
     }
@@ -109,7 +109,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMatch(const Match* node) override {
+  absl::Status HandleMatch(const Match* node) final {
     XLS_RETURN_IF_ERROR(node->matched()->Accept(this));
     // Prefer to visit arms that contain invocations first so that any type
     // information they produce is available when analyzing other arms whose
@@ -121,7 +121,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMatchArm(const MatchArm* node) override {
+  absl::Status HandleMatchArm(const MatchArm* node) final {
     for (const NameDefTree* name_def_tree : node->patterns()) {
       XLS_RETURN_IF_ERROR(name_def_tree->Accept(this));
     }
@@ -130,11 +130,11 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleRestOfTuple(const RestOfTuple* node) override {
+  absl::Status HandleRestOfTuple(const RestOfTuple* node) final {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConstantDef(const ConstantDef* node) override {
+  absl::Status HandleConstantDef(const ConstantDef* node) final {
     if (node->type_annotation() != nullptr) {
       XLS_RETURN_IF_ERROR(node->type_annotation()->Accept(this));
     }
@@ -144,7 +144,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleUnrollFor(const UnrollFor* node) override {
+  absl::Status HandleUnrollFor(const UnrollFor* node) final {
     // node->body() will not be handled because unroll_for generates new
     // unrolled body statements.
     if (node->type_annotation()) {
@@ -157,7 +157,7 @@ class Flattener : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status DefaultHandler(const AstNode* node) override {
+  absl::Status DefaultHandler(const AstNode* node) final {
     // Prefer conversion of invocations before nodes that may use them.
     std::vector<const AstNode*> invocations;
     std::vector<const AstNode*> non_invocations;

--- a/xls/dslx/type_system_v2/import_utils.cc
+++ b/xls/dslx/type_system_v2/import_utils.cc
@@ -43,7 +43,7 @@ class TypeRefUnwrapper : public AstNodeVisitorWithDefault {
   explicit TypeRefUnwrapper(const ImportData& import_data)
       : import_data_(import_data) {}
 
-  absl::Status HandleColonRef(const ColonRef* colon_ref) override {
+  absl::Status HandleColonRef(const ColonRef* colon_ref) final {
     XLS_ASSIGN_OR_RETURN(std::optional<ModuleInfo*> import_module,
                          GetImportedModuleInfo(colon_ref, import_data_));
     if (import_module.has_value()) {
@@ -58,12 +58,12 @@ class TypeRefUnwrapper : public AstNodeVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTypeAlias(const TypeAlias* alias) override {
+  absl::Status HandleTypeAlias(const TypeAlias* alias) final {
     return alias->type_annotation().Accept(this);
   }
 
   absl::Status HandleTypeRefTypeAnnotation(
-      const TypeRefTypeAnnotation* annotation) override {
+      const TypeRefTypeAnnotation* annotation) final {
     if (!annotation->parametrics().empty() && !parametrics_.empty()) {
       return TypeInferenceErrorStatus(
           annotation->span(), /* type= */ nullptr,
@@ -82,26 +82,26 @@ class TypeRefUnwrapper : public AstNodeVisitorWithDefault {
     return ToAstNode(annotation->type_ref()->type_definition())->Accept(this);
   }
 
-  absl::Status HandleProcDef(const ProcDef* def) override {
+  absl::Status HandleProcDef(const ProcDef* def) final {
     type_def_ = const_cast<ProcDef*>(def);
     return absl::OkStatus();
   }
 
-  absl::Status HandleStructDef(const StructDef* def) override {
+  absl::Status HandleStructDef(const StructDef* def) final {
     type_def_ = const_cast<StructDef*>(def);
     return absl::OkStatus();
   }
 
-  absl::Status HandleEnumDef(const EnumDef* def) override {
+  absl::Status HandleEnumDef(const EnumDef* def) final {
     type_def_ = const_cast<EnumDef*>(def);
     return absl::OkStatus();
   }
 
-  absl::Status HandleNameDef(const NameDef* name_def) override {
+  absl::Status HandleNameDef(const NameDef* name_def) final {
     return name_def->definer()->Accept(this);
   }
 
-  absl::Status HandleNameRef(const NameRef* name_ref) override {
+  absl::Status HandleNameRef(const NameRef* name_ref) final {
     return ToAstNode(name_ref->name_def())->Accept(this);
   }
 

--- a/xls/dslx/type_system_v2/inference_table.cc
+++ b/xls/dslx/type_system_v2/inference_table.cc
@@ -289,7 +289,7 @@ class InferenceTableImpl : public InferenceTable {
  public:
   absl::StatusOr<const NameRef*> DefineInternalVariable(
       InferenceVariableKind kind, AstNode* definer, std::string_view name,
-      std::optional<const TypeAnnotation*> declaration_annotation) override {
+      std::optional<const TypeAnnotation*> declaration_annotation) final {
     VLOG(6) << "DefineInternalVariable of kind " << (int)kind << " with name "
             << name << " and definer: " << definer->ToString();
     XLS_RET_CHECK(definer->GetSpan().has_value());
@@ -310,7 +310,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   absl::StatusOr<const NameRef*> DefineParametricVariable(
-      const ParametricBinding& binding) override {
+      const ParametricBinding& binding) final {
     VLOG(6) << "DefineParametricVariable of type "
             << binding.type_annotation()->ToString() << " with name "
             << binding.name_def()->ToString();
@@ -331,7 +331,7 @@ class InferenceTableImpl : public InferenceTable {
       std::optional<const Function*> caller,
       std::optional<const ParametricContext*> parent_context,
       std::optional<const TypeAnnotation*> self_type,
-      TypeInfo* invocation_type_info) override {
+      TypeInfo* invocation_type_info) final {
     VLOG(5) << "Add parametric invocation: " << node.ToString()
             << " from parent context: "
             << ::xls::dslx::ToString(parent_context);
@@ -371,7 +371,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   bool MapToCanonicalInvocationTypeInfo(ParametricContext* parametric_context,
-                                        ParametricEnv env) override {
+                                        ParametricEnv env) final {
     CHECK(parametric_context->is_invocation());
 
     // `ParametricEnv` doesn't currently capture generic types, so for the time
@@ -453,14 +453,14 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   absl::Status SetTypeAnnotation(const AstNode* node,
-                                 const TypeAnnotation* annotation) override {
+                                 const TypeAnnotation* annotation) final {
     return MutateAndCheckNodeData(
         node, [=](NodeData& data) { data.type_annotation = annotation; });
   }
 
   absl::Status AddTypeAnnotationToVariableForParametricContext(
       std::optional<const ParametricContext*> context, const NameRef* ref,
-      const TypeAnnotation* annotation) override {
+      const TypeAnnotation* annotation) final {
     XLS_ASSIGN_OR_RETURN(const InferenceVariable* variable, GetVariable(ref));
     AddTypeAnnotationForParametricContextInternal(context, variable,
                                                   annotation);
@@ -470,7 +470,7 @@ class InferenceTableImpl : public InferenceTable {
   absl::Status AddTypeAnnotationToVariableForParametricContext(
       std::optional<const ParametricContext*> context,
       const ParametricBinding* binding,
-      const TypeAnnotation* annotation) override {
+      const TypeAnnotation* annotation) final {
     XLS_ASSIGN_OR_RETURN(const InferenceVariable* variable,
                          GetVariable(binding->name_def()));
     AddTypeAnnotationForParametricContextInternal(context, variable,
@@ -501,7 +501,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   void SetAnnotationFlag(const TypeAnnotation* annotation,
-                         TypeInferenceFlag flag) override {
+                         TypeInferenceFlag flag) final {
     annotation_flags_[annotation].SetFlag(flag);
   }
 
@@ -513,7 +513,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   absl::Status SetTypeVariable(const AstNode* node,
-                               const NameRef* type) override {
+                               const NameRef* type) final {
     XLS_ASSIGN_OR_RETURN(InferenceVariable * variable, GetVariable(type));
     VLOG(6) << "SetTypeVariable node " << node->ToString() << "; type "
             << type->ToString() << " variable " << variable->ToString();
@@ -592,7 +592,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   void SetColonRefTarget(const ColonRef* colon_ref,
-                         const AstNode* target) override {
+                         const AstNode* target) final {
     colon_ref_targets_[colon_ref] = target;
   }
 
@@ -606,7 +606,7 @@ class InferenceTableImpl : public InferenceTable {
   void SetCalleeInCallerContext(
       const Invocation* invocation,
       std::optional<const ParametricContext*> caller_context,
-      const Function* callee) override {
+      const Function* callee) final {
     if (caller_context.has_value()) {
       mutable_parametric_context_data_.at(*caller_context).callees[invocation] =
           callee;
@@ -627,7 +627,7 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   absl::StatusOr<AstNode*> Clone(const AstNode* input, CloneReplacer replacer,
-                                 bool in_place) override {
+                                 bool in_place) final {
     absl::flat_hash_map<const AstNode*, AstNode*> all_pairs;
     XLS_ASSIGN_OR_RETURN(
         all_pairs, CloneAstAndGetAllPairs(
@@ -754,14 +754,14 @@ class InferenceTableImpl : public InferenceTable {
   }
 
   absl::Status SetSliceStartAndWidthExprs(
-      const AstNode* node, StartAndWidthExprs start_and_width) override {
+      const AstNode* node, StartAndWidthExprs start_and_width) final {
     return MutateAndCheckNodeData(node, [&](NodeData& data) {
       data.slice_start_and_width_exprs = start_and_width;
     });
   }
 
   std::optional<StartAndWidthExprs> GetSliceStartAndWidthExprs(
-      const AstNode* node) override {
+      const AstNode* node) final {
     const auto it = node_data_.find(node);
     return it == node_data_.end() ? std::nullopt
                                   : it->second.slice_start_and_width_exprs;
@@ -772,7 +772,7 @@ class InferenceTableImpl : public InferenceTable {
       const NameRef* variable,
       const absl::flat_hash_set<const NameRef*>&
           transitive_variable_dependencies,
-      const TypeAnnotation* unified_type) override {
+      const TypeAnnotation* unified_type) final {
     cache_.SetUnifiedTypeForVariable(GetCanonicalContext(parametric_context),
                                      variable, transitive_variable_dependencies,
                                      unified_type);
@@ -780,19 +780,19 @@ class InferenceTableImpl : public InferenceTable {
 
   std::optional<const TypeAnnotation*> GetCachedUnifiedTypeForVariable(
       std::optional<const ParametricContext*> parametric_context,
-      const NameRef* variable) override {
+      const NameRef* variable) final {
     return cache_.GetUnifiedTypeForVariable(
         GetCanonicalContext(parametric_context), variable);
   }
 
   void SetParametricEnv(const ParametricContext* parametric_context,
-                        ParametricEnv env) override {
+                        ParametricEnv env) final {
     converted_parametric_envs_[parametric_context] = std::move(env);
   }
 
   void SetParametricValueExprs(
       const ParametricContext* parametric_context,
-      absl::flat_hash_map<const NameDef*, ExprOrType> value_exprs) override {
+      absl::flat_hash_map<const NameDef*, ExprOrType> value_exprs) final {
     parametric_value_exprs_[parametric_context] = std::move(value_exprs);
   }
 
@@ -809,7 +809,7 @@ class InferenceTableImpl : public InferenceTable {
 
   absl::StatusOr<absl::flat_hash_map<const NameDef*, ExprOrType>>
   GetParametricValueExprs(
-      const ParametricContext* parametric_context) override {
+      const ParametricContext* parametric_context) final {
     const auto it = parametric_value_exprs_.find(parametric_context);
     if (it == parametric_value_exprs_.end()) {
       return absl::NotFoundError(absl::StrCat("No value exprs for context: ",

--- a/xls/dslx/type_system_v2/inference_table_converter_impl.cc
+++ b/xls/dslx/type_system_v2/inference_table_converter_impl.cc
@@ -143,7 +143,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   absl::Status ConvertSubtree(
       const AstNode* node, std::optional<const Function*> function,
       std::optional<const ParametricContext*> parametric_context,
-      bool filter_param_type_annotations = false) override {
+      bool filter_param_type_annotations = false) final {
     // Avoid converting a subtree multiple times, as a performance optimization.
     // Evaluation functions convert the `Expr` they are being asked to evaluate
     // in case it is fabricated. For an `Expr` that is actually present in the
@@ -763,7 +763,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   // provided module, its root type info is returned.
   absl::StatusOr<TypeInfo*> GetTypeInfo(
       const Module* module,
-      std::optional<const ParametricContext*> parametric_context) override {
+      std::optional<const ParametricContext*> parametric_context) final {
     TypeInfo* return_ti = base_type_info_;
     if (!proc_type_info_stack_.empty()) {
       return_ti = proc_type_info_stack_.top();
@@ -1110,12 +1110,12 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   }
 
   // Returns the resulting base type info for the entire conversion.
-  TypeInfo* GetBaseTypeInfo() override { return base_type_info_; }
+  TypeInfo* GetBaseTypeInfo() final { return base_type_info_; }
 
   absl::StatusOr<std::unique_ptr<Type>> Concretize(
       const TypeAnnotation* annotation,
       std::optional<const ParametricContext*> parametric_context,
-      bool needs_conversion_before_eval) override {
+      bool needs_conversion_before_eval) final {
     TypeSystemTrace trace = tracer_->TraceConcretize(annotation);
     VLOG(5) << "Concretize: " << annotation->ToString()
             << " in context invocation: " << ToString(parametric_context);
@@ -1327,7 +1327,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
 
   absl::StatusOr<const FunctionAndTargetObject> ResolveFunction(
       const Expr* callee, std::optional<const Function*> caller_function,
-      std::optional<const ParametricContext*> caller_context) override {
+      std::optional<const ParametricContext*> caller_context) final {
     const AstNode* function_node = nullptr;
     std::optional<Expr*> target_object;
     std::optional<const ParametricContext*> target_struct_context =
@@ -1861,7 +1861,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
       const Span& span, std::optional<const ParametricContext*> parent_context,
       const StructDef& struct_def,
       const std::vector<InterpValue>& explicit_parametrics,
-      std::optional<const StructInstanceBase*> instantiator_node) override {
+      std::optional<const StructInstanceBase*> instantiator_node) final {
     // The goal here is to come up with a complete parametric value `Expr`
     // vector, which has a value for every formal binding, by inferring or
     // defaulting whichever ones are not explicit. The algorithm is the same as
@@ -2165,7 +2165,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   absl::Status BitCountMismatchError(
       std::optional<const ParametricContext*> parametric_context,
       const TypeAnnotation* annotation1,
-      const TypeAnnotation* annotation2) override {
+      const TypeAnnotation* annotation2) final {
     if (!parametric_context.has_value()) {
       return BitCountMismatchErrorStatus(annotation1, annotation2, file_table_);
     }
@@ -2183,7 +2183,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   absl::Status SignednessMismatchError(
       std::optional<const ParametricContext*> parametric_context,
       const TypeAnnotation* annotation1,
-      const TypeAnnotation* annotation2) override {
+      const TypeAnnotation* annotation2) final {
     if (!parametric_context.has_value()) {
       return SignednessMismatchErrorStatus(annotation1, annotation2,
                                            file_table_);
@@ -2202,7 +2202,7 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
   absl::Status TypeMismatchError(
       std::optional<const ParametricContext*> parametric_context,
       const TypeAnnotation* annotation1,
-      const TypeAnnotation* annotation2) override {
+      const TypeAnnotation* annotation2) final {
     if (!parametric_context.has_value()) {
       return TypeMismatchErrorStatus(annotation1, annotation2, file_table_);
     }

--- a/xls/dslx/type_system_v2/inference_table_test.cc
+++ b/xls/dslx/type_system_v2/inference_table_test.cc
@@ -57,7 +57,7 @@ using ::testing::HasSubstr;
 
 class InferenceTableTest : public ::testing::Test {
  public:
-  void SetUp() override {
+  void SetUp() final {
     import_data_.emplace(CreateImportDataForTest());
     warning_collector_.emplace(kAllWarningsSet);
     module_ =

--- a/xls/dslx/type_system_v2/solve_for_parametrics.cc
+++ b/xls/dslx/type_system_v2/solve_for_parametrics.cc
@@ -75,7 +75,7 @@ absl::StatusOr<const TypeRefTypeAnnotation*> CanonicalizeTypeRefTypeAnnotation(
 // was last encountered on each.
 class Visitor : public AstNodeVisitorWithDefault {
  public:
-  absl::Status HandleNameRef(const NameRef* node) override {
+  absl::Status HandleNameRef(const NameRef* node) final {
     XLS_RETURN_IF_ERROR(DefaultHandler(node));
     if (std::holds_alternative<const NameDef*>(node->name_def())) {
       last_variable_ = std::get<const NameDef*>(node->name_def());
@@ -84,19 +84,19 @@ class Visitor : public AstNodeVisitorWithDefault {
   }
 
   absl::Status HandleTypeVariableTypeAnnotation(
-      const TypeVariableTypeAnnotation* node) override {
+      const TypeVariableTypeAnnotation* node) final {
     XLS_RETURN_IF_ERROR(DefaultHandler(node));
     last_tvta_ = node;
     return absl::OkStatus();
   }
 
   absl::Status HandleBuiltinTypeAnnotation(
-      const BuiltinTypeAnnotation* node) override {
+      const BuiltinTypeAnnotation* node) final {
     return HandlePossibleIntegerAnnotation(node);
   }
 
   absl::Status HandleArrayTypeAnnotation(
-      const ArrayTypeAnnotation* node) override {
+      const ArrayTypeAnnotation* node) final {
     absl::Status initial_result = HandlePossibleIntegerAnnotation(node);
     if (initial_result.ok() && !last_signedness_and_bit_count_.has_value()) {
       // Not an integer annotation, but an array of something that it still
@@ -107,27 +107,27 @@ class Visitor : public AstNodeVisitorWithDefault {
   }
 
   absl::Status HandleTupleTypeAnnotation(
-      const TupleTypeAnnotation* node) override {
+      const TupleTypeAnnotation* node) final {
     XLS_RETURN_IF_ERROR(DefaultHandler(node));
     last_direct_annotation_ = node;
     return absl::OkStatus();
   }
 
   absl::Status HandleTypeRefTypeAnnotation(
-      const TypeRefTypeAnnotation* node) override {
+      const TypeRefTypeAnnotation* node) final {
     XLS_RETURN_IF_ERROR(DefaultHandler(node));
     last_direct_annotation_ = node;
     return absl::OkStatus();
   }
 
   absl::Status HandleFunctionTypeAnnotation(
-      const FunctionTypeAnnotation* node) override {
+      const FunctionTypeAnnotation* node) final {
     XLS_RETURN_IF_ERROR(DefaultHandler(node));
     last_direct_annotation_ = node;
     return absl::OkStatus();
   }
 
-  absl::Status DefaultHandler(const AstNode* node) override {
+  absl::Status DefaultHandler(const AstNode* node) final {
     last_variable_ = std::nullopt;
     last_signedness_and_bit_count_ = std::nullopt;
     last_tvta_ = std::nullopt;

--- a/xls/dslx/type_system_v2/solve_for_parametrics_test.cc
+++ b/xls/dslx/type_system_v2/solve_for_parametrics_test.cc
@@ -54,7 +54,7 @@ using ::testing::UnorderedElementsAre;
 
 class SolveForParametricsTest : public ::testing::Test {
  public:
-  void SetUp() override { import_data_ = CreateImportDataPtrForTest(); }
+  void SetUp() final { import_data_ = CreateImportDataPtrForTest(); }
 
   absl::StatusOr<std::unique_ptr<Module>> Parse(std::string_view program,
                                                 bool parse_fn_stubs = false) {

--- a/xls/dslx/type_system_v2/type_annotation_resolver.cc
+++ b/xls/dslx/type_system_v2/type_annotation_resolver.cc
@@ -63,36 +63,36 @@ namespace {
 class NeedsResolutionDetector : public AstNodeVisitorWithDefault {
  public:
   absl::Status HandleTypeRefTypeAnnotation(
-      const TypeRefTypeAnnotation*) override {
+      const TypeRefTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
   absl::Status HandleTypeVariableTypeAnnotation(
-      const TypeVariableTypeAnnotation*) override {
+      const TypeVariableTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
   absl::Status HandleMemberTypeAnnotation(
-      const MemberTypeAnnotation*) override {
+      const MemberTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
   absl::Status HandleElementTypeAnnotation(
-      const ElementTypeAnnotation*) override {
+      const ElementTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
   absl::Status HandleReturnTypeAnnotation(
-      const ReturnTypeAnnotation*) override {
+      const ReturnTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
-  absl::Status HandleParamTypeAnnotation(const ParamTypeAnnotation*) override {
+  absl::Status HandleParamTypeAnnotation(const ParamTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
-  absl::Status HandleSelfTypeAnnotation(const SelfTypeAnnotation*) override {
+  absl::Status HandleSelfTypeAnnotation(const SelfTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
-  absl::Status HandleSliceTypeAnnotation(const SliceTypeAnnotation*) override {
+  absl::Status HandleSliceTypeAnnotation(const SliceTypeAnnotation*) final {
     return MarkNeedsResolution();
   }
 
-  absl::Status DefaultHandler(const AstNode* node) override {
+  absl::Status DefaultHandler(const AstNode* node) final {
     for (const AstNode* child : node->GetChildren(/*want_types=*/true)) {
       XLS_RETURN_IF_ERROR(child->Accept(this));
       if (needs_resolution_) {
@@ -147,7 +147,7 @@ class StatefulResolver : public TypeAnnotationResolver {
   absl::StatusOr<std::optional<const TypeAnnotation*>>
   ResolveAndUnifyTypeAnnotationsForNode(
       std::optional<const ParametricContext*> parametric_context,
-      const AstNode* node, TypeAnnotationFilter filter) override {
+      const AstNode* node, TypeAnnotationFilter filter) final {
     if (node->owner() != &module_) {
       XLS_ASSIGN_OR_RETURN(auto new_resolver, ResolverForNode(node));
       return new_resolver->ResolveAndUnifyTypeAnnotationsForNode(
@@ -238,7 +238,7 @@ class StatefulResolver : public TypeAnnotationResolver {
   absl::StatusOr<const TypeAnnotation*> ResolveAndUnifyTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
       const NameRef* type_variable, const Span& span,
-      TypeAnnotationFilter filter, bool require_bits_like) override {
+      TypeAnnotationFilter filter, bool require_bits_like) final {
     TypeSystemTrace trace = tracer_.TraceUnify(type_variable);
     VLOG(6) << "Unifying type annotations for variable "
             << type_variable->ToString();
@@ -323,7 +323,7 @@ class StatefulResolver : public TypeAnnotationResolver {
   absl::StatusOr<const TypeAnnotation*> ResolveAndUnifyTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
       std::vector<const TypeAnnotation*> annotations, const Span& span,
-      TypeAnnotationFilter filter, bool require_bits_like) override {
+      TypeAnnotationFilter filter, bool require_bits_like) final {
     XLS_RETURN_IF_ERROR(ResolveIndirectTypeAnnotations(parametric_context,
                                                        annotations, filter));
 
@@ -349,7 +349,7 @@ class StatefulResolver : public TypeAnnotationResolver {
   absl::Status ResolveIndirectTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
       std::vector<const TypeAnnotation*>& annotations,
-      TypeAnnotationFilter filter) override {
+      TypeAnnotationFilter filter) final {
     std::vector<const TypeAnnotation*> result;
     for (const TypeAnnotation* annotation : annotations) {
       if (!filter.Filter(annotation)) {
@@ -365,14 +365,14 @@ class StatefulResolver : public TypeAnnotationResolver {
 
   absl::StatusOr<const TypeAnnotation*> ResolveIndirectTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
-      const TypeAnnotation* annotation, TypeAnnotationFilter filter) override {
+      const TypeAnnotation* annotation, TypeAnnotationFilter filter) final {
     return ResolveInternal(parametric_context, annotation, filter,
                            /*type_refs_only=*/false);
   }
 
   absl::StatusOr<const TypeAnnotation*> ResolveTypeRefs(
       std::optional<const ParametricContext*> parametric_context,
-      const TypeAnnotation* annotation) override {
+      const TypeAnnotation* annotation) final {
     return ResolveInternal(parametric_context, annotation,
                            TypeAnnotationFilter::None(),
                            /*type_refs_only=*/true);
@@ -796,7 +796,7 @@ class StatefulResolver : public TypeAnnotationResolver {
           filter_(filter) {}
 
     absl::Status HandleTypeVariableTypeAnnotation(
-        const TypeVariableTypeAnnotation* variable_type_annotation) override {
+        const TypeVariableTypeAnnotation* variable_type_annotation) final {
       const bool require_bits_like =
           table_.GetAnnotationFlag(variable_type_annotation)
               .HasFlag(TypeInferenceFlag::kBitsLikeType);
@@ -809,7 +809,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleMemberTypeAnnotation(
-        const MemberTypeAnnotation* member_type) override {
+        const MemberTypeAnnotation* member_type) final {
       XLS_ASSIGN_OR_RETURN(
           result_, resolver_.ResolveMemberType(parametric_context_, member_type,
                                                filter_));
@@ -819,7 +819,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleElementTypeAnnotation(
-        const ElementTypeAnnotation* element_type) override {
+        const ElementTypeAnnotation* element_type) final {
       XLS_ASSIGN_OR_RETURN(result_,
                            resolver_.ResolveElementType(parametric_context_,
                                                         element_type, filter_));
@@ -827,7 +827,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleReturnTypeAnnotation(
-        const ReturnTypeAnnotation* return_type) override {
+        const ReturnTypeAnnotation* return_type) final {
       XLS_ASSIGN_OR_RETURN(
           result_, resolver_.ResolveReturnType(parametric_context_, return_type,
                                                filter_));
@@ -835,7 +835,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleParamTypeAnnotation(
-        const ParamTypeAnnotation* param_type) override {
+        const ParamTypeAnnotation* param_type) final {
       if (filter_.Filter(param_type)) {
         result_ = module_.Make<AnyTypeAnnotation>();
         return absl::OkStatus();
@@ -847,7 +847,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleSelfTypeAnnotation(
-        const SelfTypeAnnotation* self_type) override {
+        const SelfTypeAnnotation* self_type) final {
       XLS_ASSIGN_OR_RETURN(
           result_, resolver_.ResolveSelfType(parametric_context_, self_type));
       XLS_RET_CHECK(result_ != nullptr);
@@ -855,7 +855,7 @@ class StatefulResolver : public TypeAnnotationResolver {
     }
 
     absl::Status HandleSliceTypeAnnotation(
-        const SliceTypeAnnotation* slice_type) override {
+        const SliceTypeAnnotation* slice_type) final {
       XLS_ASSIGN_OR_RETURN(
           result_,
           resolver_.ResolveSliceType(parametric_context_, slice_type, filter_));
@@ -1054,7 +1054,7 @@ class StatelessResolver : public TypeAnnotationResolver {
   absl::StatusOr<std::optional<const TypeAnnotation*>>
   ResolveAndUnifyTypeAnnotationsForNode(
       std::optional<const ParametricContext*> parametric_context,
-      const AstNode* node, TypeAnnotationFilter filter) override {
+      const AstNode* node, TypeAnnotationFilter filter) final {
     return CreateStatefulResolver()->ResolveAndUnifyTypeAnnotationsForNode(
         parametric_context, node, filter);
   }
@@ -1077,7 +1077,7 @@ class StatelessResolver : public TypeAnnotationResolver {
 
   absl::StatusOr<const TypeAnnotation*> ResolveIndirectTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
-      const TypeAnnotation* annotation, TypeAnnotationFilter filter) override {
+      const TypeAnnotation* annotation, TypeAnnotationFilter filter) final {
     return CreateStatefulResolver()->ResolveIndirectTypeAnnotations(
         parametric_context, annotation, filter);
   }
@@ -1085,14 +1085,14 @@ class StatelessResolver : public TypeAnnotationResolver {
   absl::Status ResolveIndirectTypeAnnotations(
       std::optional<const ParametricContext*> parametric_context,
       std::vector<const TypeAnnotation*>& annotations,
-      TypeAnnotationFilter filter) override {
+      TypeAnnotationFilter filter) final {
     return CreateStatefulResolver()->ResolveIndirectTypeAnnotations(
         parametric_context, annotations, filter);
   }
 
   absl::StatusOr<const TypeAnnotation*> ResolveTypeRefs(
       std::optional<const ParametricContext*> parametric_context,
-      const TypeAnnotation* annotation) override {
+      const TypeAnnotation* annotation) final {
     return CreateStatefulResolver()->ResolveTypeRefs(parametric_context,
                                                      annotation);
   }

--- a/xls/dslx/type_system_v2/type_system_tracer.cc
+++ b/xls/dslx/type_system_v2/type_system_tracer.cc
@@ -185,21 +185,21 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
     stack_.push(&*traces_.begin());
   }
 
-  TypeSystemTrace TraceUnify(const AstNode* node) override {
+  TypeSystemTrace TraceUnify(const AstNode* node) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kUnify,
                                      .address = node,
                                      .node = node});
   }
 
-  TypeSystemTrace TraceUnify(const NameRef* type_variable) override {
+  TypeSystemTrace TraceUnify(const NameRef* type_variable) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kUnify,
                                      .inference_variable = type_variable});
   }
 
   TypeSystemTrace TraceUnify(
-      const std::vector<const TypeAnnotation*>& annotations) override {
+      const std::vector<const TypeAnnotation*>& annotations) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kUnify,
                                      .annotations = annotations});
@@ -207,7 +207,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
 
   TypeSystemTrace TraceFilter(
       TypeAnnotationFilter filter,
-      const std::vector<const TypeAnnotation*>& annotations) override {
+      const std::vector<const TypeAnnotation*>& annotations) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kFilter,
                                      .filter = filter,
@@ -216,7 +216,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
 
   TypeSystemTrace TraceResolve(
       const TypeAnnotation* annotation,
-      std::optional<const ParametricContext*> parametric_context) override {
+      std::optional<const ParametricContext*> parametric_context) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kResolve,
                                      .address = annotation,
@@ -224,14 +224,14 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
                                      .parametric_context = parametric_context});
   }
 
-  TypeSystemTrace TraceConvertNode(const AstNode* node) override {
+  TypeSystemTrace TraceConvertNode(const AstNode* node) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kConvertNode,
                                      .address = node,
                                      .node = node});
   }
 
-  TypeSystemTrace TraceConvertActualArgument(const AstNode* node) override {
+  TypeSystemTrace TraceConvertActualArgument(const AstNode* node) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kConvertActualArgument,
                                      .address = node,
@@ -241,7 +241,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
   TypeSystemTrace TraceConvertInvocation(
       const Invocation* invocation,
       std::optional<const ParametricContext*> caller_context,
-      std::optional<bool> convert_for_type_variable_unification) override {
+      std::optional<bool> convert_for_type_variable_unification) final {
     return Trace(
         TypeSystemTraceImpl{.parent = stack_.top(),
                             .kind = TraceKind::kConvertInvocation,
@@ -253,7 +253,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
   }
 
   TypeSystemTrace TraceInferImplicitParametrics(
-      const absl::flat_hash_set<const ParametricBinding*>& bindings) override {
+      const absl::flat_hash_set<const ParametricBinding*>& bindings) final {
     return Trace(
         TypeSystemTraceImpl{.parent = stack_.top(),
                             .kind = TraceKind::kInferImplicitParametrics,
@@ -262,7 +262,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
 
   TypeSystemTrace TraceEvaluate(
       std::optional<const ParametricContext*> parametric_context,
-      const Expr* expr) override {
+      const Expr* expr) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kEvaluate,
                                      .address = expr,
@@ -272,7 +272,7 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
 
   TypeSystemTrace TraceCollectConstants(
       std::optional<const ParametricContext*> parametric_context,
-      const AstNode* node) override {
+      const AstNode* node) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kCollectConstants,
                                      .address = node,
@@ -280,14 +280,14 @@ class TypeSystemTracerImpl : public TypeSystemTracer {
                                      .parametric_context = parametric_context});
   }
 
-  TypeSystemTrace TraceConcretize(const TypeAnnotation* annotation) override {
+  TypeSystemTrace TraceConcretize(const TypeAnnotation* annotation) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kConcretize,
                                      .address = annotation,
                                      .annotation = annotation});
   }
 
-  TypeSystemTrace TraceUnroll(const AstNode* node) override {
+  TypeSystemTrace TraceUnroll(const AstNode* node) final {
     return Trace(TypeSystemTraceImpl{.parent = stack_.top(),
                                      .kind = TraceKind::kUnroll,
                                      .address = node,

--- a/xls/dslx/type_system_v2/type_system_tracer_test.cc
+++ b/xls/dslx/type_system_v2/type_system_tracer_test.cc
@@ -34,7 +34,7 @@ namespace {
 
 class TypeSystemTracerTest : public ::testing::Test {
  public:
-  void SetUp() override {
+  void SetUp() final {
     tracer_ = TypeSystemTracer::Create(/*active=*/true);
     import_data_.emplace(CreateImportDataForTest());
     warning_collector_.emplace(kAllWarningsSet);

--- a/xls/dslx/virtualizable_file_system.h
+++ b/xls/dslx/virtualizable_file_system.h
@@ -48,13 +48,13 @@ class VirtualizableFilesystem {
 // A simple (and often "default") implementation of the virtualizable file
 // system that just calls into the XLS "real filesystem" routines that talk to
 // the running operating system.
-class RealFilesystem : public VirtualizableFilesystem {
+class RealFilesystem final : public VirtualizableFilesystem {
  public:
-  ~RealFilesystem() override = default;
-  absl::Status FileExists(const std::filesystem::path& path) override;
+  ~RealFilesystem() final = default;
+  absl::Status FileExists(const std::filesystem::path& path) final;
   absl::StatusOr<std::string> GetFileContents(
-      const std::filesystem::path& path) override;
-  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override;
+      const std::filesystem::path& path) final;
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() final;
 };
 
 // A fake filesystem that gives back the same file content for all requested
@@ -62,20 +62,20 @@ class RealFilesystem : public VirtualizableFilesystem {
 //
 // If `expect_path` is given in addition to the file content, then we will error
 // out if the GetFileContents has any other path.
-class UniformContentFilesystem : public VirtualizableFilesystem {
+class UniformContentFilesystem final : public VirtualizableFilesystem {
  public:
   explicit UniformContentFilesystem(
       std::string_view file_content,
       std::optional<std::string_view> expect_path = std::nullopt)
       : file_content_(file_content), expect_path_(expect_path) {}
 
-  ~UniformContentFilesystem() override = default;
+  ~UniformContentFilesystem() final = default;
 
-  absl::Status FileExists(const std::filesystem::path& path) override {
+  absl::Status FileExists(const std::filesystem::path& path) final {
     return absl::NotFoundError("UniformContentFilesystem");
   }
   absl::StatusOr<std::string> GetFileContents(
-      const std::filesystem::path& path) override {
+      const std::filesystem::path& path) final {
     if (expect_path_.has_value() && path != expect_path_.value()) {
       return absl::InvalidArgumentError(absl::StrFormat(
           "UniformContentFilesystem expected path: `%s` but got: `%s`",
@@ -83,7 +83,7 @@ class UniformContentFilesystem : public VirtualizableFilesystem {
     }
     return file_content_;
   }
-  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override {
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() final {
     return absl::NotFoundError("UniformContentFilesystem");
   }
 
@@ -97,19 +97,19 @@ class UniformContentFilesystem : public VirtualizableFilesystem {
 //
 // `cwd` is used to resolve relative paths to absolute paths before lookup in
 // the `files` map.
-class FakeFilesystem : public VirtualizableFilesystem {
+class FakeFilesystem final : public VirtualizableFilesystem {
  public:
   FakeFilesystem(absl::flat_hash_map<std::filesystem::path, std::string> files,
                  std::filesystem::path cwd);
 
-  ~FakeFilesystem() override = default;
+  ~FakeFilesystem() final = default;
 
-  absl::Status FileExists(const std::filesystem::path& path) override;
+  absl::Status FileExists(const std::filesystem::path& path) final;
 
   absl::StatusOr<std::string> GetFileContents(
-      const std::filesystem::path& path) override;
+      const std::filesystem::path& path) final;
 
-  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override {
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() final {
     return cwd_;
   }
 
@@ -120,17 +120,17 @@ class FakeFilesystem : public VirtualizableFilesystem {
 
 // A fake filesystem that always returns errors, useful in testing when we don't
 // expect any virtual filesystem operations to be performed.
-class AllErrorsFilesystem : public VirtualizableFilesystem {
+class AllErrorsFilesystem final : public VirtualizableFilesystem {
  public:
-  ~AllErrorsFilesystem() override = default;
-  absl::Status FileExists(const std::filesystem::path& path) override {
+  ~AllErrorsFilesystem() final = default;
+  absl::Status FileExists(const std::filesystem::path& path) final {
     return absl::InvalidArgumentError("AllErrorsFilesystem");
   }
   absl::StatusOr<std::string> GetFileContents(
-      const std::filesystem::path& path) override {
+      const std::filesystem::path& path) final {
     return absl::InvalidArgumentError("AllErrorsFilesystem");
   }
-  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() override {
+  absl::StatusOr<std::filesystem::path> GetCurrentDirectory() final {
     return absl::InvalidArgumentError("AllErrorsFilesystem");
   }
 };

--- a/xls/fdo/synthesized_delay_diff_utils_test.cc
+++ b/xls/fdo/synthesized_delay_diff_utils_test.cc
@@ -69,7 +69,7 @@ class FakeSynthesizer : public Synthesizer {
 
 class SynthesizedDelayDiffUtilsTest : public IrTestBase {
  public:
-  void SetUp() override {
+  void SetUp() final {
     package_ = CreatePackage();
     XLS_ASSERT_OK_AND_ASSIGN(f_, ParseFunction(R"(
 fn foobar(x: bits[8], y: bits[8], z: bits[8]) -> bits[8] {

--- a/xls/fuzzer/ast_generator.cc
+++ b/xls/fuzzer/ast_generator.cc
@@ -658,13 +658,13 @@ class FindTypeVisitor : public AstNodeVisitorWithDefault {
   bool found() const { return found_; }
 
   absl::Status HandleBuiltinTypeAnnotation(
-      const BuiltinTypeAnnotation* builtin_type) override {
+      const BuiltinTypeAnnotation* builtin_type) final {
     found_ = found_ || is_target_type_(builtin_type);
     return absl::OkStatus();
   }
 
   absl::Status HandleTupleTypeAnnotation(
-      const TupleTypeAnnotation* tuple_type) override {
+      const TupleTypeAnnotation* tuple_type) final {
     found_ = found_ || is_target_type_(tuple_type);
     for (TypeAnnotation* member_type : tuple_type->members()) {
       if (found_) {
@@ -676,63 +676,63 @@ class FindTypeVisitor : public AstNodeVisitorWithDefault {
   }
 
   absl::Status HandleArrayTypeAnnotation(
-      const ArrayTypeAnnotation* array_type) override {
+      const ArrayTypeAnnotation* array_type) final {
     found_ = found_ || is_target_type_(array_type);
     return array_type->element_type()->Accept(this);
   }
 
   absl::Status HandleTypeRefTypeAnnotation(
-      const TypeRefTypeAnnotation* type_ref_type) override {
+      const TypeRefTypeAnnotation* type_ref_type) final {
     found_ = found_ || is_target_type_(type_ref_type);
     return type_ref_type->type_ref()->Accept(this);
   }
 
   absl::Status HandleMemberTypeAnnotation(
-      const MemberTypeAnnotation*) override {
+      const MemberTypeAnnotation*) final {
     return absl::InternalError(
         "MemberTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
   absl::Status HandleElementTypeAnnotation(
-      const ElementTypeAnnotation*) override {
+      const ElementTypeAnnotation*) final {
     return absl::InternalError(
         "ElementTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
-  absl::Status HandleSliceTypeAnnotation(const SliceTypeAnnotation*) override {
+  absl::Status HandleSliceTypeAnnotation(const SliceTypeAnnotation*) final {
     return absl::InternalError(
         "SliceTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
   absl::Status HandleFunctionTypeAnnotation(
-      const FunctionTypeAnnotation*) override {
+      const FunctionTypeAnnotation*) final {
     return absl::InternalError(
         "FunctionTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
   absl::Status HandleReturnTypeAnnotation(
-      const ReturnTypeAnnotation*) override {
+      const ReturnTypeAnnotation*) final {
     return absl::InternalError(
         "ReturnTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
-  absl::Status HandleParamTypeAnnotation(const ParamTypeAnnotation*) override {
+  absl::Status HandleParamTypeAnnotation(const ParamTypeAnnotation*) final {
     return absl::InternalError(
         "ParamTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
-  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation*) override {
+  absl::Status HandleAnyTypeAnnotation(const AnyTypeAnnotation*) final {
     return absl::InternalError(
         "AnyTypeAnnotation nodes are not supported by the fuzzer.");
   }
 
   absl::Status HandleTypeVariableTypeAnnotation(
-      const TypeVariableTypeAnnotation* type_variable_type) override {
+      const TypeVariableTypeAnnotation* type_variable_type) final {
     found_ = found_ || is_target_type_(type_variable_type);
     return type_variable_type->type_variable()->Accept(this);
   }
 
-  absl::Status HandleTypeRef(const TypeRef* type_ref) override {
+  absl::Status HandleTypeRef(const TypeRef* type_ref) final {
     const TypeDefinition& type_def = type_ref->type_definition();
     if (std::holds_alternative<TypeAlias*>(type_def)) {
       return std::get<TypeAlias*>(type_def)->Accept(this);
@@ -750,23 +750,23 @@ class FindTypeVisitor : public AstNodeVisitorWithDefault {
     return std::get<ColonRef*>(type_def)->Accept(this);
   }
 
-  absl::Status HandleTypeAlias(const TypeAlias* type_alias) override {
+  absl::Status HandleTypeAlias(const TypeAlias* type_alias) final {
     return type_alias->type_annotation().Accept(this);
   }
 
-  absl::Status HandleStructDef(const StructDef* struct_def) override {
+  absl::Status HandleStructDef(const StructDef* struct_def) final {
     return HandleStructDefBaseInternal(struct_def);
   }
 
-  absl::Status HandleProcDef(const ProcDef* proc_def) override {
+  absl::Status HandleProcDef(const ProcDef* proc_def) final {
     return HandleStructDefBaseInternal(proc_def);
   }
 
-  absl::Status HandleEnumDef(const EnumDef* enum_def) override {
+  absl::Status HandleEnumDef(const EnumDef* enum_def) final {
     return enum_def->type_annotation()->Accept(this);
   }
 
-  absl::Status HandleColonRef(const ColonRef* colon_def) override {
+  absl::Status HandleColonRef(const ColonRef* colon_def) final {
     return absl::InternalError("ColonRef are not supported by the fuzzer.");
   }
 

--- a/xls/fuzzer/ir_fuzzer/ir_fuzz_test_library.cc
+++ b/xls/fuzzer/ir_fuzzer/ir_fuzz_test_library.cc
@@ -139,7 +139,7 @@ class PrintIrOnFailure : public testing::EmptyTestEventListener {
         ir_(ir),
         args_(args ? std::optional<std::string>(std::string(*args))
                    : std::nullopt) {}
-  void OnTestEnd(const testing::TestInfo& result) override {
+  void OnTestEnd(const testing::TestInfo& result) final {
     if (&result == test_ && result.result()->Failed()) {
       RecordFuzzInfoString(ir_, args_);
     }

--- a/xls/fuzzer/ir_fuzzer/query_engine_helpers.cc
+++ b/xls/fuzzer/ir_fuzzer/query_engine_helpers.cc
@@ -34,7 +34,7 @@ using NodeValues =
 namespace {
 class Observer : public EvaluationObserver {
  public:
-  void NodeEvaluated(Node* n, const Value& v) override { values_[n] = v; }
+  void NodeEvaluated(Node* n, const Value& v) final { values_[n] = v; }
   const absl::flat_hash_map<Node*, Value>& values() const& { return values_; }
   absl::flat_hash_map<Node*, Value> values() && { return std::move(values_); }
 

--- a/xls/fuzzer/ir_fuzzer/query_engine_helpers.h
+++ b/xls/fuzzer/ir_fuzzer/query_engine_helpers.h
@@ -38,7 +38,7 @@ using NodeValues =
     absl::flat_hash_map<Node*, absl::flat_hash_map<std::vector<Value>, Value>>;
 absl::StatusOr<NodeValues> SampleValuesWith(
     Function* f, std::vector<std::vector<Value>> args);
-class ScopedCheckTestChange : public testing::EmptyTestEventListener {
+class ScopedCheckTestChange final : public testing::EmptyTestEventListener {
  public:
   ScopedCheckTestChange() : unit_(testing::UnitTest::GetInstance()) {
     if (!unit_) {
@@ -46,15 +46,15 @@ class ScopedCheckTestChange : public testing::EmptyTestEventListener {
     }
     unit_->listeners().Append(this);
   }
-  ~ScopedCheckTestChange() override {
+  ~ScopedCheckTestChange() final {
     if (!unit_) {
       return;
     }
     unit_->listeners().Release(this);
   }
   bool new_failed() const { return new_failed_; }
-  virtual void OnTestPartResult(
-      const testing::TestPartResult& result) override {
+  void OnTestPartResult(
+      const testing::TestPartResult& result) final {
     if (result.failed()) {
       new_failed_ = true;
     }

--- a/xls/fuzzer/run_fuzz_codegen_test.cc
+++ b/xls/fuzzer/run_fuzz_codegen_test.cc
@@ -65,12 +65,12 @@ absl::StatusOr<std::optional<std::filesystem::path>> GetCrasherDir() {
 
 class RunFuzzCodegenTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     XLS_ASSERT_OK_AND_ASSIGN(crasher_dir_, GetCrasherDir());
     XLS_ASSERT_OK_AND_ASSIGN(temp_dir_, TempDirectory::Create());
   }
 
-  void TearDown() override {
+  void TearDown() final {
     // Take ownership of the `temp_dir_` so it will be destroyed on return; this
     // lets us use early-exit control flow.
     TempDirectory temp_dir = *std::move(temp_dir_);

--- a/xls/fuzzer/run_fuzz_minimizer_test.cc
+++ b/xls/fuzzer/run_fuzz_minimizer_test.cc
@@ -50,11 +50,11 @@ using ::testing::HasSubstr;
 
 class RunFuzzMinimizerTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     XLS_ASSERT_OK_AND_ASSIGN(temp_dir_, TempDirectory::Create());
   }
 
-  void TearDown() override {
+  void TearDown() final {
     // Take ownership of the `temp_dir_` so it will be destroyed on return; this
     // lets us use early-exit control flow.
     TempDirectory temp_dir = *std::move(temp_dir_);

--- a/xls/fuzzer/run_fuzz_test.cc
+++ b/xls/fuzzer/run_fuzz_test.cc
@@ -62,12 +62,12 @@ absl::StatusOr<std::optional<std::filesystem::path>> GetCrasherDir() {
 
 class RunFuzzTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     XLS_ASSERT_OK_AND_ASSIGN(crasher_dir_, GetCrasherDir());
     XLS_ASSERT_OK_AND_ASSIGN(temp_dir_, TempDirectory::Create());
   }
 
-  void TearDown() override {
+  void TearDown() final {
     // Take ownership of the `temp_dir_` so it will be destroyed on return; this
     // lets us use early-exit control flow.
     TempDirectory temp_dir = *std::move(temp_dir_);

--- a/xls/fuzzer/sample_generator.cc
+++ b/xls/fuzzer/sample_generator.cc
@@ -82,7 +82,7 @@ class HasMapBuiltinVisitor : public AstNodeVisitorWithDefault {
  public:
   bool GetHasMap() const { return has_map_; }
 
-  absl::Status HandleInvocation(const dslx::Invocation* n) override {
+  absl::Status HandleInvocation(const dslx::Invocation* n) final {
     std::optional<std::string_view> builtin_name =
         dslx::GetBuiltinFnName(n->callee());
     if (builtin_name.has_value()) {
@@ -99,7 +99,7 @@ class HasNonBlockingRecvVisitor : public AstNodeVisitorWithDefault {
  public:
   bool GetHasNbRecv() const { return has_nb_recv_; }
 
-  absl::Status HandleInvocation(const dslx::Invocation* n) override {
+  absl::Status HandleInvocation(const dslx::Invocation* n) final {
     std::optional<std::string_view> builtin_name =
         dslx::GetBuiltinFnName(n->callee());
     if (builtin_name.has_value()) {
@@ -120,7 +120,7 @@ class IsPotentiallyDelayingNodeVisitor : public AstNodeVisitorWithDefault {
   bool IsRecv() const { return is_recv_; }
   bool IsDelaying() const { return is_send_ || is_recv_; }
 
-  absl::Status HandleInvocation(const dslx::Invocation* n) override {
+  absl::Status HandleInvocation(const dslx::Invocation* n) final {
     std::optional<std::string_view> builtin_name =
         dslx::GetBuiltinFnName(n->callee());
     if (builtin_name.has_value()) {

--- a/xls/fuzzer/sample_runner_test.cc
+++ b/xls/fuzzer/sample_runner_test.cc
@@ -165,11 +165,11 @@ absl::StatusOr<ArgsBatch> ToArgsBatch(
 
 class SampleRunnerTest : public ::testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     XLS_ASSERT_OK_AND_ASSIGN(temp_dir_, TempDirectory::Create());
   }
 
-  void TearDown() override {
+  void TearDown() final {
     // Take ownership of the `temp_dir_` so it will be destroyed on return; this
     // lets us use early-exit control flow.
     TempDirectory temp_dir = *std::move(temp_dir_);

--- a/xls/interpreter/block_interpreter.cc
+++ b/xls/interpreter/block_interpreter.cc
@@ -73,7 +73,7 @@ class BlockInterpreter final : public IrInterpreter {
   // Ports and InstantiationInputs/Outputs are handled by the
   // ElaboratedBlockInterpreter.
 
-  absl::Status HandleRegisterRead(RegisterRead* reg_read) override {
+  absl::Status HandleRegisterRead(RegisterRead* reg_read) final {
     std::string reg_name =
         absl::StrCat(register_prefix_, reg_read->GetRegister()->name());
     auto reg_value_iter = reg_state_.find(reg_name);
@@ -84,7 +84,7 @@ class BlockInterpreter final : public IrInterpreter {
     return SetValueResult(reg_read, reg_value_iter->second);
   }
 
-  absl::Status HandleRegisterWrite(RegisterWrite* reg_write) override {
+  absl::Status HandleRegisterWrite(RegisterWrite* reg_write) final {
     std::string reg_name =
         absl::StrCat(register_prefix_, reg_write->GetRegister()->name());
     bool is_activated = !reg_write->load_enable().has_value() ||
@@ -474,7 +474,7 @@ class ElaboratedBlockInterpreter final : public ElaboratedBlockDfsVisitor {
   }
 
   absl::Status HandleInputPort(InputPort* input_port,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     if (current_instance_->parent_instance().has_value()) {
       BlockInstance* parent_instance = *current_instance_->parent_instance();
@@ -507,7 +507,7 @@ class ElaboratedBlockInterpreter final : public ElaboratedBlockDfsVisitor {
     return current_interpreter_->SetValueResult(input_port, port_iter->second);
   }
   absl::Status HandleInstantiationInput(InstantiationInput* instantiation_input,
-                                        BlockInstance* instance) override {
+                                        BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     if (instantiation_input->instantiation()->kind() ==
         InstantiationKind::kFifo) {
@@ -535,7 +535,7 @@ class ElaboratedBlockInterpreter final : public ElaboratedBlockDfsVisitor {
   }
   absl::Status HandleInstantiationOutput(
       InstantiationOutput* instantiation_output,
-      BlockInstance* instance) override {
+      BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     if (instantiation_output->instantiation()->kind() ==
         InstantiationKind::kFifo) {
@@ -579,327 +579,327 @@ class ElaboratedBlockInterpreter final : public ElaboratedBlockDfsVisitor {
                                                 child_value);
   }
   absl::Status HandleOutputPort(OutputPort* output_port,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     // Output ports have empty tuple types.
     return current_interpreter_->SetValueResult(output_port, Value::Tuple({}));
   }
 
   // The rest of these handlers simply forward to the underlying interpreter.
-  absl::Status HandleAdd(BinOp* add, BlockInstance* instance) override {
+  absl::Status HandleAdd(BinOp* add, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleAdd(add);
   }
   absl::Status HandleAfterAll(AfterAll* after_all,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleAfterAll(after_all);
   }
   absl::Status HandleMinDelay(MinDelay* min_delay,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleMinDelay(min_delay);
   }
   absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleAndReduce(and_reduce);
   }
-  absl::Status HandleArray(Array* array, BlockInstance* instance) override {
+  absl::Status HandleArray(Array* array, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleArray(array);
   }
   absl::Status HandleArrayConcat(ArrayConcat* array_concat,
-                                 BlockInstance* instance) override {
+                                 BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleArrayConcat(array_concat);
   }
   absl::Status HandleAssert(Assert* assert_op,
-                            BlockInstance* instance) override {
+                            BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleAssert(assert_op);
   }
   absl::Status HandleBitSlice(BitSlice* bit_slice,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleBitSlice(bit_slice);
   }
   absl::Status HandleBitSliceUpdate(BitSliceUpdate* update,
-                                    BlockInstance* instance) override {
+                                    BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleBitSliceUpdate(update);
   }
-  absl::Status HandleConcat(Concat* concat, BlockInstance* instance) override {
+  absl::Status HandleConcat(Concat* concat, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleConcat(concat);
   }
   absl::Status HandleCountedFor(CountedFor* counted_for,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleCountedFor(counted_for);
   }
-  absl::Status HandleCover(Cover* cover, BlockInstance* instance) override {
+  absl::Status HandleCover(Cover* cover, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleCover(cover);
   }
-  absl::Status HandleDecode(Decode* decode, BlockInstance* instance) override {
+  absl::Status HandleDecode(Decode* decode, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleDecode(decode);
   }
   absl::Status HandleDynamicBitSlice(DynamicBitSlice* dynamic_bit_slice,
-                                     BlockInstance* instance) override {
+                                     BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleDynamicBitSlice(dynamic_bit_slice);
   }
   absl::Status HandleDynamicCountedFor(DynamicCountedFor* dynamic_counted_for,
-                                       BlockInstance* instance) override {
+                                       BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleDynamicCountedFor(dynamic_counted_for);
   }
-  absl::Status HandleEncode(Encode* encode, BlockInstance* instance) override {
+  absl::Status HandleEncode(Encode* encode, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleEncode(encode);
   }
-  absl::Status HandleEq(CompareOp* eq, BlockInstance* instance) override {
+  absl::Status HandleEq(CompareOp* eq, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleEq(eq);
   }
-  absl::Status HandleGate(Gate* gate, BlockInstance* instance) override {
+  absl::Status HandleGate(Gate* gate, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleGate(gate);
   }
   absl::Status HandleIdentity(UnOp* identity,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleIdentity(identity);
   }
-  absl::Status HandleInvoke(Invoke* invoke, BlockInstance* instance) override {
+  absl::Status HandleInvoke(Invoke* invoke, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleInvoke(invoke);
   }
   absl::Status HandleLiteral(Literal* literal,
-                             BlockInstance* instance) override {
+                             BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleLiteral(literal);
   }
-  absl::Status HandleMap(Map* map, BlockInstance* instance) override {
+  absl::Status HandleMap(Map* map, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleMap(map);
   }
   absl::Status HandleArrayIndex(ArrayIndex* index,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleArrayIndex(index);
   }
   absl::Status HandleArraySlice(ArraySlice* update,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleArraySlice(update);
   }
   absl::Status HandleArrayUpdate(ArrayUpdate* update,
-                                 BlockInstance* instance) override {
+                                 BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleArrayUpdate(update);
   }
-  absl::Status HandleNaryAnd(NaryOp* and_op, BlockInstance* instance) override {
+  absl::Status HandleNaryAnd(NaryOp* and_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNaryAnd(and_op);
   }
   absl::Status HandleNaryNand(NaryOp* nand_op,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNaryNand(nand_op);
   }
-  absl::Status HandleNaryNor(NaryOp* nor_op, BlockInstance* instance) override {
+  absl::Status HandleNaryNor(NaryOp* nor_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNaryNor(nor_op);
   }
-  absl::Status HandleNaryOr(NaryOp* or_op, BlockInstance* instance) override {
+  absl::Status HandleNaryOr(NaryOp* or_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNaryOr(or_op);
   }
-  absl::Status HandleNaryXor(NaryOp* xor_op, BlockInstance* instance) override {
+  absl::Status HandleNaryXor(NaryOp* xor_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNaryXor(xor_op);
   }
-  absl::Status HandleNe(CompareOp* ne, BlockInstance* instance) override {
+  absl::Status HandleNe(CompareOp* ne, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNe(ne);
   }
-  absl::Status HandleNeg(UnOp* neg, BlockInstance* instance) override {
+  absl::Status HandleNeg(UnOp* neg, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNeg(neg);
   }
-  absl::Status HandleNot(UnOp* not_op, BlockInstance* instance) override {
+  absl::Status HandleNot(UnOp* not_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNot(not_op);
   }
-  absl::Status HandleOneHot(OneHot* one_hot, BlockInstance* instance) override {
+  absl::Status HandleOneHot(OneHot* one_hot, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleOneHot(one_hot);
   }
   absl::Status HandleOneHotSel(OneHotSelect* sel,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleOneHotSel(sel);
   }
   absl::Status HandlePrioritySel(PrioritySelect* sel,
-                                 BlockInstance* instance) override {
+                                 BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandlePrioritySel(sel);
   }
   absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce,
-                              BlockInstance* instance) override {
+                              BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleOrReduce(or_reduce);
   }
-  absl::Status HandleParam(Param* param, BlockInstance* instance) override {
+  absl::Status HandleParam(Param* param, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleParam(param);
   }
   absl::Status HandleStateRead(StateRead* state_read,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleStateRead(state_read);
   }
-  absl::Status HandleNext(Next* next, BlockInstance* instance) override {
+  absl::Status HandleNext(Next* next, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleNext(next);
   }
   absl::Status HandleReceive(Receive* receive,
-                             BlockInstance* instance) override {
+                             BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleReceive(receive);
   }
   absl::Status HandleRegisterRead(RegisterRead* reg_read,
-                                  BlockInstance* instance) override {
+                                  BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleRegisterRead(reg_read);
   }
   absl::Status HandleRegisterWrite(RegisterWrite* reg_write,
-                                   BlockInstance* instance) override {
+                                   BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleRegisterWrite(reg_write);
   }
-  absl::Status HandleReverse(UnOp* reverse, BlockInstance* instance) override {
+  absl::Status HandleReverse(UnOp* reverse, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleReverse(reverse);
   }
-  absl::Status HandleSDiv(BinOp* div, BlockInstance* instance) override {
+  absl::Status HandleSDiv(BinOp* div, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSDiv(div);
   }
-  absl::Status HandleSGe(CompareOp* ge, BlockInstance* instance) override {
+  absl::Status HandleSGe(CompareOp* ge, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSGe(ge);
   }
-  absl::Status HandleSGt(CompareOp* gt, BlockInstance* instance) override {
+  absl::Status HandleSGt(CompareOp* gt, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSGt(gt);
   }
-  absl::Status HandleSLe(CompareOp* le, BlockInstance* instance) override {
+  absl::Status HandleSLe(CompareOp* le, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSLe(le);
   }
-  absl::Status HandleSLt(CompareOp* lt, BlockInstance* instance) override {
+  absl::Status HandleSLt(CompareOp* lt, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSLt(lt);
   }
-  absl::Status HandleSMod(BinOp* mod, BlockInstance* instance) override {
+  absl::Status HandleSMod(BinOp* mod, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSMod(mod);
   }
-  absl::Status HandleSMul(ArithOp* mul, BlockInstance* instance) override {
+  absl::Status HandleSMul(ArithOp* mul, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSMul(mul);
   }
   absl::Status HandleSMulp(PartialProductOp* mul,
-                           BlockInstance* instance) override {
+                           BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSMulp(mul);
   }
-  absl::Status HandleSel(Select* sel, BlockInstance* instance) override {
+  absl::Status HandleSel(Select* sel, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSel(sel);
   }
-  absl::Status HandleSend(Send* send, BlockInstance* instance) override {
+  absl::Status HandleSend(Send* send, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSend(send);
   }
-  absl::Status HandleShll(BinOp* shll, BlockInstance* instance) override {
+  absl::Status HandleShll(BinOp* shll, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleShll(shll);
   }
-  absl::Status HandleShra(BinOp* shra, BlockInstance* instance) override {
+  absl::Status HandleShra(BinOp* shra, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleShra(shra);
   }
-  absl::Status HandleShrl(BinOp* shrl, BlockInstance* instance) override {
+  absl::Status HandleShrl(BinOp* shrl, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleShrl(shrl);
   }
   absl::Status HandleSignExtend(ExtendOp* sign_ext,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSignExtend(sign_ext);
   }
-  absl::Status HandleSub(BinOp* sub, BlockInstance* instance) override {
+  absl::Status HandleSub(BinOp* sub, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleSub(sub);
   }
-  absl::Status HandleTrace(Trace* trace_op, BlockInstance* instance) override {
+  absl::Status HandleTrace(Trace* trace_op, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleTrace(trace_op);
   }
-  absl::Status HandleTuple(Tuple* tuple, BlockInstance* instance) override {
+  absl::Status HandleTuple(Tuple* tuple, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleTuple(tuple);
   }
   absl::Status HandleTupleIndex(TupleIndex* index,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleTupleIndex(index);
   }
-  absl::Status HandleUDiv(BinOp* div, BlockInstance* instance) override {
+  absl::Status HandleUDiv(BinOp* div, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUDiv(div);
   }
-  absl::Status HandleUGe(CompareOp* ge, BlockInstance* instance) override {
+  absl::Status HandleUGe(CompareOp* ge, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUGe(ge);
   }
-  absl::Status HandleUGt(CompareOp* gt, BlockInstance* instance) override {
+  absl::Status HandleUGt(CompareOp* gt, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUGt(gt);
   }
-  absl::Status HandleULe(CompareOp* le, BlockInstance* instance) override {
+  absl::Status HandleULe(CompareOp* le, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleULe(le);
   }
-  absl::Status HandleULt(CompareOp* lt, BlockInstance* instance) override {
+  absl::Status HandleULt(CompareOp* lt, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleULt(lt);
   }
-  absl::Status HandleUMod(BinOp* mod, BlockInstance* instance) override {
+  absl::Status HandleUMod(BinOp* mod, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUMod(mod);
   }
-  absl::Status HandleUMul(ArithOp* mul, BlockInstance* instance) override {
+  absl::Status HandleUMul(ArithOp* mul, BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUMul(mul);
   }
   absl::Status HandleUMulp(PartialProductOp* mul,
-                           BlockInstance* instance) override {
+                           BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleUMulp(mul);
   }
   absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce,
-                               BlockInstance* instance) override {
+                               BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleXorReduce(xor_reduce);
   }
   absl::Status HandleZeroExtend(ExtendOp* zero_ext,
-                                BlockInstance* instance) override {
+                                BlockInstance* instance) final {
     XLS_RETURN_IF_ERROR(SetInstance(instance));
     return current_interpreter_->HandleZeroExtend(zero_ext);
   }
@@ -1079,11 +1079,11 @@ class StatelessBlockContinuation final : public BlockContinuation {
     return absl::OkStatus();
   }
 
-  absl::Status SetObserver(EvaluationObserver* obs) override {
+  absl::Status SetObserver(EvaluationObserver* obs) final {
     observer_ = obs;
     return absl::OkStatus();
   }
-  void ClearObserver() override { observer_.reset(); }
+  void ClearObserver() final { observer_.reset(); }
 
  private:
   BlockElaboration elaboration_;

--- a/xls/interpreter/function_interpreter.cc
+++ b/xls/interpreter/function_interpreter.cc
@@ -45,7 +45,7 @@ class FunctionInterpreter final : public IrInterpreter {
                       std::optional<EvaluationObserver*> observer)
       : IrInterpreter(observer), args_(args.begin(), args.end()) {}
 
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     XLS_ASSIGN_OR_RETURN(int64_t index,
                          param->function_base()->GetParamIndex(param));
     if (index >= args_.size()) {

--- a/xls/interpreter/observer.h
+++ b/xls/interpreter/observer.h
@@ -39,7 +39,7 @@ class EvaluationObserver {
 // Test observer that just collects every node value.
 class CollectingEvaluationObserver : public EvaluationObserver {
  public:
-  void NodeEvaluated(Node* n, const Value& v) override {
+  void NodeEvaluated(Node* n, const Value& v) final {
     values_.try_emplace(n).first->second.push_back(v);
   }
 

--- a/xls/interpreter/proc_interpreter.cc
+++ b/xls/interpreter/proc_interpreter.cc
@@ -50,7 +50,7 @@ namespace xls {
 namespace {
 
 // A continuation used by the ProcInterpreter.
-class ProcInterpreterContinuation : public ProcContinuation {
+class ProcInterpreterContinuation final : public ProcContinuation {
  public:
   // Construct a new continuation. Execution the proc begins with the state set
   // to its initial values with no proc nodes yet executed.
@@ -62,19 +62,19 @@ class ProcInterpreterContinuation : public ProcContinuation {
     }
   }
 
-  ~ProcInterpreterContinuation() override = default;
+  ~ProcInterpreterContinuation() final = default;
 
   std::vector<Value> GetState() const override { return state_; }
 
-  absl::Status SetState(std::vector<Value> v) override {
+  absl::Status SetState(std::vector<Value> v) final {
     XLS_RETURN_IF_ERROR(CheckConformsToStateType(v));
     state_ = std::move(v);
     return absl::OkStatus();
   }
 
   const InterpreterEvents& GetEvents() const override { return events_; }
-  InterpreterEvents& GetEvents() override { return events_; }
-  void ClearEvents() override { events_.Clear(); }
+  InterpreterEvents& GetEvents() final { return events_; }
+  void ClearEvents() final { events_.Clear(); }
   bool AtStartOfTick() const override { return node_index_ == 0; }
 
   const absl::flat_hash_map<StateElement*, std::vector<Next*>>&
@@ -140,7 +140,7 @@ class ProcIrInterpreter : public IrInterpreter {
         queue_manager_(queue_manager),
         active_next_values_(active_next_values) {}
 
-  absl::Status HandleReceive(Receive* receive) override {
+  absl::Status HandleReceive(Receive* receive) final {
     XLS_ASSIGN_OR_RETURN(ChannelQueue * queue,
                          GetChannelQueue(receive->channel_name()));
 
@@ -174,7 +174,7 @@ class ProcIrInterpreter : public IrInterpreter {
         receive, Value::Tuple({Value::Token(), *value, Value(UBits(1, 1))}));
   }
 
-  absl::Status HandleSend(Send* send) override {
+  absl::Status HandleSend(Send* send) final {
     XLS_ASSIGN_OR_RETURN(ChannelQueue * queue,
                          GetChannelQueue(send->channel_name()));
     if (send->predicate().has_value()) {
@@ -192,7 +192,7 @@ class ProcIrInterpreter : public IrInterpreter {
     return SetValueResult(send, Value::Token());
   }
 
-  absl::Status HandleStateRead(StateRead* state_read) override {
+  absl::Status HandleStateRead(StateRead* state_read) final {
     XLS_ASSIGN_OR_RETURN(
         int64_t index,
         state_read->function_base()->AsProcOrDie()->GetStateElementIndex(
@@ -200,7 +200,7 @@ class ProcIrInterpreter : public IrInterpreter {
     return SetValueResult(state_read, state_[index]);
   }
 
-  absl::Status HandleNext(Next* next) override {
+  absl::Status HandleNext(Next* next) final {
     if (next->predicate().has_value()) {
       Value predicate = ResolveAsValue(*next->predicate());
       XLS_RET_CHECK(predicate.IsBits());

--- a/xls/interpreter/proc_runtime.cc
+++ b/xls/interpreter/proc_runtime.cc
@@ -48,14 +48,14 @@
 namespace xls {
 
 // Functor for recording channel activity as trace messages.
-class ChannelTraceRecorder : public ChannelQueueCallback {
+class ChannelTraceRecorder final : public ChannelQueueCallback {
  public:
   ChannelTraceRecorder(ProcRuntime* runtime, FormatPreference format_preference)
       : runtime_(runtime), format_preference_(format_preference) {}
-  ~ChannelTraceRecorder() override = default;
+  ~ChannelTraceRecorder() final = default;
 
   void ReadValue(ChannelInstance* channel_instance,
-                 const Value& value) override {
+                 const Value& value) final {
     std::string message = absl::StrFormat("Received data on channel `%s`: %s",
                                           channel_instance->ToString(),
                                           value.ToString(format_preference_));
@@ -65,7 +65,7 @@ class ChannelTraceRecorder : public ChannelQueueCallback {
   }
 
   void WriteValue(ChannelInstance* channel_instance,
-                  const Value& value) override {
+                  const Value& value) final {
     std::string message = absl::StrFormat("Sent data on channel `%s`: %s",
                                           channel_instance->ToString(),
                                           value.ToString(format_preference_));

--- a/xls/ir/block_elaboration.cc
+++ b/xls/ir/block_elaboration.cc
@@ -916,7 +916,7 @@ absl::Status BlockElaboration::Accept(
     //
     // Create a separate trivial DFS visitor to find the cycle.
     class CycleChecker : public ElaboratedBlockDfsVisitorWithDefault {
-      absl::Status DefaultHandler(const ElaboratedNode& node) override {
+      absl::Status DefaultHandler(const ElaboratedNode& node) final {
         return absl::OkStatus();
       }
     };
@@ -1081,7 +1081,7 @@ std::vector<ElaboratedNode> ElaboratedReverseTopoSort(
     // trivial DFS visitor which will emit an error message displaying the
     // cycle.
     class CycleChecker : public ElaboratedBlockDfsVisitorWithDefault {
-      absl::Status DefaultHandler(const ElaboratedNode& node) override {
+      absl::Status DefaultHandler(const ElaboratedNode& node) final {
         return absl::OkStatus();
       }
     };

--- a/xls/ir/block_elaboration_test.cc
+++ b/xls/ir/block_elaboration_test.cc
@@ -287,7 +287,7 @@ TEST_F(ElaborationTest, ElaborateFifoInstantiation) {
 class RecordingVisitor : public ElaboratedBlockDfsVisitorWithDefault {
  public:
   absl::Status DefaultHandler(
-      const ElaboratedNode& node_and_instance) override {
+      const ElaboratedNode& node_and_instance) final {
     ordered_.push_back(node_and_instance);
     return absl::OkStatus();
   }

--- a/xls/ir/dfs_visitor_test.cc
+++ b/xls/ir/dfs_visitor_test.cc
@@ -37,7 +37,7 @@ namespace {
 // A testing visitor which records which nodes it has visited.
 class TestVisitor : public DfsVisitorWithDefault {
  public:
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     VLOG(1) << "Visiting " << node->GetName();
     visited_.push_back(node);
     visited_set_.insert(node);

--- a/xls/ir/elaborated_block_dfs_visitor_test.cc
+++ b/xls/ir/elaborated_block_dfs_visitor_test.cc
@@ -56,7 +56,7 @@ absl::StatusOr<BlockElaboration> ParseAndElaborate(std::string_view ir,
 // A testing visitor which records which nodes it has visited.
 class TestVisitor : public ElaboratedBlockDfsVisitorWithDefault {
  public:
-  absl::Status DefaultHandler(const ElaboratedNode& node) override {
+  absl::Status DefaultHandler(const ElaboratedNode& node) final {
     VLOG(1) << "Visiting " << node.ToString();
     visited_.push_back(node);
     visited_set_.insert(node);

--- a/xls/ir/function_base.cc
+++ b/xls/ir/function_base.cc
@@ -184,7 +184,7 @@ absl::Status FunctionBase::Accept(DfsVisitor* visitor) {
     // Not all nodes were visited. This indicates a cycle. Create a separate
     // trivial DFS visitor to find the cycle.
     class CycleChecker : public DfsVisitorWithDefault {
-      absl::Status DefaultHandler(Node* node) override {
+      absl::Status DefaultHandler(Node* node) final {
         return absl::OkStatus();
       }
     };

--- a/xls/ir/function_test.cc
+++ b/xls/ir/function_test.cc
@@ -392,7 +392,7 @@ TEST_F(FunctionTest, IrReservedWordIdentifiers) {
 
 class TestVisitor : public DfsVisitorWithDefault {
  public:
-  absl::Status DefaultHandler(Node* node) override { return absl::OkStatus(); }
+  absl::Status DefaultHandler(Node* node) final { return absl::OkStatus(); }
 };
 
 TEST_F(FunctionTest, GraphWithCycle) {

--- a/xls/ir/instantiation.h
+++ b/xls/ir/instantiation.h
@@ -111,11 +111,11 @@ class BlockInstantiation : public Instantiation {
   absl::StatusOr<InstantiationType> type() const override;
 
   absl::StatusOr<InstantiationPort> GetInputPort(
-      std::string_view name) override;
+      std::string_view name) final;
   absl::StatusOr<InstantiationPort> GetOutputPort(
-      std::string_view name) override;
+      std::string_view name) final;
 
-  absl::StatusOr<BlockInstantiation*> AsBlockInstantiation() override {
+  absl::StatusOr<BlockInstantiation*> AsBlockInstantiation() final {
     return this;
   }
 
@@ -136,7 +136,7 @@ class ExternInstantiation : public Instantiation {
   std::string ToString() const final;
   absl::StatusOr<InstantiationType> type() const override;
 
-  absl::StatusOr<ExternInstantiation*> AsExternInstantiation() override {
+  absl::StatusOr<ExternInstantiation*> AsExternInstantiation() final {
     return this;
   }
 
@@ -169,7 +169,7 @@ class FifoInstantiation : public Instantiation {
 
   std::string ToString() const final;
 
-  absl::StatusOr<FifoInstantiation*> AsFifoInstantiation() override {
+  absl::StatusOr<FifoInstantiation*> AsFifoInstantiation() final {
     return this;
   }
 
@@ -212,7 +212,7 @@ class DelayLineInstantiation : public Instantiation {
 
   std::string ToString() const final;
 
-  absl::StatusOr<DelayLineInstantiation*> AsDelayLineInstantiation() override {
+  absl::StatusOr<DelayLineInstantiation*> AsDelayLineInstantiation() final {
     return this;
   }
 

--- a/xls/ir/node_util.cc
+++ b/xls/ir/node_util.cc
@@ -913,7 +913,7 @@ class NodeSearch : public DfsVisitorWithDefault {
  public:
   explicit NodeSearch(Node* target) : target_(target) {}
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     if (node == target_) {
       // We've found our target, and can cancel the search. (This causes
       // Node::Accept to return early, since we've already accomplished our

--- a/xls/ir/proc_test.cc
+++ b/xls/ir/proc_test.cc
@@ -413,18 +413,18 @@ TEST_F(ProcTest, TransformStateElement) {
    public:
     absl::StatusOr<Node*> TransformStateRead(
         Proc* proc, StateRead* new_state_read,
-        StateRead* old_state_read) override {
+        StateRead* old_state_read) final {
       return proc->MakeNode<UnOp>(new_state_read->loc(), new_state_read,
                                   Op::kNeg);
     }
     absl::StatusOr<Node*> TransformNextValue(Proc* proc,
                                              StateRead* new_state_read,
-                                             Next* old_next) override {
+                                             Next* old_next) final {
       return proc->MakeNode<UnOp>(old_next->value()->loc(), old_next->value(),
                                   Op::kNeg);
     }
     absl::StatusOr<std::optional<Node*>> TransformNextPredicate(
-        Proc* proc, StateRead* new_state_read, Next* old_next) override {
+        Proc* proc, StateRead* new_state_read, Next* old_next) final {
       XLS_ASSIGN_OR_RETURN(
           Node * true_const,
           proc->MakeNode<Literal>(old_next->loc(), Value::Bool(true)));

--- a/xls/ir/proc_testutils.cc
+++ b/xls/ir/proc_testutils.cc
@@ -76,7 +76,7 @@ class UnrollProcVisitor final : public DfsVisitorWithDefault {
         activation_(activation),
         token_value_(std::move(token_value)) {}
 
-  absl::Status DefaultHandler(Node* n) override {
+  absl::Status DefaultHandler(Node* n) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     std::vector<Node*> new_ops;
     for (Node* old_op : n->operands()) {
@@ -92,7 +92,7 @@ class UnrollProcVisitor final : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleStateRead(StateRead* state_read) override {
+  absl::Status HandleStateRead(StateRead* state_read) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     if (state_read->GetType()->IsToken()) {
       values_[{state_read, activation_}] = fb_.Literal(token_value_);
@@ -104,7 +104,7 @@ class UnrollProcVisitor final : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSend(Send* s) override {
+  absl::Status HandleSend(Send* s) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     values_[{s, activation_}] = fb_.Literal(token_value_);
     BValue predicate_value;
@@ -122,12 +122,12 @@ class UnrollProcVisitor final : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNext(Next* n) override {
+  absl::Status HandleNext(Next* n) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     return absl::OkStatus();
   }
 
-  absl::Status HandleReceive(Receive* r) override {
+  absl::Status HandleReceive(Receive* r) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     BValue real_data;
     if (recv_state_.contains({r->channel_name(), activation_})) {
@@ -158,16 +158,16 @@ class UnrollProcVisitor final : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAssert(Assert* a) override {
+  absl::Status HandleAssert(Assert* a) final {
     return absl::UnimplementedError(
         "UnrollProcVisitor: assert is not supported");
   }
-  absl::Status HandleCover(Cover* c) override {
+  absl::Status HandleCover(Cover* c) final {
     return absl::UnimplementedError(
         "UnrollProcVisitor: cover is not supported");
   }
 
-  absl::Status HandleAfterAll(AfterAll* aa) override {
+  absl::Status HandleAfterAll(AfterAll* aa) final {
     XLS_RETURN_IF_ERROR(fb_.GetError());
     // TODO: https://github.com/google/xls/issues/1375 - It would be nice to
     // record this for real. The issue is that we'd need to figure out some way

--- a/xls/ir/topo_sort.cc
+++ b/xls/ir/topo_sort.cc
@@ -177,7 +177,7 @@ std::vector<Node*> ReverseTopoSort(FunctionBase* f,
     // trivial DFS visitor which will emit an error message displaying the
     // cycle.
     class CycleChecker : public DfsVisitorWithDefault {
-      absl::Status DefaultHandler(Node* node) override {
+      absl::Status DefaultHandler(Node* node) final {
         return absl::OkStatus();
       }
     };

--- a/xls/ir/verifier.cc
+++ b/xls/ir/verifier.cc
@@ -125,7 +125,7 @@ absl::Status VerifyFunctionBase(FunctionBase* function) {
 
   // Verify that there are no cycles in the node graph.
   class CycleChecker : public DfsVisitorWithDefault {
-    absl::Status DefaultHandler(Node* node) override {
+    absl::Status DefaultHandler(Node* node) final {
       return absl::OkStatus();
     }
   };
@@ -1036,7 +1036,7 @@ absl::Status VerifyBlock(Block* block, bool codegen) {
   // for cycles through instantiations. We elaborate and use a visitor on the
   // elaboration to look for more cycles through the hierarchy.
   class CycleChecker : public ElaboratedBlockDfsVisitorWithDefault {
-    absl::Status DefaultHandler(const ElaboratedNode& node) override {
+    absl::Status DefaultHandler(const ElaboratedNode& node) final {
       return absl::OkStatus();
     }
   };

--- a/xls/ir/verify_node.cc
+++ b/xls/ir/verify_node.cc
@@ -46,30 +46,30 @@ namespace {
 // operands and the type of the result.
 class NodeChecker : public DfsVisitor {
  public:
-  absl::Status HandleAdd(BinOp* add) override {
+  absl::Status HandleAdd(BinOp* add) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(add, 2));
     return ExpectAllSameBitsType(add);
   }
 
-  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) override {
+  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(and_reduce, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(and_reduce, 0));
     return ExpectHasBitsType(and_reduce, 1);
   }
 
-  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) override {
+  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(or_reduce, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(or_reduce, 0));
     return ExpectHasBitsType(or_reduce, 1);
   }
 
-  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) override {
+  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(xor_reduce, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(xor_reduce, 0));
     return ExpectHasBitsType(xor_reduce, 1);
   }
 
-  absl::Status HandleAssert(Assert* assert_op) override {
+  absl::Status HandleAssert(Assert* assert_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(assert_op, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(assert_op, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(assert_op, /*operand_no=*/1,
@@ -77,7 +77,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectHasTokenType(assert_op);
   }
 
-  absl::Status HandleTrace(Trace* trace_op) override {
+  absl::Status HandleTrace(Trace* trace_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(trace_op, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(trace_op, /*operand_no=*/1,
                                                  /*expected_bit_count=*/1));
@@ -89,29 +89,29 @@ class NodeChecker : public DfsVisitor {
     return ExpectHasTokenType(trace_op);
   }
 
-  absl::Status HandleCover(Cover* cover) override {
+  absl::Status HandleCover(Cover* cover) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(cover, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(cover, /*operand_no=*/0,
                                                  /*expected_bit_count=*/1));
     return ExpectHasTupleType(cover);
   }
 
-  absl::Status HandleNaryAnd(NaryOp* and_op) override {
+  absl::Status HandleNaryAnd(NaryOp* and_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(and_op, 0));
     return ExpectAllSameBitsType(and_op);
   }
 
-  absl::Status HandleNaryNand(NaryOp* nand_op) override {
+  absl::Status HandleNaryNand(NaryOp* nand_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(nand_op, 0));
     return ExpectAllSameBitsType(nand_op);
   }
 
-  absl::Status HandleNaryNor(NaryOp* nor_op) override {
+  absl::Status HandleNaryNor(NaryOp* nor_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(nor_op, 0));
     return ExpectAllSameBitsType(nor_op);
   }
 
-  absl::Status HandleAfterAll(AfterAll* after_all) override {
+  absl::Status HandleAfterAll(AfterAll* after_all) final {
     XLS_RETURN_IF_ERROR(ExpectHasTokenType(after_all));
     for (int64_t i = 0; i < after_all->operand_count(); ++i) {
       XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(after_all, i));
@@ -119,7 +119,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleMinDelay(MinDelay* min_delay) override {
+  absl::Status HandleMinDelay(MinDelay* min_delay) final {
     XLS_RETURN_IF_ERROR(ExpectHasTokenType(min_delay));
     XLS_RETURN_IF_ERROR(ExpectOperandCount(min_delay, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(min_delay, /*operand_no=*/0));
@@ -130,7 +130,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleReceive(Receive* receive) override {
+  absl::Status HandleReceive(Receive* receive) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountRange(receive, 1, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(receive, /*operand_no=*/0));
     if (receive->predicate().has_value()) {
@@ -186,7 +186,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSend(Send* send) override {
+  absl::Status HandleSend(Send* send) final {
     XLS_RETURN_IF_ERROR(ExpectHasTokenType(send));
     XLS_RETURN_IF_ERROR(ExpectOperandCountRange(send, 2, 3));
     XLS_RETURN_IF_ERROR(ExpectOperandHasTokenType(send, /*operand_no=*/0));
@@ -235,7 +235,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArray(Array* array) override {
+  absl::Status HandleArray(Array* array) final {
     XLS_RETURN_IF_ERROR(ExpectHasArrayType(array));
     ArrayType* array_type = array->GetType()->AsArrayOrDie();
     XLS_RETURN_IF_ERROR(ExpectOperandCount(array, array_type->size()));
@@ -246,7 +246,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleBitSlice(BitSlice* bit_slice) override {
+  absl::Status HandleBitSlice(BitSlice* bit_slice) final {
     XLS_RETURN_IF_ERROR(ExpectHasBitsType(bit_slice, bit_slice->width()));
     XLS_RETURN_IF_ERROR(ExpectOperandCount(bit_slice, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(bit_slice, 0));
@@ -274,7 +274,7 @@ class NodeChecker : public DfsVisitor {
   }
 
   absl::Status HandleDynamicBitSlice(
-      DynamicBitSlice* dynamic_bit_slice) override {
+      DynamicBitSlice* dynamic_bit_slice) final {
     XLS_RETURN_IF_ERROR(
         ExpectHasBitsType(dynamic_bit_slice, dynamic_bit_slice->width()));
     XLS_RETURN_IF_ERROR(ExpectOperandCount(dynamic_bit_slice, 2));
@@ -298,7 +298,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) override {
+  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) final {
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(update, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(update, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(update, 2));
@@ -307,7 +307,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleConcat(Concat* concat) override {
+  absl::Status HandleConcat(Concat* concat) final {
     // All operands should be bits types.
     int64_t total_bits = 0;
     for (int64_t i = 0; i < concat->operand_count(); ++i) {
@@ -318,7 +318,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectHasBitsType(concat, /*expected_bit_count=*/total_bits);
   }
 
-  absl::Status HandleCountedFor(CountedFor* counted_for) override {
+  absl::Status HandleCountedFor(CountedFor* counted_for) final {
     XLS_RET_CHECK_GE(counted_for->trip_count(), 0);
     if (counted_for->operand_count() == 0) {
       return absl::InternalError(absl::StrFormat(
@@ -402,7 +402,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectOperandHasType(counted_for, 0, counted_for->GetType());
   }
 
-  absl::Status HandleDecode(Decode* decode) override {
+  absl::Status HandleDecode(Decode* decode) final {
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(decode, 0));
     XLS_RETURN_IF_ERROR(ExpectHasBitsType(decode, decode->width()));
     // The width of the decode output must be less than or equal to
@@ -419,7 +419,7 @@ class NodeChecker : public DfsVisitor {
   }
 
   absl::Status HandleDynamicCountedFor(
-      DynamicCountedFor* dynamic_counted_for) override {
+      DynamicCountedFor* dynamic_counted_for) final {
     Function* body = dynamic_counted_for->body();
     // Verify function has signature
     //  body(i: bits[N], loop_carry_data: T, [inv_arg0, ..., inv_argN]) -> T
@@ -522,69 +522,69 @@ class NodeChecker : public DfsVisitor {
                                 dynamic_counted_for->GetType());
   }
 
-  absl::Status HandleEncode(Encode* encode) override {
+  absl::Status HandleEncode(Encode* encode) final {
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(encode, 0));
     // Width of the encode output must be ceil(log_2(max_input + 1)).
     return ExpectHasBitsType(encode,
                              CeilOfLog2(encode->operand(0)->BitCountOrDie()));
   }
 
-  absl::Status HandleUDiv(BinOp* div) override {
+  absl::Status HandleUDiv(BinOp* div) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(div, 2));
     return ExpectAllSameBitsType(div);
   }
 
-  absl::Status HandleSDiv(BinOp* div) override {
+  absl::Status HandleSDiv(BinOp* div) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(div, 2));
     return ExpectAllSameBitsType(div);
   }
 
-  absl::Status HandleUMod(BinOp* mod) override {
+  absl::Status HandleUMod(BinOp* mod) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mod, 2));
     return ExpectAllSameBitsType(mod);
   }
 
-  absl::Status HandleSMod(BinOp* mod) override {
+  absl::Status HandleSMod(BinOp* mod) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mod, 2));
     return ExpectAllSameBitsType(mod);
   }
 
-  absl::Status HandleEq(CompareOp* eq) override {
+  absl::Status HandleEq(CompareOp* eq) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(eq, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsSameTypeNoToken(eq));
     return ExpectHasBitsType(eq, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleUGe(CompareOp* ge) override {
+  absl::Status HandleUGe(CompareOp* ge) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(ge, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(ge));
     return ExpectHasBitsType(ge, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleUGt(CompareOp* gt) override {
+  absl::Status HandleUGt(CompareOp* gt) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(gt, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(gt));
     return ExpectHasBitsType(gt, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleSGe(CompareOp* ge) override {
+  absl::Status HandleSGe(CompareOp* ge) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(ge, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(ge));
     return ExpectHasBitsType(ge, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleSGt(CompareOp* gt) override {
+  absl::Status HandleSGt(CompareOp* gt) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(gt, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(gt));
     return ExpectHasBitsType(gt, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleIdentity(UnOp* identity) override {
+  absl::Status HandleIdentity(UnOp* identity) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(identity, 1));
     return ExpectAllSameType(identity);
   }
 
-  absl::Status HandleArrayIndex(ArrayIndex* index) override {
+  absl::Status HandleArrayIndex(ArrayIndex* index) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(index, 0));
     XLS_RETURN_IF_ERROR(VerifyMultidimensionalArrayIndex(
         index->indices(), index->array()->GetType(), index));
@@ -600,7 +600,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArraySlice(ArraySlice* slice) override {
+  absl::Status HandleArraySlice(ArraySlice* slice) final {
     Node* array = slice->array();
     int64_t width = slice->width();
     XLS_RETURN_IF_ERROR(ExpectOperandHasArrayType(slice, 0));
@@ -619,7 +619,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArrayUpdate(ArrayUpdate* update) override {
+  absl::Status HandleArrayUpdate(ArrayUpdate* update) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(update, 1));
     XLS_RETURN_IF_ERROR(
         ExpectSameType(update, update->GetType(), update->array_to_update(),
@@ -643,7 +643,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArrayConcat(ArrayConcat* array_concat) override {
+  absl::Status HandleArrayConcat(ArrayConcat* array_concat) final {
     // Must have at least one operand
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(array_concat, 0));
 
@@ -678,7 +678,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectHasArrayType(array_concat, zeroth_element_type, size);
   }
 
-  absl::Status HandleInvoke(Invoke* invoke) override {
+  absl::Status HandleInvoke(Invoke* invoke) final {
     // Verify the signature (inputs and output) of the invoked function matches
     // the Invoke node.
     Function* func = invoke->to_apply();
@@ -707,36 +707,36 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleLiteral(Literal* literal) override {
+  absl::Status HandleLiteral(Literal* literal) final {
     // Verify type matches underlying Value object.
     XLS_RETURN_IF_ERROR(ExpectOperandCount(literal, 0));
     return ExpectValueIsType(literal->value(), literal->GetType());
   }
 
-  absl::Status HandleULe(CompareOp* le) override {
+  absl::Status HandleULe(CompareOp* le) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(le, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(le));
     return ExpectHasBitsType(le, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleULt(CompareOp* lt) override {
+  absl::Status HandleULt(CompareOp* lt) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(lt, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(lt));
     return ExpectHasBitsType(lt, /*expected_bit_count=*/1);
   }
-  absl::Status HandleSLe(CompareOp* le) override {
+  absl::Status HandleSLe(CompareOp* le) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(le, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(le));
     return ExpectHasBitsType(le, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleSLt(CompareOp* lt) override {
+  absl::Status HandleSLt(CompareOp* lt) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(lt, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsAreBitsAndSameWidth(lt));
     return ExpectHasBitsType(lt, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleMap(Map* map) override {
+  absl::Status HandleMap(Map* map) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(map, 1));
     XLS_RETURN_IF_ERROR(ExpectHasArrayType(map));
     XLS_RETURN_IF_ERROR(ExpectHasArrayType(map->operand(0)));
@@ -762,21 +762,21 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleSMul(ArithOp* mul) override {
+  absl::Status HandleSMul(ArithOp* mul) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mul, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 1));
     return ExpectHasBitsType(mul);
   }
 
-  absl::Status HandleUMul(ArithOp* mul) override {
+  absl::Status HandleUMul(ArithOp* mul) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mul, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 1));
     return ExpectHasBitsType(mul);
   }
 
-  absl::Status HandleSMulp(PartialProductOp* mul) override {
+  absl::Status HandleSMulp(PartialProductOp* mul) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mul, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 1));
@@ -805,7 +805,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleUMulp(PartialProductOp* mul) override {
+  absl::Status HandleUMulp(PartialProductOp* mul) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(mul, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 0));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(mul, 1));
@@ -834,23 +834,23 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNe(CompareOp* ne) override {
+  absl::Status HandleNe(CompareOp* ne) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(ne, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandsSameTypeNoToken(ne));
     return ExpectHasBitsType(ne, /*expected_bit_count=*/1);
   }
 
-  absl::Status HandleNeg(UnOp* neg) override {
+  absl::Status HandleNeg(UnOp* neg) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(neg, 1));
     return ExpectAllSameBitsType(neg);
   }
 
-  absl::Status HandleNot(UnOp* not_op) override {
+  absl::Status HandleNot(UnOp* not_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(not_op, 1));
     return ExpectAllSameBitsType(not_op);
   }
 
-  absl::Status HandleOneHot(OneHot* one_hot) override {
+  absl::Status HandleOneHot(OneHot* one_hot) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(one_hot, 1));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(one_hot, 0));
     int64_t operand_bit_count = one_hot->operand(0)->BitCountOrDie();
@@ -859,7 +859,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectHasBitsType(one_hot, operand_bit_count + 1);
   }
 
-  absl::Status HandleOneHotSel(OneHotSelect* sel) override {
+  absl::Status HandleOneHotSel(OneHotSelect* sel) final {
     if (sel->operand_count() < 2) {
       return absl::InternalError(absl::StrFormat(
           "Expected %s to have at least 2 operands", sel->GetName()));
@@ -888,7 +888,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandlePrioritySel(PrioritySelect* sel) override {
+  absl::Status HandlePrioritySel(PrioritySelect* sel) final {
     if (sel->operand_count() < 2) {
       return absl::InternalError(absl::StrFormat(
           "Expected %s to have at least 3 operands", sel->GetName()));
@@ -927,17 +927,17 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNaryOr(NaryOp* or_op) override {
+  absl::Status HandleNaryOr(NaryOp* or_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(or_op, 0));
     return ExpectAllSameBitsType(or_op);
   }
 
-  absl::Status HandleNaryXor(NaryOp* xor_op) override {
+  absl::Status HandleNaryXor(NaryOp* xor_op) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountGt(xor_op, 0));
     return ExpectAllSameBitsType(xor_op);
   }
 
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     if (param->function_base()->IsProc()) {
       return absl::InternalError(
           absl::StrFormat("Param node %s is in a proc", param->GetName()));
@@ -945,7 +945,7 @@ class NodeChecker : public DfsVisitor {
     return ExpectOperandCount(param, 0);
   }
 
-  absl::Status HandleStateRead(StateRead* state_read) override {
+  absl::Status HandleStateRead(StateRead* state_read) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountRange(state_read, 0, 1));
     if (state_read->predicate().has_value()) {
       XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(state_read, /*operand_no=*/0,
@@ -964,7 +964,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleNext(Next* next) override {
+  absl::Status HandleNext(Next* next) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCountRange(next, 2, 3));
     if (!next->state_read()->Is<StateRead>()) {
       return absl::InternalError(
@@ -991,12 +991,12 @@ class NodeChecker : public DfsVisitor {
                                 proc->GetStateElementType(index));
   }
 
-  absl::Status HandleReverse(UnOp* reverse) override {
+  absl::Status HandleReverse(UnOp* reverse) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(reverse, 1));
     return ExpectAllSameBitsType(reverse);
   }
 
-  absl::Status HandleSel(Select* sel) override {
+  absl::Status HandleSel(Select* sel) final {
     if (sel->operand_count() < 2) {
       return absl::InternalError(absl::StrFormat(
           "Expected %s to have at least 2 operands", sel->GetName()));
@@ -1053,18 +1053,18 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleShll(BinOp* shll) override { return HandleShiftOp(shll); }
+  absl::Status HandleShll(BinOp* shll) final { return HandleShiftOp(shll); }
 
-  absl::Status HandleShra(BinOp* shra) override { return HandleShiftOp(shra); }
+  absl::Status HandleShra(BinOp* shra) final { return HandleShiftOp(shra); }
 
-  absl::Status HandleShrl(BinOp* shrl) override { return HandleShiftOp(shrl); }
+  absl::Status HandleShrl(BinOp* shrl) final { return HandleShiftOp(shrl); }
 
-  absl::Status HandleSub(BinOp* sub) override {
+  absl::Status HandleSub(BinOp* sub) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(sub, 2));
     return ExpectAllSameBitsType(sub);
   }
 
-  absl::Status HandleTuple(Tuple* tuple) override {
+  absl::Status HandleTuple(Tuple* tuple) final {
     XLS_RETURN_IF_ERROR(ExpectHasTupleType(tuple));
     if (!tuple->GetType()->IsTuple()) {
       return absl::InternalError(absl::StrFormat(
@@ -1083,7 +1083,7 @@ class NodeChecker : public DfsVisitor {
     return absl::OkStatus();
   }
 
-  absl::Status HandleTupleIndex(TupleIndex* index) override {
+  absl::Status HandleTupleIndex(TupleIndex* index) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(index, 1));
     XLS_RETURN_IF_ERROR(ExpectHasTupleType(index->operand(0)));
     TupleType* operand_type = index->operand(0)->GetType()->AsTupleOrDie();
@@ -1098,31 +1098,31 @@ class NodeChecker : public DfsVisitor {
                           "tuple operand element type");
   }
 
-  absl::Status HandleSignExtend(ExtendOp* sign_ext) override {
+  absl::Status HandleSignExtend(ExtendOp* sign_ext) final {
     return HandleExtendOp(sign_ext, /*nonempty_input=*/true);
   }
-  absl::Status HandleZeroExtend(ExtendOp* zero_ext) override {
+  absl::Status HandleZeroExtend(ExtendOp* zero_ext) final {
     return HandleExtendOp(zero_ext, /*nonempty_input=*/false);
   }
 
-  absl::Status HandleInputPort(InputPort* input_port) override {
+  absl::Status HandleInputPort(InputPort* input_port) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(input_port, 0));
     return absl::OkStatus();
   }
 
-  absl::Status HandleOutputPort(OutputPort* output_port) override {
+  absl::Status HandleOutputPort(OutputPort* output_port) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(output_port, 1));
     XLS_RETURN_IF_ERROR(ExpectHasEmptyTupleType(output_port));
     return absl::OkStatus();
   }
 
-  absl::Status HandleRegisterRead(RegisterRead* reg_read) override {
+  absl::Status HandleRegisterRead(RegisterRead* reg_read) final {
     XLS_RETURN_IF_ERROR(
         ExpectHasType(reg_read, reg_read->GetRegister()->type()));
     return absl::OkStatus();
   }
 
-  absl::Status HandleRegisterWrite(RegisterWrite* reg_write) override {
+  absl::Status HandleRegisterWrite(RegisterWrite* reg_write) final {
     XLS_RETURN_IF_ERROR(
         ExpectOperandHasType(reg_write, 0, reg_write->GetRegister()->type()));
     if (reg_write->GetRegister()->reset_value().has_value() &&
@@ -1161,19 +1161,19 @@ class NodeChecker : public DfsVisitor {
   }
 
   absl::Status HandleInstantiationInput(
-      InstantiationInput* instantiation_input) override {
+      InstantiationInput* instantiation_input) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(instantiation_input, 1));
     XLS_RETURN_IF_ERROR(ExpectHasEmptyTupleType(instantiation_input));
     return absl::OkStatus();
   }
 
   absl::Status HandleInstantiationOutput(
-      InstantiationOutput* instantiation_output) override {
+      InstantiationOutput* instantiation_output) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(instantiation_output, 0));
     return absl::OkStatus();
   }
 
-  absl::Status HandleGate(Gate* gate) override {
+  absl::Status HandleGate(Gate* gate) final {
     XLS_RETURN_IF_ERROR(ExpectOperandCount(gate, 2));
     XLS_RETURN_IF_ERROR(ExpectOperandHasBitsType(gate, /*operand_no=*/0,
                                                  /*expected_bit_count=*/1));

--- a/xls/jit/aot_compiler.h
+++ b/xls/jit/aot_compiler.h
@@ -37,13 +37,13 @@ class AotCompiler final : public LlvmCompiler {
       bool include_msan, int64_t opt_level = LlvmCompiler::kDefaultOptLevel,
       JitObserver* observer = nullptr);
 
-  absl::StatusOr<AotCompiler*> AsAotCompiler() override { return this; }
+  absl::StatusOr<AotCompiler*> AsAotCompiler() final { return this; }
 
   // Compiles the given LLVM module into object code.
-  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) override;
+  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) final;
 
   // Return the underlying LLVM context.
-  llvm::LLVMContext* GetContext() override { return context_.get(); }
+  llvm::LLVMContext* GetContext() final { return context_.get(); }
 
   absl::StatusOr<std::unique_ptr<llvm::TargetMachine>> CreateTargetMachine()
       override;
@@ -63,7 +63,7 @@ class AotCompiler final : public LlvmCompiler {
   }
 
  protected:
-  absl::Status InitInternal() override;
+  absl::Status InitInternal() final;
 
  private:
   // TODO(https://github.com/google/xls/issues/1639): It would be nice to

--- a/xls/jit/aot_compiler_main.cc
+++ b/xls/jit/aot_compiler_main.cc
@@ -101,18 +101,18 @@ class IntermediatesObserver final : public JitObserver {
     return requests_;
   }
   // Called when a LLVM module has been created and is ready for optimization
-  void UnoptimizedModule(const llvm::Module* module) override {
+  void UnoptimizedModule(const llvm::Module* module) final {
     llvm::raw_string_ostream ostream(unoptimized_);
     module->print(ostream, nullptr);
   }
   // Called when a LLVM module has been created and is ready for codegen
-  void OptimizedModule(const llvm::Module* module) override {
+  void OptimizedModule(const llvm::Module* module) final {
     llvm::raw_string_ostream ostream(optimized_);
     module->print(ostream, nullptr);
   }
   // Called when a LLVM module has been compiled with the asm code.
   void AssemblyCodeString(const llvm::Module* module,
-                          std::string_view asm_code) override {
+                          std::string_view asm_code) final {
     asm_ = asm_code;
   }
 

--- a/xls/jit/block_jit.cc
+++ b/xls/jit/block_jit.cc
@@ -136,7 +136,7 @@ class ElaboratedBlockJitContinuation : public BlockJitContinuation {
     return base;
   }
   absl::Status SetRegisters(
-      const absl::flat_hash_map<std::string, Value>& regs) override {
+      const absl::flat_hash_map<std::string, Value>& regs) final {
     absl::flat_hash_map<std::string, Value> translated_regs = regs;
     for (const auto& [orig, rename] : reg_rename_map_) {
       if (auto node = translated_regs.extract(orig)) {
@@ -171,7 +171,7 @@ class ElaboratedBlockJitContinuation : public BlockJitContinuation {
 class ElaboratedBlockJit : public BlockJit {
  public:
   std::unique_ptr<BlockJitContinuation> NewContinuation(
-      BlockEvaluator::OutputPortSampleTime sample_time) override {
+      BlockEvaluator::OutputPortSampleTime sample_time) final {
     return std::make_unique<ElaboratedBlockJitContinuation>(
         metadata_, this, function_, reg_rename_map_, materialized_impl_regs_,
         sample_time);
@@ -832,11 +832,11 @@ class BlockContinuationJitWrapper final : public BlockContinuation {
     return continuation_->SetRegisters(regs);
   }
 
-  void ClearObserver() override {
+  void ClearObserver() final {
     continuation_->ClearObserver();
     eval_observer_.reset();
   }
-  absl::Status SetObserver(EvaluationObserver* obs) override {
+  absl::Status SetObserver(EvaluationObserver* obs) final {
     ClearObserver();
     std::optional<RuntimeObserver*> run = obs->AsRawObserver();
     if (run) {

--- a/xls/jit/function_jit_aot_test.cc
+++ b/xls/jit/function_jit_aot_test.cc
@@ -107,7 +107,7 @@ TEST(SymbolNames, AreAsExpected) {
 
 class FunctionJitAotTest : public testing::Test {
  protected:
-  void SetUp() override {
+  void SetUp() final {
     if (!AreSymbolsAsExpected()) {
       GTEST_SKIP() << "Linking probably failed. AOTEntrypoints lists "
                       "unexpected symbol names";

--- a/xls/jit/jit_channel_queue.h
+++ b/xls/jit/jit_channel_queue.h
@@ -130,7 +130,7 @@ class JitChannelQueue : public ChannelQueue {
 
 // A thread-safe version of the JIT channel queue. All accesses are guarded by a
 // mutex.
-class ThreadSafeJitChannelQueue : public JitChannelQueue {
+class ThreadSafeJitChannelQueue final : public JitChannelQueue {
  public:
   ThreadSafeJitChannelQueue(ChannelInstance* channel_instance,
                             JitRuntime* jit_runtime)
@@ -138,10 +138,10 @@ class ThreadSafeJitChannelQueue : public JitChannelQueue {
         byte_queue_(
             jit_runtime->GetTypeByteSize(channel_instance->channel->type()),
             channel_instance->channel->kind() == ChannelKind::kSingleValue) {}
-  ~ThreadSafeJitChannelQueue() override = default;
+  ~ThreadSafeJitChannelQueue() final = default;
 
   // Write raw bytes representing a value in LLVM's native format.
-  void WriteRaw(const uint8_t* data) override {
+  void WriteRaw(const uint8_t* data) final {
     absl::MutexLock lock(&mutex_);
     byte_queue_.Write(data);
     if (!callbacks_.empty()) {
@@ -151,7 +151,7 @@ class ThreadSafeJitChannelQueue : public JitChannelQueue {
 
   // Reads raw bytes representing a value in LLVM's native format. Returns
   // true if queue was not empty and data was read.
-  bool ReadRaw(uint8_t* buffer) override {
+  bool ReadRaw(uint8_t* buffer) final {
     absl::MutexLock lock(&mutex_);
     if (generator_.has_value()) {
       std::optional<Value> generated_value = (*generator_)();
@@ -167,17 +167,17 @@ class ThreadSafeJitChannelQueue : public JitChannelQueue {
   }
 
  protected:
-  int64_t GetSizeInternal() const ABSL_SHARED_LOCKS_REQUIRED(mutex_) override;
+  int64_t GetSizeInternal() const ABSL_SHARED_LOCKS_REQUIRED(mutex_) final;
   void WriteInternal(const Value& value)
-      ABSL_SHARED_LOCKS_REQUIRED(mutex_) override;
+      ABSL_SHARED_LOCKS_REQUIRED(mutex_) final;
   std::optional<Value> ReadInternal()
-      ABSL_SHARED_LOCKS_REQUIRED(mutex_) override;
+      ABSL_SHARED_LOCKS_REQUIRED(mutex_) final;
 
   ByteQueue byte_queue_ ABSL_GUARDED_BY(mutex_);
 };
 
 // A thread-unsafe version of the JIT channel queue.
-class ThreadUnsafeJitChannelQueue : public JitChannelQueue {
+class ThreadUnsafeJitChannelQueue final : public JitChannelQueue {
  public:
   ThreadUnsafeJitChannelQueue(ChannelInstance* channel_instance,
                               JitRuntime* jit_runtime)
@@ -185,15 +185,15 @@ class ThreadUnsafeJitChannelQueue : public JitChannelQueue {
         byte_queue_(
             jit_runtime->GetTypeByteSize(channel_instance->channel->type()),
             channel_instance->channel->kind() == ChannelKind::kSingleValue) {}
-  ~ThreadUnsafeJitChannelQueue() override = default;
+  ~ThreadUnsafeJitChannelQueue() final = default;
 
-  void WriteRaw(const uint8_t* data) override {
+  void WriteRaw(const uint8_t* data) final {
     byte_queue_.Write(data);
     if (!callbacks_.empty()) {
       CallWriteCallbacks(jit_runtime_->UnpackBuffer(data, channel()->type()));
     }
   }
-  bool ReadRaw(uint8_t* buffer) override {
+  bool ReadRaw(uint8_t* buffer) final {
     if (generator_.has_value()) {
       std::optional<Value> generated_value = (*generator_)();
       if (generated_value.has_value()) {
@@ -208,17 +208,17 @@ class ThreadUnsafeJitChannelQueue : public JitChannelQueue {
   }
 
  protected:
-  int64_t GetSizeInternal() const ABSL_SHARED_LOCKS_REQUIRED(mutex_) override;
-  void WriteInternal(const Value& value) override;
-  std::optional<Value> ReadInternal() override;
+  int64_t GetSizeInternal() const ABSL_SHARED_LOCKS_REQUIRED(mutex_) final;
+  void WriteInternal(const Value& value) final;
+  std::optional<Value> ReadInternal() final;
 
   ByteQueue byte_queue_;
 };
 
 // A Channel manager which holds exclusively JitChannelQueues.
-class JitChannelQueueManager : public ChannelQueueManager {
+class JitChannelQueueManager final : public ChannelQueueManager {
  public:
-  ~JitChannelQueueManager() override = default;
+  ~JitChannelQueueManager() final = default;
 
   // Factories which create a queue manager with exclusively ThreadSafe/Unsafe
   // queues.

--- a/xls/jit/jit_proc_runtime.cc
+++ b/xls/jit/jit_proc_runtime.cc
@@ -86,21 +86,21 @@ class SharedCompiler final : public LlvmCompiler {
   bool IsSharedCompilation() const override { return true; }
 
   // Share around the same module.
-  std::unique_ptr<llvm::Module> NewModule(std::string_view ignored) override {
+  std::unique_ptr<llvm::Module> NewModule(std::string_view ignored) final {
     CHECK(the_module_) << "no module to give out!";
     auto res = std::move(*the_module_);
     the_module_.reset();
     return res;
   }
 
-  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) override {
+  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) final {
     XLS_RET_CHECK(!the_module_) << "Already took back module.";
     the_module_ = std::move(module);
     return absl::OkStatus();
   }
 
   // Return the underlying LLVM context.
-  llvm::LLVMContext* GetContext() override { return underlying_->GetContext(); }
+  llvm::LLVMContext* GetContext() final { return underlying_->GetContext(); }
   absl::StatusOr<std::unique_ptr<llvm::TargetMachine>> CreateTargetMachine()
       override {
     return underlying_->CreateTargetMachine();
@@ -114,7 +114,7 @@ class SharedCompiler final : public LlvmCompiler {
   }
 
  protected:
-  absl::Status InitInternal() override {
+  absl::Status InitInternal() final {
     return absl::InternalError("Should not be called");
   }
 

--- a/xls/jit/observer.h
+++ b/xls/jit/observer.h
@@ -110,9 +110,9 @@ class RuntimeEvaluationObserverAdapter final
                                    JitRuntime* runtime)
       : RuntimeEvaluationObserver(to_node, runtime), real_(obs) {}
 
-  std::optional<RuntimeObserver*> AsRawObserver() override { return this; }
+  std::optional<RuntimeObserver*> AsRawObserver() final { return this; }
 
-  void NodeEvaluated(Node* n, const Value& v) override {
+  void NodeEvaluated(Node* n, const Value& v) final {
     real_->NodeEvaluated(n, v);
   }
 

--- a/xls/jit/orc_jit.cc
+++ b/xls/jit/orc_jit.cc
@@ -83,27 +83,27 @@ class UnsupportedExecutorProcessControl
   }
 
   llvm::Expected<int32_t> runAsMain(llvm::orc::ExecutorAddr MainFnAddr,
-                                    llvm::ArrayRef<std::string> Args) override {
+                                    llvm::ArrayRef<std::string> Args) final {
     llvm_unreachable("Unsupported");
   }
 
   llvm::Expected<int32_t> runAsVoidFunction(
-      llvm::orc::ExecutorAddr VoidFnAddr) override {
+      llvm::orc::ExecutorAddr VoidFnAddr) final {
     llvm_unreachable("Unsupported");
   }
 
   llvm::Expected<int32_t> runAsIntFunction(llvm::orc::ExecutorAddr IntFnAddr,
-                                           int Arg) override {
+                                           int Arg) final {
     llvm_unreachable("Unsupported");
   }
 
   void callWrapperAsync(llvm::orc::ExecutorAddr WrapperFnAddr,
                         IncomingWFRHandler OnComplete,
-                        llvm::ArrayRef<char> ArgBuffer) override {
+                        llvm::ArrayRef<char> ArgBuffer) final {
     llvm_unreachable("Unsupported");
   }
 
-  llvm::Error disconnect() override { return llvm::Error::success(); }
+  llvm::Error disconnect() final { return llvm::Error::success(); }
 };
 }  // namespace
 

--- a/xls/jit/orc_jit.h
+++ b/xls/jit/orc_jit.h
@@ -37,13 +37,13 @@
 namespace xls {
 // A wrapper around ORC JIT which hides some of the internals of the LLVM
 // interface.
-class OrcJit : public LlvmCompiler {
+class OrcJit final : public LlvmCompiler {
  public:
   static constexpr int64_t kDefaultOptLevel = 2;
 
-  ~OrcJit() override;
+  ~OrcJit() final;
 
-  absl::StatusOr<OrcJit*> AsOrcJit() override { return this; }
+  absl::StatusOr<OrcJit*> AsOrcJit() final { return this; }
 
   // Create an LLVM orc jit. This can be used by the AOT generator to manually
   // control whether asan calls should be included. Users other than the AOT
@@ -60,7 +60,7 @@ class OrcJit : public LlvmCompiler {
   JitObserver* jit_observer() const { return jit_observer_; }
 
   // Compiles the given LLVM module into the JIT's execution session.
-  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) override;
+  absl::Status CompileModule(std::unique_ptr<llvm::Module>&& module) final;
 
   // Returns the address of the given JIT'ed function.
   absl::StatusOr<llvm::orc::ExecutorAddr> LoadSymbol(
@@ -68,7 +68,7 @@ class OrcJit : public LlvmCompiler {
 
   // Return the underlying LLVM context.
   // TODO: b/430302945 - This is not thread safe!
-  llvm::LLVMContext* GetContext() override {
+  llvm::LLVMContext* GetContext() final {
     return context_.withContextDo([](llvm::LLVMContext* ctxt) { return ctxt; });
   }
 
@@ -76,7 +76,7 @@ class OrcJit : public LlvmCompiler {
       override;
 
  protected:
-  absl::Status InitInternal() override;
+  absl::Status InitInternal() final;
 
  private:
   OrcJit(int64_t opt_level, bool include_msan, bool include_observer_callbacks);

--- a/xls/jit/proc_jit.cc
+++ b/xls/jit/proc_jit.cc
@@ -61,7 +61,7 @@ namespace {
 
 // A continuation used by the ProcJit. Stores control and data state of proc
 // execution for the JIT.
-class ProcJitContinuation : public ProcContinuation {
+class ProcJitContinuation final : public ProcContinuation {
  public:
   // Construct a new continuation. Execution of the proc begins with the state
   // set to its initial values with no proc nodes yet executed. `queues` is the
@@ -74,13 +74,13 @@ class ProcJitContinuation : public ProcContinuation {
                                const JittedFunctionBase& jit_func,
                                bool has_observer_callbacks);
 
-  ~ProcJitContinuation() override = default;
+  ~ProcJitContinuation() final = default;
 
   std::vector<Value> GetState() const override;
-  absl::Status SetState(std::vector<Value> v) override;
+  absl::Status SetState(std::vector<Value> v) final;
   const InterpreterEvents& GetEvents() const override { return events_; }
-  InterpreterEvents& GetEvents() override { return events_; }
-  void ClearEvents() override { events_.Clear(); }
+  InterpreterEvents& GetEvents() final { return events_; }
+  void ClearEvents() final { events_.Clear(); }
 
   bool AtStartOfTick() const override { return continuation_point_ == 0; }
 
@@ -104,8 +104,8 @@ class ProcJitContinuation : public ProcContinuation {
 
   InstanceContext* instance_context() { return &instance_context_; }
 
-  absl::Status SetObserver(EvaluationObserver* obs) override;
-  void ClearObserver() override;
+  absl::Status SetObserver(EvaluationObserver* obs) final;
+  void ClearObserver() final;
   bool SupportsObservers() const override { return has_observer_callbacks_; }
 
  private:
@@ -113,7 +113,7 @@ class ProcJitContinuation : public ProcContinuation {
    public:
     explicit RuntimeObserverShim(ProcJitContinuation* owner) : owner_(owner) {}
 
-    void RecordNodeValue(int64_t node_ptr, const uint8_t* data) override {
+    void RecordNodeValue(int64_t node_ptr, const uint8_t* data) final {
       if (!owner_->GetObserver()) {
         return;
       }

--- a/xls/jit/proc_jit_aot_psc_test.cc
+++ b/xls/jit/proc_jit_aot_psc_test.cc
@@ -161,7 +161,7 @@ TEST(SymbolNames, AreAsExpected) {
 }
 
 class ProcJitAotPscTest : public testing::Test {
-  void SetUp() override {
+  void SetUp() final {
     if (!AreCapsSymbolsAsExpected() || !AreMultiSymbolsAsExpected()) {
       GTEST_SKIP() << "Linking probably failed. AOTEntrypoints lists "
                       "unexpected symbol names";

--- a/xls/jit/proc_jit_aot_test.cc
+++ b/xls/jit/proc_jit_aot_test.cc
@@ -160,7 +160,7 @@ TEST(SymbolNames, AreAsExpected) {
 }
 
 class ProcJitAotTest : public testing::Test {
-  void SetUp() override {
+  void SetUp() final {
     if (!AreCapsSymbolsAsExpected() || !AreMultiSymbolsAsExpected()) {
       GTEST_SKIP() << "Linking probably failed. AOTEntrypoints lists "
                       "unexpected symbol names";

--- a/xls/jit/switchable_function_jit.cc
+++ b/xls/jit/switchable_function_jit.cc
@@ -111,7 +111,7 @@ absl::StatusOr<absl::flat_hash_map<Node*, Value>> ToValueMap(
 class MemoizedIrInterpreter : public IrInterpreter {
  public:
   using IrInterpreter::IrInterpreter;
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     XLS_RET_CHECK(NodeValuesMap().contains(param));
     return absl::OkStatus();
   }

--- a/xls/noc/config_ng/fake_network_component.h
+++ b/xls/noc/config_ng/fake_network_component.h
@@ -27,7 +27,7 @@ class FakeNetworkComponent : public NetworkComponent {
   explicit FakeNetworkComponent(NetworkView* network_view)
       : NetworkComponent(network_view) {}
 
-  absl::Status Visit(NetworkComponentVisitor& v) override {
+  absl::Status Visit(NetworkComponentVisitor& v) final {
     return absl::Status();
   };
 };

--- a/xls/noc/simulation/noc_traffic_injector.h
+++ b/xls/noc/simulation/noc_traffic_injector.h
@@ -253,7 +253,7 @@ class NocTrafficInjectorService : public NocSimulatorServiceShim {
   NocTrafficInjectorService(NocTrafficInjector& injector, NocSimulator)
       : injector_(&injector) {}
 
-  absl::Status RunCycle() override { return injector_->RunCycle(); }
+  absl::Status RunCycle() final { return injector_->RunCycle(); }
 
  private:
   NocTrafficInjector* injector_;

--- a/xls/noc/simulation/noc_traffic_injector_test.cc
+++ b/xls/noc/simulation/noc_traffic_injector_test.cc
@@ -427,11 +427,11 @@ TEST(NocTrafficInjectorTest, MeasureTrafficInjectionRate) {
   class NocTrafficInjectorSink : public NocSimulatorTrafficServiceShim {
    public:
     // Not used in this test.
-    absl::Status RunCycle() override { return absl::OkStatus(); }
+    absl::Status RunCycle() final { return absl::OkStatus(); }
 
     // Measures traffic sent from source.
     absl::Status SendFlitAtTime(TimedDataFlit flit,
-                                NetworkComponentId source) override {
+                                NetworkComponentId source) final {
       if (flit.cycle > max_cycle_) {
         max_cycle_ = flit.cycle;
       }

--- a/xls/noc/simulation/simulator_to_traffic_injector_shim.h
+++ b/xls/noc/simulation/simulator_to_traffic_injector_shim.h
@@ -34,11 +34,11 @@ class NocSimulatorToNocTrafficInjectorShim
       : simulator_(&simulator), traffic_injector_(&traffic_injector) {}
 
   // Called by the simulator each cycle to request for traffic.
-  absl::Status RunCycle() override { return traffic_injector_->RunCycle(); }
+  absl::Status RunCycle() final { return traffic_injector_->RunCycle(); }
 
   // Called by the traffic injector to inject traffic.
   absl::Status SendFlitAtTime(TimedDataFlit flit,
-                              NetworkComponentId source) override {
+                              NetworkComponentId source) final {
     XLS_ASSIGN_OR_RETURN(SimNetworkInterfaceSrc * src,
                          simulator_->GetSimNetworkInterfaceSrc(source));
     return src->SendFlitAtTime(flit);

--- a/xls/passes/aliasing_query_engine.h
+++ b/xls/passes/aliasing_query_engine.h
@@ -80,7 +80,7 @@ class AliasingQueryEngine final : public QueryEngine {
   Node* UnaliasNode(Node* orig) const {
     return alias_map_->Contains(orig) ? alias_map_->Find(orig)->second : orig;
   }
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return base_->Populate(f);
   }
   bool IsTracked(Node* node) const override {

--- a/xls/passes/array_untuple_pass.cc
+++ b/xls/passes/array_untuple_pass.cc
@@ -223,17 +223,17 @@ absl::StatusOr<Value> GetElementArray(const Value& base, int64_t idx) {
   return Value::Array(vals);
 }
 
-class UntupleVisitor : public DfsVisitorWithDefault {
+class UntupleVisitor final : public DfsVisitorWithDefault {
  public:
   explicit UntupleVisitor(UnionFind<Node*>& groups,
                           const absl::flat_hash_set<Node*>& excluded_groups)
       : groups_(groups), excluded_groups_(excluded_groups) {}
-  ~UntupleVisitor() override = default;
+  ~UntupleVisitor() final = default;
 
   bool changed() const { return changed_; }
-  absl::Status DefaultHandler(Node* n) override { return absl::OkStatus(); }
+  absl::Status DefaultHandler(Node* n) final { return absl::OkStatus(); }
 
-  absl::Status HandleEq(CompareOp* eq) override {
+  absl::Status HandleEq(CompareOp* eq) final {
     if (!CanUntuple(eq->operand(0))) {
       // NB we force the two sides of this to be in the same equiv class so we
       // only need to check one.
@@ -245,7 +245,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
         eq->ReplaceUsesWithNew<NaryOp>(comps, Op::kAnd).status());
     return absl::OkStatus();
   }
-  absl::Status HandleNe(CompareOp* ne) override {
+  absl::Status HandleNe(CompareOp* ne) final {
     if (!CanUntuple(ne->operand(0))) {
       // NB we force the two sides of this to be in the same equiv class so we
       // only need to check one.
@@ -257,7 +257,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
         ne->ReplaceUsesWithNew<NaryOp>(comps, Op::kOr).status());
     return absl::OkStatus();
   }
-  absl::Status HandleLiteral(Literal* lit) override {
+  absl::Status HandleLiteral(Literal* lit) final {
     if (!CanUntuple(lit)) {
       return DefaultHandler(lit);
     }
@@ -275,7 +275,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(lit, std::move(elements));
   }
 
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     if (!CanUntuple(param)) {
       return DefaultHandler(param);
     }
@@ -283,7 +283,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
         "Attempting to untuple argument of function: ", param->ToString()));
   }
 
-  absl::Status HandleStateRead(StateRead* state_read) override {
+  absl::Status HandleStateRead(StateRead* state_read) final {
     if (!CanUntuple(state_read)) {
       return DefaultHandler(state_read);
     }
@@ -307,7 +307,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(state_read, std::move(res));
   }
 
-  absl::Status HandleNext(Next* n) override {
+  absl::Status HandleNext(Next* n) final {
     if (!CanUntuple(n->state_read())) {
       return DefaultHandler(n);
     }
@@ -338,7 +338,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArrayIndex(ArrayIndex* array_index) override {
+  absl::Status HandleArrayIndex(ArrayIndex* array_index) final {
     if (!CanUntuple(array_index->array())) {
       return DefaultHandler(array_index);
     }
@@ -362,7 +362,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleArray(Array* arr) override {
+  absl::Status HandleArray(Array* arr) final {
     if (!CanUntuple(arr)) {
       return DefaultHandler(arr);
     }
@@ -391,7 +391,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(arr, std::move(elements));
   }
 
-  absl::Status HandleArrayUpdate(ArrayUpdate* update) override {
+  absl::Status HandleArrayUpdate(ArrayUpdate* update) final {
     if (!CanUntuple(update)) {
       return DefaultHandler(update);
     }
@@ -415,7 +415,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(update, std::move(results));
   }
 
-  absl::Status HandleArraySlice(ArraySlice* slice) override {
+  absl::Status HandleArraySlice(ArraySlice* slice) final {
     if (!CanUntuple(slice)) {
       return DefaultHandler(slice);
     }
@@ -433,7 +433,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(slice, std::move(res));
   }
 
-  absl::Status HandleArrayConcat(ArrayConcat* concat) override {
+  absl::Status HandleArrayConcat(ArrayConcat* concat) final {
     if (!CanUntuple(concat)) {
       return DefaultHandler(concat);
     }
@@ -461,7 +461,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(concat, std::move(res));
   }
 
-  absl::Status HandleGate(Gate* gate) override {
+  absl::Status HandleGate(Gate* gate) final {
     if (!CanUntuple(gate)) {
       return DefaultHandler(gate);
     }
@@ -478,7 +478,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
     return RecordUntuple(gate, std::move(res));
   }
 
-  absl::Status HandleSel(Select* sel) override {
+  absl::Status HandleSel(Select* sel) final {
     if (!CanUntuple(sel)) {
       return DefaultHandler(sel);
     }
@@ -491,7 +491,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
               loc, selector, cases, def, name);
         });
   }
-  absl::Status HandlePrioritySel(PrioritySelect* sel) override {
+  absl::Status HandlePrioritySel(PrioritySelect* sel) final {
     if (!CanUntuple(sel)) {
       return DefaultHandler(sel);
     }
@@ -505,7 +505,7 @@ class UntupleVisitor : public DfsVisitorWithDefault {
               loc, selector, cases, *def, name);
         });
   }
-  absl::Status HandleOneHotSel(OneHotSelect* sel) override {
+  absl::Status HandleOneHotSel(OneHotSelect* sel) final {
     if (!CanUntuple(sel)) {
       return DefaultHandler(sel);
     }

--- a/xls/passes/bdd_query_engine.cc
+++ b/xls/passes/bdd_query_engine.cc
@@ -244,7 +244,7 @@ class BddQueryEngine::AssumingQueryEngine final : public QueryEngine {
         query_engine_(query_engine_storage_.get()),
         assumption_(assumption) {}
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override;
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final;
   bool IsTracked(Node* node) const override;
   std::optional<SharedLeafTypeTree<TernaryVector>> GetTernary(
       Node* node) const override;
@@ -468,7 +468,7 @@ class BddNodeEvaluator : public AbstractNodeEvaluator<SaturatingBddEvaluator> {
     return SetValue(node, value->AsView().AsShared());
   }
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     return SetValue(node, get_variables_(node).AsShared());
   }
 

--- a/xls/passes/bit_provenance_analysis.cc
+++ b/xls/passes/bit_provenance_analysis.cc
@@ -51,7 +51,7 @@ class BitProvenanceVisitor final : public DataflowVisitor<TreeBitSources> {
   // TODO(allight): With a query engine passed down to DataflowVisitor we could
   // do a better job picking which select branches etc are possible.
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     // Generic node is the sole source of all of its bits.
     XLS_ASSIGN_OR_RETURN(
         auto tree,
@@ -71,7 +71,7 @@ class BitProvenanceVisitor final : public DataflowVisitor<TreeBitSources> {
     return SetValue(node, std::move(tree));
   }
 
-  absl::Status HandleConcat(Concat* concat) override {
+  absl::Status HandleConcat(Concat* concat) final {
     std::vector<TreeBitRange> elements;
     int64_t bit_off = 0;
     // Loop from LSB to MSB
@@ -94,7 +94,7 @@ class BitProvenanceVisitor final : public DataflowVisitor<TreeBitSources> {
                     concat->GetType(), TreeBitSources(std::move(elements))));
   }
 
-  absl::Status HandleBitSlice(BitSlice* bs) override {
+  absl::Status HandleBitSlice(BitSlice* bs) final {
     const TreeBitSources& arg = GetValue(bs->operand(0)).Get({});
     std::vector<TreeBitRange> elements;
     int64_t remaining_bits = bs->width();
@@ -152,12 +152,12 @@ class BitProvenanceVisitor final : public DataflowVisitor<TreeBitSources> {
                         ext->GetType(), TreeBitSources(std::move(elements))));
   }
 
-  absl::Status HandleSignExtend(ExtendOp* ext) override {
+  absl::Status HandleSignExtend(ExtendOp* ext) final {
     // TODO(allight): Argurably the source for the new high-bits is the old MSB
     // in sign-extend. It's not clear this would ever really be useful however.
     return HandleExtend(ext);
   }
-  absl::Status HandleZeroExtend(ExtendOp* ext) override {
+  absl::Status HandleZeroExtend(ExtendOp* ext) final {
     return HandleExtend(ext);
   }
 
@@ -251,7 +251,7 @@ class BitProvenanceVisitor final : public DataflowVisitor<TreeBitSources> {
   absl::StatusOr<TreeBitSources> JoinElements(
       Type* element_type, absl::Span<const TreeBitSources* const> data_sources,
       absl::Span<const LeafTypeTreeView<TreeBitSources>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     // TODO Find overlaps
     std::vector<TreeBitRange> range(data_sources.front()->ranges().begin(),
                                     data_sources.front()->ranges().end());

--- a/xls/passes/boolean_simplification_pass.cc
+++ b/xls/passes/boolean_simplification_pass.cc
@@ -274,19 +274,19 @@ Node* GetZ(const Frontier& frontier) {
 // relatively cheap, this seems worthwhile.
 class BooleanFlowTracker : public DfsVisitorWithDefault {
  public:
-  absl::Status HandleNaryAnd(NaryOp* and_op) override {
+  absl::Status HandleNaryAnd(NaryOp* and_op) final {
     return HandleLogicOp(and_op);
   }
-  absl::Status HandleNaryNand(NaryOp* nand_op) override {
+  absl::Status HandleNaryNand(NaryOp* nand_op) final {
     return HandleLogicOp(nand_op);
   }
-  absl::Status HandleNaryNor(NaryOp* nor_op) override {
+  absl::Status HandleNaryNor(NaryOp* nor_op) final {
     return HandleLogicOp(nor_op);
   }
-  absl::Status HandleNot(UnOp* not_op) override {
+  absl::Status HandleNot(UnOp* not_op) final {
     return HandleLogicOp(not_op);
   }
-  absl::Status HandleNaryOr(NaryOp* or_op) override {
+  absl::Status HandleNaryOr(NaryOp* or_op) final {
     return HandleLogicOp(or_op);
   }
 
@@ -374,7 +374,7 @@ class BooleanFlowTracker : public DfsVisitorWithDefault {
     return table.CreateReplacement(original->loc(), operands, f);
   }
 
-  absl::Status DefaultHandler(Node* node) override { return absl::OkStatus(); }
+  absl::Status DefaultHandler(Node* node) final { return absl::OkStatus(); }
 
   absl::Span<const std::pair<Node*, Node*>> node_replacements() {
     return node_replacements_;

--- a/xls/passes/context_sensitive_range_query_engine.cc
+++ b/xls/passes/context_sensitive_range_query_engine.cc
@@ -415,7 +415,7 @@ class ProxyContextQueryEngine final : public QueryEngine {
                           const RangeQueryEngine& range_data)
       : base_(base), range_data_(range_data) {}
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return absl::UnimplementedError(
         "Cannot populate proxy query engine. Populate must be called on "
         "original engine only.");

--- a/xls/passes/dataflow_visitor_test.cc
+++ b/xls/passes/dataflow_visitor_test.cc
@@ -94,7 +94,7 @@ absl::StatusOr<LeafTypeTree<DataSource>> VisitorDefaultHandler(Node* node) {
 // control join operator appends the control signal name.
 class TestDataflowVisitor : public DataflowVisitor<DataSource> {
  protected:
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     XLS_ASSIGN_OR_RETURN(LeafTypeTree<DataSource> result,
                          VisitorDefaultHandler(node));
     return SetValue(node, std::move(result));
@@ -119,7 +119,7 @@ class TestDataflowVisitorWithControl : public TestDataflowVisitor {
   absl::StatusOr<DataSource> JoinElements(
       Type* element_type, absl::Span<const DataSource* const> data_sources,
       absl::Span<const LeafTypeTreeView<DataSource>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     XLS_RET_CHECK(!data_sources.empty());
     DataSource result = *data_sources.front();
     for (const DataSource* other : data_sources.subspan(1)) {

--- a/xls/passes/lazy_query_engine.h
+++ b/xls/passes/lazy_query_engine.h
@@ -128,7 +128,7 @@ class LazyQueryEngine : public QueryEngine {
       FunctionBase* f, absl::flat_hash_map<Node*, LeafTypeTree<Info>> givens) {
     return info_.AttachWithGivens(f, std::move(givens));
   }
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return info_.Attach(f);
   }
 

--- a/xls/passes/lazy_ternary_query_engine.cc
+++ b/xls/passes/lazy_ternary_query_engine.cc
@@ -68,7 +68,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
     return SetValue(node, value->AsView());
   }
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     XLS_ASSIGN_OR_RETURN(
         TernaryTree unknown,
         TernaryTree::CreateFromFunction(
@@ -80,7 +80,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
     return SetValue(node, std::move(unknown));
   }
 
-  absl::Status HandleAdd(BinOp* add) override {
+  absl::Status HandleAdd(BinOp* add) final {
     Node* lhs = add->operand(0);
     Node* rhs = add->operand(1);
     return SetValue(
@@ -88,7 +88,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  add->GetType(),
                  evaluator_.Add(GetValue(lhs).Get({}), GetValue(rhs).Get({}))));
   }
-  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) override {
+  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) final {
     Node* input = and_reduce->operand(0);
     return SetValue(and_reduce,
                     TernaryTree::CreateSingleElementTree(
@@ -96,7 +96,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         evaluator_.AndReduce(GetValue(input).Get({}))));
   }
 
-  absl::Status HandleBitSlice(BitSlice* bit_slice) override {
+  absl::Status HandleBitSlice(BitSlice* bit_slice) final {
     return SetValue(
         bit_slice,
         TernaryTree::CreateSingleElementTree(
@@ -104,7 +104,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
             evaluator_.BitSlice(GetValue(bit_slice->operand(0)).Get({}),
                                 bit_slice->start(), bit_slice->width())));
   }
-  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) override {
+  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) final {
     return SetValue(update, TernaryTree::CreateSingleElementTree(
                                 update->GetType(),
                                 evaluator_.BitSliceUpdate(
@@ -112,7 +112,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                     GetValue(update->start()).Get({}),
                                     GetValue(update->update_value()).Get({}))));
   }
-  absl::Status HandleConcat(Concat* concat) override {
+  absl::Status HandleConcat(Concat* concat) final {
     std::vector<TernarySpan> operands;
     for (Node* operand : concat->operands()) {
       operands.push_back(GetValue(operand).Get({}));
@@ -121,7 +121,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                     TernaryTree::CreateSingleElementTree(
                         concat->GetType(), evaluator_.Concat(operands)));
   }
-  absl::Status HandleDecode(Decode* decode) override {
+  absl::Status HandleDecode(Decode* decode) final {
     return SetValue(decode,
                     TernaryTree::CreateSingleElementTree(
                         decode->GetType(),
@@ -129,7 +129,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                           decode->width())));
   }
   absl::Status HandleDynamicBitSlice(
-      DynamicBitSlice* dynamic_bit_slice) override {
+      DynamicBitSlice* dynamic_bit_slice) final {
     return SetValue(dynamic_bit_slice,
                     TernaryTree::CreateSingleElementTree(
                         dynamic_bit_slice->GetType(),
@@ -138,13 +138,13 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                             GetValue(dynamic_bit_slice->start()).Get({}),
                             dynamic_bit_slice->width())));
   }
-  absl::Status HandleEncode(Encode* encode) override {
+  absl::Status HandleEncode(Encode* encode) final {
     return SetValue(
         encode, TernaryTree::CreateSingleElementTree(
                     encode->GetType(),
                     evaluator_.Encode(GetValue(encode->operand(0)).Get({}))));
   }
-  absl::Status HandleEq(CompareOp* eq) override {
+  absl::Status HandleEq(CompareOp* eq) final {
     Node* lhs = eq->operand(0);
     Node* rhs = eq->operand(1);
 
@@ -158,7 +158,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                             eq->GetType(),
                             TernaryVector({evaluator_.AndReduce(leaves_eq)})));
   }
-  absl::Status HandleGate(Gate* gate) override {
+  absl::Status HandleGate(Gate* gate) final {
     TernaryValue control = GetValue(gate->operand(0)).Get({}).front();
     TernaryTreeView input = GetValue(gate->operand(1)).AsView();
     return SetValue(gate, leaf_type_tree::Map<TernaryVector, TernaryVector>(
@@ -166,7 +166,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                 return evaluator_.Gate(control, input_leaf);
                               }));
   }
-  absl::Status HandleLiteral(Literal* literal) override {
+  absl::Status HandleLiteral(Literal* literal) final {
     XLS_ASSIGN_OR_RETURN(
         LeafTypeTree<Value> value_tree,
         ValueToLeafTypeTree(literal->value(), literal->GetType()));
@@ -180,7 +180,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                           return ternary_ops::BitsToTernary(value.bits());
                         }));
   }
-  absl::Status HandleNaryAnd(NaryOp* and_op) override {
+  absl::Status HandleNaryAnd(NaryOp* and_op) final {
     std::vector<TernarySpan> operands;
     operands.reserve(and_op->operand_count());
     for (Node* operand : and_op->operands()) {
@@ -190,7 +190,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                     TernaryTree::CreateSingleElementTree(
                         and_op->GetType(), evaluator_.BitwiseAnd(operands)));
   }
-  absl::Status HandleNaryNand(NaryOp* nand_op) override {
+  absl::Status HandleNaryNand(NaryOp* nand_op) final {
     std::vector<TernarySpan> operands;
     operands.reserve(nand_op->operand_count());
     for (Node* operand : nand_op->operands()) {
@@ -201,7 +201,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                      nand_op->GetType(),
                      evaluator_.BitwiseNot(evaluator_.BitwiseAnd(operands))));
   }
-  absl::Status HandleNaryNor(NaryOp* nor_op) override {
+  absl::Status HandleNaryNor(NaryOp* nor_op) final {
     std::vector<TernarySpan> operands;
     operands.reserve(nor_op->operand_count());
     for (Node* operand : nor_op->operands()) {
@@ -212,7 +212,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         nor_op->GetType(),
                         evaluator_.BitwiseNot(evaluator_.BitwiseOr(operands))));
   }
-  absl::Status HandleNaryOr(NaryOp* or_op) override {
+  absl::Status HandleNaryOr(NaryOp* or_op) final {
     std::vector<TernarySpan> operands;
     operands.reserve(or_op->operand_count());
     for (Node* operand : or_op->operands()) {
@@ -222,7 +222,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                     TernaryTree::CreateSingleElementTree(
                         or_op->GetType(), evaluator_.BitwiseOr(operands)));
   }
-  absl::Status HandleNaryXor(NaryOp* xor_op) override {
+  absl::Status HandleNaryXor(NaryOp* xor_op) final {
     std::vector<TernarySpan> operands;
     operands.reserve(xor_op->operand_count());
     for (Node* operand : xor_op->operands()) {
@@ -232,7 +232,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                     TernaryTree::CreateSingleElementTree(
                         xor_op->GetType(), evaluator_.BitwiseXor(operands)));
   }
-  absl::Status HandleNe(CompareOp* ne) override {
+  absl::Status HandleNe(CompareOp* ne) final {
     Node* lhs = ne->operand(0);
     Node* rhs = ne->operand(1);
 
@@ -247,20 +247,20 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                             ne->GetType(),
                             TernaryVector({evaluator_.OrReduce(leaves_ne)})));
   }
-  absl::Status HandleNeg(UnOp* neg) override {
+  absl::Status HandleNeg(UnOp* neg) final {
     return SetValue(
         neg,
         TernaryTree::CreateSingleElementTree(
             neg->GetType(), evaluator_.Neg(GetValue(neg->operand(0)).Get({}))));
   }
-  absl::Status HandleNot(UnOp* not_op) override {
+  absl::Status HandleNot(UnOp* not_op) final {
     return SetValue(
         not_op,
         TernaryTree::CreateSingleElementTree(
             not_op->GetType(),
             evaluator_.BitwiseNot(GetValue(not_op->operand(0)).Get({}))));
   }
-  absl::Status HandleOneHot(OneHot* one_hot) override {
+  absl::Status HandleOneHot(OneHot* one_hot) final {
     TernarySpan input = GetValue(one_hot->operand(0)).Get({});
     TernaryVector result;
     return SetValue(one_hot, TernaryTree::CreateSingleElementTree(
@@ -269,7 +269,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                      ? evaluator_.OneHotLsbToMsb(input)
                                      : evaluator_.OneHotMsbToLsb(input)));
   }
-  absl::Status HandleOneHotSel(OneHotSelect* ohs) override {
+  absl::Status HandleOneHotSel(OneHotSelect* ohs) final {
     TernarySpan selector = GetValue(ohs->selector()).Get({});
     const bool selector_can_be_zero =
         !query_engine_.AtLeastOneBitTrue(ohs->selector());
@@ -296,20 +296,20 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
             })));
     return SetValue(ohs, std::move(result));
   }
-  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) override {
+  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) final {
     Node* input = or_reduce->operand(0);
     return SetValue(or_reduce,
                     TernaryTree::CreateSingleElementTree(
                         or_reduce->GetType(),
                         evaluator_.OrReduce(GetValue(input).Get({}))));
   }
-  absl::Status HandleReverse(UnOp* reverse) override {
+  absl::Status HandleReverse(UnOp* reverse) final {
     TernaryVector result = GetValue(reverse->operand(0)).Get({});
     absl::c_reverse(result);
     return SetValue(reverse, TernaryTree::CreateSingleElementTree(
                                  reverse->GetType(), result));
   }
-  absl::Status HandleSDiv(BinOp* div) override {
+  absl::Status HandleSDiv(BinOp* div) final {
     Node* lhs = div->operand(0);
     Node* rhs = div->operand(1);
     return SetValue(
@@ -317,7 +317,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  div->GetType(), evaluator_.SDiv(GetValue(lhs).Get({}),
                                                  GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSGe(CompareOp* ge) override {
+  absl::Status HandleSGe(CompareOp* ge) final {
     Node* lhs = ge->operand(0);
     Node* rhs = ge->operand(1);
     return SetValue(ge,
@@ -326,7 +326,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         TernaryVector({evaluator_.Not(evaluator_.SLessThan(
                             GetValue(lhs).Get({}), GetValue(rhs).Get({})))})));
   }
-  absl::Status HandleSGt(CompareOp* gt) override {
+  absl::Status HandleSGt(CompareOp* gt) final {
     Node* lhs = gt->operand(0);
     Node* rhs = gt->operand(1);
     return SetValue(
@@ -335,7 +335,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                 TernaryVector({evaluator_.SLessThan(GetValue(rhs).Get({}),
                                                     GetValue(lhs).Get({}))})));
   }
-  absl::Status HandleSLe(CompareOp* le) override {
+  absl::Status HandleSLe(CompareOp* le) final {
     Node* lhs = le->operand(0);
     Node* rhs = le->operand(1);
     return SetValue(le,
@@ -344,7 +344,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         TernaryVector({evaluator_.Not(evaluator_.SLessThan(
                             GetValue(rhs).Get({}), GetValue(lhs).Get({})))})));
   }
-  absl::Status HandleSLt(CompareOp* lt) override {
+  absl::Status HandleSLt(CompareOp* lt) final {
     Node* lhs = lt->operand(0);
     Node* rhs = lt->operand(1);
     return SetValue(
@@ -353,7 +353,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                 TernaryVector({evaluator_.SLessThan(GetValue(lhs).Get({}),
                                                     GetValue(rhs).Get({}))})));
   }
-  absl::Status HandleSMod(BinOp* mod) override {
+  absl::Status HandleSMod(BinOp* mod) final {
     Node* lhs = mod->operand(0);
     Node* rhs = mod->operand(1);
     return SetValue(
@@ -361,7 +361,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  mod->GetType(), evaluator_.SMod(GetValue(lhs).Get({}),
                                                  GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSMul(ArithOp* mul) override {
+  absl::Status HandleSMul(ArithOp* mul) final {
     TernaryVector result = evaluator_.SMul(GetValue(mul->operand(0)).Get({}),
                                            GetValue(mul->operand(1)).Get({}));
     int64_t expected_width = mul->BitCountOrDie();
@@ -373,7 +373,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
     return SetValue(
         mul, TernaryTree::CreateSingleElementTree(mul->GetType(), result));
   }
-  absl::Status HandleShll(BinOp* shll) override {
+  absl::Status HandleShll(BinOp* shll) final {
     Node* input = shll->operand(0);
     Node* amount = shll->operand(1);
     return SetValue(shll, TernaryTree::CreateSingleElementTree(
@@ -381,7 +381,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                                    GetValue(input).Get({}),
                                                    GetValue(amount).Get({}))));
   }
-  absl::Status HandleShra(BinOp* shra) override {
+  absl::Status HandleShra(BinOp* shra) final {
     Node* input = shra->operand(0);
     Node* amount = shra->operand(1);
     return SetValue(shra, TernaryTree::CreateSingleElementTree(
@@ -389,7 +389,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                                    GetValue(input).Get({}),
                                                    GetValue(amount).Get({}))));
   }
-  absl::Status HandleShrl(BinOp* shrl) override {
+  absl::Status HandleShrl(BinOp* shrl) final {
     Node* input = shrl->operand(0);
     Node* amount = shrl->operand(1);
     return SetValue(shrl, TernaryTree::CreateSingleElementTree(
@@ -397,14 +397,14 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                                                    GetValue(input).Get({}),
                                                    GetValue(amount).Get({}))));
   }
-  absl::Status HandleSignExtend(ExtendOp* sign_ext) override {
+  absl::Status HandleSignExtend(ExtendOp* sign_ext) final {
     return SetValue(sign_ext, TernaryTree::CreateSingleElementTree(
                                   sign_ext->GetType(),
                                   evaluator_.SignExtend(
                                       GetValue(sign_ext->operand(0)).Get({}),
                                       sign_ext->new_bit_count())));
   }
-  absl::Status HandleSub(BinOp* sub) override {
+  absl::Status HandleSub(BinOp* sub) final {
     Node* lhs = sub->operand(0);
     Node* rhs = sub->operand(1);
     return SetValue(
@@ -412,7 +412,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  sub->GetType(),
                  evaluator_.Sub(GetValue(lhs).Get({}), GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUDiv(BinOp* div) override {
+  absl::Status HandleUDiv(BinOp* div) final {
     Node* lhs = div->operand(0);
     Node* rhs = div->operand(1);
     return SetValue(
@@ -420,7 +420,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  div->GetType(), evaluator_.UDiv(GetValue(lhs).Get({}),
                                                  GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUGe(CompareOp* ge) override {
+  absl::Status HandleUGe(CompareOp* ge) final {
     Node* lhs = ge->operand(0);
     Node* rhs = ge->operand(1);
     return SetValue(ge,
@@ -429,7 +429,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         TernaryVector({evaluator_.UGreaterThanOrEqual(
                             GetValue(lhs).Get({}), GetValue(rhs).Get({}))})));
   }
-  absl::Status HandleUGt(CompareOp* gt) override {
+  absl::Status HandleUGt(CompareOp* gt) final {
     Node* lhs = gt->operand(0);
     Node* rhs = gt->operand(1);
     return SetValue(gt,
@@ -438,7 +438,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         TernaryVector({evaluator_.UGreaterThan(
                             GetValue(lhs).Get({}), GetValue(rhs).Get({}))})));
   }
-  absl::Status HandleULe(CompareOp* le) override {
+  absl::Status HandleULe(CompareOp* le) final {
     Node* lhs = le->operand(0);
     Node* rhs = le->operand(1);
     return SetValue(le,
@@ -447,7 +447,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                         TernaryVector({evaluator_.ULessThanOrEqual(
                             GetValue(lhs).Get({}), GetValue(rhs).Get({}))})));
   }
-  absl::Status HandleULt(CompareOp* lt) override {
+  absl::Status HandleULt(CompareOp* lt) final {
     Node* lhs = lt->operand(0);
     Node* rhs = lt->operand(1);
     return SetValue(
@@ -456,7 +456,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                 TernaryVector({evaluator_.ULessThan(GetValue(lhs).Get({}),
                                                     GetValue(rhs).Get({}))})));
   }
-  absl::Status HandleUMod(BinOp* mod) override {
+  absl::Status HandleUMod(BinOp* mod) final {
     Node* lhs = mod->operand(0);
     Node* rhs = mod->operand(1);
     return SetValue(
@@ -464,7 +464,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
                  mod->GetType(), evaluator_.UMod(GetValue(lhs).Get({}),
                                                  GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUMul(ArithOp* mul) override {
+  absl::Status HandleUMul(ArithOp* mul) final {
     TernaryVector result = evaluator_.UMul(GetValue(mul->operand(0)).Get({}),
                                            GetValue(mul->operand(1)).Get({}));
     int64_t expected_width = mul->BitCountOrDie();
@@ -476,14 +476,14 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
     return SetValue(
         mul, TernaryTree::CreateSingleElementTree(mul->GetType(), result));
   }
-  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) override {
+  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) final {
     Node* input = xor_reduce->operand(0);
     return SetValue(xor_reduce,
                     TernaryTree::CreateSingleElementTree(
                         xor_reduce->GetType(),
                         evaluator_.XorReduce(GetValue(input).Get({}))));
   }
-  absl::Status HandleZeroExtend(ExtendOp* zero_ext) override {
+  absl::Status HandleZeroExtend(ExtendOp* zero_ext) final {
     return SetValue(zero_ext, TernaryTree::CreateSingleElementTree(
                                   zero_ext->GetType(),
                                   evaluator_.ZeroExtend(
@@ -548,7 +548,7 @@ class TernaryVisitor : public DataflowVisitor<TernaryVector> {
   absl::StatusOr<TernaryVector> JoinElements(
       Type* element_type, absl::Span<const TernaryVector* const> data_sources,
       absl::Span<const LeafTypeTreeView<TernaryVector>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     if (node->Is<Select>()) {
       CHECK_EQ(control_sources.size(), 1);
       return SelectElements(/*selector=*/control_sources.front().Get({}),

--- a/xls/passes/narrowing_pass.cc
+++ b/xls/passes/narrowing_pass.cc
@@ -258,8 +258,8 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
 
   bool changed() const { return changed_; }
 
-  absl::Status DefaultHandler(Node* node) override { return NoChange(); }
-  absl::Status HandleArrayUpdate(ArrayUpdate* update) override {
+  absl::Status DefaultHandler(Node* node) final { return NoChange(); }
+  absl::Status HandleArrayUpdate(ArrayUpdate* update) final {
     if (!update->assumed_in_bounds() &&
         ArrayIndicesAssumedInBounds(
             update, update->indices(),
@@ -271,13 +271,13 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     }
     return NoChange();
   }
-  absl::Status HandleGate(Gate* gate) override {
+  absl::Status HandleGate(Gate* gate) final {
     // We explicitly never want anything to occur here except being replaced
     // with a constant.
     return NoChange();
   }
 
-  absl::Status HandleSel(Select* sel) override {
+  absl::Status HandleSel(Select* sel) final {
     if (analysis_ != AnalysisType::kRangeWithContext) {
       return NoChange();
     }
@@ -324,37 +324,37 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
             state.IsDefaultArm() ? select->cases().size() : state.arm_index(),
             select->ToString()));
   }
-  absl::Status HandleEq(CompareOp* eq) override {
+  absl::Status HandleEq(CompareOp* eq) final {
     return MaybeNarrowCompare(eq);
   }
-  absl::Status HandleNe(CompareOp* ne) override {
+  absl::Status HandleNe(CompareOp* ne) final {
     return MaybeNarrowCompare(ne);
   }
-  absl::Status HandleSGe(CompareOp* ge) override {
+  absl::Status HandleSGe(CompareOp* ge) final {
     return MaybeNarrowCompare(ge);
   }
-  absl::Status HandleSGt(CompareOp* gt) override {
+  absl::Status HandleSGt(CompareOp* gt) final {
     return MaybeNarrowCompare(gt);
   }
-  absl::Status HandleSLe(CompareOp* le) override {
+  absl::Status HandleSLe(CompareOp* le) final {
     return MaybeNarrowCompare(le);
   }
-  absl::Status HandleSLt(CompareOp* lt) override {
+  absl::Status HandleSLt(CompareOp* lt) final {
     return MaybeNarrowCompare(lt);
   }
-  absl::Status HandleUGe(CompareOp* ge) override {
+  absl::Status HandleUGe(CompareOp* ge) final {
     return MaybeNarrowCompare(ge);
   }
-  absl::Status HandleUGt(CompareOp* gt) override {
+  absl::Status HandleUGt(CompareOp* gt) final {
     return MaybeNarrowCompare(gt);
   }
-  absl::Status HandleULe(CompareOp* le) override {
+  absl::Status HandleULe(CompareOp* le) final {
     return MaybeNarrowCompare(le);
   }
-  absl::Status HandleULt(CompareOp* lt) override {
+  absl::Status HandleULt(CompareOp* lt) final {
     return MaybeNarrowCompare(lt);
   }
-  absl::Status HandleNeg(UnOp* neg) override {
+  absl::Status HandleNeg(UnOp* neg) final {
     // Narrows negate:
     //
     //  neg(0b00...00XXX) => signext(neg(0b0XXX))
@@ -536,7 +536,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return NoChange();
   }
 
-  absl::Status HandleLiteral(Literal* literal) override {
+  absl::Status HandleLiteral(Literal* literal) final {
     return MaybeNarrowLiteralArray(literal);
   }
 
@@ -681,7 +681,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
   // If leading bits are known of the shift-value we can remove any where the
   // unknown bits cannot overwrite them. We will also narrow shift_amnt and
   // split the value based on the calculated ranges of shift_amnt.
-  absl::Status HandleShll(BinOp* shll) override {
+  absl::Status HandleShll(BinOp* shll) final {
     Node* shift_value = shll->operand(0);
     Node* shift_amnt = shll->operand(1);
     // Narrow the shift amount.
@@ -790,10 +790,10 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return replace_with_narrowed(narrowed_shift_value, narrowed_shift_amnt);
   }
 
-  absl::Status HandleShra(BinOp* shra) override {
+  absl::Status HandleShra(BinOp* shra) final {
     return MaybeNarrowShiftRight(shra);
   }
-  absl::Status HandleShrl(BinOp* shrl) override {
+  absl::Status HandleShrl(BinOp* shrl) final {
     return MaybeNarrowShiftRight(shrl);
   }
 
@@ -937,7 +937,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
   //
   // Finally if the number of interesting bits is less then the slice size we
   // can slice to a smaller size and extend.
-  absl::Status HandleDynamicBitSlice(DynamicBitSlice* slice) override {
+  absl::Status HandleDynamicBitSlice(DynamicBitSlice* slice) final {
     int64_t leading_start_zeros = CountLeadingKnownZeros(slice->start(), slice);
     int64_t leading_to_slice_zeros =
         CountLeadingKnownZeros(slice->to_slice(), slice);
@@ -1060,7 +1060,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return Change(slice, res);
   }
 
-  absl::Status HandleDecode(Decode* decode) override {
+  absl::Status HandleDecode(Decode* decode) final {
     // Narrow the index operand of decode operations if the index has leading
     // zeros.
     Node* index = decode->operand(0);
@@ -1111,7 +1111,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return Change(/*original=*/decode, /*replacement=*/replacement);
   }
 
-  absl::Status HandleSub(BinOp* sub) override {
+  absl::Status HandleSub(BinOp* sub) final {
     VLOG(3) << "Trying to narrow sub: " << sub->ToString();
     XLS_RET_CHECK_EQ(sub->op(), Op::kSub);
 
@@ -1191,7 +1191,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     }
     return NoChange();
   }
-  absl::Status HandleAdd(BinOp* add) override {
+  absl::Status HandleAdd(BinOp* add) final {
     VLOG(3) << "Trying to narrow add: " << add->ToString();
 
     XLS_RET_CHECK_EQ(add->op(), Op::kAdd);
@@ -1282,10 +1282,10 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return NoChange();
   }
 
-  absl::Status HandleUMul(ArithOp* umul) override {
+  absl::Status HandleUMul(ArithOp* umul) final {
     return MaybeNarrowMultiply(umul);
   }
-  absl::Status HandleSMul(ArithOp* smul) override {
+  absl::Status HandleSMul(ArithOp* smul) final {
     return MaybeNarrowMultiply(smul);
   }
 
@@ -1436,7 +1436,7 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
 
     return NoChange();
   }
-  absl::Status HandleArrayIndex(ArrayIndex* array_index) override {
+  absl::Status HandleArrayIndex(ArrayIndex* array_index) final {
     bool changed = false;
     bool assumed_in_bounds = array_index->assumed_in_bounds();
 
@@ -1541,10 +1541,10 @@ class NarrowVisitor final : public DfsVisitorWithDefault {
     return NoChange();
   }
 
-  absl::Status HandleSMulp(PartialProductOp* mul) override {
+  absl::Status HandleSMulp(PartialProductOp* mul) final {
     return MaybeNarrowPartialMultiply(mul);
   }
-  absl::Status HandleUMulp(PartialProductOp* mul) override {
+  absl::Status HandleUMulp(PartialProductOp* mul) final {
     return MaybeNarrowPartialMultiply(mul);
   }
 

--- a/xls/passes/node_source_analysis.h
+++ b/xls/passes/node_source_analysis.h
@@ -81,7 +81,7 @@ class NodeSource {
 
 class NodeSourceDataflowVisitor : public DataflowVisitor<NodeSource> {
  public:
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     LeafTypeTree<NodeSource> result(node->GetType());
     XLS_RETURN_IF_ERROR(leaf_type_tree::ForEachIndex(
         result.AsMutableView(), [&](Type* element_type, NodeSource& element,
@@ -96,7 +96,7 @@ class NodeSourceDataflowVisitor : public DataflowVisitor<NodeSource> {
   absl::StatusOr<NodeSource> JoinElements(
       Type* element_type, absl::Span<const NodeSource* const> data_sources,
       absl::Span<const LeafTypeTreeView<NodeSource>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     if (std::all_of(
             data_sources.begin(), data_sources.end(),
             [&](const NodeSource* n) { return *n == *data_sources.front(); })) {

--- a/xls/passes/optimization_pass.h
+++ b/xls/passes/optimization_pass.h
@@ -243,13 +243,13 @@ class OptimizationContext {
  private:
   const std::vector<Node*>& ReverseTopoSortReference(FunctionBase* f);
 
-  class InvalidatingVector : public ChangeListener {
+  class InvalidatingVector final : public ChangeListener {
    public:
     explicit InvalidatingVector(FunctionBase* f, std::vector<Node*> value = {})
         : f_(f), storage_(std::move(value)) {
       f_->RegisterChangeListener(this);
     }
-    ~InvalidatingVector() override { f_->UnregisterChangeListener(this); }
+    ~InvalidatingVector() final { f_->UnregisterChangeListener(this); }
 
     InvalidatingVector(const InvalidatingVector&) = delete;
     InvalidatingVector& operator=(const InvalidatingVector&) = delete;
@@ -276,15 +276,15 @@ class OptimizationContext {
     std::vector<Node*>* operator->() { return &storage_; }
     const std::vector<Node*>* operator->() const { return &storage_; }
 
-    void NodeAdded(Node*) override { storage_.clear(); }
-    void NodeDeleted(Node*) override { storage_.clear(); }
-    void OperandChanged(Node*, Node*, absl::Span<const int64_t>) override {
+    void NodeAdded(Node*) final { storage_.clear(); }
+    void NodeDeleted(Node*) final { storage_.clear(); }
+    void OperandChanged(Node*, Node*, absl::Span<const int64_t>) final {
       storage_.clear();
     }
-    void OperandRemoved(Node*, Node*) override { storage_.clear(); }
-    void OperandAdded(Node*) override { storage_.clear(); }
-    void ReturnValueChanged(Function*, Node*) override { storage_.clear(); }
-    void NextStateElementChanged(Proc*, int64_t, Node*) override {
+    void OperandRemoved(Node*, Node*) final { storage_.clear(); }
+    void OperandAdded(Node*) final { storage_.clear(); }
+    void ReturnValueChanged(Function*, Node*) final { storage_.clear(); }
+    void NextStateElementChanged(Proc*, int64_t, Node*) final {
       storage_.clear();
     }
 

--- a/xls/passes/partial_info_query_engine.cc
+++ b/xls/passes/partial_info_query_engine.cc
@@ -75,7 +75,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
     return SetValue(node, value->AsView());
   }
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     XLS_ASSIGN_OR_RETURN(
         LeafTypeTree<PartialInformation> unknown,
         LeafTypeTree<PartialInformation>::CreateFromFunction(
@@ -87,7 +87,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
     return SetValue(node, std::move(unknown));
   }
 
-  absl::Status HandleAdd(BinOp* add) override {
+  absl::Status HandleAdd(BinOp* add) final {
     Node* lhs = add->operand(0);
     Node* rhs = add->operand(1);
     return SetValue(
@@ -95,7 +95,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  add->GetType(), partial_ops::Add(GetValue(lhs).Get({}),
                                                   GetValue(rhs).Get({}))));
   }
-  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) override {
+  absl::Status HandleAndReduce(BitwiseReductionOp* and_reduce) final {
     Node* input = and_reduce->operand(0);
     return SetValue(and_reduce,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
@@ -103,7 +103,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                         partial_ops::AndReduce(GetValue(input).Get({}))));
   }
 
-  absl::Status HandleBitSlice(BitSlice* bit_slice) override {
+  absl::Status HandleBitSlice(BitSlice* bit_slice) final {
     return SetValue(
         bit_slice,
         LeafTypeTree<PartialInformation>::CreateSingleElementTree(
@@ -111,7 +111,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             partial_ops::BitSlice(GetValue(bit_slice->operand(0)).Get({}),
                                   bit_slice->start(), bit_slice->width())));
   }
-  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) override {
+  absl::Status HandleBitSliceUpdate(BitSliceUpdate* update) final {
     return SetValue(
         update,
         LeafTypeTree<PartialInformation>::CreateSingleElementTree(
@@ -120,7 +120,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                                    GetValue(update->start()).Get({}),
                                    GetValue(update->update_value()).Get({}))));
   }
-  absl::Status HandleConcat(Concat* concat) override {
+  absl::Status HandleConcat(Concat* concat) final {
     std::vector<PartialInformation> operands;
     for (Node* operand : concat->operands()) {
       operands.push_back(GetValue(operand).Get({}));
@@ -129,7 +129,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         concat->GetType(), partial_ops::Concat(operands)));
   }
-  absl::Status HandleDecode(Decode* decode) override {
+  absl::Status HandleDecode(Decode* decode) final {
     return SetValue(
         decode, LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                     decode->GetType(),
@@ -137,7 +137,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                                         decode->width())));
   }
   absl::Status HandleDynamicBitSlice(
-      DynamicBitSlice* dynamic_bit_slice) override {
+      DynamicBitSlice* dynamic_bit_slice) final {
     return SetValue(dynamic_bit_slice,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         dynamic_bit_slice->GetType(),
@@ -146,13 +146,13 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                             GetValue(dynamic_bit_slice->start()).Get({}),
                             dynamic_bit_slice->width())));
   }
-  absl::Status HandleEncode(Encode* encode) override {
+  absl::Status HandleEncode(Encode* encode) final {
     return SetValue(
         encode, LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                     encode->GetType(),
                     partial_ops::Encode(GetValue(encode->operand(0)).Get({}))));
   }
-  absl::Status HandleEq(CompareOp* eq) override {
+  absl::Status HandleEq(CompareOp* eq) final {
     Node* lhs = eq->operand(0);
     Node* rhs = eq->operand(1);
 
@@ -166,7 +166,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         eq->GetType(), result));
   }
-  absl::Status HandleGate(Gate* gate) override {
+  absl::Status HandleGate(Gate* gate) final {
     const PartialInformation& control = GetValue(gate->operand(0)).Get({});
     LeafTypeTreeView<PartialInformation> input =
         GetValue(gate->operand(1)).AsView();
@@ -178,7 +178,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
               return partial_ops::Gate(control, input_leaf);
             }));
   }
-  absl::Status HandleLiteral(Literal* literal) override {
+  absl::Status HandleLiteral(Literal* literal) final {
     XLS_ASSIGN_OR_RETURN(
         LeafTypeTree<Value> value_tree,
         ValueToLeafTypeTree(literal->value(), literal->GetType()));
@@ -193,7 +193,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
               return PartialInformation::Precise(value.bits());
             }));
   }
-  absl::Status HandleNaryAnd(NaryOp* and_op) override {
+  absl::Status HandleNaryAnd(NaryOp* and_op) final {
     PartialInformation result = PartialInformation::Precise(
         Bits::AllOnes(and_op->GetType()->GetFlatBitCount()));
     for (Node* operand : and_op->operands()) {
@@ -203,7 +203,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         and_op->GetType(), result));
   }
-  absl::Status HandleNaryNand(NaryOp* nand_op) override {
+  absl::Status HandleNaryNand(NaryOp* nand_op) final {
     PartialInformation result = PartialInformation::Precise(
         Bits::AllOnes(nand_op->GetType()->GetFlatBitCount()));
     for (Node* operand : nand_op->operands()) {
@@ -213,7 +213,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         nand_op->GetType(), result.Not()));
   }
-  absl::Status HandleNaryNor(NaryOp* nor_op) override {
+  absl::Status HandleNaryNor(NaryOp* nor_op) final {
     PartialInformation result =
         PartialInformation::Precise(Bits(nor_op->GetType()->GetFlatBitCount()));
     for (Node* operand : nor_op->operands()) {
@@ -223,7 +223,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         nor_op->GetType(), result.Not()));
   }
-  absl::Status HandleNaryOr(NaryOp* or_op) override {
+  absl::Status HandleNaryOr(NaryOp* or_op) final {
     PartialInformation result =
         PartialInformation::Precise(Bits(or_op->GetType()->GetFlatBitCount()));
     for (Node* operand : or_op->operands()) {
@@ -233,7 +233,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         or_op->GetType(), result));
   }
-  absl::Status HandleNaryXor(NaryOp* xor_op) override {
+  absl::Status HandleNaryXor(NaryOp* xor_op) final {
     PartialInformation result =
         PartialInformation::Precise(Bits(xor_op->GetType()->GetFlatBitCount()));
     for (Node* operand : xor_op->operands()) {
@@ -243,7 +243,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         xor_op->GetType(), result));
   }
-  absl::Status HandleNe(CompareOp* ne) override {
+  absl::Status HandleNe(CompareOp* ne) final {
     Node* lhs = ne->operand(0);
     Node* rhs = ne->operand(1);
 
@@ -261,19 +261,19 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         ne->GetType(), result));
   }
-  absl::Status HandleNeg(UnOp* neg) override {
+  absl::Status HandleNeg(UnOp* neg) final {
     return SetValue(neg,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         neg->GetType(),
                         partial_ops::Neg(GetValue(neg->operand(0)).Get({}))));
   }
-  absl::Status HandleNot(UnOp* not_op) override {
+  absl::Status HandleNot(UnOp* not_op) final {
     return SetValue(
         not_op, LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                     not_op->GetType(),
                     partial_ops::Not(GetValue(not_op->operand(0)).Get({}))));
   }
-  absl::Status HandleOneHot(OneHot* one_hot) override {
+  absl::Status HandleOneHot(OneHot* one_hot) final {
     const PartialInformation& input = GetValue(one_hot->operand(0)).Get({});
     TernaryVector result;
     return SetValue(
@@ -283,7 +283,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                                     ? partial_ops::OneHotLsbToMsb(input)
                                     : partial_ops::OneHotMsbToLsb(input)));
   }
-  absl::Status HandleOneHotSel(OneHotSelect* ohs) override {
+  absl::Status HandleOneHotSel(OneHotSelect* ohs) final {
     const PartialInformation& selector = GetValue(ohs->selector()).Get({});
     const bool selector_can_be_zero =
         !query_engine_.AtLeastOneBitTrue(ohs->selector());
@@ -312,21 +312,21 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             })));
     return SetValue(ohs, std::move(result));
   }
-  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) override {
+  absl::Status HandleOrReduce(BitwiseReductionOp* or_reduce) final {
     Node* input = or_reduce->operand(0);
     return SetValue(or_reduce,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         or_reduce->GetType(),
                         partial_ops::OrReduce(GetValue(input).Get({}))));
   }
-  absl::Status HandleReverse(UnOp* reverse) override {
+  absl::Status HandleReverse(UnOp* reverse) final {
     PartialInformation result = GetValue(reverse->operand(0)).Get({});
     result.Reverse();
     return SetValue(reverse,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         reverse->GetType(), result));
   }
-  absl::Status HandleSDiv(BinOp* div) override {
+  absl::Status HandleSDiv(BinOp* div) final {
     Node* lhs = div->operand(0);
     Node* rhs = div->operand(1);
     return SetValue(
@@ -334,7 +334,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  div->GetType(), partial_ops::SDiv(GetValue(lhs).Get({}),
                                                    GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSGe(CompareOp* ge) override {
+  absl::Status HandleSGe(CompareOp* ge) final {
     Node* lhs = ge->operand(0);
     Node* rhs = ge->operand(1);
     return SetValue(
@@ -342,7 +342,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 ge->GetType(), partial_ops::SGe(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSGt(CompareOp* gt) override {
+  absl::Status HandleSGt(CompareOp* gt) final {
     Node* lhs = gt->operand(0);
     Node* rhs = gt->operand(1);
     return SetValue(
@@ -350,7 +350,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 gt->GetType(), partial_ops::SGt(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSLe(CompareOp* le) override {
+  absl::Status HandleSLe(CompareOp* le) final {
     Node* lhs = le->operand(0);
     Node* rhs = le->operand(1);
     return SetValue(
@@ -358,7 +358,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 le->GetType(), partial_ops::SLe(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSLt(CompareOp* lt) override {
+  absl::Status HandleSLt(CompareOp* lt) final {
     Node* lhs = lt->operand(0);
     Node* rhs = lt->operand(1);
     return SetValue(
@@ -366,7 +366,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 lt->GetType(), partial_ops::SLt(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSMod(BinOp* mod) override {
+  absl::Status HandleSMod(BinOp* mod) final {
     Node* lhs = mod->operand(0);
     Node* rhs = mod->operand(1);
     return SetValue(
@@ -374,7 +374,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  mod->GetType(), partial_ops::SMod(GetValue(lhs).Get({}),
                                                    GetValue(rhs).Get({}))));
   }
-  absl::Status HandleSMul(ArithOp* mul) override {
+  absl::Status HandleSMul(ArithOp* mul) final {
     Node* lhs = mul->operand(0);
     Node* rhs = mul->operand(1);
     return SetValue(
@@ -383,7 +383,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  partial_ops::SMul(GetValue(lhs).Get({}), GetValue(rhs).Get({}),
                                    mul->BitCountOrDie())));
   }
-  absl::Status HandleShll(BinOp* shll) override {
+  absl::Status HandleShll(BinOp* shll) final {
     Node* input = shll->operand(0);
     Node* amount = shll->operand(1);
     return SetValue(
@@ -392,7 +392,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             shll->GetType(), partial_ops::Shll(GetValue(input).Get({}),
                                                GetValue(amount).Get({}))));
   }
-  absl::Status HandleShra(BinOp* shra) override {
+  absl::Status HandleShra(BinOp* shra) final {
     Node* input = shra->operand(0);
     Node* amount = shra->operand(1);
     return SetValue(
@@ -401,7 +401,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             shra->GetType(), partial_ops::Shra(GetValue(input).Get({}),
                                                GetValue(amount).Get({}))));
   }
-  absl::Status HandleShrl(BinOp* shrl) override {
+  absl::Status HandleShrl(BinOp* shrl) final {
     Node* input = shrl->operand(0);
     Node* amount = shrl->operand(1);
     return SetValue(
@@ -410,7 +410,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             shrl->GetType(), partial_ops::Shrl(GetValue(input).Get({}),
                                                GetValue(amount).Get({}))));
   }
-  absl::Status HandleSignExtend(ExtendOp* sign_ext) override {
+  absl::Status HandleSignExtend(ExtendOp* sign_ext) final {
     return SetValue(
         sign_ext,
         LeafTypeTree<PartialInformation>::CreateSingleElementTree(
@@ -418,7 +418,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
             partial_ops::SignExtend(GetValue(sign_ext->operand(0)).Get({}),
                                     sign_ext->new_bit_count())));
   }
-  absl::Status HandleSub(BinOp* sub) override {
+  absl::Status HandleSub(BinOp* sub) final {
     Node* lhs = sub->operand(0);
     Node* rhs = sub->operand(1);
     return SetValue(
@@ -426,7 +426,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  sub->GetType(), partial_ops::Sub(GetValue(lhs).Get({}),
                                                   GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUDiv(BinOp* div) override {
+  absl::Status HandleUDiv(BinOp* div) final {
     Node* lhs = div->operand(0);
     Node* rhs = div->operand(1);
     return SetValue(
@@ -434,7 +434,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  div->GetType(), partial_ops::UDiv(GetValue(lhs).Get({}),
                                                    GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUGe(CompareOp* ge) override {
+  absl::Status HandleUGe(CompareOp* ge) final {
     Node* lhs = ge->operand(0);
     Node* rhs = ge->operand(1);
     return SetValue(
@@ -442,7 +442,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 ge->GetType(), partial_ops::UGe(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUGt(CompareOp* gt) override {
+  absl::Status HandleUGt(CompareOp* gt) final {
     Node* lhs = gt->operand(0);
     Node* rhs = gt->operand(1);
     return SetValue(
@@ -450,7 +450,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 gt->GetType(), partial_ops::UGt(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleULe(CompareOp* le) override {
+  absl::Status HandleULe(CompareOp* le) final {
     Node* lhs = le->operand(0);
     Node* rhs = le->operand(1);
     return SetValue(
@@ -458,7 +458,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 le->GetType(), partial_ops::ULe(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleULt(CompareOp* lt) override {
+  absl::Status HandleULt(CompareOp* lt) final {
     Node* lhs = lt->operand(0);
     Node* rhs = lt->operand(1);
     return SetValue(
@@ -466,7 +466,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                 lt->GetType(), partial_ops::ULt(GetValue(lhs).Get({}),
                                                 GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUMod(BinOp* mod) override {
+  absl::Status HandleUMod(BinOp* mod) final {
     Node* lhs = mod->operand(0);
     Node* rhs = mod->operand(1);
     return SetValue(
@@ -474,7 +474,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  mod->GetType(), partial_ops::UMod(GetValue(lhs).Get({}),
                                                    GetValue(rhs).Get({}))));
   }
-  absl::Status HandleUMul(ArithOp* mul) override {
+  absl::Status HandleUMul(ArithOp* mul) final {
     Node* lhs = mul->operand(0);
     Node* rhs = mul->operand(1);
     return SetValue(
@@ -483,14 +483,14 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
                  partial_ops::UMul(GetValue(lhs).Get({}), GetValue(rhs).Get({}),
                                    mul->BitCountOrDie())));
   }
-  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) override {
+  absl::Status HandleXorReduce(BitwiseReductionOp* xor_reduce) final {
     Node* input = xor_reduce->operand(0);
     return SetValue(xor_reduce,
                     LeafTypeTree<PartialInformation>::CreateSingleElementTree(
                         xor_reduce->GetType(),
                         partial_ops::XorReduce(GetValue(input).Get({}))));
   }
-  absl::Status HandleZeroExtend(ExtendOp* zero_ext) override {
+  absl::Status HandleZeroExtend(ExtendOp* zero_ext) final {
     return SetValue(
         zero_ext,
         LeafTypeTree<PartialInformation>::CreateSingleElementTree(
@@ -590,7 +590,7 @@ class PartialInfoVisitor : public DataflowVisitor<PartialInformation> {
       Type* element_type,
       absl::Span<const PartialInformation* const> data_sources,
       absl::Span<const LeafTypeTreeView<PartialInformation>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     if (node->Is<Select>()) {
       CHECK_EQ(control_sources.size(), 1);
       return SelectElements(/*selector=*/control_sources.front().Get({}),

--- a/xls/passes/proc_state_bits_shattering_pass.cc
+++ b/xls/passes/proc_state_bits_shattering_pass.cc
@@ -49,7 +49,7 @@ class TuplifyFlatStateElement : public Proc::StateElementTransformer {
 
   absl::StatusOr<Node*> TransformStateRead(Proc* proc,
                                            StateRead* new_state_read,
-                                           StateRead* old_state_read) override {
+                                           StateRead* old_state_read) final {
     CHECK_GT(split_ends_.size(), 1);
 
     BitsType* old_type = old_state_read->GetType()->AsBitsOrDie();
@@ -72,7 +72,7 @@ class TuplifyFlatStateElement : public Proc::StateElementTransformer {
 
   absl::StatusOr<Node*> TransformNextValue(Proc* proc,
                                            StateRead* new_state_read,
-                                           Next* old_next) override {
+                                           Next* old_next) final {
     CHECK_GT(split_ends_.size(), 1);
 
     Node* old_value = old_next->value();

--- a/xls/passes/proc_state_optimization_pass.cc
+++ b/xls/passes/proc_state_optimization_pass.cc
@@ -147,7 +147,7 @@ class StateDependencyVisitor : public DataflowVisitor<InlineBitmap> {
  public:
   explicit StateDependencyVisitor(Proc* proc) : proc_(proc) {}
 
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     // By default, conservatively assume that each element in `node` is
     // dependent upon all of the state elements which appear in the operands of
     // `node`.
@@ -155,7 +155,7 @@ class StateDependencyVisitor : public DataflowVisitor<InlineBitmap> {
                               node->GetType(), FlattenOperandBitmaps(node)));
   }
 
-  absl::Status HandleStateRead(StateRead* state_read) override {
+  absl::Status HandleStateRead(StateRead* state_read) final {
     // A state read is only dependent upon itself.
     XLS_ASSIGN_OR_RETURN(int64_t index, proc_->GetStateElementIndex(
                                             state_read->state_element()));
@@ -193,7 +193,7 @@ class StateDependencyVisitor : public DataflowVisitor<InlineBitmap> {
   absl::StatusOr<InlineBitmap> JoinElements(
       Type* element_type, absl::Span<const InlineBitmap* const> data_sources,
       absl::Span<const LeafTypeTreeView<InlineBitmap>> control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     InlineBitmap element = *data_sources.front();
     for (const InlineBitmap* data_source : data_sources.subspan(1)) {
       element.Union(*data_source);

--- a/xls/passes/proc_state_range_query_engine.cc
+++ b/xls/passes/proc_state_range_query_engine.cc
@@ -293,7 +293,7 @@ class ConstantValueIrInterpreter
   values() const {
     return map_;
   }
-  absl::Status DefaultHandler(Node* n) override {
+  absl::Status DefaultHandler(Node* n) final {
     if ((OpIsSideEffecting(n->op()) || n->op() == Op::kAfterAll) &&
         n->op() != Op::kGate) {
       // Side effecting ops (eg send, recv, trace, cover etc) either don't
@@ -395,7 +395,7 @@ class ConstantValueIrInterpreter
                n->GetType(), std::move(res)));
   }
 
-  absl::Status HandleNext(Next* n) override {
+  absl::Status HandleNext(Next* n) final {
     return absl::InternalError(absl::StrFormat(
         "Unexpected invoke of %s. Next nodes should not feed into anything.",
         n->ToString()));
@@ -406,9 +406,9 @@ class ConstantValueIrInterpreter
                            n->GetType(), absl::flat_hash_set<Bits>{}));
   }
 
-  absl::Status HandleParam(Param* p) override { return HandleNonConst(p); }
+  absl::Status HandleParam(Param* p) final { return HandleNonConst(p); }
 
-  absl::Status HandleLiteral(Literal* l) override {
+  absl::Status HandleLiteral(Literal* l) final {
     XLS_ASSIGN_OR_RETURN(LeafTypeTree<Value> value_ltt,
                          ValueToLeafTypeTree(l->value(), l->GetType()));
     return SetValue(l, leaf_type_tree::Map<absl::flat_hash_set<Bits>, Value>(
@@ -427,7 +427,7 @@ class ConstantValueIrInterpreter
       absl::Span<const absl::flat_hash_set<Bits>* const> data_sources,
       absl::Span<const LeafTypeTreeView<absl::flat_hash_set<Bits>>>
           control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     if (!element_type->IsBits()) {
       return absl::flat_hash_set<Bits>{};
     }

--- a/xls/passes/query_engine.cc
+++ b/xls/passes/query_engine.cc
@@ -441,7 +441,7 @@ class BaseForwardingQueryEngine final : public ForwardingQueryEngine {
  public:
   explicit BaseForwardingQueryEngine(const QueryEngine& qe) : qe_(qe) {}
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return absl::UnimplementedError(
         "Populate not supported on specialized query engines.");
   }

--- a/xls/passes/range_query_engine.h
+++ b/xls/passes/range_query_engine.h
@@ -87,11 +87,11 @@ class NoGivensProvider final : public RangeDataProvider {
  public:
   explicit NoGivensProvider(FunctionBase* function) : function_(function) {}
 
-  std::optional<RangeData> GetKnownIntervals(Node* node) override {
+  std::optional<RangeData> GetKnownIntervals(Node* node) final {
     return std::nullopt;
   }
 
-  absl::Status IterateFunction(DfsVisitor* visitor) override {
+  absl::Status IterateFunction(DfsVisitor* visitor) final {
     return function_->Accept(visitor);
   }
 
@@ -111,7 +111,7 @@ class RangeQueryEngine : public QueryEngine {
 
   // Populate the data in this `RangeQueryEngine` using the
   // given `FunctionBase*`;
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     NoGivensProvider givens(f);
     return PopulateWithGivens(givens);
   }

--- a/xls/passes/range_query_engine_test.cc
+++ b/xls/passes/range_query_engine_test.cc
@@ -2359,11 +2359,11 @@ class IntervalRangeGivens : public RangeDataProvider {
  public:
   explicit IntervalRangeGivens(absl::Span<Node* const> topo_sort)
       : topo_sort_(topo_sort) {}
-  std::optional<RangeData> GetKnownIntervals(Node* node) override {
+  std::optional<RangeData> GetKnownIntervals(Node* node) final {
     return std::nullopt;
   }
 
-  absl::Status IterateFunction(DfsVisitor* visitor) override {
+  absl::Status IterateFunction(DfsVisitor* visitor) final {
     for (Node* n : topo_sort_) {
       XLS_RETURN_IF_ERROR(n->VisitSingleNode(visitor));
     }
@@ -2421,11 +2421,11 @@ class LambdaRangeGivens : public RangeDataProvider {
  public:
   LambdaRangeGivens(FunctionBase* func, FKnown known)
       : func_(func), known_func_(known) {}
-  std::optional<RangeData> GetKnownIntervals(Node* node) override {
+  std::optional<RangeData> GetKnownIntervals(Node* node) final {
     return known_func_(node);
   }
 
-  absl::Status IterateFunction(DfsVisitor* visitor) override {
+  absl::Status IterateFunction(DfsVisitor* visitor) final {
     return func_->Accept(visitor);
   }
 

--- a/xls/passes/reassociation_pass.cc
+++ b/xls/passes/reassociation_pass.cc
@@ -593,7 +593,7 @@ class OneShotReassociationVisitor : public DfsVisitorWithDefault {
           operand_infos)
       : query_engine_(query_engine), operand_infos_(operand_infos) {}
 
-  absl::Status DefaultHandler(Node* n) override {
+  absl::Status DefaultHandler(Node* n) final {
     XLS_RET_CHECK(n->GetType()->IsBits()) << n;
     // If we reach here we aren't associative.
     unsigned_result_ = AssociativeElements::MakeLeaf(n);
@@ -601,21 +601,21 @@ class OneShotReassociationVisitor : public DfsVisitorWithDefault {
     return absl::OkStatus();
   }
 
-  absl::Status HandleAdd(BinOp* op) override { return HandleAssociativeOp(op); }
-  absl::Status HandleSub(BinOp* op) override { return HandleAssociativeOp(op); }
-  absl::Status HandleSMul(ArithOp* op) override {
+  absl::Status HandleAdd(BinOp* op) final { return HandleAssociativeOp(op); }
+  absl::Status HandleSub(BinOp* op) final { return HandleAssociativeOp(op); }
+  absl::Status HandleSMul(ArithOp* op) final {
     unsigned_result_ = AssociativeElements::MakeLeaf(op);
     XLS_ASSIGN_OR_RETURN(signed_result_,
                          CalculateAssociativeOp(op, /*is_signed=*/true));
     return absl::OkStatus();
   }
-  absl::Status HandleUMul(ArithOp* op) override {
+  absl::Status HandleUMul(ArithOp* op) final {
     signed_result_ = AssociativeElements::MakeLeaf(op);
     XLS_ASSIGN_OR_RETURN(unsigned_result_,
                          CalculateAssociativeOp(op, /*is_signed=*/false));
     return absl::OkStatus();
   }
-  absl::Status HandleNeg(UnOp* op) override {
+  absl::Status HandleNeg(UnOp* op) final {
     const AssociativeElements& base_signed =
         GetOperandInfo(0, /*is_signed=*/true);
     if (base_signed.op() == Op::kUMul) {
@@ -639,7 +639,7 @@ class OneShotReassociationVisitor : public DfsVisitorWithDefault {
     }
     return absl::OkStatus();
   }
-  absl::Status HandleConcat(Concat* cc) override {
+  absl::Status HandleConcat(Concat* cc) final {
     std::optional<ZeroExtLike> ext_like = ZeroExtLike::Make(cc, query_engine_);
     if (!ext_like) {
       return DefaultHandler(cc);
@@ -647,11 +647,11 @@ class OneShotReassociationVisitor : public DfsVisitorWithDefault {
     return HandleZeroExtLike(*ext_like);
   }
 
-  absl::Status HandleZeroExtend(ExtendOp* ext) override {
+  absl::Status HandleZeroExtend(ExtendOp* ext) final {
     return HandleZeroExtLike(*ZeroExtLike::Make(ext, query_engine_));
   }
 
-  absl::Status HandleSignExtend(ExtendOp* ext) override {
+  absl::Status HandleSignExtend(ExtendOp* ext) final {
     const AssociativeElements& inner_unsigned =
         GetOperandInfo(0, /*is_signed=*/false);
     std::optional<ZeroExtLike> zero_ext_like =

--- a/xls/passes/stateless_query_engine.h
+++ b/xls/passes/stateless_query_engine.h
@@ -41,7 +41,7 @@ class StatelessQueryEngine : public QueryEngine {
  public:
   StatelessQueryEngine() = default;
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return ReachedFixpoint::Unchanged;
   }
 

--- a/xls/passes/ternary_query_engine.cc
+++ b/xls/passes/ternary_query_engine.cc
@@ -168,12 +168,12 @@ class TernaryNodeEvaluator : public AbstractNodeEvaluator<TernaryEvaluator> {
   }
 
   // By default everything is considered fully unconstrained.
-  absl::Status DefaultHandler(Node* n) override {
+  absl::Status DefaultHandler(Node* n) final {
     XLS_ASSIGN_OR_RETURN(auto unconstrained, UnconstrainedOf(n->GetType()));
     return SetValue(n, std::move(unconstrained));
   }
 
-  absl::Status HandleArrayIndex(ArrayIndex* index) override {
+  absl::Status HandleArrayIndex(ArrayIndex* index) final {
     XLS_ASSIGN_OR_RETURN(auto indices, GetValueList(index->indices()));
     XLS_ASSIGN_OR_RETURN(auto array, GetCompoundValue(index->array()));
     if (indices.empty()) {
@@ -199,7 +199,7 @@ class TernaryNodeEvaluator : public AbstractNodeEvaluator<TernaryEvaluator> {
     return SetValue(index, std::move(result));
   }
 
-  absl::Status HandleArraySlice(ArraySlice* slice) override {
+  absl::Status HandleArraySlice(ArraySlice* slice) final {
     XLS_ASSIGN_OR_RETURN(auto start, GetValue(slice->start()));
     XLS_ASSIGN_OR_RETURN(CompoundValueView array,
                          GetCompoundValue(slice->array()));
@@ -220,7 +220,7 @@ class TernaryNodeEvaluator : public AbstractNodeEvaluator<TernaryEvaluator> {
     return SetValue(slice, std::move(result));
   }
 
-  absl::Status HandleArrayUpdate(ArrayUpdate* update) override {
+  absl::Status HandleArrayUpdate(ArrayUpdate* update) final {
     XLS_ASSIGN_OR_RETURN(auto indices, GetValueList(update->indices()));
     XLS_ASSIGN_OR_RETURN(auto array,
                          GetCompoundValue(update->array_to_update()));

--- a/xls/passes/token_provenance_analysis.cc
+++ b/xls/passes/token_provenance_analysis.cc
@@ -101,7 +101,7 @@ class TokenProvenanceVisitor
       absl::Span<absl::flat_hash_set<Node*> const* const> data_sources,
       absl::Span<const LeafTypeTreeView<absl::flat_hash_set<Node*>>>
           control_sources,
-      Node* node, absl::Span<const int64_t> index) override {
+      Node* node, absl::Span<const int64_t> index) final {
     if (!AreAllElementsEmpty(control_sources)) {
       return TokenError(node);
     }
@@ -118,7 +118,7 @@ class TokenProvenanceVisitor
 // visitor's traversal instead of having to topo-sort.
 class TokenProvenanceWithTopoSortVisitor : public TokenProvenanceVisitor {
  public:
-  absl::Status DefaultHandler(Node* node) override {
+  absl::Status DefaultHandler(Node* node) final {
     const bool result_contains_token = TypeHasToken(node->GetType());
     if (result_contains_token || OpIsSideEffecting(node->op())) {
       if (node->OpIn({Op::kParam, Op::kStateRead}) && !result_contains_token) {

--- a/xls/passes/tools/generate_documentation_proto.cc
+++ b/xls/passes/tools/generate_documentation_proto.cc
@@ -64,7 +64,7 @@ namespace m = clang::ast_matchers;
 // it's an ABC).
 class Callback : public m::MatchFinder::MatchCallback {
  public:
-  void run(const m::MatchFinder::MatchResult& result) override {
+  void run(const m::MatchFinder::MatchResult& result) final {
     bool updated_any = false;
     bool updated_exact = false;
     if (const clang::CXXRecordDecl* clz =

--- a/xls/passes/union_query_engine.h
+++ b/xls/passes/union_query_engine.h
@@ -114,7 +114,7 @@ class UnownedConstUnionQueryEngine : public UnownedUnionQueryEngine {
   explicit UnownedConstUnionQueryEngine(std::vector<QueryEngine const*> engines)
       : UnownedUnionQueryEngine(UnsafeConstCast(std::move(engines))) {}
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return absl::InternalError("Cannot repopulate const engines.");
   }
 

--- a/xls/passes/union_query_engine_test.cc
+++ b/xls/passes/union_query_engine_test.cc
@@ -50,7 +50,7 @@ class FakeQueryEngine : public QueryEngine {
  public:
   FakeQueryEngine() = default;
 
-  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) override {
+  absl::StatusOr<ReachedFixpoint> Populate(FunctionBase* f) final {
     return ReachedFixpoint::Unchanged;
   }
 

--- a/xls/solvers/z3_ir_equivalence_testutils.cc
+++ b/xls/solvers/z3_ir_equivalence_testutils.cc
@@ -65,7 +65,7 @@ class FuncInterpreter final : public IrInterpreter {
       const absl::flat_hash_map<std::string_view, Value>& param_vals)
       : param_vals_(param_vals) {}
 
-  absl::Status HandleParam(Param* param) override {
+  absl::Status HandleParam(Param* param) final {
     XLS_RET_CHECK(param_vals_.contains(param->name()));
     return IrInterpreter::SetValueResult(param, param_vals_.at(param->name()));
   }

--- a/xls/synthesis/fake_synthesis_server_main.cc
+++ b/xls/synthesis/fake_synthesis_server_main.cc
@@ -62,7 +62,7 @@ class FakeSynthesisServiceImpl : public SynthesisService::Service {
 
   ::grpc::Status Compile(::grpc::ServerContext* server_context,
                          const CompileRequest* request,
-                         CompileResponse* result) override {
+                         CompileResponse* result) final {
     auto start = absl::Now();
 
     result->set_slack_ps(

--- a/xls/synthesis/openroad/json_metrics_server_main.cc
+++ b/xls/synthesis/openroad/json_metrics_server_main.cc
@@ -69,7 +69,7 @@ class JsonMetricsSynthesisServiceImpl : public SynthesisService::Service {
 
   ::grpc::Status Compile(::grpc::ServerContext* server_context,
                          const CompileRequest* request,
-                         CompileResponse* result) override {
+                         CompileResponse* result) final {
     auto start = absl::Now();
 
     absl::Status metrics_status = RunMetrics(request, result);

--- a/xls/tests/testbench_thread.h
+++ b/xls/tests/testbench_thread.h
@@ -80,7 +80,7 @@ class TestbenchThread
     };
   }
 
-  void Init() override { shard_data_ = create_shard_fn_(); }
+  void Init() final { shard_data_ = create_shard_fn_(); }
 
  private:
   std::unique_ptr<ShardDataT> shard_data_;

--- a/xls/tools/memory_models.cc
+++ b/xls/tools/memory_models.cc
@@ -134,7 +134,7 @@ class RewrittenProcMemoryModel : public ProcMemoryModel {
     elements_.resize(size, AllOnesOfType(elements_type_));
   }
 
-  absl::Status Tick() override {
+  absl::Status Tick() final {
     struct Request {
       bool read = false;
       bool write = false;
@@ -188,7 +188,7 @@ class RewrittenProcMemoryModel : public ProcMemoryModel {
     return absl::OkStatus();
   }
 
-  absl::Status Reset() override {
+  absl::Status Reset() final {
     elements_.assign(elements_.size(), XsOfType(elements_type_));
     return absl::OkStatus();
   }

--- a/xls/tools/node_coverage_utils.h
+++ b/xls/tools/node_coverage_utils.h
@@ -40,14 +40,14 @@ class CoverageEvalObserver final : public EvaluationObserver,
  public:
   explicit CoverageEvalObserver(std::optional<JitRuntime*> jit = std::nullopt)
       : jit_(jit) {}
-  void NodeEvaluated(Node* n, const Value& v) override;
-  std::optional<RuntimeObserver*> AsRawObserver() override {
+  void NodeEvaluated(Node* n, const Value& v) final;
+  std::optional<RuntimeObserver*> AsRawObserver() final {
     if (jit_) {
       return this;
     }
     return std::nullopt;
   }
-  void RecordNodeValue(int64_t node_ptr, const uint8_t* data) override;
+  void RecordNodeValue(int64_t node_ptr, const uint8_t* data) final;
 
   // Prepare for proto conversion.
   absl::Status Finalize();

--- a/xls/tools/opt_main.cc
+++ b/xls/tools/opt_main.cc
@@ -85,9 +85,9 @@ class FileStderrLogSink final : public absl::LogSink {
     CHECK_OK(SetFileContents(path_, ""));
   }
 
-  ~FileStderrLogSink() override = default;
+  ~FileStderrLogSink() final = default;
 
-  void Send(const absl::LogEntry& entry) override {
+  void Send(const absl::LogEntry& entry) final {
     if (entry.log_severity() < absl::StderrThreshold()) {
       return;
     }


### PR DESCRIPTION
Readability: The `final` keyword indicates to the reader of the code that an implementation is a leaf, improving readability; it is always possible to make it `override` later.

Performance: This also can result in performance improvements as the compiler can better see devirtualization opportunities.

This changes many places in leaf implementations to be annotated `final` instead of `override`. Maybe it also helps future code to adopt this good practice.