### PR TITLE
[DSLX:FE] Prevent recursion in parametric defaults or return types.

### DIFF
--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -427,6 +427,19 @@ TEST(ParserErrorTest, SelfTypeOutsideImplReturnType) {
                  HasSubstr("Type `Self` cannot be used outside of an `impl`")));
 }
 
+TEST(ParserErrorTest, RecursionInReturnTypeDefinition) {
+  // The function name should not be in scope while parsing its signature;
+  // referencing it in the return type should be a parse-time name error.
+  constexpr std::string_view kProgram = "fn p()->xN[p()]{}";
+  FileTable file_table;
+  Scanner s{file_table, Fileno(0), std::string(kProgram)};
+  Parser parser{"test", &s};
+  absl::StatusOr<std::unique_ptr<Module>> module = parser.ParseModule();
+  EXPECT_THAT(module.status(),
+              IsPosError("ParseError",
+                         HasSubstr("Cannot find a definition for name: \"p\"")));
+}
+
 TEST(ParserErrorTest, ImplUsingMisnamedSelf) {
   constexpr std::string_view kProgram = R"(struct foo { }
 impl foo {

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -1047,6 +1047,16 @@ class ImportModuleWithTypeErrorTest(test_base.TestCase):
         stderr,
     )
 
+  def test_self_reference_in_parametric_default(self):
+    # Referencing the function name inside its own parametric default should be
+    # a parse-time name error because the function name is not yet in scope
+    # while parsing the signature.
+    contents = 'fn p<N: u3, M: u32 = { p(u3:0) }>() { () }'
+    tmp = self.create_tempfile(content=contents)
+    stderr = self._run(tmp.full_path, path_is_runfile=False)
+    self.assertIn('ParseError', stderr)
+    self.assertIn('Cannot find a definition for name: "p"', stderr)
+
   def test_duplicate_typedef_binding_in_module(self):
     stderr = self._run(
         'xls/dslx/tests/errors/duplicate_typedef_binding_in_module.x'


### PR DESCRIPTION
Previously, referencing a function in its own signature (return type or parametric default) allowed the name to resolve during signature parsing. That triggered recursive deduction/constexpr evaluation and led to an infinite loop ending in a stack overflow (e.g., in TypeInfo::GetItem via Deduce).

Cause: the parser added the function name to the scope before finishing the signature, so p was lexically visible inside p’s signature.

Change: delay binding the function name until after parsing the full signature. Now self-references in the signature produce a clear ParseError (“Cannot find a definition for name: "p"”) instead of crashing.