### PR TITLE
Adjust literals_decoder_dslx_test size for CI stability

### DIFF
--- a/xls/modules/zstd/BUILD
+++ b/xls/modules/zstd/BUILD
@@ -2696,6 +2696,7 @@ xls_dslx_library(
 xls_dslx_test(
     name = "literals_decoder_dslx_test",
     library = ":literals_decoder_dslx",
+    size = "large",
 )
 
 LITERALS_DECODER_CTRL_CODEGEN_ARGS = COMMON_CODEGEN_ARGS | {


### PR DESCRIPTION
This PR changes the size of `//xls/modules/zstd:literals_decoder_dslx_test` to `large`, as it was reported in https://github.com/google/xls/issues/4336 that the tests may time out when run in the CI.

Resolves #4336
FYI @proppy 