### PR TITLE
ir_viz: disable Flask debug mode and default to binding localhost

### DIFF
--- a/docs_src/ir_visualization.md
+++ b/docs_src/ir_visualization.md
@@ -15,6 +15,9 @@ bazel run -c opt //xls/visualization/ir_viz:app -- --delay_model=unit
 
 Then visit [http://localhost:5000](http://localhost:5000) in a browser.
 
+The server binds to `127.0.0.1` by default. To access it from another machine
+(e.g. when running inside a container), pass `--bind=0.0.0.0`.
+
 ## Screenshot
 
 The screenshot below shows a zoomed-in portion of the IR graph for the

--- a/xls/visualization/ir_viz/app.py
+++ b/xls/visualization/ir_viz/app.py
@@ -36,6 +36,14 @@ from xls.common import runfiles
 
 FLAGS = flags.FLAGS
 flags.DEFINE_bool('use_ipv6', False, 'Whether to use IPv6.')
+flags.DEFINE_string(
+    'bind',
+    '127.0.0.1',
+    'IP address of the interface to bind the HTTP server to. Defaults to '
+    'localhost. Use 0.0.0.0 to listen on all interfaces, e.g. when the '
+    'server is accessed from another machine or via a container port '
+    'forward.',
+)
 flags.DEFINE_integer('port', None, 'Port to serve on.')
 flags.DEFINE_string('delay_model', None, 'Delay model to use.')
 # TODO(meheff): Remove this flag and figure out a better way getting the actual
@@ -72,7 +80,10 @@ flags.mark_flag_as_required('delay_model')
 IR_EXAMPLES_FILE_LIST = 'xls/visualization/ir_viz/ir_examples_file_list.txt'
 
 webapp = flask.Flask('XLS UI')
-webapp.debug = True
+# Keep Flask's development/debug mode off so the Werkzeug interactive
+# debugger (which allows arbitrary code execution in the server process) is
+# never exposed to clients that reach this server.
+webapp.debug = False
 # Allow large payloads (e.g. large IR files) without Werkzeug 413 limits.
 webapp.config['MAX_CONTENT_LENGTH'] = None
 
@@ -416,7 +427,16 @@ def main(argv):
   else:
     examples = load_precanned_examples()
 
-  webapp.run(host='::' if FLAGS.use_ipv6 else '0.0.0.0', port=FLAGS.port)
+  host = '::' if FLAGS.use_ipv6 else FLAGS.bind
+  # Disable Flask's reloader and the Werkzeug interactive debugger even if the
+  # debug flag is ever re-enabled, so errors never expose an execution
+  # surface to clients on the network.
+  webapp.run(
+      host=host,
+      port=FLAGS.port,
+      debug=False,
+      use_reloader=False,
+  )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes #4200. The IR visualization web app ships with Flask's development/debug mode enabled (`webapp.debug = True`) and binds to all interfaces (`0.0.0.0`) without passing `debug=False` to `webapp.run(...)`. Flask forwards `app.debug` into Werkzeug's `use_debugger`/`use_reloader` options, so any unhandled exception while serving a request is answered with the **Werkzeug interactive debugger** page instead of a generic 500. The interactive debugger is designed for trusted local development and allows arbitrary Python evaluation in the server process, i.e. remote code execution in the server's privilege context whenever the port is reachable on the network.

## Changes

- **`xls/visualization/ir_viz/app.py`**
  - Remove `webapp.debug = True` (keep debug mode off).
  - Pass `debug=False` and `use_reloader=False` explicitly to `webapp.run(...)` as a defensive override.
  - Add a `--bind` flag (default `127.0.0.1`) to control the interface the HTTP server binds to. Users who need to reach the tool from another machine or through a container port forward can pass `--bind=0.0.0.0`.
- **`docs_src/ir_visualization.md`** — document the new `--bind` flag.

## Verification

- Read the real source (the bug is present on `main`): `webapp.debug = True` and `webapp.run(host='::' if FLAGS.use_ipv6 else '0.0.0.0', port=FLAGS.port)` with no `debug=` argument.
- Reproduced the mechanism with the repo's werkzeug version: a raising view served with `use_debugger=True` returns a 500 whose body contains the `__debugger__` interactive debugger surface; with `use_debugger=False` it returns a plain 500 with no debugger surface.
- The server now binds to `127.0.0.1` by default and never enables the interactive debugger.