### PR TITLE
[opt] strength reduce umod-by-shifted-bit

### DIFF
--- a/xls/ir/node_util.h
+++ b/xls/ir/node_util.h
@@ -48,6 +48,22 @@
 
 namespace xls {
 
+struct ShiftedBitView {
+  Node* b;
+  int64_t k;
+};
+
+// Returns (b, k) if `node` is structurally equivalent to a value with a single
+// potentially-set bit at position `k` (0 == LSb) controlled by the 1-bit value
+// `b`. The recognized forms are:
+//
+// * shll(zext(b), literal(k))
+// * concat(0..., b, 0...)
+//
+// This is a structural matcher and only recognizes literal zeros / literal shift
+// amounts (it does not use any query engine).
+std::optional<ShiftedBitView> IsOneShiftedBit(Node* node);
+
 inline bool IsLiteralZero(Node* node) {
   return node->Is<Literal>() && node->As<Literal>()->value().IsBits() &&
          node->As<Literal>()->value().bits().IsZero();

--- a/xls/passes/arith_simplification_pass.cc
+++ b/xls/passes/arith_simplification_pass.cc
@@ -1009,6 +1009,52 @@ absl::StatusOr<bool> MatchArithPatterns(int64_t opt_level, Node* n,
     }
   }
 
+  // Pattern:
+  //
+  // umod(x, shll(zext(b), k)) -> sel(b, zext(bit_slice(x, 0, k), width(x)), 0)
+  //
+  // where b is a 1-bit value.
+  if (n->op() == Op::kUMod) {
+    Node* x = n->operand(0);
+    Node* divisor = n->operand(1);
+    const int64_t bit_count = x->BitCountOrDie();
+
+    auto replace_with_select = [&](Node* b, int64_t k) -> absl::StatusOr<bool> {
+      XLS_RET_CHECK_EQ(b->BitCountOrDie(), 1);
+      if (k <= 0 || k >= bit_count) {
+        XLS_RETURN_IF_ERROR(
+            n->ReplaceUsesWithNew<Literal>(ZeroOfType(n->GetType())).status());
+        return true;
+      }
+
+      XLS_ASSIGN_OR_RETURN(
+          Node * slice, n->function_base()->MakeNode<BitSlice>(
+                            n->loc(), x, /*start=*/0, /*width=*/k));
+      XLS_ASSIGN_OR_RETURN(
+          Node * narrowed,
+          n->function_base()->MakeNode<ExtendOp>(n->loc(), slice, bit_count,
+                                                Op::kZeroExt));
+      XLS_ASSIGN_OR_RETURN(
+          Node * zero, n->function_base()->MakeNode<Literal>(
+                           n->loc(), Value(UBits(0, bit_count))));
+      XLS_RETURN_IF_ERROR(
+          n->ReplaceUsesWithNew<Select>(
+               b, std::vector<Node*>{zero, narrowed},
+               /*default_value=*/std::nullopt)
+              .status());
+      return true;
+    };
+
+    std::optional<ShiftedBitView> shifted_bit = IsOneShiftedBit(divisor);
+    if (shifted_bit.has_value()) {
+      XLS_ASSIGN_OR_RETURN(bool changed,
+                           replace_with_select(shifted_bit->b, shifted_bit->k));
+      if (changed) {
+        return true;
+      }
+    }
+  }
+
   // Pattern: UMod/SMod by a literal.
   if (n->OpIn({Op::kUMod, Op::kSMod}) &&
       query_engine.IsFullyKnown(n->operand(1))) {

--- a/xls/passes/arith_simplification_pass_test.cc
+++ b/xls/passes/arith_simplification_pass_test.cc
@@ -729,6 +729,28 @@ TEST_F(ArithSimplificationPassTest, UModByVariable) {
   EXPECT_THAT(f->return_value(), m::UMod());
 }
 
+TEST_F(ArithSimplificationPassTest, UModShiftedOneBitDivisor) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+  Type* bits32 = p->GetBitsType(32);
+  BValue x = fb.Param("x", bits32);
+  BValue b = fb.Param("b", p->GetBitsType(1));
+  const int64_t k = 2;
+  BValue divisor = fb.Shll(fb.ZeroExtend(b, 32), fb.Literal(UBits(k, 32)));
+  fb.UMod(x, divisor);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  ScopedVerifyEquivalence sve(f, kProverTimeout);
+  ASSERT_THAT(Run(p.get()), IsOkAndHolds(true));
+
+  EXPECT_THAT(
+      f->return_value(),
+      m::Select(m::Param("b"),
+                /*cases=*/{m::Literal(UBits(0, 32)),
+                           m::ZeroExt(m::BitSlice(m::Param("x"),
+                                                 /*start=*/0, /*width=*/k))}));
+}
+
 TEST_F(ArithSimplificationPassTest, UModOf13) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(Function * f, ParseFunction(R"(

--- a/xls/passes/optimization_pass_pipeline_test.cc
+++ b/xls/passes/optimization_pass_pipeline_test.cc
@@ -251,6 +251,51 @@ TEST_F(OptimizationPipelineTest, MultiplyBy16StrengthReduction) {
   EXPECT_THAT(f->return_value(), m::Concat());
 }
 
+TEST_F(OptimizationPipelineTest, UModShiftedOneBitDivisorSimplified) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+  Type* bits32 = p->GetBitsType(32);
+  BValue x = fb.Param("x", bits32);
+  BValue b = fb.Param("b", p->GetBitsType(1));
+
+  // Construct the pattern:
+  //   umod(x, shll(zext(b), k))
+  const int64_t k = 2;
+  BValue divisor = fb.Shll(fb.ZeroExtend(b, 32), fb.Literal(UBits(k, 32)));
+  fb.UMod(x, divisor);
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.Build());
+
+  ASSERT_THAT(Run(p.get()), IsOkAndHolds(true));
+
+  // In the pipeline we expect:
+  //
+  // umod(x, shll(zext(b), k)) -> sel(b, zext(bit_slice(x, 0, k), width(x)), 0)
+  //
+  // which will often then become:
+  //
+  // and(sign_ext(b), zext(bit_slice(x, 0, k), width(x))).
+  auto reduced =
+      m::ZeroExt(m::BitSlice(m::Param("x"), /*start=*/0, /*width=*/k));
+  auto and_form = m::And(m::SignExt(m::Param("b")), reduced);
+  auto and_form_flipped = m::And(reduced, m::SignExt(m::Param("b")));
+  auto sel_form = m::Select(m::Param("b"),
+                            /*cases=*/{m::Literal(UBits(0, 32)), reduced});
+  auto narrowed_and = m::And(m::SignExt(m::Param("b")),
+                             m::BitSlice(m::Param("x"), /*start=*/0,
+                                         /*width=*/k));
+  auto narrowed_and_flipped =
+      m::And(m::BitSlice(m::Param("x"), /*start=*/0, /*width=*/k),
+             m::SignExt(m::Param("b")));
+  auto concat_form =
+      m::Concat(m::Literal(UBits(0, 32 - k)), narrowed_and);
+  auto concat_form_flipped =
+      m::Concat(m::Literal(UBits(0, 32 - k)), narrowed_and_flipped);
+  EXPECT_THAT(f->return_value(),
+              ::testing::AnyOf(and_form, and_form_flipped, sel_form, concat_form,
+                               concat_form_flipped))
+      << f->DumpIr();
+}
+
 TEST_F(OptimizationPipelineTest, LogicAbsorption) {
   auto p = CreatePackage();
   XLS_ASSERT_OK_AND_ASSIGN(Function * f, ParseFunction(R"(


### PR DESCRIPTION
Uses a "View" extractor similarly to what we did for BinarySelect in the recent PR to consolidate two forms for "one bit is set" (concat and bit shifted by constant literal).