### PR TITLE
Fix omitting SystemVerilog type when copying input/output ports in `Block::Clone()`

### DIFF
--- a/xls/codegen_v_1_5/block_conversion_pass_pipeline_test.cc
+++ b/xls/codegen_v_1_5/block_conversion_pass_pipeline_test.cc
@@ -553,6 +553,80 @@ proc my_proc(my_state: (), init={()}) {
               m::OutputPort("out", m::Neg(m::InputPort("in"))));
 }
 
+TEST_F(BlockConversionTest, SimpleProcWithSystemVerilogTypes) {
+  const std::string ir_text = R"(package test
+
+chan in(bits[32], id=0, kind=single_value, ops=receive_only)
+chan out(bits[32], id=1, kind=single_value, ops=send_only)
+
+proc my_proc(my_state: (), init={()}) {
+  my_token: token = literal(value=token, id=1)
+  rcv: (token, bits[32]) = receive(my_token, channel=in)
+  data: bits[32] = tuple_index(rcv, index=1)
+  negate: bits[32] = neg(data)
+  rcv_token: token = tuple_index(rcv, index=0)
+  send: token = send(rcv_token, negate, channel=out)
+  next_my_state: () = next_value(param=my_state, value=my_state)
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> package,
+                           Parser::ParsePackage(ir_text));
+
+  const std::string ir_interface_text = R"(name: "test"
+files: "test.x"
+channels {
+  name: "in"
+  type {
+    type_enum: TUPLE
+    tuple_elements {
+      type_enum: BITS
+      bit_count: 32
+    }
+  }
+  direction: IN
+  sv_type: "Request"
+}
+channels {
+  name: "out"
+  type {
+    type_enum: TUPLE
+    tuple_elements {
+      type_enum: BITS
+      bit_count: 32
+    }
+  }
+  direction: OUT
+  sv_type: "Data"
+}
+procs {
+  base {
+    top: true
+    name: "my_proc"
+  }
+  state {
+    name: "my_state"
+    type {
+      type_enum: TUPLE
+    }
+  }
+}
+)";
+
+  PackageInterfaceProto proto;
+  google::protobuf::TextFormat::ParseFromString(ir_interface_text, &proto);
+
+  XLS_ASSERT_OK_AND_ASSIGN(Proc * proc, package->GetProc("my_proc"));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      Block * block,
+      ConvertToBlock(proc, codegen_options().package_interface(proto),
+                     SchedulingOptions().pipeline_stages(1)));
+
+  XLS_ASSERT_OK_AND_ASSIGN(InputPort* req, block->GetInputPort("in"));
+  EXPECT_EQ(req->system_verilog_type(), "Request");
+  XLS_ASSERT_OK_AND_ASSIGN(OutputPort* resp, block->GetOutputPort("out"));
+  EXPECT_EQ(resp->system_verilog_type(), "Data");
+}
+
 TEST_F(BlockConversionTest, StreamingChannelMetadataForSimpleProc) {
   Package package(TestName());
   Type* u32 = package.GetBitsType(32);

--- a/xls/codegen_v_1_5/block_finalization_pass_test.cc
+++ b/xls/codegen_v_1_5/block_finalization_pass_test.cc
@@ -66,6 +66,7 @@ TEST_F(BlockFinalizationPassTest, BasicScheduledBlock) {
   BValue in = sbb.InputPort("in", p->GetBitsType(32));
   XLS_ASSERT_OK_AND_ASSIGN(Register * data_reg,
                            sblk->AddRegister("data_reg", p->GetBitsType(32)));
+  in.node()->As<InputPort>()->set_system_verilog_type("my_type");
 
   BValue iv0 = sbb.Literal(UBits(1, 1));
   BValue or0 = sbb.Literal(UBits(1, 1));
@@ -82,7 +83,8 @@ TEST_F(BlockFinalizationPassTest, BasicScheduledBlock) {
   BValue neg1 =
       sbb.Subtract(sbb.Literal(UBits(0, 32), SourceInfo(), "neg_zero"), add0);
   sbb.RegisterWrite(data_reg, neg1);
-  sbb.OutputPort("out", neg1);
+  BValue out = sbb.OutputPort("out", neg1);
+  out.node()->As<OutputPort>()->set_system_verilog_type("my_type");
   BValue aiv1 = sbb.Literal(UBits(1, 1));
   BValue ov1 = sbb.Literal(UBits(1, 1));
   sbb.EndStage(aiv1, ov1);
@@ -105,10 +107,14 @@ TEST_F(BlockFinalizationPassTest, BasicScheduledBlock) {
   EXPECT_EQ(block->node_count(), node_count_before);
   ASSERT_TRUE(block->GetClockPort().has_value());
   EXPECT_EQ(block->GetClockPort()->name, "clk");
-  EXPECT_EQ(block->GetInputPort("in").value()->direction(),
-            PortDirection::kInput);
-  EXPECT_EQ(block->GetOutputPort("out").value()->direction(),
-            PortDirection::kOutput);
+
+  XLS_ASSERT_OK_AND_ASSIGN(InputPort* input_port, block->GetInputPort("in"));
+  EXPECT_EQ(input_port->direction(), PortDirection::kInput);
+  EXPECT_EQ(input_port->system_verilog_type(), "my_type");
+  XLS_ASSERT_OK_AND_ASSIGN(OutputPort* output_port,
+                           block->GetOutputPort("out"));
+  EXPECT_EQ(output_port->direction(), PortDirection::kOutput);
+  EXPECT_EQ(output_port->system_verilog_type(), "my_type");
   EXPECT_TRUE(block->GetRegister("data_reg").ok());
 
   EXPECT_THAT(p->blocks(),

--- a/xls/ir/block.cc
+++ b/xls/ir/block.cc
@@ -1275,11 +1275,15 @@ absl::StatusOr<Block*> Block::Clone(
       XLS_ASSIGN_OR_RETURN(
           original_to_clone[node],
           cloned_block->AddInputPort(src->name(), mapped_type, src->loc()));
+      original_to_clone[node]->As<InputPort>()->set_system_verilog_type(
+          src->system_verilog_type());
     } else if (node->Is<OutputPort>()) {
       OutputPort* src = node->As<OutputPort>();
       XLS_ASSIGN_OR_RETURN(original_to_clone[node],
                            cloned_block->AddOutputPort(
                                src->name(), cloned_operands[0], src->loc()));
+      original_to_clone[node]->As<OutputPort>()->set_system_verilog_type(
+          src->system_verilog_type());
     } else if (node->Is<RegisterRead>()) {
       RegisterRead* src = node->As<RegisterRead>();
       XLS_ASSIGN_OR_RETURN(


### PR DESCRIPTION
This pull request fixes a missing copy of input/output port's system verilog type when cloning an IR block. I've added two regression tests ensuring SystemVerilog type variable value will be properly handled when running block conversion passes.