### PR TITLE
[dslx] Allow `for`/`unroll_for` expressions as operands in binary operations

### DIFF
--- a/xls/dslx/frontend/parser.cc
+++ b/xls/dslx/frontend/parser.cc
@@ -2596,6 +2596,9 @@ absl::StatusOr<Expr*> Parser::ParseTermLhs(Bindings& outer_bindings,
     XLS_ASSIGN_OR_RETURN(lhs, ParseMatch(outer_bindings, /*is_const=*/false));
   } else if (peek->kind() == TokenKind::kOBrack) {  // Array expression.
     XLS_ASSIGN_OR_RETURN(lhs, ParseArray(outer_bindings));
+  } else if (peek->IsKeyword(Keyword::kFor) ||
+             peek->IsKeyword(Keyword::kUnrollFor)) {  // For expression.
+    XLS_ASSIGN_OR_RETURN(lhs, ParseFor(outer_bindings));
   } else if (peek->IsKeyword(Keyword::kIf)) {  // Conditional expression.
     XLS_ASSIGN_OR_RETURN(lhs,
                          ParseRangeExpression(outer_bindings, kNoRestrictions));

--- a/xls/dslx/frontend/parser_test.cc
+++ b/xls/dslx/frontend/parser_test.cc
@@ -3102,6 +3102,15 @@ TEST_F(ParserTest, ForInWithColonRefAsRangeLimit) {
                 {"m", "i"});
 }
 
+TEST_F(ParserTest, ForExpressionAsRhsOfBinop) {
+  // Regression test: inline `for` used as RHS operand of a binary expression.
+  RoundTripExpr(
+      R"(p ^ for (i, acc) in u32:0..u32:8 {
+    acc
+}(u1:1))",
+      {"p"});
+}
+
 TEST_F(ParserTest, TernaryWithOrExpressionTest) {
   RoundTripExpr("if a || b { u32:42 } else { u32:24 }", {"a", "b"});
 }


### PR DESCRIPTION
Fixes #3967

Parsing an inline `for` expression as the RHS of a binary operation (e.g., `p ^ for (i, acc) in u32:0..u32:8 { ... }(u1:1)`) produced a spurious parse error:

```
ParseError: Expected start of an expression; got: keyword:for
```

The DSLX parser's `ParseTermLhs` function handles several keyword-prefixed sub-expressions (`if`, `const if`, `const for`, `const match`, `match`) but was missing cases for plain `for` and `unroll_for`. When descending into `ParseTermLhs` to parse the RHS of a binary operator, encountering a `for` keyword hit the fallthrough error case.

The fix adds `kFor`/`kUnrollFor` handling to `ParseTermLhs`, consistent with how the same keywords are already handled in `ParseExpression` for top-level expressions.

- Adds `for` and `unroll_for` keyword cases to `ParseTermLhs` to call `ParseFor` directly
- Adds a regression test `ForExpressionAsRhsOfBinop` that round-trips `p ^ for (...) in ... { ... }(...)`
