### PR TITLE
Fixed empty function formatting error

### DIFF
--- a/xls/dslx/fmt/ast_fmt.cc
+++ b/xls/dslx/fmt/ast_fmt.cc
@@ -2287,6 +2287,12 @@ DocRef Formatter::FormatFunction(const Function& n, bool is_test) {
       fn_pieces.push_back(FormatBlock(
           *n.body(), FormatBlockOptions{.add_curls = false,
                                         .force_multiline = force_multiline}));
+
+      // Add hard line before closing parentheses if empty function has
+      // comments.
+      if (comments_.HasComments(n.body()->span())) {
+        fn_pieces.push_back(arena_.hard_line());
+      }
       fn_pieces.push_back(arena_.ccurl());
     } else {
       // For non-empty functions, we break after the signature and before

--- a/xls/dslx/fmt/ast_fmt_test.cc
+++ b/xls/dslx/fmt/ast_fmt_test.cc
@@ -392,6 +392,14 @@ TEST_F(FunctionFmtTest, FormatEmptyFn) {
   EXPECT_EQ(got, "fn f() {}");
 }
 
+// A function whose body contains only a comment must still emit a line
+// break before the closing curl.
+TEST_F(FunctionFmtTest, FormatCommentOnlyFnBody) {
+  const std::string_view original = "fn f(){//bar\n}";
+  XLS_ASSERT_OK_AND_ASSIGN(std::string got, DoFmt(original));
+  EXPECT_EQ(got, "fn f() {\n    //bar\n}");
+}
+
 TEST_F(FunctionFmtTest, LogicalOrLhsForArrayIndex) {
   const std::string_view original = "fn f(a: u32, b: u32){(a||b)[3]}";
   XLS_ASSERT_OK_AND_ASSIGN(std::string got, DoFmt(original));


### PR DESCRIPTION
A very small PR that aims to close #2377. It's fairly self-explanatory - the added code just checks if the empty function contains any comments; if so, then it adds a hard line before the closing curly braces. I believe this should always be correct, since emitted comment docs never have trailing hard lines, per the comment on lines 66-69.

Happy to answer any questions!