### PR TITLE
Function builder guard for TupleIndex with OOB index

### DIFF
--- a/xls/ir/function_builder.cc
+++ b/xls/ir/function_builder.cc
@@ -437,13 +437,23 @@ BValue BuilderBase::TupleIndex(BValue arg, int64_t idx, const SourceInfo& loc,
   if (ErrorPending()) {
     return BValue();
   }
-  if (!GetType(arg)->IsTuple()) {
+  const Type* arg_type = GetType(arg);
+  if (!arg_type->IsTuple()) {
     return SetError(
         absl::StrFormat(
             "Operand of tuple-index must be tuple-typed, is type: %s",
-            GetType(arg)->ToString()),
+            arg_type->ToString()),
         loc);
   }
+
+  const TupleType* tuple_type = arg_type->AsTupleOrDie();
+  if (idx >= tuple_type->size()) {
+    return SetError(
+        absl::StrFormat("Tuple index %d out of range for tuple type %s", idx,
+                        tuple_type->ToString()),
+        loc);
+  }
+
   return AddNode<xls::TupleIndex>(loc, arg.node(), idx, name);
 }
 

--- a/xls/ir/function_builder_test.cc
+++ b/xls/ir/function_builder_test.cc
@@ -137,6 +137,18 @@ TEST(FunctionBuilderTest, NonTupleValueToTupleIndex) {
                HasSubstr("Operand of tuple-index must be tuple-typed")));
 }
 
+TEST(FunctionBuilderTest, TupleIndexOutOfBounds) {
+  Package p("p");
+  FunctionBuilder b("tuple_index_oob_test", &p);
+  BitsType* u32 = p.GetBitsType(32);
+  BValue tup = b.Tuple({b.Param("a", u32), b.Param("b", u32)});
+  b.TupleIndex(tup, 2);
+  absl::Status status = b.Build().status();
+  EXPECT_THAT(status, StatusIs(absl::StatusCode::kInvalidArgument,
+                               HasSubstr("Tuple index 2 out of range for tuple "
+                                         "type (bits[32], bits[32])")));
+}
+
 TEST(FunctionBuilderTest, LiteralArrayTest) {
   Package p("p");
   FunctionBuilder b("literal_array", &p);


### PR DESCRIPTION
Previously this would cause a std::out_of_range which would cause a terminate -- now we give back a Status consistent with the rest of the API surface area.