### PR TITLE
dslx: reject duplicate match alternatives

### DIFF
--- a/xls/dslx/tests/errors/duplicate_enum_match_arm.x
+++ b/xls/dslx/tests/errors/duplicate_enum_match_arm.x
@@ -1,0 +1,23 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+enum Example: u2 { A = 0, B = 1, C = 2 }
+
+fn main(value: Example) -> u32 {
+  match value {
+    Example::A => u32:0,
+    Example::B | Example::A => u32:1,
+    Example::C => u32:2,
+  }
+}

--- a/xls/dslx/tests/errors/error_modules_test.py
+++ b/xls/dslx/tests/errors/error_modules_test.py
@@ -540,6 +540,18 @@ class ImportModuleWithTypeErrorTest(parameterized.TestCase):
     self.assertIn('duplicate_match_arm.x:22:5-22:8', stderr)
     self.assertIn('Exact-duplicate pattern match detected `FOO`', stderr)
 
+  def test_duplicate_enum_match_arm(self):
+    stderr = self._run(
+        'xls/dslx/tests/errors/duplicate_enum_match_arm.x',
+    )
+    self.assertIn('duplicate_enum_match_arm.x:19:5-19:15', stderr)
+    self.assertIn('duplicate_enum_match_arm.x:20:18-20:28', stderr)
+    self.assertIn('Exact-duplicate pattern match detected `Example::A`', stderr)
+    self.assertIn(
+        'previously @ xls/dslx/tests/errors/duplicate_enum_match_arm.x:19:5-19:15',
+        stderr,
+    )
+
   def test_trace_fmt_empty_err(self):
     stderr = self._run(
         'xls/dslx/tests/errors/trace_fmt_empty.x',

--- a/xls/dslx/type_system_v2/BUILD
+++ b/xls/dslx/type_system_v2/BUILD
@@ -535,6 +535,7 @@ cc_library(
         "//xls/dslx:errors",
         "//xls/dslx:import_data",
         "//xls/dslx:import_routines",
+        "//xls/dslx:status_payload_utils",
         "//xls/dslx/frontend:ast",
         "//xls/dslx/frontend:ast_cloner",
         "//xls/dslx/frontend:ast_node",

--- a/xls/dslx/type_system_v2/populate_table_visitor.cc
+++ b/xls/dslx/type_system_v2/populate_table_visitor.cc
@@ -54,6 +54,7 @@
 #include "xls/dslx/frontend/pos.h"
 #include "xls/dslx/import_data.h"
 #include "xls/dslx/import_routines.h"
+#include "xls/dslx/status_payload_utils.h"
 #include "xls/dslx/type_system/deduce_utils.h"
 #include "xls/dslx/type_system_v2/import_utils.h"
 #include "xls/dslx/type_system_v2/inference_table.h"
@@ -601,19 +602,31 @@ class PopulateInferenceTableVisitor : public PopulateTableVisitor,
                                       file_table_);
     }
 
+    auto duplicate_pattern_error = [this](const Span& original_span,
+                                          const Span& duplicate_span,
+                                          std::string_view pattern) {
+      absl::Status status = TypeInferenceErrorStatus(
+          duplicate_span, /*type=*/nullptr,
+          absl::StrFormat(
+              "Exact-duplicate pattern match detected `%s`; "
+              "only the first could possibly match; previously @ %s",
+              pattern, original_span.ToString(file_table_)),
+          file_table_);
+      AddSpanToStatusPayload(status, duplicate_span, import_data_.file_table());
+      AddSpanToStatusPayload(status, original_span, import_data_.file_table());
+      return status;
+    };
+
     std::vector<TypeAnnotation*> type_annotation_members;
-    absl::flat_hash_set<std::string> seen_patterns;
+    absl::flat_hash_map<std::string, const MatchArm*> seen_arms;
+    absl::flat_hash_map<std::string, Span> seen_patterns;
     for (MatchArm* arm : node->arms()) {
       // Identify syntactically identical match arms.
       std::string patterns_string = PatternsToString(arm);
-      if (auto [it, inserted] = seen_patterns.insert(patterns_string);
+      if (auto [it, inserted] = seen_arms.try_emplace(patterns_string, arm);
           !inserted) {
-        return TypeInferenceErrorStatus(
-            arm->GetPatternSpan(), nullptr,
-            absl::StrFormat("Exact-duplicate pattern match detected `%s`; only "
-                            "the first could possibly match",
-                            patterns_string),
-            file_table_);
+        return duplicate_pattern_error(it->second->GetPatternSpan(),
+                                       arm->GetPatternSpan(), patterns_string);
       }
 
       if (node->IsConst()) {
@@ -631,6 +644,13 @@ class PopulateInferenceTableVisitor : public PopulateTableVisitor,
       }
 
       for (const PatternTree& pattern : arm->patterns()) {
+        if (auto [it, inserted] = seen_patterns.try_emplace(
+                PatternToString(pattern), GetPatternSpan(pattern));
+            !inserted) {
+          return duplicate_pattern_error(it->second, GetPatternSpan(pattern),
+                                         it->first);
+        }
+
         XLS_RETURN_IF_ERROR(
             table_.SetTypeVariable(ToAstNode(pattern), matched_var));
       }

--- a/xls/dslx/type_system_v2/typecheck_module_v2_control_flow_test.cc
+++ b/xls/dslx/type_system_v2/typecheck_module_v2_control_flow_test.cc
@@ -866,7 +866,7 @@ const Z:u31 = match X {
 }
 
 TEST(TypecheckV2Test, MatchArmDuplicated) {
-  EXPECT_THAT(R"(
+  constexpr std::string_view kProgram = R"(
 const X = u32:1;
 const Y = u32:2;
 const Z = match X {
@@ -875,9 +875,74 @@ const Z = match X {
   u32:1 => Y,
   _ => Y
 };
+)";
+
+  EXPECT_THAT(
+      kProgram,
+      TypecheckFailsWithPayload(
+          AllOf(HasSubstr("Exact-duplicate pattern match detected `u32:1`"),
+                HasSubstr("previously @ fake.x:7:3-7:8")),
+          AllOf(HasSpan(6, 2, 6, 7), HasSpan(8, 2, 8, 7))));
+}
+
+TEST(TypecheckV2Test, MatchEnumVariantDuplicatedAcrossAlternativeArms) {
+  constexpr std::string_view kProgram = R"(
+enum E: u2 {
+  A = 0,
+  B = 1,
+  C = 2,
+}
+
+fn f(value: E) -> u32 {
+  match value {
+    E::A => u32:0,
+    E::B | E::A => u32:1,
+    E::C => u32:2,
+  }
+}
+)";
+
+  EXPECT_THAT(
+      kProgram,
+      TypecheckFailsWithPayload(
+          AllOf(HasSubstr("Exact-duplicate pattern match detected `E::A`"),
+                HasSubstr("previously @ fake.x:12:5-12:9")),
+          AllOf(HasSpan(11, 4, 11, 8), HasSpan(12, 11, 12, 15))));
+}
+
+// `E::A` and `Alias::A` denote the same enum member when `type Alias = E`.
+// Accepting both match arms is a bug: the later arm can never run, but the
+// duplicate check compares their different source spellings and misses it.
+// TODO(dank): Resolve each pattern to its enum member before comparing
+// identities, then enable this regression.
+TEST(TypecheckV2Test, DISABLED_MatchEnumVariantDuplicatedThroughTypeAlias) {
+  EXPECT_THAT(
+      R"(
+enum E: u2 { A = 0, B = 1 }
+type Alias = E;
+
+fn f(value: E) -> u32 {
+  match value {
+    E::A => u32:0,
+    Alias::A => u32:1,
+    E::B => u32:2,
+  }
+}
 )",
-              TypecheckFails(
-                  HasSubstr("Exact-duplicate pattern match detected `u32:1`")));
+      TypecheckFails(HasSubstr("Exact-duplicate pattern match detected")));
+}
+
+TEST(TypecheckV2Test, MatchEnumVariantAlternativesRemainValid) {
+  XLS_EXPECT_OK(TypecheckV2(R"(
+enum E: u2 { A = 0, B = 1, C = 2 }
+
+fn f(value: E) -> u32 {
+  match value {
+    E::A => u32:0,
+    E::B | E::C => u32:1,
+  }
+}
+)"));
 }
 
 TEST(TypecheckV2Test, MatchNonExhaustive) {


### PR DESCRIPTION
## Summary

- Reject duplicate DSLX match patterns inside grouped `|` alternatives.
- Point to both the original match pattern and its unreachable duplicate.
- Preserve valid grouped alternatives and existing duplicate-arm checks.

## Problem

DSLX currently accepts this unreachable second `E::A` pattern:

```dslx
match value {
  E::A => u32:0,
  E::B | E::A => u32:1,
  E::C => u32:2,
}
```

The compiler compares entire match arms, so it misses a repeated pattern nested
inside another arm's alternatives. Track the individual alternatives as well,
and report both occurrences when one repeats.

Programs containing exact duplicate alternatives now intentionally fail
compilation. Valid grouped alternatives continue to compile.

The separate pre-existing enum-alias spelling case remains documented by a
disabled regression and is not fixed by this change.

## Tests

The equivalent merged producer change passed:

- `//xls/dslx/type_system_v2:typecheck_module_v2_control_flow_test`
- `//xls/dslx/exhaustiveness:exhaustiveness_match_test`
- `//xls/dslx/type_system:typecheck_module_test`

The added diagnostic fixture is owned by
`//xls/dslx/tests/errors:error_modules_test`.

Current upstream `main` cannot start an ordinary Bazel build because its
`rules_hdl` patch targets a missing file; the same failure is already present
in [upstream main CI](https://github.com/google/xls/actions/runs/31119392836).
No unrelated dependency or build-configuration changes are included here.
