### PR TITLE
Add a warning for channel operations token order mismatch.

### DIFF
--- a/xls/dslx/exhaustiveness/exhaustiveness_match_test.cc
+++ b/xls/dslx/exhaustiveness/exhaustiveness_match_test.cc
@@ -98,7 +98,7 @@ void CheckNonExhaustive(std::string_view program) {
 
 void CheckExhaustiveWithRedundantPattern(std::string_view program) {
   WarningKindSet warnings =
-      DisableWarning(kAllWarningsSet, WarningKind::kUnusedDefinition);
+      DisableWarnings(kAllWarningsSet, WarningKind::kUnusedDefinition);
   ImportData import_data = CreateImportDataForTest(nullptr, warnings);
   XLS_ASSERT_OK_AND_ASSIGN(
       TypecheckedModule tm,

--- a/xls/dslx/frontend/BUILD
+++ b/xls/dslx/frontend/BUILD
@@ -821,6 +821,7 @@ cc_library(
         "@abseil-cpp//absl/base",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/log",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",

--- a/xls/dslx/frontend/ast_utils.cc
+++ b/xls/dslx/frontend/ast_utils.cc
@@ -58,8 +58,8 @@ void FlattenToSetInternal(const AstNode* node,
   }
 }
 
-BuiltinNameDef* GetBuiltinNameDef(Expr* callee) {
-  NameRef* name_ref = dynamic_cast<NameRef*>(callee);
+BuiltinNameDef* GetBuiltinNameDef(const Expr* callee) {
+  const NameRef* name_ref = dynamic_cast<const NameRef*>(callee);
   if (name_ref == nullptr) {
     return nullptr;
   }
@@ -148,7 +148,23 @@ bool IsBuiltinFn(Expr* callee, std::optional<std::string_view> target) {
   return true;
 }
 
-std::optional<std::string_view> GetBuiltinFnName(Expr* callee) {
+bool IsBuiltinChannelOp(const Expr* callee) {
+  std::optional<std::string_view> builtin_fn_name = GetBuiltinFnName(callee);
+  if (!builtin_fn_name.has_value()) {
+    return false;
+  }
+  static const absl::flat_hash_set<std::string> channel_ops = {
+      "recv",
+      "recv_if",
+      "recv_non_blocking",
+      "recv_if_non_blocking",
+      "send",
+      "send_if",
+  };
+  return channel_ops.contains(*builtin_fn_name);
+}
+
+std::optional<std::string_view> GetBuiltinFnName(const Expr* callee) {
   BuiltinNameDef* bnd = GetBuiltinNameDef(callee);
   if (bnd == nullptr) {
     return std::nullopt;

--- a/xls/dslx/frontend/ast_utils.h
+++ b/xls/dslx/frontend/ast_utils.h
@@ -68,9 +68,12 @@ bool IsTestFn(const Function* fn);
 bool IsBuiltinFn(Expr* callee,
                  std::optional<std::string_view> target = std::nullopt);
 
+// Returns true if `callee` refers to a builtin channel operation.
+bool IsBuiltinChannelOp(const Expr* callee);
+
 // Returns the name of the builtin function referred to by `callee` if it is a
 // builtin function. If `callee` isn't a builtin function, returns std::nullopt.
-std::optional<std::string_view> GetBuiltinFnName(Expr* callee);
+std::optional<std::string_view> GetBuiltinFnName(const Expr* callee);
 
 // Returns true if `callee` refers to a builtin function that requires an
 // implicit token parameter.

--- a/xls/dslx/frontend/semantics_analysis.cc
+++ b/xls/dslx/frontend/semantics_analysis.cc
@@ -28,6 +28,7 @@
 #include "absl/base/casts.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
@@ -693,6 +694,204 @@ class ProcDefTrivialNextGenerator : public AstNodeVisitorWithDefault {
   }
 };
 
+// A visitor which collects referenced token or data nodes name definitions.
+class NodeDependencyCollector : public AstNodeVisitorWithDefault {
+ public:
+  NodeDependencyCollector(
+      absl::flat_hash_set<const AstNode*>& node_dependencies)
+    : node_dependencies_(node_dependencies) {}
+
+  absl::Status HandleNameRef(const NameRef* name_ref) override {
+    VLOG(5) << absl::StreamFormat("HandleNameRef: %s", name_ref->ToString());
+    if (std::holds_alternative<const NameDef*>(name_ref->name_def())) {
+      const NameDef* name_def = std::get<const NameDef*>(name_ref->name_def());
+      node_dependencies_.insert(name_def);
+    }
+    return absl::OkStatus();
+  }
+
+  absl::Status HandleNameDef(const NameDef* name_def) override {
+    VLOG(5) << absl::StreamFormat("HandleNameDef: %s", name_def->ToString());
+    node_dependencies_.insert(name_def);
+    return absl::OkStatus();
+  }
+
+  absl::Status HandleInvocation(const Invocation* invocation) override {
+    VLOG(5) << absl::StreamFormat("HandleInvocation: %s",
+                                  invocation->ToString());
+    // If an invocation is a channel operation, then we care only about
+    // token dependencies, as data dependencies are collected by handling
+    // data argument separately due to need of having token
+    // and data dependencies separated.
+    if (IsBuiltinChannelOp(invocation)) {
+      const std::span<Expr* const> args = invocation->args();
+      return args[0]->Accept(this);
+    }
+    return DefaultHandler(invocation);
+  }
+
+  absl::Status DefaultHandler(const AstNode* node) override {
+    for (auto child : node->GetChildren(false)) {
+      XLS_RETURN_IF_ERROR(child->Accept(this));
+    }
+    return absl::OkStatus();
+  }
+
+ private:
+  absl::flat_hash_set<const AstNode*>& node_dependencies_;
+};
+
+// TokenOrderCheckData is used for storing data necessary to perform
+// dependency order check in semantics analysis post type check pass.
+struct TokenOrderCheckData {
+  std::vector<const AstNode*> data_nodes = {};
+  std::vector<const AstNode*> token_nodes = {};
+  const AstNode* operation = nullptr;
+};
+
+// A visitor which collects dependency levels for each token and data node.
+// Each `recv` channel operation defines data dependency level, based on tokens
+// it used. For every `send` node it creates an entry for a post type check pass
+// to see if sent data can be assembled at given dependency level defined by
+// `send` operation tokens.
+class DependencyOrderCollector : public AstNodeVisitorWithDefault {
+ public:
+  DependencyOrderCollector(const TypeInfo* ti)
+      : ti_(ti) {}
+
+  absl::Status DefaultHandler(const AstNode* node) override {
+    for (const AstNode* child : node->GetChildren(/*want_types=*/false)) {
+      XLS_RETURN_IF_ERROR(child->Accept(this));
+    }
+    return absl::OkStatus();
+  }
+
+  absl::Status HandleLet(const Let* let) override {
+    VLOG(5) << absl::StreamFormat("HandleLet: %s", let->ToString());
+
+    const Expr* rhs = let->rhs();
+    XLS_RETURN_IF_ERROR(rhs->Accept(this));
+    absl::flat_hash_set<const AstNode*> rhs_dependencies;
+    NodeDependencyCollector dependency_collector(rhs_dependencies);
+    XLS_RETURN_IF_ERROR(rhs->Accept(&dependency_collector));
+
+    // Check if the RHS is not an IO function. In this case treat LHS as
+    // having an equal dependency level.
+    const NameDefTree* lhs = let->name_def_tree();
+    const std::vector<NameDef*> lhs_nodes = lhs->GetNameDefs();
+    if (!io_nodes_.contains(rhs)) {
+      for (const NameDef* lhs_node : lhs_nodes) {
+        AddNodeAlias(lhs_node, rhs_dependencies);
+      }
+      return absl::OkStatus();
+    }
+
+    for (const NameDef* lhs_node : lhs_nodes) {
+      AddNodeDependency(lhs_node, rhs_dependencies);
+    }
+
+    return absl::OkStatus();
+  }
+
+  absl::Status HandleInvocation(const Invocation* invocation) override {
+    VLOG(5) << absl::StreamFormat("HandleInvocation: %s",
+                                  invocation->ToString());
+    if (std::optional<const Function*> io_builtin =
+            GetBuiltinIoFunction(invocation, ti_);
+        io_builtin.has_value()) {
+      io_nodes_.insert(invocation);
+      // Collect IO ordering check from the `send` node.
+      if (IsBuiltinSendVariant(*io_builtin)) {
+        return HandleSend(invocation);
+      }
+    }
+    return absl::OkStatus();
+  }
+
+  const std::vector<TokenOrderCheckData>& io_ordering_check_items() {
+    return io_ordering_check_items_;
+  }
+
+  unsigned int GetNodeDependencyLevel(const AstNode* token) {
+    return node_dependencies_[token];
+  }
+
+ private:
+  void AddNodeDependency(
+      const AstNode* node,
+      const absl::flat_hash_set<const AstNode*>& dependencies) {
+    unsigned int& node_dependency_level = node_dependencies_[node];
+    node_dependency_level = std::max(node_dependency_level, 1u);
+    for (const auto& dependency : dependencies) {
+      if (auto it = node_dependencies_.find(dependency);
+          it != node_dependencies_.end()) {
+        node_dependency_level = std::max(node_dependency_level,
+                                         it->second + 1u);
+      }
+    }
+  }
+
+  void AddNodeAlias(
+      const AstNode* alias,
+      const absl::flat_hash_set<const AstNode*>& aliased) {
+    unsigned int& alias_dependency_level = node_dependencies_[alias];
+    for (const auto& node : aliased) {
+      if (auto it = node_dependencies_.find(node);
+          it != node_dependencies_.end()) {
+        alias_dependency_level = std::max(alias_dependency_level, it->second);
+      }
+    }
+  }
+
+  absl::Status HandleSend(const Invocation* invocation) {
+    VLOG(5) << absl::StreamFormat("HandleSend: %s", invocation->ToString());
+
+    const std::span<Expr* const> args = invocation->args();
+
+    absl::flat_hash_set<const AstNode*> token_nodes;
+    NodeDependencyCollector token_collector(token_nodes);
+    // Token are always passed as the first argument of an IO function.
+    const Expr* const tokens_arg = args[0];
+    XLS_RETURN_IF_ERROR(tokens_arg->Accept(&token_collector));
+    std::vector<const AstNode*> token_dependencies = {};
+    token_dependencies.reserve(token_nodes.size());
+    for (const AstNode* dependency : token_nodes) {
+      token_dependencies.push_back(dependency);
+    }
+
+    absl::flat_hash_set<const AstNode*> data_nodes;
+    NodeDependencyCollector data_collector(data_nodes);
+    auto* callee_name_ref = dynamic_cast<NameRef*>(invocation->callee());
+    std::string_view called_name = callee_name_ref->identifier();
+    // Adjust data dependencies argument index to the `send` type.
+    // `*_if` IO functions have send/recv condition as the third argument.
+    if (called_name == "send") {
+      XLS_RETURN_IF_ERROR(args[2]->Accept(&data_collector));
+    } else if (called_name == "send_if") {
+      XLS_RETURN_IF_ERROR(args[3]->Accept(&data_collector));
+    } else {
+      return absl::UnimplementedError(
+          absl::StrFormat("Unhandled `send` variant: %s", called_name));
+    }
+    std::vector<const AstNode*> data_dependencies = {};
+    data_dependencies.reserve(data_nodes.size());
+    for (const AstNode* dependency : data_nodes) {
+      data_dependencies.push_back(dependency);
+    }
+    io_ordering_check_items_.push_back({
+        std::move(data_dependencies),
+        std::move(token_dependencies),
+        invocation});
+
+    return absl::OkStatus();
+  }
+
+  std::vector<TokenOrderCheckData> io_ordering_check_items_;
+  absl::flat_hash_map<const AstNode*, unsigned int> node_dependencies_;
+  absl::flat_hash_set<const AstNode*> io_nodes_;
+  const TypeInfo* ti_;
+};
+
 }  // namespace
 
 SemanticsAnalysis::SemanticsAnalysis(bool suppress_warnings)
@@ -757,7 +956,7 @@ void SemanticsAnalysis::SetNameDefType(const NameDef* def, const Type* type) {
 }
 
 absl::Status SemanticsAnalysis::RunPostTypeCheckPass(
-    WarningCollector& warning_collector) {
+    Module& module, WarningCollector& warning_collector, const TypeInfo* ti) {
   if (suppress_warnings_) {
     return absl::OkStatus();
   }
@@ -781,6 +980,41 @@ absl::Status SemanticsAnalysis::RunPostTypeCheckPass(
                 "Definition of `%s` (type `%s`) is not used in function `%s`",
                 def->identifier(), type->ToString(), f->identifier()));
       }
+    }
+  }
+
+  return RunIOOrderingAnalysis(module, warning_collector, ti);
+}
+
+absl::Status SemanticsAnalysis::RunIOOrderingAnalysis(
+    Module& module, WarningCollector& warning_collector, const TypeInfo* ti) {
+  if (!warning_collector.IsWarningEnabled(WarningKind::kIOOrderingMismatch)) {
+    return absl::OkStatus();
+  }
+
+  DependencyOrderCollector dependency_order_collector(ti);
+  for (const Proc* proc : module.GetProcs()) {
+    XLS_RETURN_IF_ERROR(proc->next().Accept(&dependency_order_collector));
+  }
+  for (auto& [data_nodes, token_nodes, operation] :
+       dependency_order_collector.io_ordering_check_items()) {
+    unsigned int data_nodes_level = 0;
+    for (const auto& data_node : data_nodes) {
+      data_nodes_level = std::max(
+          data_nodes_level,
+          dependency_order_collector.GetNodeDependencyLevel(data_node));
+    }
+    unsigned int op_tokens_level = 0;
+    for (const auto& op_token : token_nodes) {
+      op_tokens_level = std::max(
+          op_tokens_level,
+          dependency_order_collector.GetNodeDependencyLevel(op_token));
+    }
+    if (data_nodes_level > op_tokens_level) {
+      warning_collector.Add(
+          operation->GetSpan().value(), WarningKind::kIOOrderingMismatch,
+          absl::StrFormat("Operation `%s` has an IO token ordering mismatch",
+                          operation->ToString()));
     }
   }
 

--- a/xls/dslx/frontend/semantics_analysis.h
+++ b/xls/dslx/frontend/semantics_analysis.h
@@ -42,7 +42,9 @@ class SemanticsAnalysis {
                                    WarningCollector& warning_collector,
                                    ImportData& import_data);
 
-  absl::Status RunPostTypeCheckPass(WarningCollector& warning_collector);
+  absl::Status RunPostTypeCheckPass(Module& module,
+                                    WarningCollector& warning_collector,
+                                    const TypeInfo* ti);
 
   void SetNameDefType(const NameDef* def, const Type* type);
 
@@ -56,6 +58,12 @@ class SemanticsAnalysis {
       maybe_unreferenced_defs;
   absl::flat_hash_map<const NameDef*, std::unique_ptr<Type>> def_to_type_;
   bool suppress_warnings_;
+
+  // Used by kIOOrderingMismatch. It checks whether the data arg used in `send`
+  // channel operation is possible to assemble from all data available with
+  // constraints of given tokens.
+  absl::Status RunIOOrderingAnalysis(
+      Module& module, WarningCollector& warning_collector, const TypeInfo* ti);
 };
 
 }  // namespace xls::dslx

--- a/xls/dslx/run_routines/run_routines_test.cc
+++ b/xls/dslx/run_routines/run_routines_test.cc
@@ -238,7 +238,7 @@ fn qc(x: MyEnum) -> bool {
   RunComparator jit_comparator(CompareMode::kJit);
   ParseAndTestOptions options;
   options.parse_and_typecheck_options.warnings =
-      DisableWarning(kAllWarningsSet, WarningKind::kAlreadyExhaustiveMatch);
+      DisableWarnings(kAllWarningsSet, WarningKind::kAlreadyExhaustiveMatch);
   options.quickcheck_runner = &jit_comparator;
   XLS_ASSERT_OK_AND_ASSIGN(
       TestResultData result,

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -2732,6 +2732,659 @@ TEST_F(TypecheckV2Test, WidthSliceTupleSubject) {
                        HasSubstr("Expected a bits-like type; got: `(u32,)`")));
 }
 
+TEST_F(TypecheckV2Test, TokenOrderSimple) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data) = recv(tok0, req_r);
+    send(tok1, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderSendIfMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data) = recv(tok0, req_r);
+    send_if(tok0, resp_s, data > 15, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderLiteral) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, _) = recv(tok0, req_r);
+    send(tok0, resp_s, u32:5);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderSimpleMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data) = recv(tok0, req_r);
+    send(tok0, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderState) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init { u32:0 }
+
+  next (state: u32) {
+    let tok0 = send(join(), resp_s, state);
+    let (tok1, data) = recv(tok0, req_r);
+    data + state
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderDecomposedTuple) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<(u32, u32)> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<(u32, u32)> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let (tok0, (first, second)) = recv(join(), req_r);
+    send(tok0, resp_s, first);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderDecomposedTupleMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<(u32, u32)> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<(u32, u32)> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let (tok0, (first, second)) = recv(join(), req_r);
+    send(join(), resp_s, first);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderDataAlias) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let (tok0, data0) = recv(join(), req_r);
+    let data1 = data0;
+    send(tok0, resp_s, data1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderDataAliasMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let (tok0, data0) = recv(join(), req_r);
+    let data1 = data0;
+    send(join(), resp_s, data1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderCombinedVariables) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u32> in;
+  req1_r: chan<u32> in;
+  resp_s: chan<(u32, u32)> out;
+
+  config(
+    req0_r: chan<u32> in,
+    req1_r: chan<u32> in,
+    resp_s: chan<(u32, u32)> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    send(tok2, resp_s, (data0, data1));
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderCombinedVariablesMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u32> in;
+  req1_r: chan<u32> in;
+  resp_s: chan<(u32, u32)> out;
+
+  config(
+    req0_r: chan<u32> in,
+    req1_r: chan<u32> in,
+    resp_s: chan<(u32, u32)> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    send(tok1, resp_s, (data0, data1));
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderCombinedVariablesAlias) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u32> in;
+  req1_r: chan<u32> in;
+  resp_s: chan<(u32, u32)> out;
+
+  config(
+    req0_r: chan<u32> in,
+    req1_r: chan<u32> in,
+    resp_s: chan<(u32, u32)> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    let combined_data = (data0, data1);
+    send(tok2, resp_s, combined_data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderCombinedVariablesAliasMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u32> in;
+  req1_r: chan<u32> in;
+  resp_s: chan<(u32, u32)> out;
+
+  config(
+    req0_r: chan<u32> in,
+    req1_r: chan<u32> in,
+    resp_s: chan<(u32, u32)> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    let combined_data = (data0, data1);
+    send(tok1, resp_s, combined_data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderBitSliceUpdate) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u16> in;
+  req1_r: chan<u16> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req0_r: chan<u16> in,
+    req1_r: chan<u16> in,
+    resp_s: chan<u32> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    let data = data0 as u32;
+    let data = bit_slice_update(data, u32:16, data1);
+    send(tok2, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderBitSliceUpdateMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req0_r: chan<u16> in;
+  req1_r: chan<u16> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req0_r: chan<u16> in,
+    req1_r: chan<u16> in,
+    resp_s: chan<u32> out
+  ) {
+    (req0_r, req1_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(join(), req0_r);
+    let (tok2, data1) = recv(tok1, req1_r);
+    let data = data0 as u32;
+    let data = bit_slice_update(data, u32:16, data1);
+    send(tok1, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderNestedJoin) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let tok1 = join();
+    let tok2 = join();
+    let (tok3, data) = recv(join(tok0, join(tok1, tok2)), req_r);
+    send(tok3, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderAlias) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let tok1 = tok0;
+    let (tok2, data) = recv(join(tok0, tok1), req_r);
+    send(tok2, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+  EXPECT_EQ(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderAliasMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let tok2 = tok0;
+    // ...
+    let (tok1, data) = recv(tok0, req_r);
+    send(tok2, resp_s, data);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderJoinMixedLevels) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req1_r: chan<u32> in;
+  resp1_s: chan<u32> out;
+  req2_r: chan<u32> in;
+  resp2_s: chan<u32> out;
+
+  config(
+    req1_r: chan<u32> in, resp1_s: chan<u32> out,
+    req2_r: chan<u32> in, resp2_s: chan<u32> out
+  ) {
+    (req1_r, resp1_s, req2_r, resp2_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(tok0, req1_r);
+    let tok2 = send(tok1, resp1_s, data0);
+    let (tok3, data1) = recv(tok2, req2_r);
+    send(join(tok0, tok3), resp2_s, data1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderJoinMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req1_r: chan<u32> in;
+  resp1_s: chan<u32> out;
+  req2_r: chan<u32> in;
+  resp2_s: chan<u32> out;
+
+  config(
+    req1_r: chan<u32> in, resp1_s: chan<u32> out,
+    req2_r: chan<u32> in, resp2_s: chan<u32> out
+  ) {
+    (req1_r, resp1_s, req2_r, resp2_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let (tok1, data0) = recv(tok0, req1_r);
+    let tok2 = send(tok1, resp1_s, data0);
+    let (tok3, data1) = recv(tok2, req2_r);
+    send(join(tok0, tok2), resp2_s, data1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderTupleIndex) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let resp = recv(tok0, req_r);
+    send(resp.0, resp_s, resp.1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 0);
+}
+
+TEST_F(TypecheckV2Test, TokenOrderTupleIndexMismatch) {
+  std::string kProgram = R"(
+proc TokenOrder {
+  req_r: chan<u32> in;
+  resp_s: chan<u32> out;
+
+  config(
+    req_r: chan<u32> in, resp_s: chan<u32> out,
+  ) {
+    (req_r, resp_s)
+  }
+
+  init {  }
+
+  next (state: ()) {
+    let tok0 = join();
+    let resp = recv(tok0, req_r);
+    send(tok0, resp_s, resp.1);
+  }
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(TypecheckResult result,
+                           Typecheck(kProgram));
+
+  ASSERT_THAT(result.tm.warnings.warnings().size(), 1);
+  EXPECT_EQ(result.tm.warnings.warnings().at(0).kind,
+            WarningKind::kIOOrderingMismatch);
+}
+
 TEST_F(TypecheckV2Test, BadAttributeAccessOnTuple) {
   EXPECT_THAT(Typecheck(R"(
 fn main() -> () {

--- a/xls/dslx/type_system_v2/BUILD
+++ b/xls/dslx/type_system_v2/BUILD
@@ -786,6 +786,7 @@ cc_library(
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:ast_node_visitor_with_default",
         "//xls/dslx/frontend:ast_utils",
+        "//xls/dslx/frontend:builtin_stubs_utils",
         "//xls/dslx/frontend:module",
         "//xls/dslx/frontend:pos",
         "//xls/dslx/type_system:type",

--- a/xls/dslx/type_system_v2/import_utils.cc
+++ b/xls/dslx/type_system_v2/import_utils.cc
@@ -29,6 +29,7 @@
 #include "xls/dslx/frontend/ast.h"
 #include "xls/dslx/frontend/ast_node_visitor_with_default.h"
 #include "xls/dslx/frontend/ast_utils.h"
+#include "xls/dslx/frontend/builtin_stubs_utils.h"
 #include "xls/dslx/frontend/module.h"
 #include "xls/dslx/frontend/pos.h"
 #include "xls/dslx/import_data.h"
@@ -345,6 +346,40 @@ bool IsProcConstructor(const Function* function, const ProcDef* proc_def,
                        const FunctionType& function_type) {
   return function_type.return_type().IsProc() &&
          &function_type.return_type().AsProc().struct_def_base() == proc_def;
+}
+
+std::optional<const Function*> GetBuiltinIoFunction(
+    const Expr* expr, const TypeInfo* ti) {
+  if (expr->kind() != AstNodeKind::kInvocation) {
+    return std::nullopt;
+  }
+  const Invocation* invocation = absl::down_cast<const Invocation*>(expr);
+  const Function* function = ti->GetCallee(invocation).value_or(nullptr);
+  if (!function || !IsBuiltin(function)) {
+    return std::nullopt;
+  }
+
+  static const absl::flat_hash_set<std::string> io_functions = {
+      "join",
+      "recv",
+      "recv_if",
+      "recv_non_blocking",
+      "recv_if_non_blocking",
+      "send",
+      "send_if",
+  };
+  if (std::string called_name = function->identifier();
+      !io_functions.contains(called_name)) {
+    return std::nullopt;
+  }
+
+  return function;
+}
+
+bool IsBuiltinSendVariant(const Function* function) {
+  const std::string& identifier = function->identifier();
+  return IsBuiltin(function) && (identifier == "send" ||
+                                 identifier == "send_if");
 }
 
 }  // namespace xls::dslx

--- a/xls/dslx/type_system_v2/import_utils.h
+++ b/xls/dslx/type_system_v2/import_utils.h
@@ -108,6 +108,13 @@ absl::StatusOr<std::optional<const ProcDef*>> GetProcConstructedByFunction(
 bool IsProcConstructor(const Function* function, const ProcDef* proc_def,
                        const FunctionType& function_type);
 
+// Returns builtin IO function invoked by `expr`, if any.
+std::optional<const Function*> GetBuiltinIoFunction(
+    const Expr* expr, const TypeInfo* ti);
+
+// Returns whether `function` is a builtin `send` variant.
+bool IsBuiltinSendVariant(const Function* function);
+
 }  // namespace xls::dslx
 
 #endif  // XLS_DSLX_TYPE_SYSTEM_V2_IMPORT_UTILS_H_

--- a/xls/dslx/type_system_v2/typecheck_module_v2.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2.cc
@@ -152,7 +152,8 @@ absl::StatusOr<std::unique_ptr<ModuleInfo>> TypecheckModuleV2(
                                                   std::move(converter));
   if (auto* semantics_analysis =
           module_info->inference_table_converter()->GetSemanticsAnalysis()) {
-    XLS_RETURN_IF_ERROR(semantics_analysis->RunPostTypeCheckPass(*warnings));
+    XLS_RETURN_IF_ERROR(semantics_analysis->RunPostTypeCheckPass(
+                            module_info->module(), *warnings, type_info));
   }
   return module_info;
 }

--- a/xls/dslx/warning_collector.h
+++ b/xls/dslx/warning_collector.h
@@ -50,6 +50,10 @@ class WarningCollector {
 
   bool empty() const { return warnings_.empty(); }
 
+  bool IsWarningEnabled(WarningKind kind) const {
+    return WarningIsEnabled(enabled_, kind);
+  }
+
  private:
   const WarningKindSet enabled_;
   std::vector<Entry> warnings_;

--- a/xls/dslx/warning_kind.cc
+++ b/xls/dslx/warning_kind.cc
@@ -60,6 +60,8 @@ absl::StatusOr<std::string_view> WarningKindToString(WarningKind kind) {
       return "illegal_package_name";
     case WarningKind::kWidthSliceOutOfRange:
       return "width_slice_out_of_range";
+    case WarningKind::kIOOrderingMismatch:
+      return "io_ordering_mismatch";
   }
   return absl::InvalidArgumentError(
       absl::StrCat("Invalid warning kind: ", static_cast<int>(kind)));

--- a/xls/dslx/warning_kind.cc
+++ b/xls/dslx/warning_kind.cc
@@ -91,7 +91,7 @@ absl::StatusOr<WarningKindSet> WarningKindSetFromDisabledString(
   }
   for (std::string_view s : absl::StrSplit(disabled_string, ',')) {
     XLS_ASSIGN_OR_RETURN(WarningKind k, WarningKindFromString(s));
-    enabled = DisableWarning(enabled, k);
+    enabled = DisableWarnings(enabled, k);
   }
   return enabled;
 }

--- a/xls/dslx/warning_kind.h
+++ b/xls/dslx/warning_kind.h
@@ -46,8 +46,9 @@ enum class WarningKind : WarningKindInt {
   kAlreadyExhaustiveMatch = 1 << 12,
   kIllegalPackageName = 1 << 13,
   kWidthSliceOutOfRange = 1 << 14,
+  kIOOrderingMismatch = 1 << 15,
 };
-constexpr WarningKindInt kWarningKindCount = 15;
+constexpr WarningKindInt kWarningKindCount = 16;
 
 inline constexpr std::array<WarningKind, kWarningKindCount> kAllWarningKinds = {
     WarningKind::kConstexprEvalRollover,
@@ -65,6 +66,7 @@ inline constexpr std::array<WarningKind, kWarningKindCount> kAllWarningKinds = {
     WarningKind::kAlreadyExhaustiveMatch,
     WarningKind::kIllegalPackageName,
     WarningKind::kWidthSliceOutOfRange,
+    WarningKind::kIOOrderingMismatch,
 };
 
 // Flag set datatype.

--- a/xls/dslx/warning_kind.h
+++ b/xls/dslx/warning_kind.h
@@ -97,10 +97,13 @@ inline WarningKindSet Complement(WarningKindSet a) {
   return WarningKindSet{~a.value() & kAllWarningsSet.value()};
 }
 
-// Disables "warning" out of "set" and returns that updated result.
-constexpr WarningKindSet DisableWarning(WarningKindSet set,
-                                        WarningKind warning) {
-  return WarningKindSet{set.value() & ~static_cast<WarningKindInt>(warning)};
+// Disables "warnings" out of "set" and returns that updated result.
+template <typename ...Warnings>
+constexpr WarningKindSet DisableWarnings(
+    WarningKindSet set, Warnings... warnings) {
+  static_assert((std::is_same_v<WarningKind, Warnings> && ...));
+  return WarningKindSet{
+      set.value() & ~(static_cast<WarningKindInt>(warnings) | ...)};
 }
 
 constexpr WarningKindSet EnableWarning(WarningKindSet set,
@@ -117,9 +120,9 @@ inline bool WarningIsEnabled(WarningKindSet set, WarningKind warning) {
 // propagation time.
 // TODO(cdleary): 2025-02-03 Enable "already exhaustive match" by default after
 // some propagation time.
-inline constexpr WarningKindSet kDefaultWarningsSet = DisableWarning(
-    DisableWarning(kAllWarningsSet, WarningKind::kShouldUseAssert),
-    WarningKind::kAlreadyExhaustiveMatch);
+inline constexpr WarningKindSet kDefaultWarningsSet =
+    DisableWarnings(kAllWarningsSet, WarningKind::kShouldUseAssert,
+                    WarningKind::kAlreadyExhaustiveMatch);
 
 // Converts a string representation of a warnings to its corresponding enum
 // value.

--- a/xls/dslx/warning_kind.h
+++ b/xls/dslx/warning_kind.h
@@ -122,7 +122,8 @@ inline bool WarningIsEnabled(WarningKindSet set, WarningKind warning) {
 // some propagation time.
 inline constexpr WarningKindSet kDefaultWarningsSet =
     DisableWarnings(kAllWarningsSet, WarningKind::kShouldUseAssert,
-                    WarningKind::kAlreadyExhaustiveMatch);
+                    WarningKind::kAlreadyExhaustiveMatch,
+                    WarningKind::kIOOrderingMismatch);
 
 // Converts a string representation of a warnings to its corresponding enum
 // value.

--- a/xls/dslx/warning_kind_test.cc
+++ b/xls/dslx/warning_kind_test.cc
@@ -40,7 +40,21 @@ TEST(WarningKindTest, AllWarningsPresentInAllWarningSet) {
     EXPECT_TRUE(WarningIsEnabled(kAllWarningsSet, kind));
 
     // After we disable it, it should not be enabled.
-    EXPECT_FALSE(WarningIsEnabled(DisableWarning(kAllWarningsSet, kind), kind));
+    EXPECT_FALSE(WarningIsEnabled(DisableWarnings(kAllWarningsSet, kind), kind));
+  }
+}
+
+TEST(WarningKindTest, DisableMultipleWarningsAtOnce) {
+  WarningKindSet warning_set = DisableWarnings(
+      kAllWarningsSet, WarningKind::kShouldUseAssert,
+      WarningKind::kMemberNaming);
+  for (const WarningKind kind : kAllWarningKinds) {
+    if (kind == WarningKind::kShouldUseAssert ||
+        kind == WarningKind::kMemberNaming) {
+      EXPECT_FALSE(WarningIsEnabled(warning_set, kind));
+    } else {
+      EXPECT_TRUE(WarningIsEnabled(warning_set, kind));
+    }
   }
 }
 
@@ -70,7 +84,7 @@ TEST(WarningKindTest, SetIntersection) {
   EXPECT_EQ(kAllWarningsSet & kNoWarningsSet, kNoWarningsSet);
   EXPECT_EQ(kNoWarningsSet & kAllWarningsSet, kNoWarningsSet);
   EXPECT_EQ(kNoWarningsSet & kNoWarningsSet, kNoWarningsSet);
-  EXPECT_EQ(DisableWarning(kAllWarningsSet, WarningKind::kShouldUseAssert) &
+  EXPECT_EQ(DisableWarnings(kAllWarningsSet, WarningKind::kShouldUseAssert) &
                 EnableWarning(kNoWarningsSet, WarningKind::kShouldUseAssert),
             kNoWarningsSet);
 }
@@ -80,7 +94,7 @@ TEST(WarningKindTest, SetUnion) {
   EXPECT_EQ(kAllWarningsSet | kNoWarningsSet, kAllWarningsSet);
   EXPECT_EQ(kNoWarningsSet | kAllWarningsSet, kAllWarningsSet);
   EXPECT_EQ(kNoWarningsSet | kNoWarningsSet, kNoWarningsSet);
-  EXPECT_EQ(DisableWarning(kAllWarningsSet, WarningKind::kShouldUseAssert) |
+  EXPECT_EQ(DisableWarnings(kAllWarningsSet, WarningKind::kShouldUseAssert) |
                 EnableWarning(kNoWarningsSet, WarningKind::kShouldUseAssert),
             kAllWarningsSet);
 }
@@ -99,8 +113,8 @@ TEST(WarningKindTest, GetWarningsSetFromFlagsEmpty) {
 TEST(WarningKindTest, GetWarningsSetFromFlagsEmptyEnable) {
   XLS_ASSERT_OK_AND_ASSIGN(WarningKindSet set,
                            GetWarningsSetFromFlags("", "constant_naming"));
-  EXPECT_EQ(set,
-            DisableWarning(kDefaultWarningsSet, WarningKind::kConstantNaming));
+  EXPECT_EQ(
+      set, DisableWarnings(kDefaultWarningsSet, WarningKind::kConstantNaming));
 }
 
 TEST(WarningKindTest, GetWarningsSetFromFlagsContradiction) {

--- a/xls/examples/delay.x
+++ b/xls/examples/delay.x
@@ -67,9 +67,11 @@ proc Delay0or1<DATA_WIDTH:u32, DELAY_IS_ONE:bool, INIT_DATA:u32> {
 
     next (prev_recv: bits[DATA_WIDTH]) {
         let (recv_tok, next_recv) = recv(join(), data_in);
-        let to_send = if (DELAY_IS_ONE) { prev_recv } else { next_recv };
-        trace!(DELAY_IS_ONE);
-        let send_tok = send(join(), data_out, to_send);
+        const if DELAY_IS_ONE {
+            send(join(), data_out, prev_recv);
+        } else {
+            send(recv_tok, data_out, next_recv);
+        };
         (next_recv)
     }
 }

--- a/xls/fuzzer/sample_generator.cc
+++ b/xls/fuzzer/sample_generator.cc
@@ -491,7 +491,7 @@ absl::StatusOr<Sample> GenerateSample(
   // kDynamicSlice is in range, so this may result in a warning turned into an
   // error.
   dslx::ConvertOptions convert_options{
-      .warnings = dslx::DisableWarning(
+      .warnings = dslx::DisableWarnings(
           dslx::kDefaultWarningsSet, dslx::WarningKind::kWidthSliceOutOfRange),
       .lower_to_proc_scoped_channels =
           sample_options.lower_to_proc_scoped_channels(),

--- a/xls/modules/zstd/fse_dec.x
+++ b/xls/modules/zstd/fse_dec.x
@@ -222,7 +222,7 @@ u32 = {
         let tok0 = join();
 
         // receive ctrl
-        let (_, ctrl, ctrl_valid) = recv_if_non_blocking(
+        let (tok0, ctrl, ctrl_valid) = recv_if_non_blocking(
             tok0, ctrl_r, state.fsm == FseDecoderFSM::RECV_CTRL, zero!<FseDecoderCtrl>());
         if ctrl_valid { trace_fmt!("ctrl: {:#x}", ctrl); } else {  };
         let state = if ctrl_valid {
@@ -299,7 +299,7 @@ u32 = {
         };
 
         let recv_sb_output = (do_read_bits && state.sent_buf_ctrl);
-        let (_, buf_data, buf_data_valid) =
+        let (tok0, buf_data, buf_data_valid) =
             recv_if_non_blocking(tok0, rsb_data_r, recv_sb_output, zero!<RefillingSBOutput>());
         if buf_data_valid {
             trace_fmt!("[FseDecoder] Received data {:#x} in state {}", buf_data, state.fsm);

--- a/xls/modules/zstd/huffman_axi_reader.x
+++ b/xls/modules/zstd/huffman_axi_reader.x
@@ -87,7 +87,7 @@ pub proc HuffmanAxiReader<AXI_DATA_W: u32, AXI_ADDR_W: u32, AXI_ID_W: u32, AXI_D
         const _BYTES_PER_TRANSACTION = (AXI_ADDR_W / u32:8) as u8;
 
         // receive and store ctrl
-        let (_, ctrl, ctrl_valid) = recv_if_non_blocking(join(), ctrl_r, state.ctrl.len == state.bytes_sent, zero!<Ctrl>());
+        let (tok, ctrl, ctrl_valid) = recv_if_non_blocking(join(), ctrl_r, state.ctrl.len == state.bytes_sent, zero!<Ctrl>());
 
         let state = if ctrl_valid {
             trace_fmt!("[HuffmanAxiReader] Received CTRL {:#x}", ctrl);
@@ -105,7 +105,7 @@ pub proc HuffmanAxiReader<AXI_DATA_W: u32, AXI_ADDR_W: u32, AXI_ID_W: u32, AXI_D
             length: uN[AXI_ADDR_W]:1
         };
         let do_send_mem_rd_req = (state.bytes_requested < state.ctrl.len);
-        send_if(join(), mem_rd_req_s, do_send_mem_rd_req, mem_rd_req);
+        send_if(tok, mem_rd_req_s, do_send_mem_rd_req, mem_rd_req);
         if (do_send_mem_rd_req) {
             trace_fmt!("[HuffmanAxiReader] Sent memory read request {:#x}", mem_rd_req);
         } else {};

--- a/xls/modules/zstd/huffman_code_builder.x
+++ b/xls/modules/zstd/huffman_code_builder.x
@@ -139,8 +139,8 @@ pub proc WeightCodeBuilder
                 (false, false)
             }
         };
-        let (_, start, start_valid) = recv_if_non_blocking(tok, start_r, recv_start, false);
-        let (_, prescan_data, prescan_data_valid) = recv_if_non_blocking(tok, weight_r, recv_prescan, zero!<PreScanData>());
+        let (tok0, start, start_valid) = recv_if_non_blocking(tok, start_r, recv_start, false);
+        let (tok1, prescan_data, prescan_data_valid) = recv_if_non_blocking(tok, weight_r, recv_prescan, zero!<PreScanData>());
 
         if start_valid {
             trace_fmt!("[WeightCodeBuilder] Received start {:#x}", start);
@@ -233,6 +233,7 @@ pub proc WeightCodeBuilder
         } else {
             state.huffman_base_codes
         };
+        let tok = join(tok0, tok1);
         let tok = send_if(tok, weights_pow_sum_loopback_s, do_send_loopback, sum_of_weights_powers);
 
         // receive sum of weights powers from loopback

--- a/xls/modules/zstd/huffman_weights_dec.x
+++ b/xls/modules/zstd/huffman_weights_dec.x
@@ -478,7 +478,7 @@ pub proc HuffmanFseDecoder<
 
         // receive ram read response
         let do_recv_table_rd_resp = state.fsm == FSM::RECV_RAM_EVEN_RD_RESP || state.fsm == FSM::RECV_RAM_ODD_RD_RESP;
-        let (_, table_rd_resp, table_rd_resp_valid) = recv_if_non_blocking(tok, table_rd_resp_r, do_recv_table_rd_resp, zero!<FseRamRdResp>());
+        let (tok, table_rd_resp, table_rd_resp_valid) = recv_if_non_blocking(tok, table_rd_resp_r, do_recv_table_rd_resp, zero!<FseRamRdResp>());
 
         let table_record = fse_table_creator::bits_to_fse_record(table_rd_resp.data);
 
@@ -538,7 +538,7 @@ pub proc HuffmanFseDecoder<
         } else { state };
 
         let recv_sb_output = (do_read_bits && state.sent_buf_ctrl);
-        let (_, buf_data, buf_data_valid) = recv_if_non_blocking(tok, rsb_data_r, recv_sb_output, zero!<RefillingSBOutput>());
+        let (tok, buf_data, buf_data_valid) = recv_if_non_blocking(tok, rsb_data_r, recv_sb_output, zero!<RefillingSBOutput>());
         if buf_data_valid && buf_data.length as u32 > u32:0{
             trace_fmt!("[HuffmanFseDecoder] Received data {:#x} in state {}", buf_data, state.fsm);
         } else { };

--- a/xls/modules/zstd/memory/mem_reader.x
+++ b/xls/modules/zstd/memory/mem_reader.x
@@ -147,7 +147,7 @@ proc MemReaderInternal<
             len: req.length
         };
         let do_send_reader_req = !error && !is_zero_len && (state.fsm == Fsm::REQUEST);
-        let tok = send_if(tok0, reader_req_s, do_send_reader_req, reader_req);
+        let tok = send_if(tok, reader_req_s, do_send_reader_req, reader_req);
 
         let do_handle_resp = !error && (state.fsm == Fsm::RESPONSE);
         let (tok, st) = recv_if(tok0, axi_st_out_r, do_handle_resp, zero!<AxiStreamOutput>());
@@ -166,7 +166,7 @@ proc MemReaderInternal<
         let do_send_resp = do_handle_resp ||
                            (state.fsm == Fsm::RESPONSE_ERROR) ||
                            (state.fsm == Fsm::RESPONSE_ZERO);
-        let tok = send_if(tok0, resp_s, do_send_resp, reader_resp);
+        let tok = send_if(tok, resp_s, do_send_resp, reader_resp);
 
         let next_state = match (state.fsm) {
             Fsm::REQUEST => {

--- a/xls/modules/zstd/refilling_shift_buffer.x
+++ b/xls/modules/zstd/refilling_shift_buffer.x
@@ -149,7 +149,7 @@ proc RefillingShiftBufferInternal<
         // snooping logic for the ShiftBuffer control channel
         // recv and immediately send out control packets heading for ShiftBuffer,
         // unless we're flushing, if so we block receiving any new control packets
-        let (_, snoop_ctrl, snoop_ctrl_valid) = recv_if_non_blocking(tok, buffer_ctrl_r, !flushing, zero!<RSBCtrl>());
+        let (tok, snoop_ctrl, snoop_ctrl_valid) = recv_if_non_blocking(tok, buffer_ctrl_r, !flushing, zero!<RSBCtrl>());
         // If we're flushing send our packets for taking out data from the shiftbuffer
         // (that data will then be discarded)
         let ctrl_packet = if (flushing) {
@@ -188,7 +188,7 @@ proc RefillingShiftBufferInternal<
             trace_fmt!("[{:#x}] Sent request for data to memory: {:#x}", INSTANCE, mem_req);
         } else {};
         // receive data from memory
-        let (_, reader_resp, reader_resp_valid) = recv_non_blocking(tok, reader_resp_r, zero!<MemReaderResp>());
+        let (tok, reader_resp, reader_resp_valid) = recv_non_blocking(tok, reader_resp_r, zero!<MemReaderResp>());
         if reader_resp_valid {
             trace_fmt!("[{:#x}] Received data from memory: {:#x}", INSTANCE, reader_resp);
         } else {};

--- a/xls/modules/zstd/sequence_dec.x
+++ b/xls/modules/zstd/sequence_dec.x
@@ -214,19 +214,19 @@ pub proc FseLookupCtrl {
                 _    => trace_fmt!("Impossible case"),
             };
 
-            let accuracy_log = if do_set {
+            let (tok, accuracy_log) = if do_set {
                 let tok = send(tok, flci_req_s, FseLookupCtrlInternalReq {
                     cnt: state.cnt,
                     is_rle: is_rle
                  });
                 let (tok, accuracy_log) = recv(tok, flci_resp_r);
-                accuracy_log
+                (tok, accuracy_log)
             } else if is_predefined {
-                PREDEFINED_ACURACY_LOG[state.cnt]
+                (tok, PREDEFINED_ACURACY_LOG[state.cnt])
             } else if is_repeated {
-                state.accuracy_logs[state.cnt]
+                (tok, state.accuracy_logs[state.cnt])
             } else {
-                fail!("impossible_case", u7:0)
+                fail!("impossible_case", (join(), u7:0))
             };
 
             let accuracy_logs = update(state.accuracy_logs, state.cnt, accuracy_log);

--- a/xls/modules/zstd/zstd_dec.x
+++ b/xls/modules/zstd/zstd_dec.x
@@ -284,7 +284,7 @@ proc ZstdDecoderInternal<
         } else {};
 
         let output_mem_wr_req = MemWriterReq {addr: state.output_buffer, length: fh_resp.header.frame_content_size as uN[AXI_ADDR_W]};
-        let tok = send_if(tok0, output_mem_wr_req_s, fh_resp_valid, output_mem_wr_req);
+        let tok = send_if(tok1_4, output_mem_wr_req_s, fh_resp_valid, output_mem_wr_req);
 
         let do_recv_output_mem_wr_resp = (state.fsm == Fsm::WRITE_OUTPUT);
         let (tok_x, output_write_resp, output_write_done) = recv_if_non_blocking(tok0, output_mem_wr_resp_r, do_recv_output_mem_wr_resp, zero!<MemWriterResp>());


### PR DESCRIPTION
This PR adds a warning for the channel operations token mismatch which is thrown in case of impossibility to correctly assemble data used in `send` based on the operation tokens. This is handled by tracking token and data dependencies in `semantics_analysis.cc` with `DependencyOrderCollector`. Each node is assigned a dependency level based on nodes it gets its values from. In case of aliases, data combining or data processing it stays the same, but the levels increments after every IO operation. With the collected dependency data, the final check can be simply performed by comparing dependency levels of `send` operation tokens and data values.

For example, token used in the second `send` here can indicate that a value is sent before it is received.

```
...
let tok0 = join();
let (tok1, data0) = recv(tok0, req0_r);
let tok2 = send(tok1, resp0_s, data0); // correct token
let (tok3, data1) = recv(tok2, req1_r);
let tok2 = send(tok1, resp1_s, data1); // wrong token
...
```

With changes from this pull request, it will throw the following warning during the type check stage:

```
let (tok3, data1) = recv(tok2, req1_r);
let tok2 = send(tok1, resp1_s, data1); // wrong token
~~~~~~~~~~~~~~~^--------------------^ Operation `send(tok1, resp1_s, data1)` has an IO token ordering mismatch
```