### PR TITLE
Use newer bant features to optimize its use

### DIFF
--- a/xls/dev_tools/make-compilation-db.sh
+++ b/xls/dev_tools/make-compilation-db.sh
@@ -43,9 +43,8 @@ BAZEL_OPTS="-c opt --remote_download_outputs=all"
   //xls/dslx/tests/trace_fmt_issue_651:trace_{u16,u21,s32,enum,u16_hex,u21_hex}_wrapper \
   //xls/dslx/stdlib/tests:bfloat16_{eq,gt,gte,lt,lte}_2_jit_wrapper.h \
   //xls/contrib/mlir:{math,arith}_to_xls \
-  $("${BANT}" list-targets @or-tools//... | awk '/cc_proto_library/ {print $3}') \
-  $("${BANT}" list-targets | \
-    awk '/cc_proto_library|genrule|xls_dslx_cpp_type_library|cc_xls_ir_jit_wrapper|xls_ir_cc_library|gentbl_cc_library|cc_grpc_library/ {print $3}')
+  $("${BANT}" list-targets @or-tools//... -g "cc_proto_library" -c3) \
+  $("${BANT}" list-targets ... -g "cc_proto_library|genrule|xls_dslx_cpp_type_library|cc_xls_ir_jit_wrapper|xls_ir_cc_library|gentbl_cc_library|cc_grpc_library" -c3)
 
 # Create compilation DB. Command 'compilation-db' creates a huge *.json file,
 # but compile_flags.txt is perfectly sufficient and easier for tools to use.

--- a/xls/dev_tools/run-build-cleaner.sh
+++ b/xls/dev_tools/run-build-cleaner.sh
@@ -23,7 +23,16 @@ BANT=$($(dirname $0)/get-bant-path.sh)
 
 # Run depend-on-what-you-use build-cleaner.
 # Print buildifier commands to fix if needed.
-"${BANT}" dwyu "$@"
+#  * Use graph-augment to tell bant to build a dependency graph
+#    from the root, so that it has seen all potential targets
+#    satisfying a header even if we only dwyu on a pattern deep
+#    inside.
+#  * use --bracket-include=ignore as xlscc provides headers
+#    that look exactly like system headers, and we don't want
+#    to consider them as potential reason to depend on.
+#    (//xls/contrib/xlscc:synth_only provides
+#    //xls/contrib/xlscc:synth_only_headers)
+"${BANT}" dwyu --graph-augment=... --bracket-include=ignore "$@"
 
 BANT_EXIT=$?
 if [ ${BANT_EXIT} -eq ${BANT_EXIT_ON_DWYU_ISSUES} ]; then


### PR DESCRIPTION
 * In the compilation db, we now can use built-in features of bant to grep and select columns without having to resort to awk; less system dependencies.
 * For the build-cleaner, tell bant to entirely ignore angle-bracket includes (we have all our vendored includes in double-quotes already, but we also don't want to have system headers that look like they are provided by xlscc be considered).
 * For build-cleaner: also build the internal dependencies starting from root, even if we only have a more narrow pattern to dwyu selected.