### PR TITLE
xls/dev_tools/check_cpp: relax includes check

### DIFF
--- a/xls/dev_tools/check_cpp_includes.py
+++ b/xls/dev_tools/check_cpp_includes.py
@@ -48,6 +48,8 @@ ALLOWED_INCLUDE_STARTS = frozenset([
     'linenoise.h',
     'libs/json11/',
     'proto/profile.pb.h',  # the pprof format header.
+    '/tmp',  # For tests.
+    'path/to',  # For tests.
     '%s',  # For format strings embedded in files.
 ])
 


### PR DESCRIPTION
Allow list include patterns used in tests.

This should fix build at head:
```
2025-09-19T23:24:42.3391270Z Check C++ absolute includes..............................................Failed
2025-09-19T23:24:42.3391802Z - hook id: check-cpp-absolute-includes
2025-09-19T23:24:42.3392341Z - exit code: 1
2025-09-19T23:24:42.3392488Z 
2025-09-19T23:24:42.3392765Z xls/dslx/cpp_transpiler/cpp_transpiler_test.cc: Found non-absolute includes:
2025-09-19T23:24:42.3393237Z   path/to/some_types.h
2025-09-19T23:24:42.3393504Z   path/to/other_types.h
2025-09-19T23:24:42.3393745Z   /tmp/fake_path.h
2025-09-19T23:24:42.3394011Z   path/to/some_types.h
2025-09-19T23:24:42.3394248Z   path/to/other_types.h
```