### PR TITLE
Avoid trailing whitespace and expose macro statements in the c api.

### DIFF
--- a/xls/codegen/vast/vast.cc
+++ b/xls/codegen/vast/vast.cc
@@ -33,7 +33,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/str_join.h"
-#include "absl/strings/str_replace.h"
+#include "absl/strings/str_split.h"
 #include "absl/types/span.h"
 #include "absl/types/variant.h"
 #include "xls/codegen/vast/verilog_keywords.h"
@@ -1399,7 +1399,15 @@ std::string Comment::Emit(LineInfo* line_info) const {
   LineInfoStart(line_info, this);
   LineInfoIncrease(line_info, NumberOfNewlines(text_));
   LineInfoEnd(line_info, this);
-  return absl::StrCat("// ", absl::StrReplaceAll(text_, {{"\n", "\n// "}}));
+  std::vector<std::string> lines = absl::StrSplit(text_, '\n');
+  for (std::string& line : lines) {
+    if (line.empty()) {
+      line = "//";
+    } else {
+      line = absl::StrCat("// ", line);
+    }
+  }
+  return absl::StrJoin(lines, "\n");
 }
 
 std::string InlineVerilogStatement::Emit(LineInfo* line_info) const {

--- a/xls/codegen/vast/vast_test.cc
+++ b/xls/codegen/vast/vast_test.cc
@@ -2831,6 +2831,7 @@ TEST_P(VastTest, SimpleGenerateLoop) {
                                            f.Make<Index>(si, input, i));
   generate_loop->Add<BlankLine>(si);
   generate_loop->Add<Comment>(si, "This is a comment.");
+  generate_loop->Add<Comment>(si, "");
   generate_loop->Add<InlineVerilogStatement>(si, "inline_verilog_statement;");
 
   LineInfo line_info;
@@ -2843,6 +2844,7 @@ TEST_P(VastTest, SimpleGenerateLoop) {
     assign my_output[i] = my_input[i];
 
     // This is a comment.
+    //
     inline_verilog_statement;
   end
 endmodule)");


### PR DESCRIPTION
Avoid trailing whitespace with an empty comment and expose macro statements in generate statements in the C API.