### PR TITLE
[viz] Add delay models to the ir_to_json_main target to fix IR viz.

### DIFF
--- a/xls/visualization/ir_viz/BUILD
+++ b/xls/visualization/ir_viz/BUILD
@@ -269,6 +269,7 @@ cc_binary(
         "//xls/common/status:status_macros",
         "//xls/estimators/delay_model:delay_estimator",
         "//xls/estimators/delay_model:delay_estimators",
+        "//xls/estimators/delay_model/models",
         "//xls/ir",
         "//xls/ir:ir_parser",
         "//xls/scheduling:pipeline_schedule",


### PR DESCRIPTION
Previously you would get e.g.:

```
Error: NOT_FOUND: No delay estimator found named "asap7".

No estimators are registered.

This can be caused by a few different issues.

1) Was InitXls called?

   This needs be called early during binary startup or before running other xls
   code.

2) Were estimators linked into the binary?

   Estimators need to be linked in order to be available. The standard
   estimators are linked from '//xls/estimators/delay_model/models'
   and are also exported as '//xls/estimators' and
   '//xls/public:passes_and_estimators'. At least one of these must
   be in the 'deps' tree to ensure that estimators are available.
```

(but it would not be surfaced in the IR viz web app you'd just see "error running command")