### PR TITLE
[dslx] Improve lowering of one_hot_sel and priority_sel builtins

### DIFF
--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -2856,6 +2856,12 @@ absl::Status FunctionConverter::HandleInvocation(const Invocation* node) {
   if (called_name == "join") {
     return HandleBuiltinJoin(node);
   }
+  if (called_name == "one_hot_sel") {
+    return HandleBuiltinOneHotSel(node);
+  }
+  if (called_name == "priority_sel") {
+    return HandleBuiltinPrioritySel(node);
+  }
   if (called_name == "map") {
     return HandleMap(node).status();
   }
@@ -2918,9 +2924,7 @@ absl::Status FunctionConverter::HandleInvocation(const Invocation* node) {
           {"enumerate", &FunctionConverter::HandleBuiltinEnumerate},
           {"gate!", &FunctionConverter::HandleBuiltinGate},
           {"one_hot", &FunctionConverter::HandleBuiltinOneHot},
-          {"one_hot_sel", &FunctionConverter::HandleBuiltinOneHotSel},
           {"or_reduce", &FunctionConverter::HandleBuiltinOrReduce},
-          {"priority_sel", &FunctionConverter::HandleBuiltinPrioritySel},
           {"rev", &FunctionConverter::HandleBuiltinRev},
           {"signex", &FunctionConverter::HandleBuiltinSignex},
           {"smulp", &FunctionConverter::HandleBuiltinSMulp},
@@ -4883,40 +4887,53 @@ absl::Status FunctionConverter::HandleBuiltinOneHot(const Invocation* node) {
   return absl::OkStatus();
 }
 
+absl::StatusOr<std::vector<BValue>>
+FunctionConverter::GetSelectCasesForArrayLiteral(const Array* array) {
+  std::vector<BValue> cases;
+  for (Expr* member : array->members()) {
+    XLS_RETURN_IF_ERROR(Visit(member));
+    XLS_ASSIGN_OR_RETURN(BValue member_value, Use(member));
+    cases.push_back(member_value);
+  }
+
+  if (array->has_ellipsis()) {
+    XLS_ASSIGN_OR_RETURN(std::unique_ptr<Type> type, ResolveType(array));
+    const ArrayType* array_type = dynamic_cast<ArrayType*>(type.get());
+    XLS_RET_CHECK_NE(array_type, nullptr);
+    XLS_ASSIGN_OR_RETURN(int64_t array_size, array_type->size().GetAsInt64());
+    while (cases.size() < array_size) {
+      cases.push_back(cases.back());
+    }
+  }
+
+  if (cases.empty()) {
+    return absl::InvalidArgumentError(
+        absl::StrFormat("Array %s was empty.", array->ToString()));
+  }
+  return cases;
+}
+
 absl::Status FunctionConverter::HandleBuiltinOneHotSel(const Invocation* node) {
   XLS_RET_CHECK_EQ(node->args().size(), 2);
+  XLS_RETURN_IF_ERROR(Visit(node->args()[0]));
   XLS_ASSIGN_OR_RETURN(BValue selector, Use(node->args()[0]));
 
-  // Implementation note:  During IR conversion, we will scalarize the
-  // array element into BValues using multiple ArrayIndex ops
-  // to create cases for the select operation.  This will bloat the
-  // unoptimized IR  -- especially in the case where we are given
-  // a literal array.
-  //
-  // For example, given a `one_hot_sel(sel, cases=[a, b, c])` the un-opt IR
-  // will redundantly create individual array_index ops for each element
-  // to then pass to the select op:
-  //   array_val: bits[32][4] = array(a, b, c)
-  //   literal_0: bits[32] = literal(value=0)
-  //   literal_1: bits[32] = literal(value=1)
-  //   literal_2: bits[32] = literal(value=2)
-  //   array_index_0: bits[32] = array_index(array_val, indices=[literal_0])
-  //   array_index_1: bits[32] = array_index(array_val, indices=[literal_1])
-  //   array_index_2: bits[32] = array_index(array_val, indices=[literal_2])
-  //   one_hot_sel_val: bits[32]
-  //     = one_hot_sel(s, cases=[array_index_0, array_index_1, array_index_2])
-  //
-  // This is ok as the optimizer will look through this and simplify to
-  //   one_hot_sel_val: bits[32] = one_hot_sel(s, cases=[a, b, c])
-  //
   const Expr* cases_arg = node->args()[1];
-  std::vector<BValue> cases;
+  if (const auto* array = dynamic_cast<const Array*>(cases_arg)) {
+    XLS_ASSIGN_OR_RETURN(std::vector<BValue> cases,
+                         GetSelectCasesForArrayLiteral(array));
+    Def(node, [&](const SourceInfo& loc) {
+      return function_builder_->OneHotSelect(selector, cases, loc);
+    });
+    return absl::OkStatus();
+  }
 
+  XLS_RETURN_IF_ERROR(Visit(cases_arg));
   XLS_ASSIGN_OR_RETURN(BValue bvalue_cases_arg, Use(cases_arg));
   XLS_ASSIGN_OR_RETURN(xls::ArrayType * cases_arg_type,
                        bvalue_cases_arg.GetType()->AsArray());
-
   Def(node, [&](const SourceInfo& loc) {
+    std::vector<BValue> cases;
     for (int64_t i = 0; i < cases_arg_type->size(); ++i) {
       BValue index = function_builder_->Literal(UBits(i, kUsizeBits), loc);
       BValue bvalue_case =
@@ -4933,18 +4950,30 @@ absl::Status FunctionConverter::HandleBuiltinOneHotSel(const Invocation* node) {
 absl::Status FunctionConverter::HandleBuiltinPrioritySel(
     const Invocation* node) {
   XLS_RET_CHECK_EQ(node->args().size(), 3);
+  XLS_RETURN_IF_ERROR(Visit(node->args()[0]));
   XLS_ASSIGN_OR_RETURN(BValue selector, Use(node->args()[0]));
 
-  // See implementation note for HandleBuiltinOneHotSel().
   const Expr* cases_arg = node->args()[1];
-  std::vector<BValue> cases;
+  if (const auto* array = dynamic_cast<const Array*>(cases_arg)) {
+    XLS_ASSIGN_OR_RETURN(std::vector<BValue> cases,
+                         GetSelectCasesForArrayLiteral(array));
+    XLS_RETURN_IF_ERROR(Visit(node->args()[2]));
+    XLS_ASSIGN_OR_RETURN(BValue default_value, Use(node->args()[2]));
+    Def(node, [&](const SourceInfo& loc) {
+      return function_builder_->PrioritySelect(selector, cases, default_value,
+                                               loc);
+    });
+    return absl::OkStatus();
+  }
 
+  XLS_RETURN_IF_ERROR(Visit(cases_arg));
   XLS_ASSIGN_OR_RETURN(BValue bvalue_cases_arg, Use(cases_arg));
   XLS_ASSIGN_OR_RETURN(xls::ArrayType * cases_arg_type,
                        bvalue_cases_arg.GetType()->AsArray());
+  XLS_RETURN_IF_ERROR(Visit(node->args()[2]));
   XLS_ASSIGN_OR_RETURN(BValue default_value, Use(node->args()[2]));
-
   Def(node, [&](const SourceInfo& loc) {
+    std::vector<BValue> cases;
     for (int64_t i = 0; i < cases_arg_type->size(); ++i) {
       BValue index = function_builder_->Literal(UBits(i, kUsizeBits), loc);
       BValue bvalue_case =

--- a/xls/dslx/ir_convert/function_converter.h
+++ b/xls/dslx/ir_convert/function_converter.h
@@ -511,6 +511,12 @@ class FunctionConverter {
   absl::Status HandleBuiltinLabeledRead(const Invocation* node);
   absl::Status HandleBuiltinLabeledWrite(const Invocation* node);
   absl::Status HandleBuiltinOneHot(const Invocation* node);
+
+  // Returns the scalar select cases represented by an inline array literal,
+  // including ellipsis expansion, without materializing an IR array value.
+  absl::StatusOr<std::vector<BValue>> GetSelectCasesForArrayLiteral(
+      const Array* array);
+
   absl::Status HandleBuiltinOneHotSel(const Invocation* node);
   absl::Status HandleBuiltinOrReduce(const Invocation* node);
   absl::Status HandleBuiltinPrioritySel(const Invocation* node);

--- a/xls/dslx/ir_convert/ir_converter_legacy_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_legacy_test.cc
@@ -1408,8 +1408,20 @@ fn main(x: u10, y: u10) -> u10 {
 TEST_F(IrConverterLegacyTest, OneHotSelSplat) {
   constexpr std::string_view program =
       R"(
-fn main(s: u2) -> u32 {
-  one_hot_sel(s, u32[2]:[2, 3])
+fn main(s: u3, a: u32, b: u32, c: u32) -> u32 {
+  one_hot_sel(s, [a, b, c])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertModuleForTest(program, kNoPosOptions));
+  ExpectIr(converted);
+}
+
+TEST_F(IrConverterLegacyTest, OneHotSelSplatWithEllipsis) {
+  constexpr std::string_view program =
+      R"(
+fn main(s: u3, a: u32) -> u32 {
+  one_hot_sel(s, u32[3]:[a, ...])
 }
 )";
   XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
@@ -1437,8 +1449,8 @@ fn main(s: u2) -> u32 {
 TEST_F(IrConverterLegacyTest, PrioritySelSplat) {
   constexpr std::string_view program =
       R"(
-fn main(s: u2) -> u32 {
-  priority_sel(s, u32[2]:[u32:2, u32:3], u32:4)
+fn main(s: u3, a: u32, b: u32, c: u32, default_value: u32) -> u32 {
+  priority_sel(s, [a, b, c], default_value)
 }
 )";
   XLS_ASSERT_OK_AND_ASSIGN(std::string converted,

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -1713,8 +1713,20 @@ fn main(x: u10, y: u10) -> u10 {
 TEST_F(IrConverterTest, OneHotSelSplat) {
   constexpr std::string_view program =
       R"(
-fn main(s: u2) -> u32 {
-  one_hot_sel(s, u32[2]:[2, 3])
+fn main(s: u3, a: u32, b: u32, c: u32) -> u32 {
+  one_hot_sel(s, [a, b, c])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertModuleForTest(program));
+  ExpectIr(converted);
+}
+
+TEST_F(IrConverterTest, OneHotSelSplatWithEllipsis) {
+  constexpr std::string_view program =
+      R"(
+fn main(s: u3, a: u32) -> u32 {
+  one_hot_sel(s, u32[3]:[a, ...])
 }
 )";
   XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
@@ -1742,8 +1754,8 @@ fn main(s: u2) -> u32 {
 TEST_F(IrConverterTest, PrioritySelSplat) {
   constexpr std::string_view program =
       R"(
-fn main(s: u2) -> u32 {
-  priority_sel(s, u32[2]:[u32:2, u32:3], u32:4)
+fn main(s: u3, a: u32, b: u32, c: u32, default_value: u32) -> u32 {
+  priority_sel(s, [a, b, c], default_value)
 }
 )";
   XLS_ASSERT_OK_AND_ASSIGN(std::string converted,

--- a/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_OneHotSelSplat.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_OneHotSelSplat.ir
@@ -2,13 +2,6 @@ package test_module
 
 file_number 0 "test_module.x"
 
-fn __test_module__main(s: bits[2] id=1) -> bits[32] {
-  literal.2: bits[32] = literal(value=2, id=2)
-  literal.3: bits[32] = literal(value=3, id=3)
-  array.4: bits[32][2] = array(literal.2, literal.3, id=4)
-  literal.5: bits[32] = literal(value=0, id=5)
-  literal.7: bits[32] = literal(value=1, id=7)
-  array_index.6: bits[32] = array_index(array.4, indices=[literal.5], id=6)
-  array_index.8: bits[32] = array_index(array.4, indices=[literal.7], id=8)
-  ret one_hot_sel.9: bits[32] = one_hot_sel(s, cases=[array_index.6, array_index.8], id=9)
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2, b: bits[32] id=3, c: bits[32] id=4) -> bits[32] {
+  ret one_hot_sel.5: bits[32] = one_hot_sel(s, cases=[a, b, c], id=5)
 }

--- a/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_OneHotSelSplatWithEllipsis.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_OneHotSelSplatWithEllipsis.ir
@@ -1,0 +1,7 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2) -> bits[32] {
+  ret one_hot_sel.3: bits[32] = one_hot_sel(s, cases=[a, a, a], id=3)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_PrioritySelSplat.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_legacy_test_PrioritySelSplat.ir
@@ -2,14 +2,6 @@ package test_module
 
 file_number 0 "test_module.x"
 
-fn __test_module__main(s: bits[2] id=1) -> bits[32] {
-  literal.2: bits[32] = literal(value=2, id=2)
-  literal.3: bits[32] = literal(value=3, id=3)
-  array.4: bits[32][2] = array(literal.2, literal.3, id=4)
-  literal.6: bits[32] = literal(value=0, id=6)
-  literal.8: bits[32] = literal(value=1, id=8)
-  array_index.7: bits[32] = array_index(array.4, indices=[literal.6], id=7)
-  array_index.9: bits[32] = array_index(array.4, indices=[literal.8], id=9)
-  literal.5: bits[32] = literal(value=4, id=5)
-  ret priority_sel.10: bits[32] = priority_sel(s, cases=[array_index.7, array_index.9], default=literal.5, id=10)
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2, b: bits[32] id=3, c: bits[32] id=4, default_value: bits[32] id=5) -> bits[32] {
+  ret priority_sel.6: bits[32] = priority_sel(s, cases=[a, b, c], default=default_value, id=6)
 }

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_OneHotSelSplat.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_OneHotSelSplat.ir
@@ -2,13 +2,6 @@ package test_module
 
 file_number 0 "test_module.x"
 
-fn __test_module__main(s: bits[2] id=1) -> bits[32] {
-  literal.2: bits[32] = literal(value=2, id=2)
-  literal.3: bits[32] = literal(value=3, id=3)
-  array.4: bits[32][2] = array(literal.2, literal.3, id=4)
-  literal.5: bits[32] = literal(value=0, id=5)
-  literal.7: bits[32] = literal(value=1, id=7)
-  array_index.6: bits[32] = array_index(array.4, indices=[literal.5], id=6)
-  array_index.8: bits[32] = array_index(array.4, indices=[literal.7], id=8)
-  ret one_hot_sel.9: bits[32] = one_hot_sel(s, cases=[array_index.6, array_index.8], id=9)
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2, b: bits[32] id=3, c: bits[32] id=4) -> bits[32] {
+  ret one_hot_sel.5: bits[32] = one_hot_sel(s, cases=[a, b, c], id=5)
 }

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_OneHotSelSplatWithEllipsis.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_OneHotSelSplatWithEllipsis.ir
@@ -1,0 +1,7 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2) -> bits[32] {
+  ret one_hot_sel.3: bits[32] = one_hot_sel(s, cases=[a, a, a], id=3)
+}

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_PrioritySelSplat.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_PrioritySelSplat.ir
@@ -2,14 +2,6 @@ package test_module
 
 file_number 0 "test_module.x"
 
-fn __test_module__main(s: bits[2] id=1) -> bits[32] {
-  literal.2: bits[32] = literal(value=2, id=2)
-  literal.3: bits[32] = literal(value=3, id=3)
-  array.4: bits[32][2] = array(literal.2, literal.3, id=4)
-  literal.6: bits[32] = literal(value=0, id=6)
-  literal.8: bits[32] = literal(value=1, id=8)
-  array_index.7: bits[32] = array_index(array.4, indices=[literal.6], id=7)
-  array_index.9: bits[32] = array_index(array.4, indices=[literal.8], id=9)
-  literal.5: bits[32] = literal(value=4, id=5)
-  ret priority_sel.10: bits[32] = priority_sel(s, cases=[array_index.7, array_index.9], default=literal.5, id=10)
+fn __test_module__main(s: bits[3] id=1, a: bits[32] id=2, b: bits[32] id=3, c: bits[32] id=4, default_value: bits[32] id=5) -> bits[32] {
+  ret priority_sel.6: bits[32] = priority_sel(s, cases=[a, b, c], default=default_value, id=6)
 }


### PR DESCRIPTION
Inline array literals passed to one_hot_sel and priority_sel can already be scalarized directly during IR conversion. Do that before generic argument lowering so no-opt IR does not materialize a temporary array and then recover its members with constant array_index nodes.

Keep the existing array-index fallback for non-literal case expressions, and preserve ellipsis expansion for literal arrays.