### PR TITLE
Fix Z3 compilation in debug builds by defining Z3DEBUG

### DIFF
--- a/dependency_support/z3/bundled.BUILD.bazel
+++ b/dependency_support/z3/bundled.BUILD.bazel
@@ -32,6 +32,13 @@ package(
 
 gen_srcs()
 
+# Z3 declares its 4-argument `allocate` under `Z3DEBUG` but gates the `alloc()`
+# macro that calls it on `_DEBUG`, which our toolchain sets in `-c dbg` builds.
+config_setting(
+    name = "dbg_build",
+    values = {"compilation_mode": "dbg"},
+)
+
 common_copts = [
     "-fexceptions",
     "-fsigned-char",
@@ -49,7 +56,10 @@ common_copts = [
     "-D_EXTERNAL_RELEASE",
     "-D_LINUX_",
     "-D_NO_OMP_",
-]
+] + select({
+    ":dbg_build": ["-DZ3DEBUG"],
+    "//conditions:default": [],
+})
 
 common_linkopts = [
     "-lpthread",


### PR DESCRIPTION
Fixes #4741 

`-c dbg` builds fail because the toolchain defines `_DEBUG` and Z3 gates the `alloc()` macro on `#if _DEBUG` but declares the matching 4-argument `allocate` under `#if Z3DEBUG`. Fine when both are the same, but when mismatched, every `alloc()` fails.

Defines `Z3DEBUG` in `common_copts` only if in debug mode so `opt` and `fastbuild` are unaffected.

Note `Z3DEBUG` also enables Z3's internal `SASSERT` assertions in debug builds.

Verified on macOS arm64:
- `-c dbg @z3//:z3lib`: fails before, passes after
- `-c opt` and default `fastbuild`: passes as expected
- `bazel aquery`: `-DZ3DEBUG` present in 830 `dbg` compile actions, 0 in `opt`