### PR TITLE
fix(passes): skip interval analysis for wide mult/div/mod ops to prev…

### DIFF
--- a/xls/passes/partial_info_query_engine.cc
+++ b/xls/passes/partial_info_query_engine.cc
@@ -645,6 +645,12 @@ bool IsExpensiveToEvaluate(
       Op::kShra,
       Op::kBitSliceUpdate,
       Op::kDynamicBitSlice,
+      Op::kUMul,
+      Op::kSMul,
+      Op::kUDiv,
+      Op::kSDiv,
+      Op::kUMod,
+      Op::kSMod,
   });
   if (is_complex_evaluation) {
     return node->operand(0)->GetType()->GetFlatBitCount() >

--- a/xls/passes/range_query_engine.cc
+++ b/xls/passes/range_query_engine.cc
@@ -115,6 +115,9 @@ class RangeQueryVisitor : public DfsVisitor {
   // What size we should minimize interval sets to by default.
   static constexpr int64_t kDefaultIntervalSize = 16;
 
+  // How many bits of operand width we allow for complex evaluations.
+  static constexpr int64_t kComplexEvaluationLimit = 256;
+
   // The maximum number of points covered by an interval set that can be
   // iterated over in an analysis.
 
@@ -1200,6 +1203,10 @@ absl::Status RangeQueryVisitor::HandleReverse(UnOp* reverse) {
 
 absl::Status RangeQueryVisitor::HandleSDiv(BinOp* div) {
   INITIALIZE_OR_SKIP(div);
+  if (div->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        div, IntervalSet::Maximal(div->GetType()->GetFlatBitCount()));
+  }
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, div->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, div->operand(1));
   return SetIntervalSet(div, interval_ops::SDiv(l, r));
@@ -1235,6 +1242,10 @@ absl::Status RangeQueryVisitor::HandleSLt(CompareOp* lt) {
 
 absl::Status RangeQueryVisitor::HandleSMod(BinOp* mod) {
   INITIALIZE_OR_SKIP(mod);
+  if (mod->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        mod, IntervalSet::Maximal(mod->GetType()->GetFlatBitCount()));
+  }
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, mod->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, mod->operand(1));
   return SetIntervalSet(mod, interval_ops::SMod(l, r));
@@ -1242,6 +1253,10 @@ absl::Status RangeQueryVisitor::HandleSMod(BinOp* mod) {
 
 absl::Status RangeQueryVisitor::HandleSMul(ArithOp* mul) {
   INITIALIZE_OR_SKIP(mul);
+  if (mul->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        mul, IntervalSet::Maximal(mul->GetType()->GetFlatBitCount()));
+  }
 
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, mul->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, mul->operand(1));
@@ -1387,6 +1402,10 @@ absl::Status RangeQueryVisitor::HandleTupleIndex(TupleIndex* index) {
 
 absl::Status RangeQueryVisitor::HandleUDiv(BinOp* div) {
   INITIALIZE_OR_SKIP(div);
+  if (div->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        div, IntervalSet::Maximal(div->GetType()->GetFlatBitCount()));
+  }
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, div->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, div->operand(1));
   return SetIntervalSet(div, interval_ops::UDiv(l, r));
@@ -1426,6 +1445,10 @@ absl::Status RangeQueryVisitor::HandleULt(CompareOp* lt) {
 
 absl::Status RangeQueryVisitor::HandleUMod(BinOp* mod) {
   INITIALIZE_OR_SKIP(mod);
+  if (mod->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        mod, IntervalSet::Maximal(mod->GetType()->GetFlatBitCount()));
+  }
 
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, mod->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, mod->operand(1));
@@ -1434,6 +1457,10 @@ absl::Status RangeQueryVisitor::HandleUMod(BinOp* mod) {
 
 absl::Status RangeQueryVisitor::HandleUMul(ArithOp* mul) {
   INITIALIZE_OR_SKIP(mul);
+  if (mul->operand(0)->GetType()->GetFlatBitCount() > kComplexEvaluationLimit) {
+    return SetIntervalSet(
+        mul, IntervalSet::Maximal(mul->GetType()->GetFlatBitCount()));
+  }
 
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(l, mul->operand(0));
   ASSIGN_INTERVAL_SET_REF_OR_RETURN(r, mul->operand(1));


### PR DESCRIPTION
Fixes a fuzzer timeout issue where the optimization passes (SelectRangeSimplificationPass and NarrowingPass) hang on very wide bit-width operations (e.g., 1697-bit integers from crasher run_crasher_test_2026-05-05_45c4.x).

Root Cause
When the fuzzer generates wide integer operations (such as multiplications, divisions, and modulos), the RangeQueryEngine and PartialInfoQueryEngine attempt range analysis. Evaluating these complex operations on extremely wide types involves calculating the Cartesian product of the operands' intervals (up to 256 evaluations). This repeatedly executes costly multi-precision integer operations (e.g., bits_ops::UMul, bits_ops::UDiv), causing a huge CPU bottleneck and leading to fuzzer timeouts.

Fix
PartialInfoQueryEngine: Added multiplication, division, and modulo operations (Op::kUMul, Op::kSMul, Op::kUDiv, Op::kSDiv, Op::kUMod, Op::kSMod) to IsExpensiveToEvaluate(). If the operand width exceeds kComplexEvaluationLimit (256 bits), it skips ternary/partial evaluation.
RangeQueryEngine: Added a similar threshold limit (kComplexEvaluationLimit = 256) to the visitor handlers for these operations (HandleUMul, HandleSMul, HandleUDiv, HandleSDiv, HandleUMod, HandleSMod), returning a maximal/unconstrained interval set immediately instead of running expensive interval operations.