### PR TITLE
[DSLX:FE] Fix internal error for type keyword in match pattern position.

### DIFF
--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -1787,7 +1787,7 @@ absl::StatusOr<NameDefTree*> Parser::ParsePattern(Bindings& bindings,
 
   if (peek->IsKindIn({TokenKind::kNumber, TokenKind::kCharacter, Keyword::kTrue,
                       Keyword::kFalse}) ||
-      peek->IsTypeKeyword()) {
+      (peek->IsTypeKeyword() && !peek->IsKeyword(Keyword::kType))) {
     XLS_ASSIGN_OR_RETURN(Number * number, ParseNumber(bindings));
     XLS_ASSIGN_OR_RETURN(bool peek_is_double_dot,
                          PeekTokenIs(TokenKind::kDoubleDot));

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -735,6 +735,22 @@ TEST(ParserErrorTest, ParseErrorForImplWithoutStructDef) {
       IsPosError("ParseError", HasSubstr("Cannot find a definition for name")));
 }
 
+TEST(ParserErrorTest, TypeKeywordInPatternPositionIsParseError) {
+  constexpr std::string_view kProgram = R"(fn f(x: u2) -> u2 {
+    match 0 {
+      type
+    }
+  })";
+
+  FileTable file_table;
+  Scanner s{file_table, Fileno(0), std::string(kProgram)};
+  Parser parser{"test", &s};
+  absl::StatusOr<std::unique_ptr<Module>> module = parser.ParseModule();
+  EXPECT_THAT(module.status(),
+              IsPosError("ParseError",
+                         HasSubstr("Expected pattern; got keyword:type")));
+}
+
 TEST_F(ParserTest, StructDefRoundTrip) {
   RoundTrip(R"(pub struct foo<A: u32, B: bits[16]> {
     a: bits[A],


### PR DESCRIPTION
Previously, ParsePattern treated any type keyword as the start of a numeric literal, so `match 0 { type` attempted number parsing and failed with a confusing `INVALID_ARGUMENT: "String is not a BuiltinType: \"type\""`. This change excludes type from the number-start detection in ParsePattern, so it now yields a clear parse error: "Expected pattern; got keyword:type". Added a targeted parser test to lock in the behavior.