### PR TITLE
Remove obsolete builtin `enumerate` IR conversion test

### DIFF
--- a/xls/dslx/ir_convert/ir_converter_legacy_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_legacy_test.cc
@@ -824,19 +824,6 @@ fn main(input: u8[2]) -> u8[2] {
   ExpectIr(converted);
 }
 
-// TODO(https://github.com/google/xls/issues/1289): Need to be able to convert
-// enumerate builtin.
-TEST_F(IrConverterLegacyTest, DISABLED_ArrayEnumerate) {
-  constexpr std::string_view program = R"(
-fn main(array: u8[4]) -> (u32, u8)[4]) {
-  enumerate(array)
-}
-)";
-  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
-                           ConvertOneFunctionForTest(program, "main"));
-  ExpectIr(converted);
-}
-
 TEST_F(IrConverterLegacyTest, SplatStructInstance) {
   constexpr std::string_view program =
       R"(


### PR DESCRIPTION
This pull request removes disabled IR conversion test for the builtin version of `enumerate`.

IR conversion check for the DSLX implementation can be found [here](https://github.com/google/xls/blob/9f1384b0327f1b26c49e749072f85e80aa43fb71/xls/dslx/ir_convert/ir_converter_test.cc#L472-L482).