### PR TITLE
Fix flags set in transpiler compilation.

### DIFF
--- a/xls/build_rules/xls_dslx_rules.bzl
+++ b/xls/build_rules/xls_dslx_rules.bzl
@@ -520,7 +520,7 @@ def _xls_dslx_generate_cpp_type_files_impl(ctx):
     dslx_path = ":${PWD}:" + ctx.genfiles_dir.path + ":" + ctx.bin_dir.path + dslx_srcs_wsroot_path + wsroot_dslx_path
 
     # Make arguments for the cpp_transpiler tool.
-    cc_source_dir = ctx.actions.declare_directory(ctx.label.name + "_srcs")
+    cc_source_dir = ctx.actions.declare_directory(ctx.label.name + "_srcs.cc")
     h_file = ctx.outputs.header_file
 
     include_header_files = []

--- a/xls/build_rules/xls_dslx_rules.bzl
+++ b/xls/build_rules/xls_dslx_rules.bzl
@@ -520,6 +520,8 @@ def _xls_dslx_generate_cpp_type_files_impl(ctx):
     dslx_path = ":${PWD}:" + ctx.genfiles_dir.path + ":" + ctx.bin_dir.path + dslx_srcs_wsroot_path + wsroot_dslx_path
 
     # Make arguments for the cpp_transpiler tool.
+    # Add an extension to the directory that helps bazel classify the contents
+    # as C++, otherwise it will not append configured --cxxopt for compilation.
     cc_source_dir = ctx.actions.declare_directory(ctx.label.name + "_srcs.cc")
     h_file = ctx.outputs.header_file
 

--- a/xls/build_rules/xls_dslx_rules.bzl
+++ b/xls/build_rules/xls_dslx_rules.bzl
@@ -522,6 +522,7 @@ def _xls_dslx_generate_cpp_type_files_impl(ctx):
     # Make arguments for the cpp_transpiler tool.
     # Add an extension to the directory that helps bazel classify the contents
     # as C++, otherwise it will not append configured --cxxopt for compilation.
+    # Also see https://github.com/bazelbuild/bazel/issues/14843
     cc_source_dir = ctx.actions.declare_directory(ctx.label.name + "_srcs.cc")
     h_file = ctx.outputs.header_file
 


### PR DESCRIPTION
Files compiled with the transpiler rule were
not compiled with c++ flags (e.g. all the flags such as --cxxopt in .bazelrc), which results in them not picking up e.g. -std=c++20 flags (which will be important in the hermetic compiler; in the old compiler this was forced by setting it in a different place).

So e.g. the following never received all cxx flags:

```
bazel build -c opt -s //xls/dslx/cpp_transpiler:test_types_lib
```

Solution: the previously named `_gen_test_types_lib_srcs` subdirectory is named now `_gen_test_types_lib_srcs.cc` which helps bazels flag matcher to choose the correct compiler and flags.