### PR TITLE
Fix IR conversion bug in for loops.

### DIFF
--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -1650,8 +1650,10 @@ absl::StatusOr<BValue> FunctionConverter::HandleForBody(
 
   XLS_ASSIGN_OR_RETURN(BValue init, Use(node->init()));
   if (implicit_token_data_.has_value()) {
-    BValue activated = trip_count == 0 ? function_builder_->Literal(UBits(0, 1))
-                                       : implicit_token_data_->activated;
+    BValue activated = trip_count == 0
+                           ? function_builder_->Literal(UBits(0, 1))
+                           : implicit_token_data_->create_control_predicate();
+
     init = function_builder_->Tuple(
         {implicit_token_data_->entry_token, activated, init});
   }

--- a/xls/dslx/tests/BUILD
+++ b/xls/dslx/tests/BUILD
@@ -912,6 +912,16 @@ dslx_lang_test(
 )
 
 dslx_lang_test(
+    name = "assert_in_for_under_inactive_conditional",
+    compare = "interpreter",
+    # Don't convert to IR because we want to compare the IR interpreter and
+    # DSL interpreter. convert_to_ir=True disables comparison.
+    convert_to_ir = False,
+    # IR asserts are software-only; skip z3 equivalence.
+    test_ir_equivalence = False,
+)
+
+dslx_lang_test(
     name = "quickcheck_fn_with_fail",
     # Primarily a #[quickcheck] function.
     convert_to_ir = False,

--- a/xls/dslx/tests/assert_in_for_under_inactive_conditional.x
+++ b/xls/dslx/tests/assert_in_for_under_inactive_conditional.x
@@ -1,0 +1,28 @@
+// Copyright 2025 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() -> () { () }
+
+fn bar() -> () { assert!(false, "Should not happen."); }
+
+fn foo(x: bool) -> () {
+    if x {
+        for (_, ()) in u32:0..u32:4 {
+            bar()
+        }(())
+    }
+}
+
+#[test]
+fn test_main_no_assert_when_false() { foo(false) }


### PR DESCRIPTION
The implicit activation bit was improperly generated inside for loops in some cases. This resulted in spurious asserts or other side-effecting operations firing improperly. This manifested as a divergence in assert behavior in a test between DSLX interpreter and IR interpreter .