### PR TITLE
Fix most warnings in compile (build gardening :))

### DIFF
--- a/xls/contrib/xlscc/translator.h
+++ b/xls/contrib/xlscc/translator.h
@@ -1077,7 +1077,7 @@ class Translator final : public GeneratorBase,
 
   absl::StatusOr<TrackedBValue> GetIOOpRetValueFromSlice(
       NATIVE_BVAL slice_ret_val, const GeneratedFunctionSlice& slice,
-      const xls::SourceInfo& loc);
+      const xls::SourceInfo& loc) final;
 
   absl::StatusOr<std::optional<const IOOp*>> GetPreviousOp(
       const IOOp& op, const xls::SourceInfo& loc);
@@ -1432,7 +1432,7 @@ class Translator final : public GeneratorBase,
       clang::QualType t, const xls::SourceInfo& loc,
       bool array_as_tuple = false) final;
   absl::StatusOr<xls::Type*> TranslateTypeToXLS(std::shared_ptr<CType> t,
-                                                const xls::SourceInfo& loc);
+                                                const xls::SourceInfo& loc) final;
   absl::StatusOr<std::shared_ptr<CType>> ResolveTypeInstance(
       std::shared_ptr<CType> t) final;
   absl::StatusOr<std::shared_ptr<CType>> ResolveTypeInstanceDeeply(

--- a/xls/fuzzer/ir_fuzzer/gen_ir_nodes_pass.h
+++ b/xls/fuzzer/ir_fuzzer/gen_ir_nodes_pass.h
@@ -48,8 +48,9 @@ class GenIrNodesPass : public IrFuzzVisitor {
       : p_(p),
         fuzz_program_(fuzz_program),
         helpers_(fuzz_program_.version(), max_bit_width),
-        max_bit_width_(max_bit_width.value_or(IrFuzzHelpers::kMaxFuzzBitWidth)),
-        remaining_param_bits_(param_bits) {
+        remaining_param_bits_(param_bits),
+        max_bit_width_(
+            max_bit_width.value_or(IrFuzzHelpers::kMaxFuzzBitWidth)) {
     function_states_.emplace_back(p, top_name, fuzz_program_.version(),
                                   fuzz_program_.combine_list_method(),
                                   std::nullopt, max_bit_width);

--- a/xls/passes/data_flow_node_info.h
+++ b/xls/passes/data_flow_node_info.h
@@ -96,10 +96,10 @@ class DataFlowLazyNodeInfo : public LazyNodeInfo<Info> {
 
   DataFlowLazyNodeInfo(const DataFlowLazyNodeInfo& o)
       : LazyNodeInfo<Info>(o),
+        query_engine_(o.query_engine_),
         default_info_source_(o.default_info_source_),
         compute_tree_for_source_(o.compute_tree_for_source_),
         include_selectors_(o.include_selectors_),
-        query_engine_(o.query_engine_),
         parent_(o.parent_),
         parent_node_(o.parent_node_) {
     for (const auto& [invoke, callee_info] : o.cached_callee_infos_) {
@@ -225,11 +225,9 @@ class DataFlowLazyNodeInfo : public LazyNodeInfo<Info> {
                                   ->AsArrayOrDie())) {
           LeafTypeTree<Info> ret = leaf_type_tree::Clone(
               operand_infos[xls::ArrayUpdate::kArgOperand]->AsView());
-          MutableLeafTypeTreeView<Info> ret_view =
-              ret.AsMutableView(literal_indices);
-          leaf_type_tree::ReplaceElements(
+          CHECK_OK(leaf_type_tree::ReplaceElements(
               ret.AsMutableView(literal_indices),
-              operand_infos[xls::ArrayUpdate::kUpdateValueOperand]->AsView());
+              operand_infos[xls::ArrayUpdate::kUpdateValueOperand]->AsView()));
           return ret;
         }
 
@@ -311,7 +309,7 @@ class DataFlowLazyNodeInfo : public LazyNodeInfo<Info> {
 
           CHECK_NE(LazyNodeData<LeafTypeTree<Info>>::bound_function(), nullptr);
 
-          cached_callee_infos_.at(invoke)->Attach(callee);
+          CHECK_OK(cached_callee_infos_.at(invoke)->Attach(callee));
         }
 
         Derived* callee_info = cached_callee_infos_.at(invoke).get();
@@ -321,7 +319,8 @@ class DataFlowLazyNodeInfo : public LazyNodeInfo<Info> {
         CHECK_EQ(invoke->operand_count(), callee->params().size());
 
         for (int64_t p = 0; p < callee->params().size(); ++p) {
-          callee_info->SetForced(callee->params().at(p), *operand_infos[p]);
+          CHECK_OK(callee_info->SetForced(callee->params().at(p),
+                                          *operand_infos[p]));
         }
 
         SharedLeafTypeTree<Info> callee_info_opt =


### PR DESCRIPTION
There are many hundred warnings in the build, most coming from the same places, but since they are in headers they show up many times.

Fixes

   * Add an override/final to a overriding virtual method where that was missing.
   * Fix field order in the constructor initialization to match member sequence.
   * Don't silently ignore absl::Status, instead wrap them in CHECK_OK() to make sure the nodiscard value makes itself known on issues.