### PR TITLE
[bugfix] Ensure nodes aren't cloned multiple times

### DIFF
--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -1019,71 +1019,14 @@ class AstCloner : public AstNodeVisitor {
   absl::Status HandleTypeRef(const TypeRef* n) override {
     TypeDefinition new_type_definition = n->type_definition();
 
-    // A TypeRef doesn't own its referenced type definition. Reuse an existing
-    // type definition in the target module (by identifier) to avoid
-    // duplicating type defs when cloning subtrees into an already-cloned
-    // module. If none exists yet, clone the referenced definition now.
+    // A TypeRef doesn't own its referenced type definition, so we have to
+    // explicitly visit it.
     XLS_RETURN_IF_ERROR(absl::visit(
-        Visitor{
-            // Reuse an existing same-named type definition already present
-            // in the target module for module-scoped type defs.
-            [&](TypeAlias* ref) -> absl::Status {
-              absl::StatusOr<TypeDefinition> existing =
-                  module(n)->GetTypeDefinition(ref->identifier());
-              if (existing.ok()) {
-                new_type_definition = *existing;
-                return absl::OkStatus();
-              }
-              XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
-              new_type_definition =
-                  down_cast<decltype(ref)>(old_to_new_.at(ref));
-              return absl::OkStatus();
-            },
-            [&](StructDef* ref) -> absl::Status {
-              absl::StatusOr<TypeDefinition> existing =
-                  module(n)->GetTypeDefinition(ref->identifier());
-              if (existing.ok()) {
-                new_type_definition = *existing;
-                return absl::OkStatus();
-              }
-              XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
-              new_type_definition =
-                  down_cast<decltype(ref)>(old_to_new_.at(ref));
-              return absl::OkStatus();
-            },
-            [&](ProcDef* ref) -> absl::Status {
-              absl::StatusOr<TypeDefinition> existing =
-                  module(n)->GetTypeDefinition(ref->identifier());
-              if (existing.ok()) {
-                new_type_definition = *existing;
-                return absl::OkStatus();
-              }
-              XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
-              new_type_definition =
-                  down_cast<decltype(ref)>(old_to_new_.at(ref));
-              return absl::OkStatus();
-            },
-            [&](EnumDef* ref) -> absl::Status {
-              absl::StatusOr<TypeDefinition> existing =
-                  module(n)->GetTypeDefinition(ref->identifier());
-              if (existing.ok()) {
-                new_type_definition = *existing;
-                return absl::OkStatus();
-              }
-              XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
-              new_type_definition =
-                  down_cast<decltype(ref)>(old_to_new_.at(ref));
-              return absl::OkStatus();
-            },
-            // For ColonRef* and UseTreeEntry* we cannot look up by identifier
-            // in the target module; just clone/visit as before.
-            [&](auto* ref) -> absl::Status {
-              XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
-              new_type_definition =
-                  down_cast<decltype(ref)>(old_to_new_.at(ref));
-              return absl::OkStatus();
-            },
-        },
+        Visitor{[&](auto* ref) -> absl::Status {
+          XLS_RETURN_IF_ERROR(ReplaceOrVisit(ref));
+          new_type_definition = down_cast<decltype(ref)>(old_to_new_.at(ref));
+          return absl::OkStatus();
+        }},
         n->type_definition()));
 
     old_to_new_[n] = module(n)->Make<TypeRef>(n->span(), new_type_definition);

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -949,16 +949,19 @@ class AstCloner : public AstNodeVisitor {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
     XLS_RETURN_IF_ERROR(ReplaceOrVisit(&n->fn()));
-    old_to_new_[n] = module(n)->Make<TestFunction>(
-        n->span(), *down_cast<Function*>(old_to_new_.at(&n->fn())));
+    XLS_ASSIGN_OR_RETURN(Function * new_fn, CastIfNotVerbatim<Function*>(
+                                                old_to_new_.at(&n->fn())));
+    old_to_new_[n] = module(n)->Make<TestFunction>(n->span(), *new_fn);
     return absl::OkStatus();
   }
 
   absl::Status HandleTestProc(const TestProc* n) override {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
-    old_to_new_[n] = module(n)->Make<TestProc>(
-        down_cast<Proc*>(old_to_new_.at(n->proc())), n->expected_fail_label());
+    XLS_ASSIGN_OR_RETURN(Proc * new_proc,
+                         CastIfNotVerbatim<Proc*>(old_to_new_.at(n->proc())));
+    old_to_new_[n] =
+        module(n)->Make<TestProc>(new_proc, n->expected_fail_label());
     return absl::OkStatus();
   }
 

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -1648,8 +1648,7 @@ fn foo(x: MyU32) -> MyU32 {
                                                     "the_module", file_table));
   XLS_ASSERT_OK_AND_ASSIGN(Function * foo,
                            module->GetMemberOrError<Function>("foo"));
-  XLS_ASSERT_OK_AND_ASSIGN(TypeAlias * alias,
-                           module->GetMemberOrError<TypeAlias>("MyU32"));
+  XLS_ASSERT_OK(module->GetMemberOrError<TypeAlias>("MyU32"));
 
   // Clone just the function into the same target module.
   XLS_ASSERT_OK_AND_ASSIGN(AstNode * clone, CloneAst(foo));


### PR DESCRIPTION
`AstCloner` previously attempted to prevent double-cloning by checking the `old_to_new_` mapping inside `VisitChildren`. However, this missed the case where `ReplaceOrVisit` was invoked directly on a node. In such cases, the same node could be cloned multiple times, breaking semantics.

For example, with the following code, the old logic would incorrectly produce distinct type entities for the argument and return type in the clone:

```dslx
type MyU32 = u32;
fn foo(x: MyU32) -> MyU32 {
  x
}
```

This PR fixes the issue by moving the `old_to_new_` check into `ReplaceOrVisit` and ensures nodes are only cloned once regardless of how they are visited.

This change revealed another bug: `HandleTestFunction` and `HandleTestProc` were not using `CastIfNotVerbatim` and would cause failure in the formatter test suite. This pull request make it consistent with existing implementations like `HandleFunction` and fixed the test failure.