### PR TITLE
Prevent parameter names of top functions from being changed during ir conversion.

### DIFF
--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -819,18 +819,27 @@ absl::Status FunctionConverter::HandleParam(const Param* node) {
   VLOG(5) << "FunctionConverter::HandleParam: " << node->ToString();
   XLS_ASSIGN_OR_RETURN(xls::Type * type,
                        ResolveTypeToIr(node->type_annotation()));
-  Def(node->name_def(), [&](const SourceInfo& loc) {
+  BValue param = Def(node->name_def(), [&](const SourceInfo& loc) {
     return function_builder_->Param(node->identifier(), type);
   });
+  if (is_top_ && param.GetName() != node->identifier()) {
+    return IrConversionErrorStatus(
+        node->span(),
+        absl::StrFormat(
+            "Top function parameter name `%s` would be changed to `%s` in IR. "
+            "Choose a different name.",
+            node->identifier(), param.GetName()),
+        file_table());
+  }
   XLS_RET_CHECK(function_proto_);
-  PackageInterfaceProto::NamedValue* param =
+  PackageInterfaceProto::NamedValue* param_proto =
       function_proto_.value()->add_parameters();
-  param->set_name(node->identifier());
-  *param->mutable_type() = type->ToProto();
+  param_proto->set_name(node->identifier());
+  *param_proto->mutable_type() = type->ToProto();
   XLS_ASSIGN_OR_RETURN(std::optional<std::string> sv_value,
                        current_type_info_->FindSvType(node->type_annotation()));
   if (sv_value) {
-    param->set_sv_type(*sv_value);
+    param_proto->set_sv_type(*sv_value);
   }
   return absl::OkStatus();
 }

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -227,6 +227,27 @@ TEST_F(IrConverterTest, NamedConstant) {
   ExpectIr(converted);
 }
 
+TEST_F(IrConverterTest, TopFunctionParamNameMustBePreserved) {
+  constexpr std::string_view program = R"(fn f(source: u32) -> u32 { source })";
+
+  EXPECT_THAT(
+      ConvertOneFunctionForTest(program, "f"),
+      StatusIs(absl::StatusCode::kInternal,
+               HasSubstr("Top function parameter name `source` would be "
+                         "changed to `_source` in IR.")));
+}
+
+TEST_F(IrConverterTest, NonTopFunctionParamNameCanStillBeLegalized) {
+  constexpr std::string_view program = R"(
+fn helper(source: u32) -> u32 { source }
+fn top() -> u32 { helper(u32:1) }
+)";
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted, ConvertModuleForTest(program));
+  EXPECT_THAT(converted,
+              HasSubstr("fn __test_module__helper(_source: bits[32]"));
+}
+
 TEST_F(IrConverterTest, Concat) {
   constexpr std::string_view program =
       R"(fn f(x: bits[31]) -> u32 {

--- a/xls/modules/aes/aes.x
+++ b/xls/modules/aes/aes.x
@@ -184,23 +184,23 @@ fn test_key_schedule_128() {
             u8:0xb9 ++ u8:0xae ++ u8:0x62 ++ u8:0xe0]);
 }
 
-pub fn encrypt(key: Key, key_width: KeyWidth, block: Block) -> Block {
+pub fn encrypt(key: Key, key_width: KeyWidth, blk: Block) -> Block {
     let num_rounds = get_num_rounds(key_width);
 
     let round_keys = create_key_schedule(key, key_width);
-    let block = aes_common::add_round_key(block, round_keys[0]);
+    let blk = aes_common::add_round_key(blk, round_keys[0]);
 
-    let block = for (round, last_block): (u32, Block) in u32:1..MAX_NUM_ROUNDS {
-        let block = aes_common::sub_bytes(last_block);
-        let block = aes_common::shift_rows(block);
-        let block = aes_common::mix_columns(block);
-        let block = aes_common::add_round_key(block, round_keys[round]);
-        if round < num_rounds { block } else { last_block }
-    }(block);
-    let block = aes_common::sub_bytes(block);
-    let block = aes_common::shift_rows(block);
-    let block = aes_common::add_round_key(block, round_keys[num_rounds]);
-    block
+    let blk = for (round, last_block): (u32, Block) in u32:1..MAX_NUM_ROUNDS {
+        let blk = aes_common::sub_bytes(last_block);
+        let blk = aes_common::shift_rows(blk);
+        let blk = aes_common::mix_columns(blk);
+        let blk = aes_common::add_round_key(blk, round_keys[round]);
+        if round < num_rounds { blk } else { last_block }
+    }(blk);
+    let blk = aes_common::sub_bytes(blk);
+    let blk = aes_common::shift_rows(blk);
+    let blk = aes_common::add_round_key(blk, round_keys[num_rounds]);
+    blk
 }
 
 #[test]
@@ -255,30 +255,30 @@ fn test_encrypt_128() {
     assert_eq(actual, expected)
 }
 
-pub fn decrypt(key: Key, key_width: KeyWidth, block: Block) -> Block {
+pub fn decrypt(key: Key, key_width: KeyWidth, blk: Block) -> Block {
     let num_rounds = get_num_rounds(key_width);
     let round_keys = create_key_schedule(key, key_width);
 
-    let block = aes_common::add_round_key(block, round_keys[num_rounds]);
-    let block = aes_common::inv_shift_rows(block);
-    let block = aes_common::inv_sub_bytes(block);
+    let blk = aes_common::add_round_key(blk, round_keys[num_rounds]);
+    let blk = aes_common::inv_shift_rows(blk);
+    let blk = aes_common::inv_sub_bytes(blk);
 
-    let block = for (i, last_block): (u32, Block) in u32:1..MAX_NUM_ROUNDS {
+    let blk = for (i, last_block): (u32, Block) in u32:1..MAX_NUM_ROUNDS {
         let round = num_rounds - i;
-        let block = if i < num_rounds {
-            let block = aes_common::add_round_key(last_block, round_keys[round]);
-            let block = aes_common::inv_mix_columns(block);
-            let block = aes_common::inv_shift_rows(block);
-            let block = aes_common::inv_sub_bytes(block);
-            block
+        let blk = if i < num_rounds {
+            let blk = aes_common::add_round_key(last_block, round_keys[round]);
+            let blk = aes_common::inv_mix_columns(blk);
+            let blk = aes_common::inv_shift_rows(blk);
+            let blk = aes_common::inv_sub_bytes(blk);
+            blk
         } else {
             last_block
         };
-        block
-    }(block);
+        blk
+    }(blk);
 
-    let block = aes_common::add_round_key(block, round_keys[0]);
-    block
+    let blk = aes_common::add_round_key(blk, round_keys[0]);
+    blk
 }
 
 #[test]


### PR DESCRIPTION
The parameter names of top functions become part of the exposed interface in the generated code. These names need to be preserved. This change raises an error if the legalized name during IR conversion differs from the original name.

A potentially more flexible change would be allow keywords as identifiers, but that is pretty invasive and I don't know if there are hidden problems here. This change at lease prevents silently renaming the visible interface of functions/modules.