### PR TITLE
Remove `continue-on-error` flag from the `Test ZSTD module` job

### DIFF
--- a/.github/workflows/modules-zstd.yml
+++ b/.github/workflows/modules-zstd.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on:
       labels: ubuntu-22.04-64core
     timeout-minutes: 600
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR removes `continue-on-error` flag from the `Test ZSTD module` job which caused the overall job result appear as successful in the `Actions` page [workflows list](https://github.com/google/xls/actions/workflows/modules-zstd.yml) despite failures in some stages.