### PR TITLE
Throw `invalid_argument` error in case of dynamic indexing of channels array

### DIFF
--- a/xls/dslx/ir_convert/ir_converter_legacy_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_legacy_test.cc
@@ -4016,33 +4016,6 @@ proc main {
   ExpectIr(converted);
 }
 
-TEST_F(IrConverterLegacyTest, ProcMemberInDynamicLoopUnsupported) {
-  constexpr std::string_view program = R"(
-proc Proc {
-  inputs: chan<s32>[2] in;
-  outputs: chan<s32>[2] out;
-  config() {
-    let (a, b) = chan<s32>[2]("c");
-    (b, a)
-  }
-  init { () }
-  next(state: ()) {
-    let tok = join();
-    for (i, _) in u32:0..u32:2 {
-        recv(tok, inputs[i]);
-        send(tok, outputs[i], s32:1);
-    } (());
-  }
-}
-)";
-  EXPECT_THAT(
-      ConvertModuleForTest(program),
-      StatusIs(
-          absl::StatusCode::kUnimplemented,
-          HasSubstr(
-              "Accessing proc member in non-unrolled loop is unsupported")));
-}
-
 TEST_F(IrConverterLegacyTest, GenericTypePassthroughFunction) {
   if (TypeInferenceVersion::kVersion2 == TypeInferenceVersion::kVersion1) {
     return;

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -3779,33 +3779,6 @@ proc main {
   ExpectIr(converted);
 }
 
-TEST_F(IrConverterTest, ProcMemberInDynamicLoopUnsupported) {
-  constexpr std::string_view program = R"(
-proc Proc {
-  inputs: chan<s32>[2] in;
-  outputs: chan<s32>[2] out;
-  config() {
-    let (a, b) = chan<s32>[2]("c");
-    (b, a)
-  }
-  init { () }
-  next(state: ()) {
-    let tok = join();
-    for (i, _) in u32:0..u32:2 {
-        recv(tok, inputs[i]);
-        send(tok, outputs[i], s32:1);
-    } (());
-  }
-}
-)";
-  EXPECT_THAT(
-      ConvertModuleForTest(program),
-      StatusIs(
-          absl::StatusCode::kUnimplemented,
-          HasSubstr(
-              "Accessing proc member in non-unrolled loop is unsupported")));
-}
-
 TEST_F(IrConverterTest, GenericTypePassthroughFunction) {
   XLS_ASSERT_OK_AND_ASSIGN(std::string converted, ConvertModuleForTest(R"(
 #![feature(generics)]

--- a/xls/dslx/type_system/typecheck_module_test.cc
+++ b/xls/dslx/type_system/typecheck_module_test.cc
@@ -4854,5 +4854,104 @@ TEST_F(TypecheckV2Test, AssertFmtArgCountMismatch) {
                          "but has 1 argument(s)")));
 }
 
+TEST_F(TypecheckV2Test, DynamicChannelArrayIndexing) {
+  constexpr std::string_view kProgram = R"(
+proc Test {
+  sel_r: chan<u32> in;
+  array_r: chan<u32>[10] in;
+  data_s: chan<u32> out;
+
+  init { }
+
+  config(
+     sel_r: chan<u32> in,
+     array_r: chan<u32>[10] in,
+     data_s: chan<u32> out
+  ) { (sel_r, array_r, data_s) }
+
+  next(state: ()) {
+    let (tok, sel) = recv(join(), sel_r);
+    let (tok, result) = recv(tok, array_r[sel]);
+    let tok = send(tok, data_s, result);
+  }
+}
+)";
+  EXPECT_THAT(
+      Typecheck(kProgram),
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("Non-constexpr value used in channel array indexing")));
+}
+
+TEST_F(TypecheckV2Test, ProcMemberInDynamicLoop) {
+  constexpr std::string_view kProgram = R"(
+proc Proc {
+  inputs: chan<s32>[2] in;
+  outputs: chan<s32>[2] out;
+  config() {
+    let (a, b) = chan<s32>[2]("c");
+    (b, a)
+  }
+
+  init {  }
+
+  next(state: ()) {
+    let tok = join();
+    for (i, _) in u32:0..u32:2 {
+        recv(tok, inputs[i]);
+        send(tok, outputs[i], s32:1);
+    } (());
+  }
+}
+)";
+  EXPECT_THAT(
+      Typecheck(kProgram),
+      StatusIs(absl::StatusCode::kInvalidArgument,
+               HasSubstr("Non-constexpr value used in channel array indexing")));
+}
+
+TEST_F(TypecheckV2Test, ProcMemberInUnrollFor) {
+  XLS_EXPECT_OK(Typecheck(R"(
+proc Proc {
+  inputs: chan<s32>[2] in;
+  outputs: chan<s32>[2] out;
+  config() {
+    let (a, b) = chan<s32>[2]("c");
+    (b, a)
+  }
+
+  init {  }
+
+  next(state: ()) {
+    let tok = join();
+    unroll_for! (i, _) in u32:0..u32:2 {
+        recv(tok, inputs[i]);
+        send(tok, outputs[i], s32:1);
+    } (());
+  }
+})"));
+}
+
+TEST_F(TypecheckV2Test, ProcMemberInConstFor) {
+  XLS_EXPECT_OK(Typecheck(R"(
+proc Proc {
+  inputs: chan<s32>[2] in;
+  outputs: chan<s32>[2] out;
+  config() {
+    let (a, b) = chan<s32>[2]("c");
+    (b, a)
+  }
+
+  init {  }
+
+  next(state: ()) {
+    let tok = join();
+    const for (i, _) in u32:0..u32:2 {
+        recv(tok, inputs[i]);
+        send(tok, outputs[i], s32:1);
+    } (());
+  }
+})"));
+}
+
 }  // namespace
 }  // namespace xls::dslx

--- a/xls/dslx/type_system_v2/constant_collector.cc
+++ b/xls/dslx/type_system_v2/constant_collector.cc
@@ -345,6 +345,13 @@ class Visitor : public AstNodeVisitorWithDefault {
   }
 
   absl::Status HandleIndex(const Index* index) override {
+    if (type_.IsChannel() && std::holds_alternative<Expr*>(index->rhs()) &&
+        !Evaluate(std::get<Expr*>(index->rhs())).ok()) {
+      return xls::dslx::TypeInferenceErrorStatus(
+          index->span(), &type_,
+          "Non-constexpr value used in channel array indexing", file_table_);
+    }
+
     // A `Slice` actually has its bounds stored in `TypeInfo` out-of-band from
     // the real type info, mirroring the `StartAndWidthExprs` that we store in
     // the `InferenceTable`.

--- a/xls/modules/zstd/ram_printer.x
+++ b/xls/modules/zstd/ram_printer.x
@@ -42,7 +42,7 @@ pub proc RamPrinter<DATA_WIDTH: u32, SIZE: u32, NUM_PARTITIONS: u32, ADDR_WIDTH:
         let is_idle = state.status == RamPrinterStatus::IDLE;
         let (tok, _) = recv_if(tok, print_r, is_idle, ());
 
-        let (tok, row) = for (i, (tok, row)): (u32, (token, bits[DATA_WIDTH][NUM_MEMORIES])) in
+        let (tok, row) = const for (i, (tok, row)): (u32, (token, bits[DATA_WIDTH][NUM_MEMORIES])) in
             u32:0..NUM_MEMORIES {
             let tok = send(tok, rd_req_s[i], ram::ReadWordReq<NUM_PARTITIONS>(state.addr));
             let (tok, resp) = recv(tok, rd_resp_r[i]);

--- a/xls/modules/zstd/zstd_dec_test.x
+++ b/xls/modules/zstd/zstd_dec_test.x
@@ -789,7 +789,7 @@ proc ZstdDecoderTest {
                 let tok = send(tok, fh_ram_wr_req_s, req);
                 let tok = send(tok, bh_ram_wr_req_s, req);
                 let tok = send(tok, raw_ram_wr_req_s, req);
-                for (i, tok): (u32, token) in u32:0..AXI_CHAN_N {
+                const for (i, tok): (u32, token) in u32:0..AXI_CHAN_N {
                     send(tok, comp_ram_wr_req_s[i], req)
                 }(tok)
             }(tok);


### PR DESCRIPTION
This PR adds throwing an error in case of dynamic indexing of channels array. It is handled by checking constness of value used for indexing an array of channels in `semantics_analysis.cc`.

- [x]  Fix `test_constexpr_rollover_warning` test in `error_modules_test.py`.