### PR TITLE
dslx: preserve global constant bindings when cloning modules

### DIFF
--- a/xls/dslx/frontend/ast_cloner.cc
+++ b/xls/dslx/frontend/ast_cloner.cc
@@ -295,10 +295,13 @@ class AstCloner : public AstNodeVisitor {
       new_type_annotation = absl::down_cast<TypeAnnotation*>(
           old_to_new_.at(n->type_annotation()));
     }
-    old_to_new_[n] = module(n)->Make<ConstantDef>(
-        n->span(), absl::down_cast<NameDef*>(old_to_new_.at(n->name_def())),
-        new_type_annotation, absl::down_cast<Expr*>(old_to_new_.at(n->value())),
-        n->is_public());
+    NameDef* new_name_def =
+        absl::down_cast<NameDef*>(old_to_new_.at(n->name_def()));
+    ConstantDef* new_constant = module(n)->Make<ConstantDef>(
+        n->span(), new_name_def, new_type_annotation,
+        absl::down_cast<Expr*>(old_to_new_.at(n->value())), n->is_public());
+    new_name_def->set_definer(new_constant);
+    old_to_new_[n] = new_constant;
     return absl::OkStatus();
   }
 

--- a/xls/dslx/frontend/ast_cloner_test.cc
+++ b/xls/dslx/frontend/ast_cloner_test.cc
@@ -2376,6 +2376,37 @@ fn foo(a: u32, b: u32) -> u32 {
   }
 }
 
+TEST(AstClonerTest, ConstantSetsNameDefDefinerOnClone) {
+  constexpr std::string_view kProgram = R"(
+const ANSWER = u32:42;
+
+fn read() -> u32 {
+  ANSWER
+}
+)";
+
+  FileTable file_table;
+  XLS_ASSERT_OK_AND_ASSIGN(auto module, ParseModule(kProgram, "constant.x",
+                                                    "the_module", file_table));
+  XLS_ASSERT_OK_AND_ASSIGN(ConstantDef * original,
+                           module->GetConstantDef("ANSWER"));
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Module> clone,
+                           CloneModule(*module.get()));
+  XLS_ASSERT_OK_AND_ASSIGN(ConstantDef * cloned,
+                           clone->GetConstantDef("ANSWER"));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * read,
+                           clone->GetMemberOrError<Function>("read"));
+
+  EXPECT_NE(cloned->name_def(), original->name_def());
+  EXPECT_EQ(cloned->name_def()->definer(), cloned);
+
+  std::optional<NameRef*> reference = FindFirstNameRefWithId(read, "ANSWER");
+  ASSERT_TRUE(reference.has_value());
+  ASSERT_TRUE(std::holds_alternative<const NameDef*>((*reference)->name_def()));
+  EXPECT_EQ(std::get<const NameDef*>((*reference)->name_def()),
+            cloned->name_def());
+}
+
 TEST(AstClonerTest, ImportSetsNameDefDefinerOnClone) {
   constexpr std::string_view kImportedProgram =
       "pub const PLACEHOLDER = u32:0;";


### PR DESCRIPTION
## Summary

- Preserve the owning definition of constants when cloning DSLX modules.
- Add a regression covering both cloned definitions and references.

## Problem

For a module such as:

```dslx
const ANSWER = u32:42;

fn read() -> u32 {
  ANSWER
}
```

`AstCloner::HandleConstantDef` creates the cloned constant's name before its
owning definition. It never connects that name back to the new definition,
leaving `cloned_constant->name_def()->definer()` null even though references
point to the cloned name.

Connect the cloned name to its cloned constant after creating both objects.
The existing constant reference continues to point to that same cloned name.

## Tests

The new regression first failed because the cloned name had a null definer and
then passed with the production fix. The complete
`//xls/dslx/frontend:ast_cloner_test` target passed on the equivalent merged
producer change, together with relevant DSLX typechecking suites.

Current upstream `main` cannot start an ordinary Bazel build because its
`rules_hdl` patch targets a missing file; the same failure is already present
in [upstream main CI](https://github.com/google/xls/actions/runs/31119392836).
No unrelated dependency or build-configuration changes are included here.
