### PR TITLE
Bump `bazel_rules_hdl` version

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -193,7 +193,7 @@ bazel_dep(name = "openroad", repo_name = "org_theopenroadproject")
 
 git_override(
     module_name = "rules_hdl",
-    commit = "94e28d604085707499fd5aa1fd96519b1acda216",
+    commit = "19cf04d10582d37119a4adbf0cb4fd681c05a3fb",
     remote = "https://github.com/hdl/bazel_rules_hdl.git",
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -408,8 +408,8 @@
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/MODULE.bazel": "827f54f492a3ce549c940106d73de332c2b30cebd0c20c0bc5d786aba7f116cb",
     "https://bcr.bazel.build/modules/googletest/1.17.0.bcr.2/source.json": "3664514073a819992320ffbce5825e4238459df344d8b01748af2208f8d2e1eb",
     "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
-    "https://bcr.bazel.build/modules/gperf/3.1/MODULE.bazel": "e5f8efcdcdfa6e00c69772ffc7a1dbef3b554e99e68d7736f127615299f8722a",
-    "https://bcr.bazel.build/modules/gperf/3.1/source.json": "2b576a8fcac95162cb9c48d494f7d8e573ba464169a0d6d1e7522fb950562f79",
+    "https://bcr.bazel.build/modules/gperf/3.1.bcr.2/MODULE.bazel": "2740ed3e0728432ece115aa5e36bf1b05372af7974a270bf6aab3c65de1717d6",
+    "https://bcr.bazel.build/modules/gperf/3.1.bcr.2/source.json": "963e17013ae8124ca2ff3d08e62010699d2ed97d3cf9bd7b2f1fc92f0f050397",
     "https://bcr.bazel.build/modules/grpc-java/1.66.0/MODULE.bazel": "86ff26209fac846adb89db11f3714b3dc0090fb2fb81575673cc74880cda4e7e",
     "https://bcr.bazel.build/modules/grpc-java/1.69.0/MODULE.bazel": "53887af6a00b3b406d70175d3d07e84ea9362016ff55ea90b9185f0227bfaf98",
     "https://bcr.bazel.build/modules/grpc-java/1.69.0/source.json": "daf42ef1f7a2b86d9178d288c5245802f9b6157adc302b2b05c8fd12cbd79659",
@@ -1959,7 +1959,7 @@
     },
     "@@rules_hdl+//dependency_support:pdks_extension.bzl%pdks_extension": {
       "general": {
-        "bzlTransitiveDigest": "vdhT5DhEVCWOeBZYlbsu4jWwdf84ifwyhThHxWM2tas=",
+        "bzlTransitiveDigest": "Hq3iqg0PvCoo8de6+6iwsyCBPt9uqNHM/g18UtvjuSM=",
         "usagesDigest": "5lFHxPa5VvFbuAg0csU5YFkGi37ZkNlfGZrnv1fluqA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -2017,7 +2017,11 @@
               ],
               "strip_prefix": "skywater-pdk-3d7617a1acb92ea883539bcf22a632d6361a5de4",
               "sha256": "49e5b03c26131a03eb038697d396a6ebf14058d78196f5d95c2bbdb0bdc8f32e",
-              "build_file": "@@rules_hdl+//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel"
+              "build_file": "@@rules_hdl+//dependency_support/com_google_skywater_pdk:bundled.BUILD.bazel",
+              "patches": [
+                "@@rules_hdl+//dependency_support/com_google_skywater_pdk:patches/fix-invalid-escape.patch"
+              ],
+              "patch_strip": 1
             }
           },
           "com_google_skywater_pdk_sky130_fd_sc_hd": {


### PR DESCRIPTION
This pull request bumps `bazel_rules_hdl` version to latest after [#443](https://github.com/hdl/bazel_rules_hdl/pull/443) fixing discrepancy between synthesis logs and `benchmark_synth` log parsing logic was merged.

The issue can be reproduced by running `bazel run //xls/examples:serialized_decomposer_benchmark_synth && echo $?` on latest XLS main (commit [5c678faf](https://github.com/google/xls/commit/5c678faf4d910576417556839db0d7c6d3846f57)).