### PR TITLE
Fix runfile issues in mlir tests

### DIFF
--- a/xls/contrib/mlir/testdata/BUILD.bazel
+++ b/xls/contrib/mlir/testdata/BUILD.bazel
@@ -46,10 +46,14 @@ RUNFILES_DIR = LITE_CFG_PY.parents[3].absolute().as_posix()''',
         size = "small",
         srcs = [src],
         data = [
+            "i16/dot_product.x",
+            "i32/dot_product.x",
             "lit.cfg.py",
             "lit.site.cfg.py",
+            "struct_type.x",
             "//xls/contrib/mlir:xls_opt",
             "//xls/contrib/mlir:xls_translate",
+            "//xls/dslx/stdlib:x_files",
             "//xls/tools:codegen_main",
             "//xls/tools:eval_ir_main",
             "//xls/tools:eval_proc_main",
@@ -63,13 +67,6 @@ RUNFILES_DIR = LITE_CFG_PY.parents[3].absolute().as_posix()''',
         [
             "**/*.mlir",
             "**/*.ir",
-        ],
-        # TODO(jpienaar): The lookup in RUNFILES does not seem to work for these files with the
-        # current lit setup.
-        exclude = [
-            "**/translate_import_*.mlir",
-            "**/translate_foreign.mlir",
-            "**/optimize_using_xls.mlir",
         ],
     )
 ]

--- a/xls/contrib/mlir/testdata/lit.site.cfg.py.in
+++ b/xls/contrib/mlir/testdata/lit.site.cfg.py.in
@@ -35,3 +35,9 @@ except NameError:
 config.mlir_xls_tools_dir = os.path.join("@MLIR_XLS_TOOLS_DIR@", "contrib/mlir")
 config.xls_tools_dir = os.path.join("@XLS_TOOLS_DIR@", "tools")
 lit_config.load_config(config, os.path.join("@MLIR_XLS_SOURCE_DIR@", "contrib/mlir/testdata/lit.cfg.py"))
+
+if 'RUNFILES_DIR' in locals():
+    config.environment['RUNFILES_DIR'] = RUNFILES_DIR
+for key, value in os.environ.items():
+    if key.startswith('RUNFILES_'):
+        config.environment[key] = value

--- a/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.cc
+++ b/xls/contrib/mlir/tools/xls_translate/xls_translate_from_mlir.cc
@@ -1065,9 +1065,9 @@ FailureOr<PackageInfo> importDslxInstantiation(
   llvm::raw_string_ostream os(dslx);
   // Read the file in path into a string.
   std::string file_contents;
-  auto fileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(path);
+  auto fileOrErr = llvm::MemoryBuffer::getFileOrSTDIN(fsPath.string());
   if (fileOrErr.getError()) {
-    llvm::errs() << "Failed to read file: " << path << "\n";
+    llvm::errs() << "Failed to read file: " << fsPath.string() << "\n";
     return failure();
   }
   os << (*fileOrErr)->getBuffer();


### PR DESCRIPTION
The lit tests didn't pass on the runfiles, so fixed that in lit.site.cfg.py.in; this then fixed #4589 (after also passing the relevant file in the `data=[]` files.

This unlocked enabling the other commented out tests as well, however it also revealed another fix needed: in xls_translate_from_mlir.cc we resolve the path to a file (using runfiles), but then used the original path instead of the resolved path to open the file. This worked accidentally when in the same filesystem, but if this is a runfile path, we need to use that.

With these changes, all these test now work in an RBE environment, in which the remote bazel executor only sees what is actually passed via runfiles.

Fixes: https://github.com/google/xls/issues/4589