### PR TITLE
Fix bazel build by updating LLVM hash in MODULE.bazel.lock.

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -919,7 +919,7 @@
     },
     "//dependency_support/llvm:extension.bzl%llvm_raw_ext": {
       "general": {
-        "bzlTransitiveDigest": "am2UIt6FmOnZ58NSRgp1lLrG+vlKFGaUWu3l5CZDaHI=",
+        "bzlTransitiveDigest": "kcWiK47y6NHH4p173EbpB1Y6eGxw4Xan63pXwhSauRo=",
         "usagesDigest": "2L4aUO+mN7yb6ncsan8L0mvPbVM94Dnps3QE6J8hcHw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -929,7 +929,7 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
               "build_file_content": "# empty",
-              "sha256": "eddb0cf6d6ab1bebf7990fcba6683eb633fa0b05ea6ea47ca562b4b871140793",
+              "sha256": "bf5df505f7bd7a6b1a0819f31b8f71f8f54ea2fd86c00e4bb6ae06295dc3743c",
               "patches": [
                 "@@//dependency_support/llvm:llvm.patch",
                 "@@//dependency_support/llvm:zlib-header.patch",
@@ -938,9 +938,9 @@
               "patch_args": [
                 "-p1"
               ],
-              "strip_prefix": "llvm-project-030e74c2808a9af58c6b4ef461fd0c2c7039d647",
+              "strip_prefix": "llvm-project-f3a69752ac184360afeb921d157ae08b89c2c091",
               "urls": [
-                "https://github.com/llvm/llvm-project/archive/030e74c2808a9af58c6b4ef461fd0c2c7039d647.tar.gz"
+                "https://github.com/llvm/llvm-project/archive/f3a69752ac184360afeb921d157ae08b89c2c091.tar.gz"
               ]
             }
           }


### PR DESCRIPTION
This PR fixes the build broken by the last two integrates by running the command that the corresponding (and failing) CI test target recommends running:

> Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.