### PR TITLE
[DSLX:FE] Fix for instantiation of builtin trace_fmt!

### DIFF
--- a/xls/dslx/frontend/builtins_metadata.cc
+++ b/xls/dslx/frontend/builtins_metadata.cc
@@ -48,10 +48,26 @@ const absl::flat_hash_map<std::string, BuiltinsData>& GetParametricBuiltins() {
           // Typically built-ins are done as AST nodes if they require some
           // special syntactic construct that is not capable of being handled
           // with the normal grammar.
-          {"all_ones!", {.signature = "() -> T", .is_ast_node = true}},
-          {"zero!", {.signature = "() -> T", .is_ast_node = true}},
-          {"trace_fmt!", {.signature = "(T) -> T", .is_ast_node = true}},
-          {"vtrace_fmt!", {.signature = "(u32, T) -> T", .is_ast_node = true}},
+          {"all_ones!",
+           {.signature = "() -> T",
+            .is_ast_node = true,
+            .requires_implicit_token = false,
+            .allows_explicit_parametrics = true}},
+          {"zero!",
+           {.signature = "() -> T",
+            .is_ast_node = true,
+            .requires_implicit_token = false,
+            .allows_explicit_parametrics = true}},
+          {"trace_fmt!",
+           {.signature = "(T) -> T",
+            .is_ast_node = true,
+            .requires_implicit_token = false,
+            .allows_explicit_parametrics = false}},
+          {"vtrace_fmt!",
+           {.signature = "(u32, T) -> T",
+            .is_ast_node = true,
+            .requires_implicit_token = false,
+            .allows_explicit_parametrics = false}},
 
           // -- Normal built-in functions
           //

--- a/xls/dslx/frontend/builtins_metadata.h
+++ b/xls/dslx/frontend/builtins_metadata.h
@@ -36,6 +36,14 @@ struct BuiltinsData {
   // but built-ins that demand a token like `assert!`, `cover!`, `fail!` etc do
   // have this set.
   bool requires_implicit_token = false;
+
+  // Indicates whether the builtin permits explicit parametric instantiation
+  // via angle brackets at the callsite; e.g. `zero!<T>()`.
+  //
+  // Defaults to false. Only a small subset of AST-node builtins (e.g. `zero!`,
+  // `all_ones!`) should set this to true. Non-AST builtins are not gated by
+  // this flag.
+  bool allows_explicit_parametrics = false;
 };
 
 // Map from the name of the parametric builtin function; e.g. `assert_eq` to a

--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -2458,6 +2458,36 @@ absl::StatusOr<Expr*> Parser::ParseTermRhs(Expr* lhs, Bindings& outer_bindings,
 
       XLS_ASSIGN_OR_RETURN(bool has_open_paren,
                            PeekTokenIs(TokenKind::kOParen));
+      // Disallow explicit parametrics (even empty) for AST-node builtins that
+      // do not accept parametrics per metadata. Expand the error span to cover
+      // the full invocation (up to the closing ')') if present.
+      if (auto* name_ref = dynamic_cast<NameRef*>(lhs)) {
+        if (auto* builtin = TryGet<BuiltinNameDef*>(name_ref->name_def())) {
+          std::string name = builtin->identifier();
+          const auto& meta = GetParametricBuiltins();
+          if (auto it = meta.find(name); it != meta.end()) {
+            const BuiltinsData& data = it->second;
+            if (data.is_ast_node && !data.allows_explicit_parametrics) {
+              Pos end_pos = GetPos();
+              if (has_open_paren) {
+                CHECK_OK(PopToken().status());
+                Bindings* b = sub_txn.bindings();
+                XLS_ASSIGN_OR_RETURN(
+                    std::vector<Expr*> ignored_args,
+                    ParseCommaSeq<Expr*>(
+                        [b, this] { return ParseExpression(*b); },
+                        TokenKind::kCParen));
+                end_pos = GetPos();
+              }
+              return ParseErrorStatus(
+                  Span(new_pos, end_pos),
+                  absl::Substitute(
+                      "$0 macro does not expect parametric arguments.", name));
+            }
+          }
+        }
+      }
+
       if (!has_open_paren) {
         sub_txn.CommitAndCancelCleanup(&sub_cleanup);
         return module_->Make<FunctionRef>(lhs->span(), lhs, *parametrics);

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -990,6 +990,21 @@ TEST_F(ParserTest, VTraceFmtWithArgs) {
 })");
 }
 
+TEST_F(ParserTest, TraceFmtExplicitParametricsDisallowed) {
+  const std::string text = R"(fn main() {
+    trace_fmt!<>;
+  })";
+
+  Scanner s{file_table_, Fileno(0), std::string{text}};
+  Parser parser{"test", &s};
+  absl::StatusOr<std::unique_ptr<Module>> module = parser.ParseModule();
+  EXPECT_THAT(
+      module,
+      StatusIs(
+          absl::StatusCode::kInvalidArgument,
+          HasSubstr("trace_fmt! macro does not expect parametric arguments.")));
+}
+
 TEST_F(ParserTest, ParseProcWithConst) {
   RoundTrip(R"(proc simple {
     const MAX_X = u32:10;


### PR DESCRIPTION
Preivously this would cause an internal TypeMissing error:

```
[cdleary@cdleary-devbox-ng ~/proj/xlsynth (main)] 2025-08-19 12:23:23
$ bazel-bin/xls/dslx/interpreter_main /tmp/sample.x 
/tmp/sample.x:2:5-2:15
0001: fn main() {
0002:     trace_fmt!<>;
~~~~~~~~~~^--------^ TypeMissingError: node: 0x5c5184ec7f70 user: 0x5c5184e7ced0 internal error: AST node is missing a corresponding type: trace_fmt! 0x5c5184ec7f70 (kind: BuiltinNameDef) defined @ <no span>. This may be due to recursion, which is not supported.
0003:   }
[cdleary@cdleary-devbox-ng ~/proj/xlsynth (main)] 2025-08-19 12:24:22
$ cat /tmp/sample.x 
fn main() {
    trace_fmt!<>;
  }
  ```
  
This was triggering because a malformed trace_fmt!<> with explicit parametrics slipped past parsing as a generic invocation, so the builtin callee never got a concrete type recorded and DeduceNameRef later hit a missing-type lookup (TypeMissingError). Unlike arg count and argument type checks (which are semantic and rightly live in typechecking), "no explicit parametrics" and "first arg is a literal format string" are syntactic invariants of the macro. The parser is arguably the right layer to enforce them because it’s the only place that can reliably build a well-formed FormatMacro AST with pre-parsed format steps that later phases assume. Deferring this to typechecking would either force carrying raw parametrics/strings through the AST (complicating IR conversion and weakening invariants) or add brittle special-casing in deduction, and it would delay a clear user error into an internal missing-type failure. This also matches builtins metadata (no parametrics allowed) and existing tests that expect parse-time errors.