### PR TITLE
Make sure .bazelrc configures the whole c++20 options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -35,6 +35,7 @@ build:macos --macos_minimum_os=10.13
 # Minimum c++ standard used. We set it in the llvm toolchain, but
 # we also need to specify it here when it is not possible to use that toolchain.
 build --cxxopt "-std=c++20"            --host_cxxopt "-std=c++20"
+build --client_env=BAZEL_CXXOPTS=-std=c++20
 
 # Depending on the installation, clang or clang-tidy need to be told that
 # a c++ file is, indeed, containing c++ (bazel just invokes clang, not clang++)


### PR DESCRIPTION
The c++20 options were removed in the .bazelrc in favor of configuring it in the llvm toolchain configured in the MODULE.bazel.

https://github.com/google/xls/commit/17525ebe11980848e0e74f875d9e7b508e17224a

...however, this only works if the toolchain can be used. Since it is not hermetic, it needs to be disabled on many platforms. So the original way of c++20 config was partially re-instantiated in

https://github.com/google/xls/commit/41f6104f2b0fc91c3a6ae22d299859cff51da3cc

Turns out, also the `BAZEL_CXXOPTS=-std=c++20` needs to be set again. This is happening in this PR.