### PR TITLE
[opt] Hoist comparisons across selects when it is cheap to do so

### DIFF
--- a/xls/ir/node_util.cc
+++ b/xls/ir/node_util.cc
@@ -1587,4 +1587,28 @@ absl::StatusOr<Node*> GenericSelect::MakePredicateForDefault() const {
           absl::StrFormat("%s is not a select like operation.", n->ToString()));
   }
 }
+
+absl::StatusOr<Node*> GenericSelect::MakeSelectLikeWithNewArms(
+    absl::Span<Node* const> new_cases, std::optional<Node*> new_default_value,
+    const SourceInfo& loc) const {
+  XLS_RET_CHECK(valid());
+  XLS_RET_CHECK_EQ(new_cases.size(), cases().size());
+  FunctionBase* fb = AsNode()->function_base();
+  return std::visit(
+      Visitor{[&](Select* /*unused*/) -> absl::StatusOr<Node*> {
+                return fb->MakeNode<Select>(loc, selector(), new_cases,
+                                            new_default_value);
+              },
+              [&](PrioritySelect* /*unused*/) -> absl::StatusOr<Node*> {
+                XLS_RET_CHECK(new_default_value.has_value());
+                return fb->MakeNode<PrioritySelect>(loc, selector(), new_cases,
+                                                    *new_default_value);
+              },
+              [&](OneHotSelect* /*unused*/) -> absl::StatusOr<Node*> {
+                XLS_RET_CHECK(!new_default_value.has_value());
+                return fb->MakeNode<OneHotSelect>(loc, selector(), new_cases);
+              }},
+      sel_);
+}
+
 }  // namespace xls

--- a/xls/passes/stateless_query_engine_test.cc
+++ b/xls/passes/stateless_query_engine_test.cc
@@ -117,6 +117,31 @@ TEST_F(StatelessQueryEngineTest, OneHotMsb) {
   EXPECT_TRUE(query_engine.ExactlyOneBitTrue(f->return_value()));
 }
 
+TEST_F(StatelessQueryEngineTest, ExactlyOneBitTrueConcatNotXAndX) {
+  Package p("test_package");
+  FunctionBuilder fb("f", &p);
+  BValue x = fb.Param("x", p.GetBitsType(1));
+  BValue selector = fb.Concat({fb.Not(x), x});
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.BuildWithReturnValue(selector));
+  VLOG(3) << f->DumpIr();
+
+  StatelessQueryEngine query_engine;
+  EXPECT_TRUE(query_engine.ExactlyOneBitTrue(f->return_value()));
+}
+
+TEST_F(StatelessQueryEngineTest, ExactlyOneBitTrueConcatEqXZeroAndX) {
+  Package p("test_package");
+  FunctionBuilder fb("f", &p);
+  BValue x = fb.Param("x", p.GetBitsType(1));
+  BValue x_eq_zero = fb.Eq(x, fb.Literal(UBits(0, 1)));
+  BValue selector = fb.Concat({x_eq_zero, x});
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, fb.BuildWithReturnValue(selector));
+  VLOG(3) << f->DumpIr();
+
+  StatelessQueryEngine query_engine;
+  EXPECT_TRUE(query_engine.ExactlyOneBitTrue(f->return_value()));
+}
+
 TEST_F(StatelessQueryEngineTest, ZeroExtend) {
   Package p("test_package");
   FunctionBuilder fb("f", &p);

--- a/xls/passes/union_query_engine.cc
+++ b/xls/passes/union_query_engine.cc
@@ -14,6 +14,7 @@
 
 #include "xls/passes/union_query_engine.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -235,6 +236,27 @@ bool UnownedUnionQueryEngine::AtLeastOneTrue(
     }
   }
   return false;
+}
+
+bool UnownedUnionQueryEngine::AtMostOneBitTrue(Node* node) const {
+  return std::any_of(engines_.begin(), engines_.end(),
+                     [&](const QueryEngine* engine) {
+                       return engine->AtMostOneBitTrue(node);
+                     });
+}
+
+bool UnownedUnionQueryEngine::AtLeastOneBitTrue(Node* node) const {
+  return std::any_of(engines_.begin(), engines_.end(),
+                     [&](const QueryEngine* engine) {
+                       return engine->AtLeastOneBitTrue(node);
+                     });
+}
+
+bool UnownedUnionQueryEngine::ExactlyOneBitTrue(Node* node) const {
+  return std::any_of(engines_.begin(), engines_.end(),
+                     [&](const QueryEngine* engine) {
+                       return engine->ExactlyOneBitTrue(node);
+                     });
 }
 
 bool UnownedUnionQueryEngine::KnownEquals(const TreeBitLocation& a,

--- a/xls/passes/union_query_engine.h
+++ b/xls/passes/union_query_engine.h
@@ -101,6 +101,12 @@ class UnownedUnionQueryEngine : public QueryEngine {
   bool IsAllZeros(Node* n) const override;
   bool IsAllOnes(Node* n) const override;
 
+  // Returns true if at most/at least/exactly one of the bits in 'node' is true.
+  // 'node' must be bits-typed.
+  bool AtMostOneBitTrue(Node* node) const override;
+  bool AtLeastOneBitTrue(Node* node) const override;
+  bool ExactlyOneBitTrue(Node* node) const override;
+
   Bits MaxUnsignedValue(Node* node) const override;
   Bits MinUnsignedValue(Node* node) const override;
   std::optional<int64_t> KnownLeadingZeros(Node* node) const override;


### PR DESCRIPTION
Add a SelectSimplificationPass rewrite to push CompareOp through sel / priority_sel / one_hot_sel when comparing against a literal and the select-like node has ≤1 non-literal arm (including default) plus a single-user guard.

e.g.

```
eq(priority_sel(s, cases=[a, b, c], default=d), t)
  -> priority_sel(s,
                  cases=[eq(a, t), eq(b, t), eq(c, t)],
                  default=eq(d, t))
```

The fact we only do it when (at most) one case is non-constant means it should be more area-preserving to push this through. (It does suggest maybe we want some knob like --speculation_level=N similar to how we have --opt_level=N in the future though.)

For one_hot_sel, apply only when the selector is provably exactly-one-hot (IsKnownOneHotSelector), including common “one-hot by construction” patterns.

Extend GenericSelect with a small helper to rebuild the same select-like op with new arms (MakeSelectLikeWithNewArms).

Add query_engine_utils (+ tests) and new select_simplification_pass tests covering prio/sel/onehot, non-commutative operand ordering, and all-literal arms.