### PR TITLE
Fix channel queue UB when read/writing zero bytes.

### DIFF
--- a/xls/jit/jit_channel_queue.h
+++ b/xls/jit/jit_channel_queue.h
@@ -53,12 +53,16 @@ class ByteQueue {
 
   void Write(const uint8_t* data) {
 #ifdef ABSL_HAVE_MEMORY_SANITIZER
-    __msan_unpoison(data, channel_element_size_);
+    if (channel_element_size_ > 0) {
+      __msan_unpoison(data, channel_element_size_);
+    }
 #endif
     if (bytes_used_ == max_byte_count_ && !is_single_value_) {
       Resize();
     }
-    memcpy(circular_buffer_.data() + write_index_, data, channel_element_size_);
+    if (channel_element_size_ > 0) {
+      memcpy(circular_buffer_.data() + write_index_, data, channel_element_size_);
+    }
     if (is_single_value_) {
       bytes_used_ = allocated_element_size_;
     } else {
@@ -74,8 +78,10 @@ class ByteQueue {
     if (bytes_used_ == 0) {
       return false;
     }
-    memcpy(buffer, circular_buffer_.data() + read_index_,
-           channel_element_size_);
+    if (channel_element_size_ > 0) {
+      memcpy(buffer, circular_buffer_.data() + read_index_,
+             channel_element_size_);
+    }
     if (!is_single_value_) {
       // Reads are destructive for non single-value channels.
       bytes_used_ -= allocated_element_size_;


### PR DESCRIPTION
Make sure we don't memcpy() zero bytes to/from nullptrs.

The test `//xls/jit:jit_channel_queue_test` was failing

 * ThreadSafeJitChannelQueueTest/ChannelQueueTestBase.ChannelWithEmptyTuple/0
 * LockLessJitChannelQueueTest/ChannelQueueTestBase.ChannelWithEmptyTuple/0

with current clang.

These were testing with `Value::Tuple({})`, which results in a `channel_element_size_` of zero. With zero size, the optimization in the `std::vector<uint8_t> buffer(queue.element_size())` realizes it doesn't need any memory and optimizes to be a `nullptr` data...

Then `memcpy()` attempt to copy zero bytes to a nullptr is UB, and at that point everything else was optimized away, so queue->GetSize() returned wrong values.

(test failure: https://github.com/google/xls/actions/runs/29505219434/job/87644096322?pr=4568#step:8:1643 )