### PR TITLE
Clarify logic around choosing the quickcheck evaluator.

### DIFF
--- a/xls/dslx/interpreter_main.cc
+++ b/xls/dslx/interpreter_main.cc
@@ -33,6 +33,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
+#include "re2/re2.h"
 #include "xls/common/exit_status.h"
 #include "xls/common/file/filesystem.h"
 #include "xls/common/init_xls.h"
@@ -47,7 +48,6 @@
 #include "xls/dslx/virtualizable_file_system.h"
 #include "xls/dslx/warning_kind.h"
 #include "xls/ir/format_preference.h"
-#include "re2/re2.h"
 
 // LINT.IfChange
 ABSL_FLAG(std::string, dslx_path, "",
@@ -95,6 +95,10 @@ ABSL_FLAG(std::string, evaluator, "dslx-interpreter",
           "the XLS-IR JIT. ir-interpreter' is the XLS-IR interpreter.");
 ABSL_FLAG(std::optional<bool>, type_inference_v2, std::nullopt,
           "Whether to use type system v2 when type checking the input.");
+ABSL_FLAG(
+    bool, run_quickcheck_when_interpreting, false,
+    "Whether to run quickchecks when using the IR interpreter. By default, "
+    "this flag is off because the IR interpreter is too slow.");
 // LINT.ThenChange(//xls/build_rules/xls_dslx_rules.bzl)
 
 namespace xls::dslx {
@@ -169,16 +173,31 @@ absl::StatusOr<TestResult> RealMain(
   XLS_ASSIGN_OR_RETURN(std::string module_name, PathToName(entry_module_path));
 
   std::unique_ptr<AbstractRunComparator> run_comparator;
-  switch (compare_flag) {
-    case CompareFlag::kNone:
-      break;
-    case CompareFlag::kJit:
-      run_comparator = std::make_unique<RunComparator>(CompareMode::kJit);
-      break;
-    case CompareFlag::kInterpreter:
-      run_comparator =
+  // When comparison is on, use the same mode (JIT/interpreter) as the
+  // comparator. Otherwise, use the same mode as the evaluator flag. Using the
+  // IR interpreter requires --run_quickcheck_when_interpreting.
+  std::unique_ptr<AbstractRunComparator> quickcheck_runner;
+  if (compare_flag == CompareFlag::kNone) {
+    if (evaluator == EvaluatorType::kIrJit) {
+      quickcheck_runner = std::make_unique<RunComparator>(CompareMode::kJit);
+    } else if (evaluator == EvaluatorType::kIrInterpreter) {
+      if (absl::GetFlag(FLAGS_run_quickcheck_when_interpreting)) {
+        quickcheck_runner =
+            std::make_unique<RunComparator>(CompareMode::kInterpreter);
+      }
+    } else {
+      // Quickcheck is never run with the DSLX interpreter.
+    }
+  } else if (compare_flag == CompareFlag::kJit) {
+    run_comparator = std::make_unique<RunComparator>(CompareMode::kJit);
+    quickcheck_runner = std::make_unique<RunComparator>(CompareMode::kJit);
+  } else {
+    CHECK(compare_flag == CompareFlag::kInterpreter);
+    run_comparator = std::make_unique<RunComparator>(CompareMode::kInterpreter);
+    if (absl::GetFlag(FLAGS_run_quickcheck_when_interpreting)) {
+      quickcheck_runner =
           std::make_unique<RunComparator>(CompareMode::kInterpreter);
-      break;
+    }
   }
 
   std::optional<RE2> test_filter_re;
@@ -206,6 +225,7 @@ absl::StatusOr<TestResult> RealMain(
       .test_filter = test_filter_re_ptr,
       .format_preference = format_preference,
       .run_comparator = run_comparator.get(),
+      .quickcheck_runner = quickcheck_runner.get(),
       .execute = execute,
       .seed = seed,
       .trace_channels = trace_channels,

--- a/xls/dslx/run_routines/run_routines.cc
+++ b/xls/dslx/run_routines/run_routines.cc
@@ -411,7 +411,7 @@ static bool ValuesAreValid(absl::Span<const Value> values,
 absl::StatusOr<QuickCheckResults> DoQuickCheck(
     bool requires_implicit_token, dslx::FunctionType* dslx_fn_type,
     xls::Function* ir_function, std::string_view ir_name,
-    AbstractRunComparator* run_comparator, int64_t seed,
+    AbstractRunComparator* quickcheck_runner, int64_t seed,
     QuickCheckTestCases test_cases) {
   QuickCheckResults results;
   std::minstd_rand rng_engine(seed);
@@ -482,7 +482,7 @@ absl::StatusOr<QuickCheckResults> DoQuickCheck(
     // failures, flag-controlled, ...).
     absl::Span<const Value> this_arg_set = results.arg_sets.back();
     XLS_ASSIGN_OR_RETURN(xls::Value result,
-                         DropInterpreterEvents(run_comparator->RunIrFunction(
+                         DropInterpreterEvents(quickcheck_runner->RunIrFunction(
                              ir_name, ir_function, this_arg_set)));
 
     // In the case of an implicit token signature we get (token, bool) as the
@@ -546,7 +546,7 @@ static absl::StatusOr<QuickcheckIrFn> FindQuickcheckIrFn(Function* dslx_fn,
                       absl::StrJoin(ir_package->GetFunctionNames(), ", ")));
 }
 
-static absl::Status RunQuickCheck(AbstractRunComparator* run_comparator,
+static absl::Status RunQuickCheck(AbstractRunComparator* quickcheck_runner,
                                   Package* ir_package, QuickCheck* quickcheck,
                                   TypeInfo* type_info, int64_t seed) {
   // Note: DSLX function.
@@ -573,8 +573,8 @@ static absl::Status RunQuickCheck(AbstractRunComparator* run_comparator,
       QuickCheckResults qc_results,
       DoQuickCheck(
           qc_fn.calling_convention == CallingConvention::kImplicitToken,
-          dslx_fn_type, qc_fn.ir_function, qc_fn.ir_name, run_comparator, seed,
-          quickcheck->test_cases()));
+          dslx_fn_type, qc_fn.ir_function, qc_fn.ir_name, quickcheck_runner,
+          seed, quickcheck->test_cases()));
 
   // Extract the (inputs, outputs) from the results.
   const auto& [inputs, outputs] = qc_results;
@@ -627,15 +627,17 @@ static absl::Status RunQuickCheck(AbstractRunComparator* run_comparator,
       *dslx_fn->owner()->file_table());
 }
 
-static absl::Status RunQuickChecksIfJitEnabled(
+static absl::Status RunQuickChecksIfEnabled(
     const RE2* test_filter, Module* entry_module, TypeInfo* type_info,
-    AbstractRunComparator* run_comparator, Package* ir_package,
+    AbstractRunComparator* quickcheck_runner, Package* ir_package,
     std::optional<int64_t> seed, TestResultData& result,
     VirtualizableFilesystem& vfs) {
-  if (run_comparator == nullptr) {
+  if (quickcheck_runner == nullptr) {
     // TODO(leary): 2024-02-08 Note that this skips /all/ the quickchecks so we
     // don't make an entry for it right now in the test XML.
-    std::cerr << "[ SKIPPING QUICKCHECKS  ] (JIT is disabled)" << "\n";
+    std::cerr << "[ SKIPPING QUICKCHECKS  ] (JIT is disabled and quickcheck is "
+                 "not enabled with the interpreter)"
+              << "\n";
     return absl::OkStatus();
   }
   if (!seed.has_value()) {
@@ -671,8 +673,8 @@ static absl::Status RunQuickChecksIfJitEnabled(
     }
     std::cerr << "[ RUN QUICKCHECK        ] " << quickcheck_name
               << " cases: " << quickcheck->test_cases().ToString() << "\n";
-    const absl::Status status =
-        RunQuickCheck(run_comparator, ir_package, quickcheck, type_info, *seed);
+    const absl::Status status = RunQuickCheck(quickcheck_runner, ir_package,
+                                              quickcheck, type_info, *seed);
     const absl::Duration duration = absl::Now() - test_case_start;
     if (!status.ok()) {
       HandleError(result, status, quickcheck_name, start_pos, test_case_start,
@@ -952,7 +954,8 @@ absl::StatusOr<TestResultData> AbstractTestRunner::ParseAndTest(
   // with the interpreter.
   std::unique_ptr<Package> ir_package;
   PostFnEvalHook post_fn_eval_hook;
-  if (options.run_comparator != nullptr) {
+  if (options.run_comparator != nullptr ||
+      options.quickcheck_runner != nullptr) {
     absl::StatusOr<dslx::PackageConversionData> ir_package_conversion_data =
         ConvertModuleToPackage(entry_module, &import_data,
                                options.convert_options);
@@ -1050,9 +1053,9 @@ absl::StatusOr<TestResultData> AbstractTestRunner::ParseAndTest(
 
   // Run quickchecks, but only if the JIT is enabled.
   if (!entry_module->GetQuickChecks().empty()) {
-    XLS_RETURN_IF_ERROR(RunQuickChecksIfJitEnabled(
+    XLS_RETURN_IF_ERROR(RunQuickChecksIfEnabled(
         options.test_filter, entry_module, tm->type_info,
-        options.run_comparator, ir_package.get(), options.seed, result,
+        options.quickcheck_runner, ir_package.get(), options.seed, result,
         import_data.vfs()));
   }
 

--- a/xls/dslx/run_routines/run_routines.h
+++ b/xls/dslx/run_routines/run_routines.h
@@ -101,6 +101,7 @@ struct ParseAndTestOptions {
   const RE2* test_filter = nullptr;
   FormatPreference format_preference = FormatPreference::kDefault;
   AbstractRunComparator* run_comparator = nullptr;
+  AbstractRunComparator* quickcheck_runner = nullptr;
   bool execute = true;
   std::optional<int64_t> seed = std::nullopt;
   ConvertOptions convert_options;
@@ -292,7 +293,7 @@ struct QuickCheckResults {
 absl::StatusOr<QuickCheckResults> DoQuickCheck(
     bool requires_implicit_token, dslx::FunctionType* dslx_fn_type,
     xls::Function* ir_function, std::string_view ir_name,
-    AbstractRunComparator* run_comparator, int64_t seed,
+    AbstractRunComparator* quickcheck_runner, int64_t seed,
     QuickCheckTestCases test_cases);
 
 }  // namespace xls::dslx

--- a/xls/dslx/run_routines/run_routines_test.cc
+++ b/xls/dslx/run_routines/run_routines_test.cc
@@ -182,7 +182,7 @@ fn trivial(x: u5) -> bool { id(true) }
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.seed = int64_t{2};
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
@@ -206,7 +206,7 @@ fn trivial(x: u2) -> bool { id(true) }
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
       ParseAndTest(kProgram, kModuleName, kFilename, options));
@@ -239,7 +239,7 @@ fn qc(x: MyEnum) -> bool {
   ParseAndTestOptions options;
   options.parse_and_typecheck_options.warnings =
       DisableWarning(kAllWarningsSet, WarningKind::kAlreadyExhaustiveMatch);
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
       ParseAndTest(kProgram, kModuleName, kFilename, options));
@@ -266,7 +266,7 @@ fn qc(x: EmptyEnum) -> bool {
   options.vfs_factory = [kProgram] {
     return std::make_unique<UniformContentFilesystem>(kProgram, "test.x");
   };
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
       ParseAndTest(kProgram, kModuleName, kFilename, options));
@@ -294,7 +294,7 @@ fn qc(x: xN[S][4]) -> MyBool2 {
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
       ParseAndTest(kProgram, kModuleName, kFilename, options));
@@ -313,7 +313,7 @@ fn qc_with_implicit_token(x: u2) -> bool {
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.vfs_factory = [kProgram] {
     return std::make_unique<UniformContentFilesystem>(kProgram, "test.x");
   };
@@ -342,7 +342,7 @@ fn bfloat16_bits_to_float32_bits_upcast_is_zero_pad(x: bits[BF16_TOTAL_SZ]) -> b
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
 
   const std::filesystem::path root("/");
   auto get_stdlib_contents = [](std::string_view filename) -> std::string {
@@ -386,7 +386,7 @@ fn trivial(x: u11) -> bool { x != u11::MAX }
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.vfs_factory = [kProgram] {
     return std::make_unique<UniformContentFilesystem>(kProgram, "test.x");
   };
@@ -408,7 +408,7 @@ fn trivial(x: u5, y: u6) -> bool { !(x == u5::MAX && y == u6::MAX) }
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.vfs_factory = [kProgram] {
     return std::make_unique<UniformContentFilesystem>(kProgram, "test.x");
   };
@@ -430,7 +430,7 @@ fn trivial(x: u5) -> bool { id(true) }
   constexpr const char* kFilename = "test.x";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,
       ParseAndTest(kProgram, kModuleName, kFilename, options));
@@ -452,7 +452,7 @@ fn qc(x: bool) -> bool { do_fail(x) }
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
   options.seed = int64_t{2316476071057580};
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.vfs_factory = [kProgram] {
     return std::make_unique<UniformContentFilesystem>(kProgram, "test.x");
   };
@@ -472,7 +472,7 @@ fn trivial(x: u5) -> bool { false }
   constexpr const char* kModuleName = "test";
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
-  options.run_comparator = &jit_comparator;
+  options.quickcheck_runner = &jit_comparator;
   options.seed = int64_t{42};
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,


### PR DESCRIPTION
Previously, the quickcheck evaluator piggy-backed on the comparison runner which meant if you ran the interpreter with --evaluator=jit --comparison=none you'd get a confusing message about not running the quickcheck tests because the jit is disabled. Now a separate options field holds the quickcheck runner. It uses the comparison one if comparison is enabled, otherwise uses the --evaluator one. Also, allow the ir-interpreter to be used for quickchecks but only if a special flag is passed in (--run_quickcheck_when_interpreting).

Fixes #2970