### PR TITLE
dslx/fmt: formatter now allows comments inside multi-line array literals

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -127,6 +127,13 @@ std::optional<DocRef> Formatter::FormatCommentsBetween(
   return ConcatN(arena_, pieces);
 }
 
+bool Formatter::FirstCommentTrails(const Pos& from, const Pos& to) {
+  std::vector<const CommentData*> comments =
+      comments_.GetComments(Span(from, to));
+  return !comments.empty() &&
+         comments.front()->span.start().lineno() == from.lineno();
+}
+
 // If there is a '.' modifier in the attribute given by s (e.g. if it's of the
 // form "ProcName.config") strips off the trailing modifier and returns the
 // stem.
@@ -588,13 +595,101 @@ DocRef Formatter::FormatBreakBody(const Array& n) {
   return ConcatNGroup(arena_, rest);
 }
 
-DocRef Formatter::FormatArray(const Array& n) {
+DocRef Formatter::FormatArrayWithoutComments(const Array& n) {
   DocRef on_break_body = FormatBreakBody(n);
   DocRef on_flat_body = FormatFlatBody(n);
 
   DocRef body = arena_.MakeGroup(arena_.MakeFlatChoice(
       /*on_flat=*/on_flat_body, /*on_break=*/on_break_body));
   return arena_.MakeConcat(FormatMakeArrayLeader(n), body);
+}
+
+DocRef Formatter::FormatArray(const Array& n) {
+  Span array_span = n.span();
+
+  // Detect if there are any comments in the span of the array.
+  bool any_comments = comments_.HasComments(array_span);
+
+  if (!any_comments) {
+    // Do it the old way.
+    return FormatArrayWithoutComments(n);
+  }
+
+  absl::Span<Expr* const> items = n.members();
+  std::vector<DocRef> body_pieces;
+  std::vector<DocRef> current_run;
+  Pos last_array_element_span_limit = array_span.start();
+
+  auto flush_run = [&]() {
+    if (current_run.empty()) {
+      return;
+    }
+    body_pieces.push_back(FormatJoin(
+        current_run, Joiner::kCommaBreak1AsGroupTrailingCommaAlways));
+    current_run.clear();
+  };
+
+  // Split into multiple runs of continuous elements between comments.
+  // Each run is formatted using FormatJoin to clump elements.
+  for (const auto* item : items) {
+    const Span& span = item->span();
+
+    // If there are comments between the previous member and this one,
+    // they end the current run.
+    if (std::optional<DocRef> comments = FormatCommentsBetween(
+            last_array_element_span_limit, span.start(), nullptr)) {
+      flush_run();
+
+      if (!body_pieces.empty()) {
+        // If comments started on the same line as the previous element,
+        // add a space. Otherwise add a hard line.
+        const bool same_line =
+            FirstCommentTrails(last_array_element_span_limit, span.start());
+        body_pieces.push_back(same_line ? arena_.space() : arena_.hard_line());
+      }
+
+      // Append comment value
+      body_pieces.push_back(comments.value());
+      // Comments should always be followed by a hard line.
+      body_pieces.push_back(arena_.hard_line());
+    }
+
+    current_run.push_back(Format(item));
+    last_array_element_span_limit = span.limit();
+  }
+  flush_run();
+
+  // Handle ellipsis
+  // TODO: we currently don't have a way of checking whether the
+  // ellipsis comes before or after the final, trailing comment.
+  // Would be good functionality to add in.
+  if (n.has_ellipsis()) {
+    body_pieces.push_back(
+      ConcatNGroup(arena_, {arena_.break1(), arena_.MakeText("...")}));
+  }
+
+  // Comments between the last member and the end of the array.
+  if (std::optional<DocRef> terminal_comment = FormatCommentsBetween(
+          last_array_element_span_limit, array_span.limit(), nullptr)) {
+    if (body_pieces.empty()) {
+      // Edge case: empty array with comments
+      body_pieces.push_back(terminal_comment.value());
+    } else {
+      const bool same_line =
+          FirstCommentTrails(last_array_element_span_limit, array_span.limit());
+      body_pieces.push_back(same_line ? arena_.space() : arena_.hard_line());
+      body_pieces.push_back(terminal_comment.value());
+    }
+  }
+
+  DocRef guts = ConcatN(arena_, body_pieces);
+  return ConcatN(arena_, {
+                             FormatMakeArrayLeader(n),
+                             arena_.hard_line(),
+                             arena_.MakeNest(guts),
+                             arena_.hard_line(),
+                             arena_.cbracket(),
+                         });
 }
 
 DocRef Formatter::FormatAttr(const Attr& n) {

--- a/xls/dslx/fmt/ast_fmt.h
+++ b/xls/dslx/fmt/ast_fmt.h
@@ -102,6 +102,10 @@ class Formatter {
       std::optional<Pos> start, const Pos& limit,
       std::optional<Span>* last_comment_span = nullptr);
 
+  // Returns true if the first comment in the span [from, to) begins on the same
+  // source line as `from`
+  bool FirstCommentTrails(const Pos& from, const Pos& to);
+
   template <typename T>
   DocRef FormatImplOrTrait(const T& n, Keyword keyword,
                            DocRef name_or_struct_ref);
@@ -110,6 +114,7 @@ class Formatter {
   virtual DocRef FormatAllOnesMacro(const AllOnesMacro& n);
   virtual DocRef FormatArray(const Array& n);
   virtual DocRef FormatArrayTypeAnnotation(const ArrayTypeAnnotation& n);
+  virtual DocRef FormatArrayWithoutComments(const Array& n);
   virtual DocRef FormatAttr(const Attr& n);
   virtual DocRef FormatAttribute(const Attribute& n);
   virtual DocRef FormatBinop(const Binop& n);

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1714,6 +1714,75 @@ pub const A0 = sN[W_A0][NUM_PIECES]:[
 )");
 }
 
+TEST_F(ModuleFmtTest, ConstantDefArrayWithComments) {
+  DoFmt(R"(pub const VALS = u32[8]:[
+    // this is one comment
+    1, 2, 3, 4,
+    // this is another comment
+    5, 6, 7, 8,
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayWithInlineComments) {
+  DoFmt(R"(pub const VALS = u32[8]:[
+    1, 2, 3, 4, // this is one comment
+    5, 6, 7, 8, // this is another comment
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayWithMixedComments) {
+  DoFmt(R"(pub const VALS = u32[8]:[
+    1, 2, // this is one comment
+    3, 4, 5, 6,
+    // inline comment
+    7, 8,
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayWithTrailingComments) {
+  DoFmt(R"(pub const VALS = u32[2]:[
+    1, 2,
+    // trailing comment 1
+    // trailing comment 2
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayEmptyWithComments) {
+  DoFmt(R"(pub const VALS = u32[0]:[
+    // this is an empty array
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayWithEllipsisAndComment) {
+  DoFmt(R"(pub const VALS = u32[8]:[
+    // first few
+    1, 2, 3, 4, 5, 6, 7, ...
+];
+)");
+}
+
+TEST_F(ModuleFmtTest, ConstantDefArrayCommentsClumpNonCanonical) {
+  DoFmt(R"(pub const VALS = u32[4]:[
+    1,
+    2,
+    // note
+    3,
+    4,
+];
+)",
+        R"(pub const VALS = u32[4]:[
+    1, 2,
+    // note
+    3, 4,
+];
+)");
+}
+
 TEST_F(ModuleFmtTest, EnumDefTwoValues) {
   DoFmt("pub enum MyEnum:u32{A=1,B=2}\n",
         R"(pub enum MyEnum : u32 {


### PR DESCRIPTION
This is an attempt to close the issue that I filed [here](https://github.com/google/xls/issues/4638). The formatter no longer errors when given multi-line array literals containing comments. A couple of notes:

1. Unlike tuples containing comments, arrays that contain comments still maintain "clumping" behavior from before - they fit as many elements on a line as they can, until a comment is encountered. So
```
[ 
    1,
    2, 
    // comment
    3, 
] 
```
formats as
```
[ 
    1, 2, 
    // comment
    3, 
] 
```
2. Another difference between FormatArray and FormatTuple is that FormatArray can distinguish between comments that are at the end of a line (e.g. `2, 3, // comment`) versus those that are on their own line. The helper function `FirstCommentTrails` is useful not only because it is called multiple times in FormatArray, but might be useful to resolving the TODO on line 1530 within FormatTuple, which I would be interested in resolving.
3. The only issue that I've identified with this commit as it stands is that ellipsis can sometimes be formatted a little weirdly. Namely, when there is an ellipsis immediately following a comment, the ellipsis is moved before the comment. So 
```
[ 
    1,
    2, 
    // comment
    ...
] 
```
formats as 
```
[ 
    1, 2, ...
    // comment
] 
```
I am happy to look into this in the future as well, but thought it was worth filing the PR as is since this is already a significant improvement.

I'm a newcomer to XLS and open source generally, so please let me know if there is anything I can improve on! I would love to make more contributions.
