### PR TITLE
[DSLX:TS] fix regression in typecheck_main with synthetic-spanned AST nodes

### DIFF
--- a/xls/dslx/type_system/type_info_to_proto.cc
+++ b/xls/dslx/type_system/type_info_to_proto.cc
@@ -882,9 +882,19 @@ absl::StatusOr<std::string> ToHumanString(const TypeInfoProto& tip,
                                           FileTable& file_table) {
   std::vector<std::string> lines;
   for (int64_t i = 0; i < tip.nodes_size(); ++i) {
+    const AstNodeTypeInfoProto& node = tip.nodes(static_cast<int32_t>(i));
+    if (!node.has_span()) {
+      continue;
+    }
+    Span span = FromProto(node.span(), file_table);
+    // TIv2 can synthesize internal bookkeeping nodes with a `<no-file>` span.
+    // Keep them in the serialized proto, but omit them from the humanized text
+    // form because they cannot be resolved back to a source-backed AST node.
+    if (span.GetFilename(file_table) == kNoFilePath) {
+      continue;
+    }
     XLS_ASSIGN_OR_RETURN(std::string node_str,
-                         ToHumanString(tip.nodes(static_cast<int32_t>(i)),
-                                       import_data, file_table));
+                         ToHumanString(node, import_data, file_table));
     lines.push_back(std::move(node_str));
   }
   return absl::StrJoin(lines, "\n");

--- a/xls/dslx/type_system/type_info_to_proto_test.cc
+++ b/xls/dslx/type_system/type_info_to_proto_test.cc
@@ -54,14 +54,9 @@ class TypeInfoToProtoWithBothTypecheckVersionsTest : public ::testing::Test {
         ParseAndTypecheck(program, "fake.x", "fake", import_data, nullptr));
 
     XLS_ASSERT_OK_AND_ASSIGN(TypeInfoProto tip, TypeInfoToProto(*tm.type_info));
-
-    std::string nodes_text = absl::StrJoin(
-        tip.nodes(), "\n",
-        [&](std::string* out, const AstNodeTypeInfoProto& node) {
-          absl::StrAppend(
-              out, ToHumanString(node, *import_data, import_data->file_table())
-                       .value());
-        });
+    XLS_ASSERT_OK_AND_ASSIGN(
+        std::string nodes_text,
+        ToHumanString(tip, *import_data, import_data->file_table()));
 
     std::string test_name(TestName());
     // Remove parametric test suite suffix.
@@ -169,6 +164,33 @@ fn test_simple_nondistinct() {
 }
 )";
   DoRun(program);
+}
+
+TEST_F(TypeInfoToProtoWithBothTypecheckVersionsTest,
+       SkipsSyntheticNoFileEntriesInHumanizedOutput) {
+  std::string program = R"(
+fn bool_update() -> bool[1] {
+  update(bool[1]:[false], u1:0, true)
+}
+
+fn bit_update() -> u8 {
+  bit_slice_update(u8:0, u3:0, true)
+}
+)";
+  ImportData import_data = CreateImportDataForTest();
+  XLS_ASSERT_OK_AND_ASSIGN(
+      TypecheckedModule tm,
+      ParseAndTypecheck(program, "fake.x", "fake", &import_data, nullptr));
+  XLS_ASSERT_OK_AND_ASSIGN(TypeInfoProto tip, TypeInfoToProto(*tm.type_info));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      std::string nodes_text,
+      ToHumanString(tip, import_data, import_data.file_table()));
+
+  EXPECT_THAT(nodes_text,
+              ::testing::HasSubstr("update(bool[1]:[false], u1:0, true)"));
+  EXPECT_THAT(nodes_text,
+              ::testing::HasSubstr("bit_slice_update(u8:0, u3:0, true)"));
+  EXPECT_THAT(nodes_text, ::testing::Not(::testing::HasSubstr("<no-file>")));
 }
 
 }  // namespace

--- a/xls/dslx/type_system/typecheck_main_test.py
+++ b/xls/dslx/type_system/typecheck_main_test.py
@@ -27,6 +27,16 @@ _TYPECHECK_MAIN_PATH = runfiles.get_path('xls/dslx/type_system/typecheck_main')
 
 class TypecheckMainTest(absltest.TestCase):
 
+  def _run_typecheck_main(self, content: str) -> subp.CompletedProcess[str]:
+    f = self.create_tempfile(content=content)
+    return subp.run(
+        [_TYPECHECK_MAIN_PATH, f.full_path],
+        encoding='utf-8',
+        check=True,
+        stdout=subp.PIPE,
+        stderr=subp.PIPE,
+    )
+
   def test_module_with_import(self):
     mod_path = runfiles.get_path('xls/dslx/tests/mod_const_enum_importer.x')
     basedir = mod_path
@@ -42,16 +52,27 @@ class TypecheckMainTest(absltest.TestCase):
     content = """fn f(x: u8) -> u9 {
   one_hot(x, false)
 }"""
-    f = self.create_tempfile(content=content)
-    p = subp.run(
-        [_TYPECHECK_MAIN_PATH, f.full_path],
-        encoding='utf-8',
-        check=True,
-        stdout=subp.PIPE,
-        stderr=subp.PIPE,
-    )
+    p = self._run_typecheck_main(content)
     self.assertEqual(p.returncode, 0)
     self.assertNotIn('Could not find node with kind', p.stderr)
+
+  def test_bool_update_does_not_crash_pretty_print(self):
+    p = self._run_typecheck_main("""fn f() -> bool[1] {
+  update(bool[1]:[false], u1:0, true)
+}""")
+    self.assertEqual(p.returncode, 0)
+    self.assertIn('update(bool[1]:[false], u1:0, true)', p.stdout)
+    self.assertNotIn('<no-file>', p.stdout)
+    self.assertNotIn('Could not find module: <no-file>', p.stderr)
+
+  def test_bit_slice_update_does_not_crash_pretty_print(self):
+    p = self._run_typecheck_main("""fn f() -> u8 {
+  bit_slice_update(u8:0, u3:0, true)
+}""")
+    self.assertEqual(p.returncode, 0)
+    self.assertIn('bit_slice_update(u8:0, u3:0, true)', p.stdout)
+    self.assertNotIn('<no-file>', p.stdout)
+    self.assertNotIn('Could not find module: <no-file>', p.stderr)
 
   def test_disable_warnings_as_errors(self):
     content = 'fn f() { let x = u32:42; }'


### PR DESCRIPTION
The synthetically created nodes didn't have a way to resolve them into text for display from `typecheck_main`.

(`typecheck_main` might not be used too often in Google internal flows but it's generally a handy "does this code typecheck" validator so we don't want it to error out on valid code.)