### PR TITLE
Fix HandleImport to set the definer

### DIFF
--- a/xls/dslx/frontend/BUILD
+++ b/xls/dslx/frontend/BUILD
@@ -68,6 +68,7 @@ cc_test(
         "//xls/common/status:matchers",
         "//xls/common/status:status_macros",
         "//xls/dslx:command_line_utils",
+        "//xls/dslx:create_import_data",
         "//xls/dslx:parse_and_typecheck",
         "//xls/dslx:virtualizable_file_system",
         "@com_google_absl//absl/container:flat_hash_map",

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -419,9 +419,12 @@ class AstCloner : public AstNodeVisitor {
   absl::Status HandleImport(const Import* n) override {
     XLS_RETURN_IF_ERROR(VisitChildren(n));
 
-    old_to_new_[n] = module(n)->Make<Import>(
-        n->span(), n->subject(),
-        *down_cast<NameDef*>(old_to_new_.at(&n->name_def())), n->alias());
+    NameDef* new_name_def = down_cast<NameDef*>(old_to_new_.at(&n->name_def()));
+    Import* new_import = module(n)->Make<Import>(n->span(), n->subject(),
+                                                 *new_name_def, n->alias());
+    // Mirror parser behavior: bind the name to its definer (the Import).
+    new_name_def->set_definer(new_import);
+    old_to_new_[n] = new_import;
     return absl::OkStatus();
   }
 


### PR DESCRIPTION
This pull request fixes the `HandleImport` method of the `AstCloner` to set the definer for the cloned `NameDef`.