### PR TITLE
Preserve source locations in optimization passes

### DIFF
--- a/xls/codegen/vast/vast.cc
+++ b/xls/codegen/vast/vast.cc
@@ -548,6 +548,7 @@ std::string VerilogFile::Emit(LineInfo* line_info) const {
         [=](auto* m) {
           std::string pre_emit = m->PreEmit(line_info);
           if (!pre_emit.empty()) {
+            LineInfoIncrease(line_info, 1);
             return pre_emit + "\n" + m->Emit(line_info);
           }
           return m->Emit(line_info);
@@ -585,6 +586,7 @@ std::string CaseArm::Emit(LineInfo* line_info) const {
       Visitor{[=](Expression* named) {
                 std::string pre_emit = named->PreEmit(line_info);
                 if (!pre_emit.empty()) {
+                  LineInfoIncrease(line_info, 1);
                   return pre_emit + "\n" + named->Emit(line_info);
                 }
                 return named->Emit(line_info);
@@ -610,6 +612,7 @@ std::string StatementBlock::Emit(LineInfo* line_info) const {
     std::string pre_emit = statement->PreEmit(line_info);
     if (!pre_emit.empty()) {
       lines.push_back(pre_emit);
+      LineInfoIncrease(line_info, 1);
     }
     lines.push_back(statement->Emit(line_info));
     LineInfoIncrease(line_info, 1);
@@ -665,6 +668,7 @@ std::string MacroStatementBlock::Emit(LineInfo* line_info) const {
     std::string pre_emit = statement->PreEmit(line_info);
     if (!pre_emit.empty()) {
       absl::StrAppend(&result, Indent(pre_emit), "\n");
+      LineInfoIncrease(line_info, 1);
     }
     absl::StrAppend(&result, Indent(statement->Emit(line_info)), "\n");
     LineInfoIncrease(line_info, 1);
@@ -796,6 +800,7 @@ std::string VerilogFunction::Emit(LineInfo* line_info) const {
     std::string pre_emit = reg_def->PreEmit(line_info);
     if (!pre_emit.empty()) {
       lines.push_back(pre_emit);
+      LineInfoIncrease(line_info, 1);
     }
     lines.push_back(reg_def->Emit(line_info));
     LineInfoIncrease(line_info, 1);
@@ -1344,6 +1349,7 @@ std::string EmitModuleMember(LineInfo* line_info, const ModuleMember& member) {
       [=](auto* d) {
         std::string pre_emit = d->PreEmit(line_info);
         if (!pre_emit.empty()) {
+          LineInfoIncrease(line_info, 1);
           return pre_emit + "\n" + d->Emit(line_info);
         }
         return d->Emit(line_info);

--- a/xls/codegen/vast/vast_test.cc
+++ b/xls/codegen/vast/vast_test.cc
@@ -1326,6 +1326,55 @@ TEST_P(VastTest, SrcAttributeAnnotations) {
 endmodule)");
 }
 
+TEST_P(VastTest, MultiLocationCommentAnnotations) {
+  absl::flat_hash_map<Fileno, std::string> filemap = {
+      {Fileno(0), std::string("test.x")}};
+  VerilogFile f(GetFileType(), AnnotationType::kComment, filemap);
+
+  Module* m = f.AddModule("top", SourceInfo());
+  SourceInfo multi(std::vector<SourceLocation>{
+      SourceLocation(Fileno(0), Lineno(1), Colno(1)),
+      SourceLocation(Fileno(0), Lineno(2), Colno(3))});
+  XLS_ASSERT_OK(m->AddReg("a", f.BitVectorType(8, SourceInfo()), multi));
+
+  EXPECT_EQ(m->Emit(/*line_info=*/nullptr),
+            R"(module top;
+  // test.x:1:1 test.x:2:3
+  reg [7:0] a;
+endmodule)");
+}
+
+TEST_P(VastTest, MultiLocationCommentAnnotationsLineInfo) {
+  absl::flat_hash_map<Fileno, std::string> filemap = {
+      {Fileno(0), std::string("test.x")}};
+  VerilogFile f(GetFileType(), AnnotationType::kComment, filemap);
+
+  Module* m = f.AddModule("top", SourceInfo());
+  SourceInfo multi(std::vector<SourceLocation>{
+      SourceLocation(Fileno(0), Lineno(1), Colno(1)),
+      SourceLocation(Fileno(0), Lineno(2), Colno(3))});
+  XLS_ASSERT_OK_AND_ASSIGN(
+      LogicRef * a, m->AddReg("a", f.BitVectorType(8, SourceInfo()), multi));
+  XLS_ASSERT_OK_AND_ASSIGN(
+      LogicRef * b,
+      m->AddReg("b", f.BitVectorType(8, SourceInfo()), SourceInfo()));
+
+  LineInfo line_info;
+  EXPECT_EQ(f.Emit(&line_info),
+            R"(module top;
+  // test.x:1:1 test.x:2:3
+  reg [7:0] a;
+  reg [7:0] b;
+endmodule
+)");
+  EXPECT_EQ(line_info.LookupNode(a->def()).value(),
+            std::vector<LineSpan>{LineSpan(2, 2)});
+  EXPECT_EQ(line_info.LookupNode(b->def()).value(),
+            std::vector<LineSpan>{LineSpan(3, 3)});
+  EXPECT_EQ(line_info.LookupNode(m).value(),
+            std::vector<LineSpan>{LineSpan(0, 4)});
+}
+
 TEST_P(VastTest, DirectiveAnnotations) {
   absl::flat_hash_map<Fileno, std::string> filemap = {
       {Fileno(0), std::string("test.x")},

--- a/xls/codegen/verilog_conversion_test.cc
+++ b/xls/codegen/verilog_conversion_test.cc
@@ -173,6 +173,21 @@ class VerilogConversionTest : public VerilogTestBase {
     return bb.Build();
   }
 
+  // Make and return a block which ANDs two u32 numbers with source location
+  absl::StatusOr<Block*> MakeAnnotationTestBlock(std::string_view name,
+                                                 Package* package) {
+    package->SetFileno(Fileno(0), "test.x");
+    Type* u32 = package->GetBitsType(32);
+    BlockBuilder bb(name, package);
+    BValue a = bb.InputPort("a", u32);
+    BValue b = bb.InputPort("b", u32);
+    SourceInfo multi(std::vector<SourceLocation>{
+        SourceLocation(Fileno(0), Lineno(1), Colno(1)),
+        SourceLocation(Fileno(0), Lineno(2), Colno(3))});
+    bb.OutputPort("sum", bb.And(a, b, multi));
+    return bb.Build();
+  }
+
   absl::StatusOr<CodegenResult> MakeMultiProc(FifoConfig fifo_config,
                                               uint64_t data_width) {
     Package package(TestName());
@@ -2528,6 +2543,53 @@ INSTANTIATE_TEST_SUITE_P(
                          // output flopping
                          testing::ValuesIn(kFloppingParams))),
     ParameterizedTestNameWithFlopping<ZeroWidthVerilogConversionTest>);
+
+TEST_P(VerilogConversionTest, StrategyNoneEmitsNoAnnotations) {
+  Package package(TestBaseName());
+  XLS_ASSERT_OK_AND_ASSIGN(Block * block,
+                           MakeAnnotationTestBlock(TestBaseName(), &package));
+
+  CodegenOptions options = codegen_options();
+  options.source_annotation_strategy(
+      CodegenOptions::SourceAnnotationStrategy::kNone);
+  XLS_ASSERT_OK_AND_ASSIGN(std::string verilog,
+                           GenerateVerilog(block, options));
+
+  EXPECT_THAT(verilog, testing::Not(testing::HasSubstr("test.x")));
+}
+
+TEST_P(VerilogConversionTest, StrategyCommentEmitsLocationComments) {
+  Package package(TestBaseName());
+  XLS_ASSERT_OK_AND_ASSIGN(Block * block,
+                           MakeAnnotationTestBlock(TestBaseName(), &package));
+
+  CodegenOptions options = codegen_options();
+  options.source_annotation_strategy(
+      CodegenOptions::SourceAnnotationStrategy::kComment);
+  XLS_ASSERT_OK_AND_ASSIGN(std::string verilog,
+                           GenerateVerilog(block, options));
+
+  EXPECT_THAT(verilog,
+              testing::HasSubstr("// test.x:1:1 test.x:2:3"));
+}
+
+TEST_P(VerilogConversionTest, StrategyLineDirectiveEmitsLineDirectives) {
+  Package package(TestBaseName());
+  XLS_ASSERT_OK_AND_ASSIGN(Block * block,
+                           MakeAnnotationTestBlock(TestBaseName(), &package));
+
+  CodegenOptions options = codegen_options();
+  options.source_annotation_strategy(
+      CodegenOptions::SourceAnnotationStrategy::kLineDirective);
+  XLS_ASSERT_OK_AND_ASSIGN(std::string verilog,
+                           GenerateVerilog(block, options));
+
+  if (UseSystemVerilog()) {
+    EXPECT_THAT(verilog, testing::HasSubstr("`line 1 \"test.x\" 0"));
+  } else {
+    EXPECT_THAT(verilog, testing::Not(testing::HasSubstr("test.x")));
+  }
+}
 
 }  // namespace
 }  // namespace verilog

--- a/xls/ir/node_util.cc
+++ b/xls/ir/node_util.cc
@@ -87,6 +87,18 @@ std::vector<Node*> RemoveRedundantNodes(
 
 }  // namespace
 
+SourceInfo MergeLocs(absl::Span<Node* const> operands) {
+  SourceInfo loc;
+  for (Node* operand : operands) {
+    for (const SourceLocation& location : operand->loc().locations) {
+      if (!absl::c_linear_search(loc.locations, location)) {
+        loc.locations.push_back(location);
+      }
+    }
+  }
+  return loc;
+}
+
 bool IsLiteralWithRunOfSetBits(Node* node, int64_t* leading_zero_count,
                                int64_t* set_bit_count,
                                int64_t* trailing_zero_count) {
@@ -610,10 +622,7 @@ absl::StatusOr<Node*> JoinWithAnd(FunctionBase* f,
   }
 
   if (!loc.has_value()) {
-    loc = unique_operands.front()->loc();
-    for (Node* operand : unique_operands) {
-      loc = loc->Extend(operand->loc());
-    }
+    loc = MergeLocs(new_operands);
   }
 
   return NaryAndIfNeeded(f, unique_operands, name, *loc);
@@ -719,10 +728,7 @@ absl::StatusOr<Node*> JoinWithOr(FunctionBase* f,
   }
 
   if (!loc.has_value()) {
-    loc = operands.front()->loc();
-    for (Node* operand : operands) {
-      loc = loc->Extend(operand->loc());
-    }
+    loc = MergeLocs(new_operands);
   }
 
   return NaryOrIfNeeded(f, unique_operands, name, *loc);

--- a/xls/ir/node_util.h
+++ b/xls/ir/node_util.h
@@ -85,6 +85,9 @@ bool IsLiteralWithRunOfSetBits(Node* node, int64_t* leading_zero_count,
                                int64_t* set_bit_count,
                                int64_t* trailing_zero_count);
 
+// Merges and deduplicates every SourceLocation across `operands`.
+SourceInfo MergeLocs(absl::Span<Node* const> operands);
+
 // Returns whether node is a literal "mask" value, which is of the form:
 // 0b[0]*[1]+
 //

--- a/xls/ir/node_util_test.cc
+++ b/xls/ir/node_util_test.cc
@@ -1558,5 +1558,21 @@ TEST_F(NodeUtilTest, ReplaceWithOrWithFilter) {
   EXPECT_EQ(xor_ac_node->operand(0), replacement);
 }
 
+TEST_F(NodeUtilTest, ResolveLocMergesAndDedups) {
+  auto p = CreatePackage();
+  FunctionBuilder fb(TestName(), p.get());
+  SourceLocation loc_a(Fileno(0), Lineno(1), Colno(1));
+  SourceLocation loc_b(Fileno(0), Lineno(2), Colno(1));
+  BValue a = fb.Param("a", p->GetBitsType(32), SourceInfo(loc_a));
+  BValue b = fb.Param("b", p->GetBitsType(32), SourceInfo(loc_b));
+  BValue c = fb.Param("c", p->GetBitsType(32), SourceInfo(loc_a));
+  XLS_ASSERT_OK(fb.Build().status());
+
+  SourceInfo resolved = MergeLocs({a.node(), b.node(), c.node()});
+  ASSERT_EQ(resolved.locations.size(), 2);
+  EXPECT_EQ(resolved.locations[0].ToString(), loc_a.ToString());
+  EXPECT_EQ(resolved.locations[1].ToString(), loc_b.ToString());
+}
+
 }  // namespace
 }  // namespace xls

--- a/xls/ir/source_location.h
+++ b/xls/ir/source_location.h
@@ -48,6 +48,8 @@ class SourceLocation {
                            colno_.value());
   }
 
+  bool operator==(const SourceLocation& other) const = default;
+
   std::strong_ordering operator<=>(const SourceLocation& other) const {
     if (fileno_ != other.fileno_) {
       return fileno_.value() <=> other.fileno_.value();

--- a/xls/passes/BUILD
+++ b/xls/passes/BUILD
@@ -950,6 +950,7 @@ xls_pass(
         "//xls/common/status:ret_check",
         "//xls/common/status:status_macros",
         "//xls/ir",
+        "//xls/ir:node_util",
         "//xls/ir:op",
         "//xls/ir:source_location",
         "//xls/ir:type",

--- a/xls/passes/array_simplification_pass.cc
+++ b/xls/passes/array_simplification_pass.cc
@@ -272,7 +272,7 @@ absl::StatusOr<SimplifyResult> SimplifyArrayIndex(
       const int64_t operand_no = i + ArrayIndex::kIndexOperandStart;
       XLS_ASSIGN_OR_RETURN(Node * zero,
                            array_index->function_base()->MakeNode<Literal>(
-                               SourceInfo(), Value(UBits(0, 1))));
+                               index->loc(), Value(UBits(0, 1))));
       XLS_RETURN_IF_ERROR(array_index->ReplaceOperandNumber(
           operand_no, zero, /*type_must_match=*/false));
     }
@@ -728,8 +728,9 @@ absl::StatusOr<SimplifyResult> SimplifyArrayUpdate(
     if (remaining_indices.empty()) {
       updated_value = array_update->update_value();
     } else {
-      XLS_ASSIGN_OR_RETURN(Node * zero, func->MakeNode<Literal>(
-                                            SourceInfo(), Value(UBits(0, 1))));
+      XLS_ASSIGN_OR_RETURN(
+          Node * zero,
+          func->MakeNode<Literal>(array_update->loc(), Value(UBits(0, 1))));
       XLS_ASSIGN_OR_RETURN(
           Node * remaining_array,
           array_update->function_base()->MakeNode<ArrayIndex>(

--- a/xls/passes/bit_slice_simplification_pass.cc
+++ b/xls/passes/bit_slice_simplification_pass.cc
@@ -102,7 +102,8 @@ absl::StatusOr<std::optional<Node*>> GetUnscaledIndex(
     XLS_ASSIGN_OR_RETURN(
         Node * unscaled_index,
         scaled_index->function_base()->MakeNode<BitSlice>(
-            SourceInfo(), scaled_index, /*start=*/bits_to_remove,
+            scaled_index->loc(), scaled_index,
+            /*start=*/bits_to_remove,
             /*width=*/scaled_index->BitCountOrDie() - bits_to_remove));
     return unscaled_index;
   }
@@ -743,7 +744,7 @@ absl::StatusOr<Node*> EquivalentStaticBitSlice(
 
   XLS_RET_CHECK(start.IsBits());
   if (bits_ops::UGreaterThanOrEqual(start.bits(), operand_width)) {
-    return to_slice->function_base()->MakeNode<Literal>(SourceInfo(),
+    return to_slice->function_base()->MakeNode<Literal>(loc,
                                                         Value(UBits(0, width)));
   }
   int64_t start_index = static_cast<int64_t>(*start.bits().ToUint64());
@@ -860,9 +861,10 @@ absl::StatusOr<bool> SimplifyScaledDynamicBitSlice(DynamicBitSlice* bit_slice,
                                bit_slice->loc(), bit_slice->to_slice(),
                                /*start=*/element_start,
                                /*width=*/bit_count - element_start));
-      XLS_ASSIGN_OR_RETURN(array_element,
-                           bit_slice->function_base()->MakeNode<ExtendOp>(
-                               SourceInfo(), slice, width, Op::kZeroExt));
+      XLS_ASSIGN_OR_RETURN(
+          array_element,
+          bit_slice->function_base()->MakeNode<ExtendOp>(
+              MergeLocs({bit_slice, slice}), slice, width, Op::kZeroExt));
     }
     array_elements.push_back(array_element);
   }
@@ -876,7 +878,7 @@ absl::StatusOr<bool> SimplifyScaledDynamicBitSlice(DynamicBitSlice* bit_slice,
   if (addressable_items > array_elements.size()) {
     XLS_ASSIGN_OR_RETURN(past_the_end,
                          bit_slice->function_base()->MakeNode<Literal>(
-                             SourceInfo(), Value(UBits(0, width))));
+                             bit_slice->loc(), Value(UBits(0, width))));
     addressable_items = array_elements.size();
   }
   XLS_ASSIGN_OR_RETURN(
@@ -956,9 +958,10 @@ absl::StatusOr<bool> SimplifyScaledBitSliceUpdate(BitSliceUpdate* update,
                                update->loc(), update->to_update(),
                                /*start=*/element_start,
                                /*width=*/bit_count - element_start));
-      XLS_ASSIGN_OR_RETURN(array_element,
-                           update->function_base()->MakeNode<ExtendOp>(
-                               SourceInfo(), slice, width, Op::kZeroExt));
+      XLS_ASSIGN_OR_RETURN(
+          array_element,
+          update->function_base()->MakeNode<ExtendOp>(
+              MergeLocs({update, slice}), slice, width, Op::kZeroExt));
     }
     array_elements.push_back(array_element);
   }
@@ -978,9 +981,10 @@ absl::StatusOr<bool> SimplifyScaledBitSliceUpdate(BitSliceUpdate* update,
           ? Bits::MinBitCountUnsigned(array_elements.size() - 1)
           : 1;
   for (int64_t i = 0; i < array_elements.size(); ++i) {
-    XLS_ASSIGN_OR_RETURN(Literal * element_index,
-                         array_update->function_base()->MakeNode<Literal>(
-                             SourceInfo(), Value(UBits(i, index_width))));
+    XLS_ASSIGN_OR_RETURN(
+        Literal * element_index,
+        array_update->function_base()->MakeNode<Literal>(
+            array_update->loc(), Value(UBits(i, index_width))));
     XLS_ASSIGN_OR_RETURN(Node * updated_array_element,
                          array_update->function_base()->MakeNode<ArrayIndex>(
                              array_update->loc(), array_update,
@@ -991,7 +995,9 @@ absl::StatusOr<bool> SimplifyScaledBitSliceUpdate(BitSliceUpdate* update,
       // Disregard any bits past the end of the original bit vector.
       XLS_ASSIGN_OR_RETURN(updated_array_element,
                            array_update->function_base()->MakeNode<BitSlice>(
-                               SourceInfo(), updated_array_element, /*start=*/0,
+                               MergeLocs({array_update, updated_array_element}),
+                               updated_array_element,
+                               /*start=*/0,
                                /*width=*/bit_count - (i * width)));
     }
     updated_array_elements.push_back(updated_array_element);

--- a/xls/passes/comparison_simplification_pass.cc
+++ b/xls/passes/comparison_simplification_pass.cc
@@ -404,7 +404,7 @@ absl::StatusOr<bool> ComparisonSimplificationPass::RunOnFunctionBaseInternal(
           Value(precise_value.value()).ToString(), node->ToString());
       XLS_ASSIGN_OR_RETURN(
           Literal * literal,
-          f->MakeNode<Literal>(SourceInfo(), Value(precise_value.value())));
+          f->MakeNode<Literal>(node->loc(), Value(precise_value.value())));
       XLS_RETURN_IF_ERROR(node->ReplaceUsesWithNew<CompareOp>(
                                   equivalences.at(node).node, literal, Op::kEq)
                               .status());
@@ -423,7 +423,7 @@ absl::StatusOr<bool> ComparisonSimplificationPass::RunOnFunctionBaseInternal(
           Value(precise_value.value()).ToString(), node->ToString());
       XLS_ASSIGN_OR_RETURN(
           Literal * literal,
-          f->MakeNode<Literal>(SourceInfo(), Value(precise_value.value())));
+          f->MakeNode<Literal>(node->loc(), Value(precise_value.value())));
       XLS_RETURN_IF_ERROR(node->ReplaceUsesWithNew<CompareOp>(
                                   equivalences.at(node).node, literal, Op::kNe)
                               .status());
@@ -441,7 +441,7 @@ absl::StatusOr<bool> ComparisonSimplificationPass::RunOnFunctionBaseInternal(
                                     node->ToString());
       XLS_ASSIGN_OR_RETURN(
           Literal * literal,
-          f->MakeNode<Literal>(SourceInfo(), Value(limit.value())));
+          f->MakeNode<Literal>(node->loc(), Value(limit.value())));
       XLS_RETURN_IF_ERROR(node->ReplaceUsesWithNew<CompareOp>(
                                   equivalences.at(node).node, literal, Op::kULt)
                               .status());
@@ -458,7 +458,7 @@ absl::StatusOr<bool> ComparisonSimplificationPass::RunOnFunctionBaseInternal(
                                     node->ToString());
       XLS_ASSIGN_OR_RETURN(
           Literal * literal,
-          f->MakeNode<Literal>(SourceInfo(), Value(limit.value())));
+          f->MakeNode<Literal>(node->loc(), Value(limit.value())));
       XLS_RETURN_IF_ERROR(node->ReplaceUsesWithNew<CompareOp>(
                                   equivalences.at(node).node, literal, Op::kUGt)
                               .status());

--- a/xls/passes/conditional_specialization_pass.cc
+++ b/xls/passes/conditional_specialization_pass.cc
@@ -632,26 +632,28 @@ absl::StatusOr<std::optional<Node*>> CheckMatch(
       } else {
         XLS_ASSIGN_OR_RETURN(Node * negated,
                              node->function_base()->MakeNode<UnOp>(
-                                 SourceInfo(), node, Op::kNot));
+                                 MergeLocs({user, node}), node, Op::kNot));
         return negated;
       }
     }
     XLS_ASSIGN_OR_RETURN(Node * matched_value,
                          node->function_base()->MakeNode<Literal>(
-                             SourceInfo(), Value(*precise_value)));
+                             user->loc(), Value(*precise_value)));
     XLS_ASSIGN_OR_RETURN(Node * matched_value_check,
                          node->function_base()->MakeNode<CompareOp>(
-                             SourceInfo(), node, matched_value, Op::kEq));
+                             MergeLocs({user, node, matched_value}), node,
+                             matched_value, Op::kEq));
     return matched_value_check;
   }
   if (std::optional<Bits> punctured_value = partial.GetPuncturedValue();
       punctured_value.has_value()) {
     XLS_ASSIGN_OR_RETURN(Node * punctured_literal,
                          node->function_base()->MakeNode<Literal>(
-                             SourceInfo(), Value(*punctured_value)));
+                             user->loc(), Value(*punctured_value)));
     XLS_ASSIGN_OR_RETURN(Node * punctured_value_check,
                          node->function_base()->MakeNode<CompareOp>(
-                             SourceInfo(), node, punctured_literal, Op::kNe));
+                             MergeLocs({user, node, punctured_literal}), node,
+                             punctured_literal, Op::kNe));
     return punctured_value_check;
   }
 

--- a/xls/passes/proc_state_tuple_flattening_pass.cc
+++ b/xls/passes/proc_state_tuple_flattening_pass.cc
@@ -75,7 +75,7 @@ absl::Status DecomposeNodeHelper(Node* node, std::vector<Node*>& elements) {
     for (int64_t i = 0; i < node->GetType()->AsTupleOrDie()->size(); ++i) {
       XLS_ASSIGN_OR_RETURN(
           Node * tuple_index,
-          node->function_base()->MakeNode<TupleIndex>(SourceInfo(), node, i));
+          node->function_base()->MakeNode<TupleIndex>(node->loc(), node, i));
       XLS_RETURN_IF_ERROR(DecomposeNodeHelper(tuple_index, elements));
     }
   } else {
@@ -114,7 +114,7 @@ absl::StatusOr<Node*> ComposeNodeHelper(Type* type,
                             linear_index, f));
       tuple_elements.push_back(element);
     }
-    return f->MakeNode<Tuple>(SourceInfo(), tuple_elements);
+    return f->MakeNode<Tuple>(MergeLocs(tuple_elements), tuple_elements);
   }
   return elements[linear_index++];
 }

--- a/xls/passes/select_lifting_pass.cc
+++ b/xls/passes/select_lifting_pass.cc
@@ -694,8 +694,10 @@ absl::StatusOr<bool> CheckLatencyIncrease(
                              select_to_optimize.AsNode()->loc()));
     XLS_ASSIGN_OR_RETURN(
         tmp_lifted_op,
-        func->MakeNode<ArrayIndex>(SourceInfo(), info.shared_node,
-                                   absl::Span<Node* const>{tmp_new_select}));
+        func->MakeNode<ArrayIndex>(
+            MergeLocs({select_to_optimize.AsNode(), info.shared_node,
+                       tmp_new_select}),
+            info.shared_node, absl::Span<Node* const>{tmp_new_select}));
   } else {
     Type* other_operand_type = nullptr;
     if (!info.other_operands.empty()) {
@@ -745,7 +747,9 @@ absl::StatusOr<bool> CheckLatencyIncrease(
       case Op::kShra: {
         XLS_ASSIGN_OR_RETURN(
             tmp_lifted_op,
-            func->MakeNode<BinOp>(SourceInfo(), lhs, rhs, info.lifted_op));
+            func->MakeNode<BinOp>(
+                MergeLocs({select_to_optimize.AsNode(), lhs, rhs}), lhs, rhs,
+                info.lifted_op));
         break;
       }
       case Op::kEq:
@@ -768,8 +772,9 @@ absl::StatusOr<bool> CheckLatencyIncrease(
       case Op::kXor: {
         XLS_ASSIGN_OR_RETURN(
             tmp_lifted_op,
-            func->MakeNode<NaryOp>(SourceInfo(), std::vector<Node*>{lhs, rhs},
-                                   info.lifted_op));
+            func->MakeNode<NaryOp>(
+                MergeLocs({select_to_optimize.AsNode(), lhs, rhs}),
+                std::vector<Node*>{lhs, rhs}, info.lifted_op));
         break;
       }
       case Op::kUMul:
@@ -777,7 +782,7 @@ absl::StatusOr<bool> CheckLatencyIncrease(
         XLS_ASSIGN_OR_RETURN(
             tmp_lifted_op,
             func->MakeNode<ArithOp>(
-                SourceInfo(), lhs, rhs,
+                MergeLocs({select_to_optimize.AsNode(), lhs, rhs}), lhs, rhs,
                 select_to_optimize.AsNode()->GetType()->GetFlatBitCount(),
                 info.lifted_op));
         break;
@@ -1053,8 +1058,9 @@ absl::StatusOr<TransformationResult> LiftSelectForArrayIndex(
   VLOG(3) << "    Step 1: add the new arrayIndex node";
   XLS_ASSIGN_OR_RETURN(
       Node * new_array_index,
-      func->MakeNode<ArrayIndex>(SourceInfo(), array_reference,
-                                 absl::MakeConstSpan({new_select})));
+      func->MakeNode<ArrayIndex>(
+          MergeLocs({select_to_optimize.AsNode(), array_reference, new_select}),
+          array_reference, absl::MakeConstSpan({new_select})));
 
   // Step 2: replace the uses of the original "select" node with the only
   //         exception of the new array access
@@ -1151,8 +1157,9 @@ absl::StatusOr<TransformationResult> LiftSelectForBinaryOperation(
     case Op::kShrl:
     case Op::kShra: {
       XLS_ASSIGN_OR_RETURN(
-          new_binop,
-          func->MakeNode<BinOp>(SourceInfo(), lhs, rhs, info.lifted_op));
+          new_binop, func->MakeNode<BinOp>(
+                         MergeLocs({select_to_optimize.AsNode(), lhs, rhs}),
+                         lhs, rhs, info.lifted_op));
       break;
     }
     case Op::kEq:
@@ -1174,9 +1181,9 @@ absl::StatusOr<TransformationResult> LiftSelectForBinaryOperation(
     case Op::kOr:
     case Op::kXor: {
       XLS_ASSIGN_OR_RETURN(
-          new_binop,
-          func->MakeNode<NaryOp>(SourceInfo(), std::vector<Node*>{lhs, rhs},
-                                 info.lifted_op));
+          new_binop, func->MakeNode<NaryOp>(
+                         MergeLocs({select_to_optimize.AsNode(), lhs, rhs}),
+                         std::vector<Node*>{lhs, rhs}, info.lifted_op));
       break;
     }
     case Op::kUMul:
@@ -1184,7 +1191,7 @@ absl::StatusOr<TransformationResult> LiftSelectForBinaryOperation(
       XLS_ASSIGN_OR_RETURN(
           new_binop,
           func->MakeNode<ArithOp>(
-              SourceInfo(), lhs, rhs,
+              MergeLocs({select_to_optimize.AsNode(), lhs, rhs}), lhs, rhs,
               select_to_optimize.AsNode()->GetType()->GetFlatBitCount(),
               info.lifted_op));
     } break;

--- a/xls/passes/token_dependency_pass.cc
+++ b/xls/passes/token_dependency_pass.cc
@@ -217,11 +217,12 @@ absl::StatusOr<bool> TokenDependencyPass::RunOnFunctionBaseInternal(
         if (input->GetType()->IsToken()) {
           XLS_ASSIGN_OR_RETURN(
               Node * supplying_token,
-              f->MakeNode<TupleIndex>(SourceInfo(), supplying_io, 0));
-          XLS_ASSIGN_OR_RETURN(
-              Node * new_token,
-              f->MakeNode<AfterAll>(
-                  SourceInfo(), std::vector<Node*>{supplying_token, input}));
+              f->MakeNode<TupleIndex>(MergeLocs({io, supplying_io}),
+                                      supplying_io, 0));
+          XLS_ASSIGN_OR_RETURN(Node * new_token,
+                               f->MakeNode<AfterAll>(
+                                   MergeLocs({io, supplying_token, input}),
+                                   std::vector<Node*>{supplying_token, input}));
           bool operand_replaced = io->ReplaceOperand(input, new_token);
           changed = changed || operand_replaced;
         }

--- a/xls/passes/token_simplification_pass.cc
+++ b/xls/passes/token_simplification_pass.cc
@@ -30,6 +30,7 @@
 #include "xls/common/status/ret_check.h"
 #include "xls/common/status/status_macros.h"
 #include "xls/ir/function_base.h"
+#include "xls/ir/node_util.h"
 #include "xls/ir/nodes.h"
 #include "xls/ir/op.h"
 #include "xls/ir/source_location.h"
@@ -140,15 +141,19 @@ absl::StatusOr<bool> PushDownMinDelay(AfterAll* node) {
     Node* new_input = nullptr;
     if (new_delay > 0) {
       XLS_ASSIGN_OR_RETURN(
-          new_input,
-          f->MakeNode<MinDelay>(SourceInfo(), input->operand(0), new_delay));
+          new_input, f->MakeNode<MinDelay>(MergeLocs({node, input->operand(0)}),
+                                           input->operand(0), new_delay));
     } else {
       new_input = input->operand(0);
     }
     new_operands.push_back(new_input);
   }
-  XLS_ASSIGN_OR_RETURN(Node * new_node,
-                       f->MakeNode<AfterAll>(SourceInfo(), new_operands));
+  std::vector<Node*> loc_operands = {node};
+  loc_operands.insert(loc_operands.end(), new_operands.begin(),
+                      new_operands.end());
+  XLS_ASSIGN_OR_RETURN(
+      Node * new_node,
+      f->MakeNode<AfterAll>(MergeLocs(loc_operands), new_operands));
   XLS_RETURN_IF_ERROR(
       node->ReplaceUsesWithNew<MinDelay>(new_node, least_delay).status());
   XLS_RETURN_IF_ERROR(f->RemoveNode(node));
@@ -190,8 +195,12 @@ absl::StatusOr<bool> CollapseAfterAll(AfterAll* node) {
       new_operands.push_back(operand);
     }
 
-    XLS_ASSIGN_OR_RETURN(Node * replacement,
-                         f->MakeNode<AfterAll>(SourceInfo(), new_operands));
+    std::vector<Node*> loc_operands = {user};
+    loc_operands.insert(loc_operands.end(), new_operands.begin(),
+                        new_operands.end());
+    XLS_ASSIGN_OR_RETURN(
+        Node * replacement,
+        f->MakeNode<AfterAll>(MergeLocs(loc_operands), new_operands));
     XLS_RETURN_IF_ERROR(user->ReplaceUsesWith(replacement));
     XLS_RETURN_IF_ERROR(f->RemoveNode(user));
     changed = true;
@@ -303,8 +312,12 @@ absl::StatusOr<bool> RemoveDuplicateAfterAll(AfterAll* node) {
     std::vector<Node*> sorted_operands(operands.begin(), operands.end());
     std::sort(sorted_operands.begin(), sorted_operands.end(),
               Node::NodeIdLessThan());
-    XLS_ASSIGN_OR_RETURN(Node * replacement,
-                         f->MakeNode<AfterAll>(SourceInfo(), sorted_operands));
+    std::vector<Node*> loc_operands = {node};
+    loc_operands.insert(loc_operands.end(), sorted_operands.begin(),
+                        sorted_operands.end());
+    XLS_ASSIGN_OR_RETURN(
+        Node * replacement,
+        f->MakeNode<AfterAll>(MergeLocs(loc_operands), sorted_operands));
     XLS_RETURN_IF_ERROR(node->ReplaceUsesWith(replacement));
     XLS_RETURN_IF_ERROR(f->RemoveNode(node));
     return true;

--- a/xls/passes/visibility_expr_builder.cc
+++ b/xls/passes/visibility_expr_builder.cc
@@ -565,8 +565,7 @@ absl::StatusOr<Node*> VisibilityBuilder::BuildVisibilityIRExpr(
 
   XLS_ASSIGN_OR_RETURN(
       Literal * always_visible,
-      func->MakeNode<Literal>(SourceInfo(), Value(UBits(1, 1))));
-
+      func->MakeNode<Literal>(node->loc(), Value(UBits(1, 1))));
   absl::flat_hash_map<Node*, Node*> node_to_visibility_ir_cache;
   absl::flat_hash_map<std::tuple<Op, Node*, Node*>, Node*> binary_op_cache;
   XLS_ASSIGN_OR_RETURN(Node * result_expr,


### PR DESCRIPTION
This PR adds a `MergeLocs `helper that merges and deduplicates source locations across a node's operands.
It's used wherever passes synthesize replacement nodes, since those call sites often dropped the
original location, making it harder to trace optimized IR and generated Verilog back to the source DSLX.
`VastNode::PreEmit` is also updated to emit one comment per merged location, with line-count tracking
adjusted accordingly. Tests cover `MergeLocs` and each annotation strategy end to end.