### PR TITLE
Fixed bug where formatter adds comma to empty tuple with comment

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -1551,9 +1551,14 @@ DocRef Formatter::FormatTuple(const XlsTuple& n) {
   // Append comments between the last element and the end of the tuple
   if (std::optional<DocRef> terminal_comment = FormatCommentsBetween(
           last_tuple_element_span_limit, tuple_span.limit(), nullptr)) {
-    // Add trailing comma before the terminal comment too.
-    guts = ConcatN(arena_, {guts, arena_.comma(), arena_.space(),
-                            terminal_comment.value()});
+    if (n.empty()) {
+      // Edge case: comment inside empty tuple. Don't add comma here.
+      guts = ConcatN(arena_, {guts, terminal_comment.value()});
+    } else {
+      // Add trailing comma before the terminal comment too.
+      guts = ConcatN(arena_, {guts, arena_.comma(), arena_.space(),
+                              terminal_comment.value()});
+    }
   } else if (n.members().size() == 1) {
     // No trailing comment, but add a comma if it's a singleton.
     guts = ConcatN(arena_, {guts, arena_.comma()});

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -1438,6 +1438,16 @@ TEST_F(FunctionFmtTest, SingletonTupleWithLeadingComment) {
   EXPECT_EQ(got, expected);
 }
 
+TEST_F(FunctionFmtTest, EmptyTupleWithComment) {
+  const std::string_view original = R"(fn foo() {
+    let a = (
+        // just a comment
+    );
+})";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string got, DoFmt(original));
+  EXPECT_EQ(got, original);
+}
+
 TEST_F(FunctionFmtTest, FunctionWithLambda) {
   const std::string_view original =
       R"(fn f() -> u32 { (|i, j| -> u32 { i + j + u32:2 })(u32:0, u32:1) })";


### PR DESCRIPTION
This is a very small PR that closes #4676. Empty tuples containing comments no longer have commas added inside them. This is solved by adding a conditional inside the terminal comment check, which checks if the tuple is empty or not.