### PR TITLE
Add support for generating compile_commands.json.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,7 @@
 # more tutorial information.
 
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
@@ -57,4 +58,17 @@ diff_test(
     name = "fuzztest_config_test",
     file1 = "fuzztest.bazelrc",
     file2 = ":fuzztest_generated_bazelrc",
+)
+
+# To generate compilation DB, run:
+#   bazel build -c opt //xls/... -k
+#   bazel run //:refresh_compile_commands
+#
+# The first command ensures all generated c++ files are built. It takes a
+# while and is not strictly necessary but will result in better
+# cross-referencing.
+refresh_compile_commands(
+    name = "refresh_compile_commands",
+    exclude_external_sources = True,
+    targets = {"//xls/...": "-c opt"},
 )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,8 @@ proj/xls$ pip install mdformat mdformat-tables mdformat-footnote
 ```
 
 The file `.mdformat.toml` in the top source directory contains the mdformat
-configuration settings.
+configuration settings. These settings should be picked up automatically
+by mdformat. Invoke mdformat directly on any modified markdown files.
 
 ### DSLX snippets in documentation
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,3 +64,13 @@ bazel_dep(name = "protoc-gen-validate", version = "1.2.1.bcr.1")
 
 # compilation DB; build_cleaner
 bazel_dep(name = "bant", version = "0.2.2", dev_dependency = True)
+
+# Hedron's Compile Commands Extractor for Bazel
+# https://github.com/hedronvision/bazel-compile-commands-extractor
+bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
+git_override(
+    module_name = "hedron_compile_commands",
+    remote = "https://github.com/hedronvision/bazel-compile-commands-extractor.git",
+    # Updated 2025/08/19.
+    commit = "abb61a688167623088f8768cc9264798df6a9d10",
+)

--- a/README.md
+++ b/README.md
@@ -176,9 +176,27 @@ localhost instances of [bazel-remote](https://github.com/buchgr/bazel-remote/).
 
 ### Getting Clangd completions
 
-A `compile_flags.txt` file compatible with clangd and similar tools can be
-created by running `xls/dev_tools/make-compilation-db.sh`. Follow directions for
-your editor to install clangd code completion.
+There are two ways of getting clangd completions and related features.
+
+A `compile_flags.txt` file compatible with clangd and similar
+tools can be created by running `xls/dev_tools/make-compilation-db.sh`.
+This approach is faster but does not account for differences in the way
+individual targets are built.
+
+Alternatively,
+[hedronvision/bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor)
+can be used to generate a `compile_commands.json` file that
+clangd can consume. This approach is slower to setup but the
+compiler flags are tailored for each target. The
+`compile_commands.json` file can be built by running:
+
+```bash
+bazel build -c opt //xls/... -k
+bazel run //:refresh_compile_commands
+```
+
+See the comments in the top-level
+[BUILD](https://github.com/google/xls/blob/main/BUILD) file for more details.
 
 ## Stack Diagram and Project Layout
 


### PR DESCRIPTION
Use hedronvision/bazel-compile-commands-extractor to generate the
compile_commands.json file. This file is used by clangd for autocomplete
and other IDE featues. This approach is more robust than the existing
dev_tools/make-compilation-db.sh approach and results with many fewer
error/warning false positives being flagged in the UI (unused includes,
undefined symbols, etc).

As configured the json file is large (70MB) but not enormous and does not
seem to pose problems for clangd.