### PR TITLE
Propagate annotated widths into range literals in nested arrays (Re: #3564)

### DIFF
--- a/xls/dslx/type_system/deduce_expr.cc
+++ b/xls/dslx/type_system/deduce_expr.cc
@@ -191,7 +191,7 @@ static absl::StatusOr<std::unique_ptr<ArrayType>> DeduceArrayInternal(
     // Likewise, propagate the annotated element type to range endpoints so
     // nested arrays of ranges adopt the intended width.
     const Type* target_range_type = &annotated->element_type();
-    if (auto* array_elem = dynamic_cast<const ArrayType*>(target_range_type)) {
+    while (auto* array_elem = dynamic_cast<const ArrayType*>(target_range_type)) {
       target_range_type = &array_elem->element_type();
     }
     if (GetBitsLike(*target_range_type)) {

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -3380,6 +3380,17 @@ fn test_array2d_tiv2() {
   XLS_EXPECT_OK(Typecheck(kProgram));
 }
 
+TEST_F(TypecheckV2Test, RangeAnnotatesDeepNestedArrays) {
+  constexpr absl::string_view kProgram = R"(
+#[test]
+fn test_array3d_tiv2() {
+    let data: u32[2][2][2] = [[0..2, 2..4], [4..6, 6..8]];
+    assert_eq(u32:0 ++ u32:2 ++ u32:4, data[0][0][0] ++ data[0][1][0] ++ data[1][0][0]);
+}
+)";
+  XLS_EXPECT_OK(Typecheck(kProgram));
+}
+
 TEST_F(TypecheckV2Test, RangeInclusive) {
   constexpr std::string_view kProgram = R"(
 const a:u32[5] = u32:0..=u32:4;

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -3371,13 +3371,12 @@ fn main() {
 
 TEST_F(TypecheckV2Test, RangeAnnotatesNestedArrays) {
   constexpr absl::string_view kProgram = R"(
-#![test]
+#[test]
 fn test_array2d_tiv2() {
     let data: u32[8][2] = [0..8, 8..16];
     assert_eq(u32:0 ++ u32:8, data[0][0] ++ data[1][0]);
 }
-)
-";
+)";
   XLS_EXPECT_OK(Typecheck(kProgram));
 }
 

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -3369,6 +3369,18 @@ fn main() {
   XLS_EXPECT_OK(Typecheck(kProgram));
 }
 
+TEST_F(TypecheckV2Test, RangeAnnotatesNestedArrays) {
+  constexpr absl::string_view kProgram = R"(
+#![test]
+fn test_array2d_tiv2() {
+    let data: u32[8][2] = [0..8, 8..16];
+    assert_eq(u32:0 ++ u32:8, data[0][0] ++ data[1][0]);
+}
+)
+";
+  XLS_EXPECT_OK(Typecheck(kProgram));
+}
+
 TEST_F(TypecheckV2Test, RangeInclusive) {
   constexpr std::string_view kProgram = R"(
 const a:u32[5] = u32:0..=u32:4;


### PR DESCRIPTION
Hey team! 

While looking into #3564, I tracked the bug down to the DSLX type inference for array literals. A range like 0..8 infers the narrowest bit width needed for its endpoints, and when I wrote `let data: u32[8][2] = [0..8, 8..16];` the outer annotation only enforced the shape, not the inner element width. Because the type checker only propagated the annotated element type into top‑level literal numbers, the `Range` members kept their narrow widths, so data[0][0] wasn’t a u32 and the assertion failed with mismatched widths. 

I fixed this by extending the existing propagation... when an array literal has an annotation, we now also push that annotated element type down into the start and end of any unannotated `Range` members (resolving through one level if the element type itself is an array). With the endpoints coerced to the target bits type, the `Range` deduces to the right element width and the nested array becomes u32[8][2] as annotated. 

I added a regression test mirroring the original repro to lock in the behavior. 

Thanks in advance for the review. Wishing everyone a bug free and relaxing holiday season!

Fixes: [#3564](https://github.com/google/xls/issues/3564)