### PR TITLE
Add target module and old_to_new context to the replacer interface

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -3167,7 +3167,10 @@ absl::StatusOr<std::string> AutoFmt(VirtualizableFilesystem& vfs,
   FormatDisabler disabler(vfs, comments, *m.fs_path());
   XLS_ASSIGN_OR_RETURN(
       std::unique_ptr<Module> clone,
-      CloneModule(m, std::bind_front(&FormatDisabler::operator(), &disabler)));
+      CloneModule(m, [&](const AstNode* node, Module*,
+                         const absl::flat_hash_map<const AstNode*, AstNode*>&) {
+        return disabler(node);
+      }));
   return AutoFmt(*clone, comments, text_width);
 }
 
@@ -3177,7 +3180,10 @@ absl::StatusOr<std::string> AutoFmt(VirtualizableFilesystem& vfs,
   FormatDisabler disabler(vfs, comments, contents);
   XLS_ASSIGN_OR_RETURN(
       std::unique_ptr<Module> clone,
-      CloneModule(m, std::bind_front(&FormatDisabler::operator(), &disabler)));
+      CloneModule(m, [&](const AstNode* node, Module*,
+                         const absl::flat_hash_map<const AstNode*, AstNode*>&) {
+        return disabler(node);
+      }));
   return AutoFmt(*clone, comments, text_width);
 }
 

--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -1205,7 +1205,8 @@ class AstCloner : public AstNodeVisitor {
     if (old_to_new_.contains(node)) {
       return absl::OkStatus();
     }
-    XLS_ASSIGN_OR_RETURN(std::optional<AstNode*> replacement, replacer_(node));
+    XLS_ASSIGN_OR_RETURN(std::optional<AstNode*> replacement,
+                         replacer_(node, module(node), old_to_new_));
     if (replacement.has_value()) {
       old_to_new_[node] = *replacement;
       return absl::OkStatus();
@@ -1238,17 +1239,20 @@ class AstCloner : public AstNodeVisitor {
 
 }  // namespace
 
-std::optional<AstNode*> PreserveTypeDefinitionsReplacer(const AstNode* node) {
+std::optional<AstNode*> PreserveTypeDefinitionsReplacer(
+    const AstNode* node, Module* module,
+    const absl::flat_hash_map<const AstNode*, AstNode*>&) {
   if (node->kind() == AstNodeKind::kTypeRef) {
     const auto* type_ref = down_cast<const TypeRef*>(node);
-    return node->owner()->Make<TypeRef>(type_ref->span(),
-                                        type_ref->type_definition());
+    return module->Make<TypeRef>(type_ref->span(), type_ref->type_definition());
   }
   return std::nullopt;
 }
 
 CloneReplacer NameRefReplacer(const NameDef* def, Expr* replacement) {
-  return [=](const AstNode* node) -> std::optional<AstNode*> {
+  return [=](const AstNode* node, Module* new_module,
+             const absl::flat_hash_map<const AstNode*, AstNode*>&)
+             -> std::optional<AstNode*> {
     if (node->kind() == AstNodeKind::kNameRef) {
       const auto* name_ref = down_cast<const NameRef*>(node);
       if (std::holds_alternative<const NameDef*>(name_ref->name_def()) &&
@@ -1262,14 +1266,16 @@ CloneReplacer NameRefReplacer(const NameDef* def, Expr* replacement) {
 
 CloneReplacer NameRefReplacer(
     const absl::flat_hash_map<const NameDef*, NameDef*>* replacement_defs) {
-  return [=](const AstNode* original_node) -> std::optional<AstNode*> {
+  return [=](const AstNode* original_node, Module* new_module,
+             const absl::flat_hash_map<const AstNode*, AstNode*>&)
+             -> std::optional<AstNode*> {
     if (original_node->kind() == AstNodeKind::kNameRef) {
       const auto* original_ref = down_cast<const NameRef*>(original_node);
       const AstNode* def = ToAstNode(original_ref->name_def());
       if (def->kind() == AstNodeKind::kNameDef) {
         const auto it = replacement_defs->find(down_cast<const NameDef*>(def));
         if (it != replacement_defs->end()) {
-          return original_node->owner()->Make<NameRef>(
+          return new_module->Make<NameRef>(
               original_ref->span(), original_ref->identifier(), it->second);
         }
       }
@@ -1285,8 +1291,11 @@ CloneAstAndGetAllPairs(const AstNode* root,
   if (root->kind() == AstNodeKind::kModule) {
     return absl::InvalidArgumentError("Clone a module via 'CloneModule'.");
   }
+  Module* new_module =
+      target_module.has_value() ? *target_module : root->owner();
+  absl::flat_hash_map<const AstNode*, AstNode*> empty_old_to_new;
   XLS_ASSIGN_OR_RETURN(std::optional<AstNode*> root_replacement,
-                       replacer(root));
+                       replacer(root, new_module, empty_old_to_new));
   if (root_replacement.has_value()) {
     return absl::flat_hash_map<const AstNode*, AstNode*>{
         {root, *root_replacement}};
@@ -1317,15 +1326,19 @@ absl::StatusOr<std::unique_ptr<Module>> CloneModule(const Module& module,
 }
 
 CloneReplacer ChainCloneReplacers(CloneReplacer first, CloneReplacer second) {
-  return [first = std::move(first),
-          second = std::move(second)](const AstNode* node) mutable
-             -> absl::StatusOr<std::optional<AstNode*>> {
-    XLS_ASSIGN_OR_RETURN(std::optional<AstNode*> first_result, first(node));
-    XLS_ASSIGN_OR_RETURN(
-        std::optional<AstNode*> second_result,
-        second(first_result.has_value() ? *first_result : node));
-    return second_result.has_value() ? second_result : first_result;
-  };
+  return
+      [first = std::move(first), second = std::move(second)](
+          const AstNode* node, Module* module,
+          const absl::flat_hash_map<const AstNode*, AstNode*>&
+              old_to_new) mutable -> absl::StatusOr<std::optional<AstNode*>> {
+        XLS_ASSIGN_OR_RETURN(std::optional<AstNode*> first_result,
+                             first(node, module, old_to_new));
+        XLS_ASSIGN_OR_RETURN(
+            std::optional<AstNode*> second_result,
+            second(first_result.has_value() ? *first_result : node, module,
+                   old_to_new));
+        return second_result.has_value() ? second_result : first_result;
+      };
 }
 
 // Verifies that `node` consists solely of "new" AST nodes and none that are

--- a/xls/dslx/type_system_v2/inference_table.cc
+++ b/xls/dslx/type_system_v2/inference_table.cc
@@ -626,6 +626,9 @@ class InferenceTableImpl : public InferenceTable {
                        input, target_module,
                        ChainCloneReplacers(&PreserveTypeDefinitionsReplacer,
                                            std::move(replacer))));
+    // VerifyClone won't pass here.
+    // XLS_RETURN_IF_ERROR(
+    //     VerifyClone(input, all_pairs.at(input), *input->owner()->file_table()));
     for (const auto& [old_node, new_node] : all_pairs) {
       if (old_node != new_node) {
         const auto it = node_data_.find(old_node);
@@ -1007,15 +1010,19 @@ CloneReplacer NameRefMapper(
     const absl::flat_hash_map<const NameDef*, ExprOrType>& map,
     std::optional<Module*> target_module) {
   return [table = &table, map = &map, target_module](
-             const AstNode* node) -> absl::StatusOr<std::optional<AstNode*>> {
+             const AstNode* node, Module* new_module,
+             const absl::flat_hash_map<const AstNode*, AstNode*>&)
+             -> absl::StatusOr<std::optional<AstNode*>> {
     if (node->kind() == AstNodeKind::kNameRef) {
       const auto* ref = down_cast<const NameRef*>(node);
       if (std::holds_alternative<const NameDef*>(ref->name_def())) {
         const auto it = map->find(std::get<const NameDef*>(ref->name_def()));
         if (it != map->end()) {
+          Module* module_for_clone =
+              target_module ? *target_module : new_module;
           return table->Clone(ToAstNode(it->second),
                               &PreserveTypeDefinitionsReplacer,
-                              target_module ? *target_module : ref->owner());
+                              module_for_clone);
         }
       }
     }

--- a/xls/dslx/type_system_v2/inference_table_converter_impl.cc
+++ b/xls/dslx/type_system_v2/inference_table_converter_impl.cc
@@ -2209,7 +2209,9 @@ class InferenceTableConverterImpl : public InferenceTableConverter,
     if (real_self_type.has_value()) {
       replacer = ChainCloneReplacers(
           std::move(replacer),
-          [&](const AstNode* node) -> absl::StatusOr<std::optional<AstNode*>> {
+          [&](const AstNode* node, Module*,
+              const absl::flat_hash_map<const AstNode*, AstNode*>&)
+              -> absl::StatusOr<std::optional<AstNode*>> {
             if (node->kind() == AstNodeKind::kTypeAnnotation &&
                 down_cast<const TypeAnnotation*>(node)
                     ->IsAnnotation<SelfTypeAnnotation>()) {

--- a/xls/dslx/type_system_v2/type_annotation_resolver.cc
+++ b/xls/dslx/type_system_v2/type_annotation_resolver.cc
@@ -421,12 +421,16 @@ class StatefulResolver : public TypeAnnotationResolver {
       }
 
       ObservableCloneReplacer replace_indirect(
-          &replaced_anything, [&](const AstNode* node) {
+          &replaced_anything,
+          [&](const AstNode* node, Module*,
+              const absl::flat_hash_map<const AstNode*, AstNode*>&) {
             return ReplaceIndirectTypeAnnotations(node, parametric_context,
                                                   annotation, filter);
           });
       ObservableCloneReplacer replace_type_aliases(
-          &replaced_anything, [&](const AstNode* node) {
+          &replaced_anything,
+          [&](const AstNode* node, Module*,
+              const absl::flat_hash_map<const AstNode*, AstNode*>&) {
             return ReplaceTypeAliasWithTarget(node);
           });
       XLS_ASSIGN_OR_RETURN(
@@ -1030,7 +1034,8 @@ class StatefulResolver : public TypeAnnotationResolver {
         AstNode * result,
         table_.Clone(
             annotation,
-            [&](const AstNode* node)
+            [&](const AstNode* node, Module* new_module,
+                const absl::flat_hash_map<const AstNode*, AstNode*>&)
                 -> absl::StatusOr<std::optional<AstNode*>> {
               if (node->kind() == AstNodeKind::kTypeRef) {
                 return const_cast<AstNode*>(node);
@@ -1049,7 +1054,7 @@ class StatefulResolver : public TypeAnnotationResolver {
                 return std::nullopt;
               }
 
-              auto* result = node->owner()->Make<Number>(
+              auto* result = new_module->Make<Number>(
                   Span::None(), value.ToString(/*humanize=*/true),
                   NumberKind::kOther, nullptr, /*in_parens=*/false,
                   /*leave_span_intact=*/true);


### PR DESCRIPTION
Depends on #2975.

This PR cherry-picks the first commit from #2976, as the remaining commits still need further discussion.
The selected commit introduces the target module context and the old_to_new mapping to the replacer interface.

In #2976, I’ve also added a few more commits and a discussion that I’d like to get reviewed. Suggestions and feedback are very welcome.