### PR TITLE
Fixes to reject indexing into a zero sized array.

### DIFF
--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -109,6 +109,13 @@ fn main() -> u2 { p<u32:1>(u2:0) }
   XLS_EXPECT_OK(Typecheck(text));
 }
 
+TEST_P(TypecheckBothVersionsTest, IndexZeroSizedArray) {
+  std::string_view text = R"(fn f(a: u8[0], b: u3) -> u8 { a[b] })";
+  EXPECT_THAT(Typecheck(text),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("Zero-sized arrays cannot be indexed")));
+}
+
 // The type of the default expression is wrong for the parametric binding of X.
 //
 // It's /always/ wrong, but it's also not used, so this test is pointing out "do

--- a/xls/ir/function_builder_test.cc
+++ b/xls/ir/function_builder_test.cc
@@ -692,16 +692,15 @@ TEST(FunctionBuilderTest, ArrayIndexMultipleDimensions) {
   EXPECT_EQ(func->return_value()->GetType(), element_type);
 }
 
-TEST(FunctionBuilderTest, ArrayIndexNilIndex) {
+TEST(FunctionBuilderTest, ArrayIndexBitsSubjectNilIndex) {
   Package p("p");
   FunctionBuilder b("f", &p);
   BValue a = b.Param("a", p.GetBitsType(123));
   b.ArrayIndex(a, {});
 
-  XLS_ASSERT_OK_AND_ASSIGN(Function * func, b.Build());
-  EXPECT_THAT(func->return_value(),
-              m::ArrayIndex(m::Param("a"), /*indices=*/{}));
-  EXPECT_EQ(func->return_value()->GetType(), p.GetBitsType(123));
+  EXPECT_THAT(b.Build().status(),
+              StatusIs(absl::StatusCode::kInvalidArgument,
+                       HasSubstr("Expected operand 0 of array_index")));
 }
 
 TEST(FunctionBuilderTest, ArrayIndexWrongIndexType) {

--- a/xls/ir/type.h
+++ b/xls/ir/type.h
@@ -184,6 +184,7 @@ class ArrayType : public Type {
 
   Type* element_type() const { return element_type_; }
   int64_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
 
   int64_t GetFlatBitCount() const override {
     return element_type_->GetFlatBitCount() * size_;

--- a/xls/ir/verifier_test.cc
+++ b/xls/ir/verifier_test.cc
@@ -45,6 +45,21 @@ class VerifierTest : public IrTestBase {
   VerifierTest() = default;
 };
 
+TEST_F(VerifierTest, ArrayIndexOfEmptyArray) {
+  std::string input = R"(
+package p
+
+fn f(a: bits[8][0], i: bits[3]) -> bits[8] {
+  ret array_index.1: bits[8] = array_index(a, indices=[i])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(auto p, ParsePackageNoVerify(input));
+  EXPECT_THAT(
+      VerifyPackage(p.get()),
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("Array index cannot be applied to an empty array")));
+}
+
 TEST_F(VerifierTest, BadSelect) {
   static constexpr std::string_view input = R"(
 package subrosa

--- a/xls/passes/array_simplification_pass.cc
+++ b/xls/passes/array_simplification_pass.cc
@@ -308,6 +308,13 @@ absl::StatusOr<SimplifyResult> SimplifyArrayIndex(
     } else {
       XLS_ASSIGN_OR_RETURN(operand_no, first_index.ToUint64());
     }
+    // If there are no remaining indices, replace with the selected element
+    // directly instead of creating an ArrayIndex with an empty index list.
+    if (array_index->indices().size() == 1) {
+      XLS_RETURN_IF_ERROR(
+          array_index->ReplaceUsesWith(array->operand(operand_no)));
+      return SimplifyResult::Changed({array->operand(operand_no)});
+    }
     XLS_ASSIGN_OR_RETURN(
         ArrayIndex * new_array_index,
         array_index->ReplaceUsesWithNew<ArrayIndex>(

--- a/xls/solvers/z3_ir_translator_test.cc
+++ b/xls/solvers/z3_ir_translator_test.cc
@@ -1291,13 +1291,15 @@ fn f() -> bits[32] {
   EXPECT_THAT(proven_eq, IsProvenTrue());
 }
 
-TEST_F(Z3IrTranslatorTest, IndexBitsType) {
+TEST_F(Z3IrTranslatorTest, IndexSingleElementArray) {
   const std::string program = R"(
 package p
 
 fn f() -> bits[32] {
   eight: bits[32] = literal(value=8)
-  ret result: bits[32] = array_index(eight, indices=[])
+  zero: bits[32] = literal(value=0)
+  arr: bits[32][1] = array(eight)
+  ret result: bits[32] = array_index(arr, indices=[zero])
 }
 )";
 


### PR DESCRIPTION
Since the last element of the array does not exist we cannot use our typical
"clamp to last in bounds" out of bounds indexing behavior.

This uncovered that we were accidentally creating an array index to into a nil
tuple in the array simplifier, so we special case where there is only one
element to avoid creating this invalid IR. This made the fuzzing pass the new
verifier conditions.

Fixes #2574