### PR TITLE
Fix gmock template deduction hickup.

### DIFF
--- a/xls/dslx/cpp_transpiler/test_types_test.cc
+++ b/xls/dslx/cpp_transpiler/test_types_test.cc
@@ -589,8 +589,8 @@ TEST(TestTypesTest, BigBits) {
   test::MyU555 from_val{};
   from_val[1] = true;
   from_val[3] = true;
-  EXPECT_THAT(test::MyU555FromValue(Value(UBits(0b1010, 555))),
-              IsOkAndHolds(from_val));
+  XLS_ASSERT_OK_AND_ASSIGN(test::MyU555 result, test::MyU555FromValue(Value(UBits(0b1010, 555))));
+  EXPECT_EQ(result, from_val);
   EXPECT_EQ(
       test::MyU555ToString(from_val),
       "bits[555]:"


### PR DESCRIPTION
The `EXPECT_THAT(..., IsOkAndHolds(from_val))` with a `from_value` of `test::MyU555` (which in turn is a std::bitset<555>) ran the mock template metaprogramming into circles attempting to deduce bitset constructability in a way that ended up triggering a static_assert() in the stdlib.

So instead, break this into two steps: first verify that value can be ok constructed, then compare.