### PR TITLE
[build] Add enum switch fallback to make GCC happy.

### DIFF
--- a/xls/dslx/value_format_descriptor.cc
+++ b/xls/dslx/value_format_descriptor.cc
@@ -89,6 +89,8 @@ absl::Status ValueFormatDescriptor::Accept(ValueFormatVisitor& v) const {
     case ValueFormatDescriptorKind::kStruct:
       return v.HandleStruct(*this);
   }
+  return absl::InvalidArgumentError(absl::StrFormat(
+      "Out of bounds ValueFormatDescriptorKind: %d", static_cast<int>(kind())));
 }
 
 }  // namespace xls::dslx


### PR DESCRIPTION
Note that gcc is an unsupported environment, this is just a change towards best effort buildability.

Without this you get an error like:

```
ERROR: /home/cdleary/proj/xlsynth/xls/dslx/BUILD:224:11: Compiling xls/dslx/value_format_descriptor.cc failed: (Exit 1): gcc failed: error executing CppCompile command (from target //xls/dslx:value_format_descriptor) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -g0 -O2 '-D_FORTIFY_SOURCE=1' -DNDEBUG -ffunction-sections ... (remaining 41 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
xls/dslx/value_format_descriptor.cc: In member function 'absl::lts_20250512::Status xls::dslx::ValueFormatDescriptor::Accept(xls::dslx::ValueFormatVisitor&) const':
xls/dslx/value_format_descriptor.cc:92:1: error: control reaches end of non-void function [-Werror=return-type]
   92 | }
      | ^
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-deprecated-copy-with-user-provided-copy' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-nullability-completeness' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-bitwise-instead-of-logical' may have been intended to silence earlier diagnostics
cc1plus: some warnings being treated as errors
Target //xls/public:c_api_test failed to build
```