### PR TITLE
Create and save residual metadata from codegen

### DIFF
--- a/xls/codegen/BUILD
+++ b/xls/codegen/BUILD
@@ -66,6 +66,7 @@ cc_library(
         ":codegen_options",
         ":codegen_pass",
         ":codegen_pass_pipeline",
+        ":codegen_residual_data_cc_proto",
         ":codegen_result",
         ":module_signature",
         ":verilog_line_map_cc_proto",
@@ -192,6 +193,7 @@ cc_library(
         ":codegen_options",
         ":codegen_pass",
         ":codegen_pass_pipeline",
+        ":codegen_residual_data_cc_proto",
         ":codegen_result",
         ":module_signature",
         ":verilog_line_map_cc_proto",
@@ -292,6 +294,7 @@ cc_library(
         ":codegen_options",
         ":codegen_pass",
         ":codegen_pass_pipeline",
+        ":codegen_residual_data_cc_proto",
         ":codegen_result",
         ":module_signature",
         ":verilog_line_map_cc_proto",
@@ -589,6 +592,7 @@ cc_library(
     srcs = ["codegen_options.cc"],
     hdrs = ["codegen_options.h"],
     deps = [
+        ":codegen_residual_data_cc_proto",
         ":module_signature_cc_proto",
         ":op_override",
         ":ram_configuration",
@@ -763,6 +767,7 @@ cc_library(
     hdrs = ["block_generator.h"],
     deps = [
         ":codegen_options",
+        ":codegen_residual_data_cc_proto",
         ":conversion_utils",
         ":expression_flattening",
         ":module_builder",
@@ -999,6 +1004,21 @@ cc_proto_library(
 py_proto_library(
     name = "verilog_line_map_py_pb2",
     deps = [":verilog_line_map_proto"],
+)
+
+proto_library(
+    name = "codegen_residual_data_proto",
+    srcs = ["codegen_residual_data.proto"],
+)
+
+cc_proto_library(
+    name = "codegen_residual_data_cc_proto",
+    deps = [":codegen_residual_data_proto"],
+)
+
+py_proto_library(
+    name = "codegen_residual_data_py_pb2",
+    deps = [":codegen_residual_data_proto"],
 )
 
 cc_test(
@@ -2077,6 +2097,7 @@ cc_library(
     hdrs = ["codegen_result.h"],
     visibility = ["//xls:xls_users"],
     deps = [
+        ":codegen_residual_data_cc_proto",
         ":module_signature",
         ":verilog_line_map_cc_proto",
         ":xls_metrics_cc_proto",

--- a/xls/codegen/block_generator.cc
+++ b/xls/codegen/block_generator.cc
@@ -277,8 +277,8 @@ absl::StatusOr<std::vector<Stage>> SplitBlockIntoStages(
   return stages;
 }
 
-// Returns a sequence of node IDs which is the emission order from the
-// from the residual data, or an empty vector if none exists.
+// Returns a sequence of node IDs which is the emission order from the residual
+// data, or an empty vector if none exists.
 std::vector<int64_t> NodeIdOrderFromResidualData(
     std::string_view block_name, const CodegenResidualData& container) {
   std::vector<int64_t> ids;

--- a/xls/codegen/block_generator.cc
+++ b/xls/codegen/block_generator.cc
@@ -38,6 +38,7 @@
 #include "absl/strings/str_format.h"
 #include "absl/types/span.h"
 #include "xls/codegen/codegen_options.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/conversion_utils.h"
 #include "xls/codegen/expression_flattening.h"
 #include "xls/codegen/module_builder.h"
@@ -276,6 +277,23 @@ absl::StatusOr<std::vector<Stage>> SplitBlockIntoStages(
   return stages;
 }
 
+// Returns a sequence of node IDs which is the emission order from the
+// from the residual data, or an empty vector if none exists.
+std::vector<int64_t> NodeIdOrderFromResidualData(
+    std::string_view block_name, const CodegenResidualData& container) {
+  std::vector<int64_t> ids;
+  for (const BlockResidualData& block_data : container.blocks()) {
+    if (block_data.block_name() == block_name) {
+      ids.reserve(block_data.nodes_size());
+      for (const NodeResidualData& n : block_data.nodes()) {
+        ids.push_back(n.node_id());
+      }
+      break;
+    }
+  }
+  return ids;
+}
+
 // Abstraction encapsulating the necessary information to generate
 // (System)Verilog for an IR block.
 class BlockGenerator {
@@ -283,7 +301,8 @@ class BlockGenerator {
   // Generates (System)Verilog from the given block into the given Verilog file
   // using the given options.
   static absl::Status Generate(Block* block, VerilogFile* file,
-                               const CodegenOptions& options) {
+                               const CodegenOptions& options,
+                               CodegenResidualData* output_residual_data) {
     // If reset is specified in the codegen options, it should match the reset
     // behavior in the block.
     if (options.reset().has_value()) {
@@ -327,21 +346,24 @@ class BlockGenerator {
           "Block has registers but no clock port");
     }
 
-    BlockGenerator generator(block, options, clock_name, reset_proto, file);
+    BlockGenerator generator(block, options, clock_name, reset_proto, file,
+                             output_residual_data);
     return generator.Emit();
   }
 
  private:
-  BlockGenerator(
-      Block* block, const CodegenOptions& options,
-      std::optional<std::string_view> clock_name,
-      std::optional<ResetProto> reset_proto,
-      VerilogFile* file)
+  BlockGenerator(Block* block, const CodegenOptions& options,
+                 std::optional<std::string_view> clock_name,
+                 std::optional<ResetProto> reset_proto, VerilogFile* file,
+                 CodegenResidualData* output_residual_data)
       : block_(block),
         options_(options),
         reset_proto_(reset_proto),
         file_(file),
-        mb_(block->name(), file_, options, clock_name, reset_proto) {
+        mb_(block->name(), file_, options, clock_name, reset_proto),
+        block_residual_data_(output_residual_data != nullptr
+                                 ? output_residual_data->add_blocks()
+                                 : nullptr) {
     if (!options.randomize_order_seed().empty()) {
       std::seed_seq seed_seq(options.randomize_order_seed().begin(),
                              options.randomize_order_seed().end());
@@ -351,11 +373,19 @@ class BlockGenerator {
 
   // Generates and returns the Verilog text for the underlying block.
   absl::Status Emit() {
+    if (block_residual_data_ != nullptr) {
+      block_residual_data_->set_block_name(std::string(block_->name()));
+    }
     XLS_RETURN_IF_ERROR(EmitInputPorts());
     // TODO(meheff): 2021/11/04 Emit instantiations in pipeline stages if
     // possible.
     XLS_RETURN_IF_ERROR(DeclareInstantiationOutputs());
     if (options_.emit_as_pipeline()) {
+      if (options_.residual_data().has_value()) {
+        return absl::UnimplementedError(
+            "Reference residual data is not supported when generating "
+            "pipelines");
+      }
       // Emits the block as a sequence of pipeline stages. First reconstruct the
       // stages and emit the stages one-by-one. Emitting as a pipeline is purely
       // cosmetic relative to the emit_as_pipeline=false option as the Verilog
@@ -391,7 +421,19 @@ class BlockGenerator {
           MaybeShuffle(block_->GetRegisters(), shuffled_storage, rng_);
 
       XLS_RETURN_IF_ERROR(DeclareRegisters(registers));
-      XLS_RETURN_IF_ERROR(EmitLogic(TopoSort(block_, rng_)));
+      // Determine emission order using residual reference order if available.
+      std::vector<Node*> order;
+      if (options_.residual_data().has_value()) {
+        std::vector<int64_t> ref_ids = NodeIdOrderFromResidualData(
+            block_->name(), *options_.residual_data());
+        if (!ref_ids.empty()) {
+          order = StableTopoSort(block_, ref_ids);
+        }
+      }
+      if (order.empty()) {
+        order = TopoSort(block_, rng_);
+      }
+      XLS_RETURN_IF_ERROR(EmitLogic(order));
       XLS_RETURN_IF_ERROR(AssignRegisters(registers));
     }
 
@@ -461,6 +503,15 @@ class BlockGenerator {
     absl::flat_hash_map<Node*, int64_t> node_depth;
     for (Node* node : nodes) {
       VLOG(3) << "Emitting logic for: " << node->GetName();
+
+      NodeResidualData* residual_node_data = nullptr;
+      if (block_residual_data_ != nullptr) {
+        residual_node_data = block_residual_data_->add_nodes();
+        residual_node_data->set_node_name(node->GetName());
+        residual_node_data->set_node_id(node->id());
+        // Default to false; only set to true in the few inline cases.
+        residual_node_data->set_emitted_inline(false);
+      }
 
       // TODO(google/xls#653): support per-node overrides?
       std::optional<OpOverride> op_override =
@@ -630,6 +681,9 @@ class BlockGenerator {
         if (!emit_as_assignment) {
           node_depth[node] = inline_depth;
         }
+        if (residual_node_data != nullptr) {
+          residual_node_data->set_emitted_inline(!emit_as_assignment);
+        }
         continue;
       }
 
@@ -666,6 +720,9 @@ class BlockGenerator {
         XLS_ASSIGN_OR_RETURN(node_exprs_[node],
                              mb_.EmitAsInlineExpression(node, inputs));
         node_depth[node] = inline_depth;
+        if (residual_node_data != nullptr) {
+          residual_node_data->set_emitted_inline(true);
+        }
       }
     }
     return absl::OkStatus();
@@ -965,6 +1022,8 @@ class BlockGenerator {
   // Map from xls::Register* to the ModuleBuilder register abstraction
   // representing the underlying Verilog register.
   absl::flat_hash_map<xls::Register*, ModuleBuilder::Register> mb_registers_;
+  // Optional output for capturing residual data.
+  BlockResidualData* block_residual_data_ = nullptr;
 };
 
 // Recursive visitor of blocks in a DFS order. Edges are block instantiations.
@@ -1011,9 +1070,9 @@ absl::StatusOr<std::vector<Block*>> GatherInstantiatedBlocks(Block* top) {
 
 }  // namespace
 
-absl::StatusOr<std::string> GenerateVerilog(Block* top,
-                                            const CodegenOptions& options,
-                                            VerilogLineMap* verilog_line_map) {
+absl::StatusOr<std::string> GenerateVerilog(
+    Block* top, const CodegenOptions& options, VerilogLineMap* verilog_line_map,
+    CodegenResidualData* output_residual_data) {
   VLOG(2) << absl::StreamFormat(
       "Generating Verilog for packge with with top level block `%s`:",
       top->name());
@@ -1024,7 +1083,8 @@ absl::StatusOr<std::string> GenerateVerilog(Block* top,
   VerilogFile file(options.use_system_verilog() ? FileType::kSystemVerilog
                                                 : FileType::kVerilog);
   for (Block* block : blocks) {
-    XLS_RETURN_IF_ERROR(BlockGenerator::Generate(block, &file, options));
+    XLS_RETURN_IF_ERROR(
+        BlockGenerator::Generate(block, &file, options, output_residual_data));
     if (block != blocks.back()) {
       file.Add(file.Make<BlankLine>(SourceInfo()));
       file.Add(file.Make<BlankLine>(SourceInfo()));

--- a/xls/codegen/block_generator.h
+++ b/xls/codegen/block_generator.h
@@ -19,6 +19,7 @@
 
 #include "absl/status/statusor.h"
 #include "xls/codegen/codegen_options.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/verilog_line_map.pb.h"
 #include "xls/ir/block.h"
 
@@ -27,10 +28,13 @@ namespace verilog {
 
 // Generates and returns (System)Verilog text implementing the given top-level
 // block. The text will include a Verilog module corresponding to the given
-// block as well as module definitions for any instantiated blocks.
+// block as well as module definitions for any instantiated blocks. Line map
+// and residual data will be written out if the corressponding pointers are not
+// null.
 absl::StatusOr<std::string> GenerateVerilog(
     Block* top, const CodegenOptions& options,
-    VerilogLineMap* verilog_line_map = nullptr);
+    VerilogLineMap* verilog_line_map = nullptr,
+    CodegenResidualData* output_residual_data = nullptr);
 
 }  // namespace verilog
 }  // namespace xls

--- a/xls/codegen/codegen_options.cc
+++ b/xls/codegen/codegen_options.cc
@@ -24,6 +24,7 @@
 #include "xls/codegen/module_signature.pb.h"
 #include "xls/codegen/op_override.h"
 #include "xls/codegen/ram_configuration.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/common/proto_adaptor_utils.h"
 #include "xls/ir/op.h"
 #include "xls/ir/register.h"

--- a/xls/codegen/codegen_options.h
+++ b/xls/codegen/codegen_options.h
@@ -25,6 +25,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/types/span.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/module_signature.pb.h"
 #include "xls/codegen/op_override.h"
 #include "xls/codegen/ram_configuration.h"
@@ -356,6 +357,15 @@ class CodegenOptions {
   CodegenOptions& add_invariant_assertions(bool value);
   bool add_invariant_assertions() const { return add_invariant_assertions_; }
 
+  // Optional residual data container to populate during codegen.
+  CodegenOptions& set_residual_data(CodegenResidualData data) {
+    residual_data_ = std::move(data);
+    return *this;
+  }
+  const std::optional<CodegenResidualData>& residual_data() const {
+    return residual_data_;
+  }
+
  private:
   std::optional<std::string> entry_;
   std::optional<std::string> module_name_;
@@ -395,6 +405,7 @@ class CodegenOptions {
   std::string fifo_module_ = "xls_fifo_wrapper";
   std::string nodata_fifo_module_ = "";
   std::vector<int32_t> randomize_order_seed_;
+  std::optional<CodegenResidualData> residual_data_;
 };
 
 template <typename Sink>

--- a/xls/codegen/codegen_residual_data.proto
+++ b/xls/codegen/codegen_residual_data.proto
@@ -1,0 +1,41 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package xls.verilog;
+
+// Metadata about how a particular IR node is emitted to Verilog.
+message NodeResidualData {
+  // Name of the IR node.
+  optional string node_name = 1;
+  // Unique id of the IR node.
+  optional int64 node_id = 2;
+  // Whether the node was emitted inline (i.e., without a named temporary).
+  optional bool emitted_inline = 3;
+}
+
+// Metadata about how a block is emitted to Verilog.
+message BlockResidualData {
+  // Name of the block this residual data corresponds to.
+  optional string block_name = 1;
+
+  // Node metadata in the order nodes are emitted in the Verilog.
+  repeated NodeResidualData nodes = 2;
+}
+
+// Container for residual data across multiple blocks.
+message CodegenResidualData {
+  repeated BlockResidualData blocks = 1;
+}

--- a/xls/codegen/codegen_result.h
+++ b/xls/codegen/codegen_result.h
@@ -17,6 +17,7 @@
 
 #include <string>
 
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/module_signature.h"
 #include "xls/codegen/verilog_line_map.pb.h"
 #include "xls/codegen/xls_metrics.pb.h"
@@ -30,6 +31,7 @@ struct CodegenResult {
   VerilogLineMap verilog_line_map;
   ModuleSignature signature;
   XlsMetricsProto block_metrics;
+  CodegenResidualData residual_data;
   PassPipelineMetricsProto pass_pipeline_metrics;
 };
 

--- a/xls/codegen/combinational_generator.cc
+++ b/xls/codegen/combinational_generator.cc
@@ -24,6 +24,7 @@
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/codegen_pass_pipeline.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/codegen_result.h"
 #include "xls/codegen/module_signature.h"
 #include "xls/codegen/verilog_line_map.pb.h"
@@ -59,9 +60,10 @@ absl::StatusOr<CodegenResult> GenerateCombinationalModule(
   XLS_RET_CHECK(context.metadata().contains(context.top_block()));
   XLS_RET_CHECK(context.top_block()->GetSignature().has_value());
   VerilogLineMap verilog_line_map;
-  XLS_ASSIGN_OR_RETURN(
-      std::string verilog,
-      GenerateVerilog(context.top_block(), options, &verilog_line_map));
+  CodegenResidualData residual_data;
+  XLS_ASSIGN_OR_RETURN(std::string verilog,
+                       GenerateVerilog(context.top_block(), options,
+                                       &verilog_line_map, &residual_data));
 
   XLS_ASSIGN_OR_RETURN(
       ModuleSignature signature,
@@ -78,6 +80,7 @@ absl::StatusOr<CodegenResult> GenerateCombinationalModule(
                        .verilog_line_map = verilog_line_map,
                        .signature = signature,
                        .block_metrics = metrics,
+                       .residual_data = residual_data,
                        .pass_pipeline_metrics = results.ToProto()};
 }
 

--- a/xls/codegen/pipeline_generator.cc
+++ b/xls/codegen/pipeline_generator.cc
@@ -29,6 +29,7 @@
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/codegen_pass_pipeline.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/codegen_result.h"
 #include "xls/codegen/module_signature.h"
 #include "xls/codegen/verilog_line_map.pb.h"
@@ -82,10 +83,11 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
                 context.top_block()->GetSignature().has_value());
 
   VerilogLineMap verilog_line_map;
+  CodegenResidualData residual_data;
   XLS_ASSIGN_OR_RETURN(
       std::string verilog,
       GenerateVerilog(context.top_block(), pass_options.codegen_options,
-                      &verilog_line_map));
+                      &verilog_line_map, &residual_data));
 
   XLS_ASSIGN_OR_RETURN(
       ModuleSignature signature,
@@ -103,6 +105,7 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
       .verilog_line_map = verilog_line_map,
       .signature = signature,
       .block_metrics = metrics,
+      .residual_data = std::move(residual_data),
       .pass_pipeline_metrics = results.ToProto(),
   };
 }
@@ -149,9 +152,10 @@ absl::StatusOr<CodegenResult> ToPipelineModuleText(
                 context.HasMetadataForBlock(context.top_block()) &&
                 context.top_block()->GetSignature().has_value());
   VerilogLineMap verilog_line_map;
-  XLS_ASSIGN_OR_RETURN(
-      std::string verilog,
-      GenerateVerilog(context.top_block(), options, &verilog_line_map));
+  CodegenResidualData residual_data;
+  XLS_ASSIGN_OR_RETURN(std::string verilog,
+                       GenerateVerilog(context.top_block(), options,
+                                       &verilog_line_map, &residual_data));
 
   XLS_ASSIGN_OR_RETURN(
       ModuleSignature signature,

--- a/xls/codegen/unified_generator.cc
+++ b/xls/codegen/unified_generator.cc
@@ -26,6 +26,7 @@
 #include "xls/codegen/codegen_options.h"
 #include "xls/codegen/codegen_pass.h"
 #include "xls/codegen/codegen_pass_pipeline.h"
+#include "xls/codegen/codegen_residual_data.pb.h"
 #include "xls/codegen/codegen_result.h"
 #include "xls/codegen/module_signature.h"
 #include "xls/codegen/passes_ng/stage_conversion_pass_pipeline.h"
@@ -144,10 +145,11 @@ absl::StatusOr<CodegenResult> GenerateModuleText(
 
   // VAST Generation: Block to Verilog codegen pass.
   VerilogLineMap verilog_line_map;
+  CodegenResidualData residual_data;
   XLS_ASSIGN_OR_RETURN(
       std::string verilog,
       GenerateVerilog(codegen_context.top_block(), pass_options.codegen_options,
-                      &verilog_line_map));
+                      &verilog_line_map, &residual_data));
 
   XLS_ASSIGN_OR_RETURN(
       ModuleSignature signature,

--- a/xls/fdo/BUILD
+++ b/xls/fdo/BUILD
@@ -122,6 +122,8 @@ cc_library(
         "//xls/codegen:block_generator",
         "//xls/codegen:codegen_options",
         "//xls/codegen:codegen_pass",
+        "//xls/codegen:codegen_residual_data_cc_proto",
+        "//xls/codegen:verilog_line_map_cc_proto",
         "//xls/common:casts",
         "//xls/common:thread",
         "//xls/common/status:ret_check",

--- a/xls/ir/topo_sort.h
+++ b/xls/ir/topo_sort.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "absl/random/bit_gen_ref.h"
+#include "absl/types/span.h"
 #include "xls/ir/function_base.h"
 #include "xls/ir/node.h"
 
@@ -44,6 +45,14 @@ std::vector<Node*> TopoSort(
 // As above, but returns a reverse topo order.
 std::vector<Node*> ReverseTopoSort(
     FunctionBase* f, std::optional<absl::BitGenRef> randomizer = std::nullopt);
+
+// Returns a topological sort using a reference ordering to influence the
+// returned order. `reference_sort` is a not necessarily strict subset of the
+// ids of the nodes in `f`. The order of any pair of nodes in `reference_order`
+// is maintained in the returned toposort if possible (ordering is not
+// prohibited by dependencies in `f`).
+std::vector<Node*> StableTopoSort(FunctionBase* f,
+                                  absl::Span<int64_t const> reference_order);
 
 }  // namespace xls
 

--- a/xls/tools/BUILD
+++ b/xls/tools/BUILD
@@ -658,7 +658,10 @@ proto_library(
     name = "codegen_flags_proto",
     srcs = ["codegen_flags.proto"],
     visibility = ["//xls:xls_users"],
-    deps = ["//xls/ir:xls_ir_interface_proto"],
+    deps = [
+        "//xls/codegen:codegen_residual_data_proto",
+        "//xls/ir:xls_ir_interface_proto",
+    ],
 )
 
 py_proto_library(
@@ -679,6 +682,8 @@ cc_library(
     hdrs = ["codegen_flags.h"],
     deps = [
         ":codegen_flags_cc_proto",
+        "//xls/codegen:codegen_residual_data_cc_proto",
+        "//xls/common:proto_adaptor_utils",
         "//xls/common/file:filesystem",
         "//xls/common/status:ret_check",
         "//xls/common/status:status_macros",
@@ -704,6 +709,7 @@ cc_library(
         "//xls/codegen:block_generator",
         "//xls/codegen:block_metrics",
         "//xls/codegen:codegen_options",
+        "//xls/codegen:codegen_residual_data_cc_proto",
         "//xls/codegen:codegen_result",
         "//xls/codegen:combinational_generator",
         "//xls/codegen:op_override",
@@ -850,6 +856,7 @@ py_test(
         ":block_to_verilog_main",
     ],
     deps = [
+        "//xls/codegen:codegen_residual_data_py_pb2",
         "//xls/codegen:module_signature_py_pb2",
         "//xls/common:runfiles",
         "//xls/common:test_base",
@@ -870,6 +877,7 @@ py_test(
     shard_count = 50,
     tags = ["optonly"],
     deps = [
+        "//xls/codegen:codegen_residual_data_py_pb2",
         "//xls/codegen:module_signature_py_pb2",
         "//xls/common:runfiles",
         "//xls/common:test_base",

--- a/xls/tools/block_to_verilog_main.cc
+++ b/xls/tools/block_to_verilog_main.cc
@@ -79,6 +79,13 @@ absl::Status RealMain(std::string_view ir_path) {
                          codegen_result.signature.proto()));
   }
 
+  // Optionally write residual data textproto capturing node emission order.
+  if (!absl::GetFlag(FLAGS_output_residual_data_path).empty()) {
+    XLS_RETURN_IF_ERROR(
+        SetTextProtoFile(absl::GetFlag(FLAGS_output_residual_data_path),
+                         codegen_result.residual_data));
+  }
+
   if (verilog_path.empty()) {
     std::cout << codegen_result.verilog_text;
   } else {

--- a/xls/tools/block_to_verilog_main_test.py
+++ b/xls/tools/block_to_verilog_main_test.py
@@ -15,6 +15,7 @@
 import subprocess
 from google.protobuf import text_format
 from absl.testing import absltest
+from xls.codegen import codegen_residual_data_pb2
 from xls.codegen import module_signature_pb2
 from xls.common import runfiles
 from xls.common import test_base
@@ -24,7 +25,7 @@ BLOCK_TO_VERILOG_MAIN_PATH = runfiles.get_path(
     'xls/tools/block_to_verilog_main'
 )
 
-COMBINATIONAL_BLOCK_IR = '''package add
+BLOCK_IR = '''package add
 
 #[signature("""module_name: "my_function" data_ports { direction: PORT_DIRECTION_INPUT name: "a" width: 32 type { type_enum: BITS bit_count: 32 } }
                                           data_ports { direction: PORT_DIRECTION_INPUT name: "b" width: 32 type { type_enum: BITS bit_count: 32 } }
@@ -34,10 +35,11 @@ COMBINATIONAL_BLOCK_IR = '''package add
 top block my_function(a: bits[32], b: bits[32], out: bits[32]) {
   a: bits[32] = input_port(name=a, id=6)
   b: bits[32] = input_port(name=b, id=7)
-  sum: bits[32] = add(a, b, id=8)
-  not_sum: bits[32] = not(sum, id=9)
-  not_not_sum: bits[32] = not(not_sum, id=10)
-  out: () = output_port(not_not_sum, name=out, id=11)
+  neg_a: bits[32] = neg(a, id=8)
+  not_b: bits[32] = not(b, id=9)
+  id_not_b: bits[32] = identity(not_b, id=10)
+  sum: bits[32] = add(neg_a, id_not_b, id=11)
+  out: () = output_port(sum, name=out, id=12)
 }
 '''
 
@@ -64,9 +66,29 @@ top block my_function(a: bits[32], out: bits[32]) {
 
 class BlockToVerilogMainTest(absltest.TestCase):
 
+  def write_residual_data(self, node_pairs, filename):
+    ref = codegen_residual_data_pb2.CodegenResidualData()
+    b = ref.blocks.add()
+    b.block_name = 'my_function'
+    for name, node_id in node_pairs:
+      n = b.nodes.add()
+      n.node_name = name
+      n.node_id = node_id
+    path = test_base.create_named_output_text_file(filename)
+    with open(path, 'w') as f:
+      f.write(text_format.MessageToString(ref))
+    return path
+
+  def find_line_number(self, text: str, substring: str) -> int:
+    """Returns line number of first occurrence of substring, or fails if not found."""
+    for i, line in enumerate(text.splitlines(), start=1):
+      if substring in line:
+        return i
+    self.fail(f"Substring '{substring}' not found in provided text")
+
   def test_block_ir_generates_verilog(self):
     # Use a simple combinational block IR directly.
-    block_ir_file = self.create_tempfile(content=COMBINATIONAL_BLOCK_IR)
+    block_ir_file = self.create_tempfile(content=BLOCK_IR)
     verilog_path = test_base.create_named_output_text_file('my_function.v')
     signature_path = test_base.create_named_output_text_file(
         'my_function.sig.textproto'
@@ -81,20 +103,15 @@ class BlockToVerilogMainTest(absltest.TestCase):
 
     with open(verilog_path, 'r') as f:
       verilog = f.read()
-      # Basic checks on generated Verilog.
       self.assertIn('module my_function(', verilog)
       self.assertIn('endmodule', verilog)
-      # Expect at least one input and output port declaration.
       self.assertIn('input wire', verilog)
       self.assertIn('output wire', verilog)
-
-    # Parse and check the emitted signature textproto.
     with open(signature_path, 'r') as f:
       sig_proto = text_format.Parse(
           f.read(), module_signature_pb2.ModuleSignatureProto()
       )
       self.assertEqual(sig_proto.module_name, 'my_function')
-      # Expect 3 data ports: a (in), b (in), out (out).
       self.assertLen(sig_proto.data_ports, 3)
       names = [p.name for p in sig_proto.data_ports]
       self.assertEqual(names, ['a', 'b', 'out'])
@@ -105,19 +122,153 @@ class BlockToVerilogMainTest(absltest.TestCase):
   def test_block_ir_with_instantiation(self):
     ir_file = self.create_tempfile(content=INSTANTIATION_IR)
     verilog_path = test_base.create_named_output_text_file('inst_block.v')
+    residual_path = test_base.create_named_output_text_file('inst_residual.textproto')
 
     subprocess.check_call([
         BLOCK_TO_VERILOG_MAIN_PATH,
         '--alsologtostderr',
+        '--output_residual_data_path=' + residual_path,
         '--output_verilog_path=' + verilog_path,
         ir_file.full_path,
     ])
-
     with open(verilog_path, 'r') as f:
       verilog = f.read()
       self.assertIn('module my_function(', verilog)
       self.assertIn('module sub_block', verilog)
       self.assertIn('sub_block my_inst', verilog)
+
+    # Verify residual data contains entries for both sub_block and top block.
+    with open(residual_path, 'r') as f:
+      residual = text_format.Parse(
+          f.read(), codegen_residual_data_pb2.CodegenResidualData()
+      )
+    block_names = {b.block_name for b in residual.blocks}
+    self.assertIn('sub_block', block_names)
+    self.assertIn('my_function', block_names)
+
+  def test_block_ir_with_specified_order(self):
+    block_ir_file = self.create_tempfile(content=BLOCK_IR)
+
+    def write_residual(node_pairs, filename):
+      ref = codegen_residual_data_pb2.CodegenResidualData()
+      b = ref.blocks.add()
+      b.block_name = 'my_function'
+      for name, node_id in node_pairs:
+        n = b.nodes.add()
+        n.node_name = name
+        n.node_id = node_id
+      path = test_base.create_named_output_text_file(filename)
+      with open(path, 'w') as f:
+        f.write(text_format.MessageToString(ref))
+      return path
+
+    # Provide name/id pairs corresponding to BLOCK_IR ids.
+    ref1_path = self.write_residual_data([
+        ('neg_a', 8), ('not_b', 9), ('id_not_b', 10),
+    ], 'ref_block_order1.textproto')
+    verilog1_path = test_base.create_named_output_text_file('ordered1.v')
+
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--separate_lines',
+        '--generator=combinational',
+        '--output_verilog_path=' + verilog1_path,
+        '--reference_residual_data_path=' + ref1_path,
+        block_ir_file.full_path,
+    ])
+    with open(verilog1_path, 'r') as f:
+      v1 = f.read()
+      # Sanity-check the module is emitted and matches expected top name.
+      self.assertIn('module my_function(', v1)
+      self.assertLess(
+          self.find_line_number(v1, 'assign neg_a ='),
+          self.find_line_number(v1, 'assign not_b ='),
+      )
+      self.assertLess(
+          self.find_line_number(v1, 'assign not_b ='),
+          self.find_line_number(v1, 'assign id_not_b ='),
+      )
+
+    ref2_path = self.write_residual_data([
+        ('not_b', 9), ('neg_a', 8), ('id_not_b', 10),
+    ], 'ref_block_order2.textproto') 
+    verilog2_path = test_base.create_named_output_text_file('ordered2.v')
+
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--separate_lines',
+        '--generator=combinational',
+        '--output_verilog_path=' + verilog2_path,
+        '--reference_residual_data_path=' + ref2_path,
+        block_ir_file.full_path,
+    ])
+    with open(verilog2_path, 'r') as f:
+      v2 = f.read()
+      self.assertIn('module my_function(', v2)
+      self.assertLess(
+          self.find_line_number(v2, 'assign not_b ='),
+          self.find_line_number(v2, 'assign neg_a ='),
+      )
+      self.assertLess(
+          self.find_line_number(v2, 'assign neg_a ='),
+          self.find_line_number(v2, 'assign id_not_b ='),
+      )
+
+  def test_block_ir_residual_roundtrip(self):
+    # Emit residual in first invocation, consume as reference in second.
+    block_ir_file = self.create_tempfile(content=BLOCK_IR)
+
+    residual_path = test_base.create_named_output_text_file('residual_roundtrip.textproto')
+    verilog1_path = test_base.create_named_output_text_file('roundtrip1.v')
+
+    # First run: write Verilog and residual data.
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--alsologtostderr',
+        '--generator=combinational',
+        '--output_verilog_path=' + verilog1_path,
+        '--output_residual_data_path=' + residual_path,
+        block_ir_file.full_path,
+    ])
+
+    # Verify residual contents and node count.
+    with open(residual_path, 'r') as f:
+      residual = text_format.Parse(
+          f.read(), codegen_residual_data_pb2.CodegenResidualData()
+      )
+      self.assertEqual(len(residual.blocks), 1)
+
+    # Second run: consume the residual as reference and ensure identical output.
+    verilog2_path = test_base.create_named_output_text_file('roundtrip2.v')
+    subprocess.check_call([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--alsologtostderr',
+        '--generator=combinational',
+        '--output_verilog_path=' + verilog2_path,
+        '--reference_residual_data_path=' + residual_path,
+        block_ir_file.full_path,
+    ])
+
+    with open(verilog1_path, 'r') as f1, open(verilog2_path, 'r') as f2:
+      self.assertEqual(f1.read(), f2.read())
+
+  def test_pipeline_generator_rejects_reference_residual(self):
+    # Using reference residual data with pipeline generator should fail.
+    block_ir_file = self.create_tempfile(content=BLOCK_IR)
+
+    ref_path = self.write_residual_data([
+        ('neg_a', 8), ('not_b', 9), ('id_not_b', 10),
+    ], 'ref_pipeline_order.textproto')
+
+    proc = subprocess.run([
+        BLOCK_TO_VERILOG_MAIN_PATH,
+        '--generator=pipeline',
+        '--reference_residual_data_path=' + ref_path,
+        block_ir_file.full_path,
+    ], capture_output=True, text=True)
+
+    self.assertNotEqual(proc.returncode, 0)
+    self.assertIn('not supported when generating pipelines', proc.stderr)
 
 
 if __name__ == '__main__':

--- a/xls/tools/codegen_flags.cc
+++ b/xls/tools/codegen_flags.cc
@@ -408,6 +408,7 @@ static absl::StatusOr<bool> SetOptionsFromFlags(CodegenFlagsProto& proto) {
   // the flags proto so downstream codegen can consume without file I/O.
   if (FLAGS_reference_residual_data_path.IsSpecifiedOnCommandLine() &&
       !absl::GetFlag(FLAGS_reference_residual_data_path).empty()) {
+    any_flags_set = true;
     verilog::CodegenResidualData reference;
     XLS_RETURN_IF_ERROR(xls::ParseTextProtoFile(
         absl::GetFlag(FLAGS_reference_residual_data_path), &reference));

--- a/xls/tools/codegen_flags.h
+++ b/xls/tools/codegen_flags.h
@@ -31,6 +31,8 @@ ABSL_DECLARE_FLAG(std::string, output_signature_path);
 ABSL_DECLARE_FLAG(std::string, output_verilog_line_map_path);
 ABSL_DECLARE_FLAG(std::string, output_scheduling_pass_metrics_path);
 ABSL_DECLARE_FLAG(std::string, output_codegen_pass_metrics_path);
+ABSL_DECLARE_FLAG(std::string, output_residual_data_path);
+ABSL_DECLARE_FLAG(std::string, reference_residual_data_path);
 ABSL_DECLARE_FLAG(std::string, top);
 ABSL_DECLARE_FLAG(std::optional<std::string>,
                   codegen_options_used_textproto_file);

--- a/xls/tools/codegen_flags.proto
+++ b/xls/tools/codegen_flags.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package xls;
 
 import "xls/ir/xls_ir_interface.proto";
+import "xls/codegen/codegen_residual_data.proto";
 
 enum GeneratorKind {
   GENERATOR_KIND_INVALID = 0;
@@ -99,4 +100,8 @@ message CodegenFlagsProto {
   // If false, runtime invariant assertions (e.g. one-hot selector checks)
   // are omitted from generated RTL.  Default is true.
   optional bool add_invariant_assertions = 42;
+
+  // Parsed reference residual data. When present, codegen uses this to
+  // influence emission order; preferred over reading from a path at runtime.
+  optional verilog.CodegenResidualData reference_residual_data = 43;
 }

--- a/xls/tools/codegen_main.cc
+++ b/xls/tools/codegen_main.cc
@@ -73,6 +73,11 @@ absl::Status RealMain(std::string_view ir_path) {
 
   XLS_ASSIGN_OR_RETURN(CodegenFlagsProto codegen_flags_proto,
                        GetCodegenFlags());
+  if (codegen_flags_proto.has_reference_residual_data()) {
+    return absl::UnimplementedError(
+        "Reference residual data is not supported in codegen_main; use "
+        "block_to_verilog_main");
+  }
   if (!codegen_flags_proto.top().empty()) {
     XLS_RETURN_IF_ERROR(p->SetTopByName(codegen_flags_proto.top()));
   }
@@ -142,6 +147,12 @@ absl::Status RealMain(std::string_view ir_path) {
   if (!absl::GetFlag(FLAGS_block_metrics_path).empty()) {
     XLS_RETURN_IF_ERROR(SetTextProtoFile(
         absl::GetFlag(FLAGS_block_metrics_path), codegen_result.block_metrics));
+  }
+
+  if (!absl::GetFlag(FLAGS_output_residual_data_path).empty()) {
+    XLS_RETURN_IF_ERROR(
+        SetTextProtoFile(absl::GetFlag(FLAGS_output_residual_data_path),
+                         codegen_result.residual_data));
   }
 
   const std::string& verilog_path = absl::GetFlag(FLAGS_output_verilog_path);

--- a/xls/tools/codegen_main_test.py
+++ b/xls/tools/codegen_main_test.py
@@ -161,12 +161,6 @@ class CodeGenMainTest(parameterized.TestCase):
       want: str = runfiles.get_contents_as_text(path)
       self.assertMultiLineEqual(got, want)
 
-  def _find_line_number(self, text: str, substring: str) -> int:
-    for i, line in enumerate(text.splitlines(), start=1):
-      if substring in line:
-        return i
-    self.fail(f"Substring '{substring}' not found in provided text")
-
   def test_combinational(self):
     ir_file = self.create_tempfile(content=NOT_ADD_IR)
 

--- a/xls/tools/codegen_main_test.py
+++ b/xls/tools/codegen_main_test.py
@@ -25,6 +25,7 @@ from google.protobuf import text_format
 from absl.testing import absltest
 from absl.testing import parameterized
 from xls.codegen import module_signature_pb2
+from xls.codegen import codegen_residual_data_pb2
 from xls.common import runfiles
 from xls.common import test_base
 
@@ -159,6 +160,12 @@ class CodeGenMainTest(parameterized.TestCase):
     else:
       want: str = runfiles.get_contents_as_text(path)
       self.assertMultiLineEqual(got, want)
+
+  def _find_line_number(self, text: str, substring: str) -> int:
+    for i, line in enumerate(text.splitlines(), start=1):
+      if substring in line:
+        return i
+    self.fail(f"Substring '{substring}' not found in provided text")
 
   def test_combinational(self):
     ir_file = self.create_tempfile(content=NOT_ADD_IR)
@@ -636,6 +643,61 @@ class CodeGenMainTest(parameterized.TestCase):
 
     # The tables should include a line for dce pass (dead code elimination).
     self.assertIn('dce', codegen_metrics_output)
+
+  def test_output_residual_data_path_writes_textproto(self):
+    ir_file = self.create_tempfile(content=NOT_ADD_IR)
+    residual_path = test_base.create_named_output_text_file(
+        'residual_data.textproto'
+    )
+
+    subprocess.check_call([
+        CODEGEN_MAIN_PATH,
+        '--generator=combinational',
+        '--alsologtostderr',
+        '--top=not_add',
+        '--output_residual_data_path=' + residual_path,
+        ir_file.full_path,
+    ])
+
+    with open(residual_path, 'r') as f:
+      residual = text_format.Parse(
+          f.read(), codegen_residual_data_pb2.CodegenResidualData()
+      )
+      # Exactly one block; nodes should include ports and logic in emission order.
+      self.assertGreaterEqual(len(residual.blocks), 1)
+      nodes = residual.blocks[0].nodes
+      # For NOT_ADD_IR we expect two inputs and two ops: [x, y, add, not]
+      self.assertLen(nodes, 5)
+      self.assertTrue(nodes[-3].node_name.startswith('add'))
+      self.assertTrue(nodes[-2].node_name.startswith('not'))
+
+  def test_reference_residual_flag_rejected_in_codegen_main(self):
+    ir_file = self.create_tempfile(content=NOT_ADD_IR)
+
+    # Produce a residual file to use as a reference input.
+    initial_residual_path = test_base.create_named_output_text_file(
+        'initial_residual.textproto'
+    )
+    subprocess.check_call([
+        CODEGEN_MAIN_PATH,
+        '--generator=combinational',
+        '--alsologtostderr',
+        '--top=not_add',
+        '--output_residual_data_path=' + initial_residual_path,
+        ir_file.full_path,
+    ])
+
+    # Reference residual should cause codegen_main to error.
+    proc = subprocess.run([
+        CODEGEN_MAIN_PATH,
+        '--generator=combinational',
+        '--alsologtostderr',
+        '--top=not_add',
+        '--reference_residual_data_path=' + initial_residual_path,
+        ir_file.full_path,
+    ], capture_output=True, text=True)
+    self.assertNotEqual(proc.returncode, 0)
+    self.assertIn('Reference residual data is not supported in codegen_main', proc.stderr)
 
   def _one_hot_ir(self) -> str:
     """Returns IR text containing a priority_select amenable to the reduction pass."""


### PR DESCRIPTION
This residual data currently just includes the emission order of the nodes into verilog though it will likely expand. It can be consumed in later codegen processes to reuse the emission order and minimize the differences in the generated Verilog. For example if you dump the residual metadata from IR sample A and use it for codegen'ing IR sample A' (small diff from A) then the resulting verilog from A' will have a very similar emission order assuming a correspondence of node ids between A and A'.