### PR TITLE
Add binary for generating verilog from block IR. 

### DIFF
--- a/docs_src/tools.md
+++ b/docs_src/tools.md
@@ -17,6 +17,12 @@ tool may be run against arbitrary IR not just the fixed set of XLS benchmarks.
 The output of this tool is scraped by `run_benchmarks` to construct a table
 comparing metrics against a mint CL across the benchmark suite.
 
+## [`block_to_verilog_main`](https://github.com/google/xls/tree/main/xls/tools/block_to_verilog_main.cc)
+
+Lowers a XLS IR file containing a block into Verilog. This the final step of
+what `codegen_main` performs. This tool accepts the same codegen options as
+`codegen_main`.
+
 ## [`booleanify_main`](https://github.com/google/xls/tree/main/xls/dev_tools/booleanify_main.cc)
 
 Rewrites an XLS IR function in terms of its ops' fundamental AND/OR/NOT

--- a/xls/tools/BUILD
+++ b/xls/tools/BUILD
@@ -701,6 +701,8 @@ cc_library(
     deps = [
         ":codegen_flags_cc_proto",
         ":scheduling_options_flags_cc_proto",
+        "//xls/codegen:block_generator",
+        "//xls/codegen:block_metrics",
         "//xls/codegen:codegen_options",
         "//xls/codegen:codegen_result",
         "//xls/codegen:combinational_generator",
@@ -725,6 +727,7 @@ cc_library(
         "//xls/scheduling:scheduling_pass",
         "//xls/scheduling:scheduling_pass_pipeline",
         "//xls/scheduling:scheduling_result",
+        "@com_google_absl//absl/container:flat_hash_set",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
         "@com_google_absl//absl/status",
@@ -756,6 +759,32 @@ cc_binary(
         "//xls/scheduling:pipeline_schedule",
         "//xls/scheduling:scheduling_options",
         "//xls/scheduling:scheduling_result",
+        "@com_google_absl//absl/flags:flag",
+        "@com_google_absl//absl/log",
+        "@com_google_absl//absl/log:check",
+        "@com_google_absl//absl/status",
+        "@com_google_absl//absl/strings:str_format",
+    ],
+)
+
+cc_binary(
+    name = "block_to_verilog_main",
+    srcs = ["block_to_verilog_main.cc"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":codegen",
+        ":codegen_flags",
+        ":codegen_flags_cc_proto",
+        "//xls/codegen:codegen_result",
+        "//xls/codegen:module_signature",
+        "//xls/common:exit_status",
+        "//xls/common:init_xls",
+        "//xls/common/file:filesystem",
+        "//xls/common/status:ret_check",
+        "//xls/common/status:status_macros",
+        "//xls/dev_tools:tool_timeout",
+        "//xls/ir:ir_parser",
+        "//xls/ir:verifier",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/log",
         "@com_google_absl//absl/log:check",
@@ -811,6 +840,21 @@ py_test(
     deps = [
         "//xls/common:runfiles",
         "//xls/common:test_base",
+    ],
+)
+
+py_test(
+    name = "block_to_verilog_main_test",
+    srcs = ["block_to_verilog_main_test.py"],
+    data = [
+        ":block_to_verilog_main",
+    ],
+    deps = [
+        "//xls/codegen:module_signature_py_pb2",
+        "//xls/common:runfiles",
+        "//xls/common:test_base",
+        "@abseil-py//absl/testing:absltest",
+        "@com_google_protobuf//:protobuf_python",
     ],
 )
 

--- a/xls/tools/block_to_verilog_main.cc
+++ b/xls/tools/block_to_verilog_main.cc
@@ -1,0 +1,104 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "absl/flags/flag.h"
+#include "absl/log/check.h"
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/strings/str_format.h"
+#include "xls/codegen/codegen_result.h"
+#include "xls/common/exit_status.h"
+#include "xls/common/file/filesystem.h"
+#include "xls/common/init_xls.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/verifier.h"
+#include "xls/tools/codegen.h"
+#include "xls/tools/codegen_flags.h"
+#include "xls/tools/codegen_flags.pb.h"
+
+static constexpr std::string_view kUsage = R"(
+Generates Verilog from a given block IR file. Example invocation:
+
+  block_to_verilog_main --output_verilog_path=OUT BLOCK_IR
+)";
+
+namespace xls {
+namespace {
+
+absl::Status RealMain(std::string_view ir_path) {
+  if (ir_path == "-") {
+    ir_path = "/dev/stdin";
+  }
+  XLS_ASSIGN_OR_RETURN(std::string ir_contents, GetFileContents(ir_path));
+  XLS_ASSIGN_OR_RETURN(std::unique_ptr<Package> p,
+                       Parser::ParsePackage(ir_contents, ir_path));
+
+  XLS_ASSIGN_OR_RETURN(CodegenFlagsProto codegen_flags_proto,
+                       GetCodegenFlags());
+
+  XLS_ASSIGN_OR_RETURN(verilog::CodegenResult codegen_result,
+                       BlockToVerilog(p.get(), codegen_flags_proto));
+
+  std::string verilog_path = absl::GetFlag(FLAGS_output_verilog_path);
+  if (!verilog_path.empty()) {
+    for (int64_t i = 0; i < codegen_result.verilog_line_map.mapping_size();
+         ++i) {
+      codegen_result.verilog_line_map.mutable_mapping(i)->set_verilog_file(
+          verilog_path);
+    }
+  }
+
+  std::string verilog_line_map_path =
+      absl::GetFlag(FLAGS_output_verilog_line_map_path);
+  if (!verilog_line_map_path.empty()) {
+    XLS_RETURN_IF_ERROR(SetTextProtoFile(verilog_line_map_path,
+                                         codegen_result.verilog_line_map));
+  }
+
+  if (!absl::GetFlag(FLAGS_output_signature_path).empty()) {
+    XLS_RETURN_IF_ERROR(
+        SetTextProtoFile(absl::GetFlag(FLAGS_output_signature_path),
+                         codegen_result.signature.proto()));
+  }
+
+  if (verilog_path.empty()) {
+    std::cout << codegen_result.verilog_text;
+  } else {
+    XLS_RETURN_IF_ERROR(
+        SetFileContents(verilog_path, codegen_result.verilog_text));
+  }
+  return absl::OkStatus();
+}
+
+}  // namespace
+}  // namespace xls
+
+int main(int argc, char** argv) {
+  std::vector<std::string_view> positional_arguments =
+      xls::InitXls(kUsage, argc, argv);
+
+  if (positional_arguments.size() != 1) {
+    LOG(QFATAL) << absl::StreamFormat("Expected invocation: %s IR_FILE",
+                                      argv[0]);
+  }
+  std::string_view ir_path = positional_arguments[0];
+  return xls::ExitStatus(xls::RealMain(ir_path));
+}

--- a/xls/tools/block_to_verilog_main_test.py
+++ b/xls/tools/block_to_verilog_main_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for xls.tools.block_to_verilog_main."""
-
 import subprocess
 from google.protobuf import text_format
 

--- a/xls/tools/block_to_verilog_main_test.py
+++ b/xls/tools/block_to_verilog_main_test.py
@@ -42,7 +42,6 @@ top block my_function(a: bits[32], b: bits[32], out: bits[32]) {
 }
 '''
 
-# A block IR that instantiates a simple sub_block and wires input to output.
 INSTANTIATION_IR = '''package inst
 
 block sub_block(in: bits[32], out: bits[32]) {

--- a/xls/tools/block_to_verilog_main_test.py
+++ b/xls/tools/block_to_verilog_main_test.py
@@ -1,0 +1,125 @@
+# Copyright 2025 The XLS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for xls.tools.block_to_verilog_main."""
+
+import subprocess
+from google.protobuf import text_format
+
+from absl.testing import absltest
+from xls.common import test_base
+from xls.common import runfiles
+from xls.codegen import module_signature_pb2
+
+
+BLOCK_TO_VERILOG_MAIN_PATH = runfiles.get_path('xls/tools/block_to_verilog_main')
+
+COMBINATIONAL_BLOCK_IR = '''package add
+
+#[signature("""module_name: "my_function" data_ports { direction: PORT_DIRECTION_INPUT name: "a" width: 32 type { type_enum: BITS bit_count: 32 } }
+                                          data_ports { direction: PORT_DIRECTION_INPUT name: "b" width: 32 type { type_enum: BITS bit_count: 32 } }
+                                          data_ports { direction: PORT_DIRECTION_OUTPUT name: "out" width: 32 type { type_enum: BITS bit_count: 32 } } 
+                                          fixed_latency { latency: 0 } """)]
+
+top block my_function(a: bits[32], b: bits[32], out: bits[32]) {
+  a: bits[32] = input_port(name=a, id=6)
+  b: bits[32] = input_port(name=b, id=7)
+  sum: bits[32] = add(a, b, id=8)
+  not_sum: bits[32] = not(sum, id=9)
+  not_not_sum: bits[32] = not(not_sum, id=10)
+  out: () = output_port(not_not_sum, name=out, id=11)
+}
+'''
+
+# A block IR that instantiates a simple sub_block and wires input to output.
+INSTANTIATION_IR = '''package inst
+
+block sub_block(in: bits[32], out: bits[32]) {
+  in: bits[32] = input_port(name=in, id=1)
+  out: () = output_port(in, name=out, id=2)
+}
+
+// Signature for the top block module interface.
+#[signature("""module_name: "my_function" data_ports { direction: PORT_DIRECTION_INPUT name: "a" width: 32 type { type_enum: BITS bit_count: 32 } }
+                                          data_ports { direction: PORT_DIRECTION_OUTPUT name: "out" width: 32 type { type_enum: BITS bit_count: 32 } }
+                                          fixed_latency { latency: 0 } """)]
+top block my_function(a: bits[32], out: bits[32]) {
+  instantiation my_inst(block=sub_block, kind=block)
+  a: bits[32] = input_port(name=a, id=3)
+  a_in: () = instantiation_input(a, instantiation=my_inst, port_name=in, id=4)
+  y: bits[32] = instantiation_output(instantiation=my_inst, port_name=out, id=5)
+  out: () = output_port(y, name=out, id=6)
+}
+'''
+
+class BlockToVerilogMainTest(absltest.TestCase):
+
+  def test_block_ir_generates_verilog(self):
+    # Use a simple combinational block IR directly.
+    block_ir_file = self.create_tempfile(content=COMBINATIONAL_BLOCK_IR)
+    verilog_path = test_base.create_named_output_text_file('my_function.v')
+    signature_path = test_base.create_named_output_text_file(
+        'my_function.sig.textproto'
+    )
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--alsologtostderr',
+        '--output_signature_path=' + signature_path,
+        '--output_verilog_path=' + verilog_path,
+        block_ir_file.full_path,
+    ])
+
+    with open(verilog_path, 'r') as f:
+      verilog = f.read()
+      # Basic sanity checks on generated Verilog.
+      self.assertIn('module my_function(', verilog)
+      self.assertIn('endmodule', verilog)
+      # Expect at least one input and output port declaration.
+      self.assertIn('input wire', verilog)
+      self.assertIn('output wire', verilog)
+
+    # Parse and sanity-check the emitted signature textproto.
+    with open(signature_path, 'r') as f:
+      sig_proto = text_format.Parse(
+          f.read(), module_signature_pb2.ModuleSignatureProto()
+      )
+      self.assertEqual(sig_proto.module_name, 'my_function')
+      # Expect 3 data ports: a (in), b (in), out (out).
+      self.assertLen(sig_proto.data_ports, 3)
+      names = [p.name for p in sig_proto.data_ports]
+      self.assertEqual(names, ['a', 'b', 'out'])
+      dirs = [p.direction for p in sig_proto.data_ports]
+      # 1=input, 2=output
+      self.assertEqual(dirs, [1, 1, 2])
+
+  def test_block_ir_with_instantiation(self):
+    ir_file = self.create_tempfile(content=INSTANTIATION_IR)
+    verilog_path = test_base.create_named_output_text_file('inst_block.v')
+
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--alsologtostderr',
+        '--output_verilog_path=' + verilog_path,
+        ir_file.full_path,
+    ])
+
+    with open(verilog_path, 'r') as f:
+      verilog = f.read()
+      self.assertIn('module my_function(', verilog)
+      self.assertIn('module sub_block', verilog)
+      self.assertIn('sub_block my_inst', verilog)
+
+
+if __name__ == '__main__':
+  absltest.main()

--- a/xls/tools/codegen.cc
+++ b/xls/tools/codegen.cc
@@ -26,8 +26,11 @@
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
+#include "absl/container/flat_hash_set.h"
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_result.h"
+#include "xls/codegen/block_generator.h"
+#include "xls/codegen/block_metrics.h"
 #include "xls/codegen/combinational_generator.h"
 #include "xls/codegen/op_override.h"
 #include "xls/codegen/pipeline_generator.h"
@@ -484,6 +487,44 @@ ScheduleAndCodegen(
                                            metadata, &schedules));
   return std::make_pair(std::move(scheduling_result),
                         std::move(codegen_result));
+}
+
+absl::StatusOr<verilog::CodegenResult> BlockToVerilog(
+    Package* p, const CodegenFlagsProto& codegen_flags_proto) {
+  XLS_RETURN_IF_ERROR(MaybeSetTop(p, codegen_flags_proto));
+  XLS_ASSIGN_OR_RETURN(verilog::CodegenOptions options,
+                       CodegenOptionsFromProto(codegen_flags_proto));
+
+  if (!p->GetTop().has_value()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Package %s has no top set.", p->name()));
+  }
+  FunctionBase* top_fb = p->GetTop().value();
+  if (!top_fb->IsBlock()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Top `%s` is not a block.", top_fb->name()));
+  }
+  Block* top_block = top_fb->AsBlockOrDie();
+
+  verilog::VerilogLineMap verilog_line_map;
+  XLS_ASSIGN_OR_RETURN(std::string verilog,
+                       verilog::GenerateVerilog(top_block, options,
+                                                 &verilog_line_map));
+
+  XLS_RET_CHECK(top_block->GetSignature().has_value())
+      << "Top block is missing a ModuleSignature.";
+  XLS_ASSIGN_OR_RETURN(verilog::ModuleSignature signature,
+                       verilog::ModuleSignature::FromProto(*top_block->GetSignature()));
+
+  verilog::XlsMetricsProto metrics;
+  XLS_ASSIGN_OR_RETURN(
+      *metrics.mutable_block_metrics(),
+      verilog::GenerateBlockMetrics(top_block, /*delay_estimator=*/nullptr));
+
+  return verilog::CodegenResult{.verilog_text = std::move(verilog),
+                                .verilog_line_map = std::move(verilog_line_map),
+                                .signature = std::move(signature),
+                                .block_metrics = std::move(metrics)};
 }
 
 }  // namespace xls

--- a/xls/tools/codegen.h
+++ b/xls/tools/codegen.h
@@ -56,6 +56,10 @@ ScheduleAndCodegen(
     const SchedulingOptionsFlagsProto& scheduling_options_flags_proto,
     const CodegenFlagsProto& codegen_flags_proto, bool with_delay_model);
 
+// Convert block IR to Verilog.
+absl::StatusOr<verilog::CodegenResult> BlockToVerilog(
+    Package* p, const CodegenFlagsProto& codegen_flags_proto);
+
 }  // namespace xls
 
 #endif  // XLS_TOOLS_CODEGEN_H_


### PR DESCRIPTION
The codegen_main binary takes a function/proc and produces verilog
creating block IR along the away but there no currently no way of producing
verilog from existing block IR. This tool does that accepting the same set of
codegen flags.