### PR TITLE
Fix IR conversion of static impl functions on parametric structs

### DIFF
--- a/xls/dslx/get_conversion_records.cc
+++ b/xls/dslx/get_conversion_records.cc
@@ -176,7 +176,8 @@ class ConversionRecordVisitor : public AstNodeRecursiveVisitor {
   // dealt with in `HandleInvocation`.
   absl::Status HandleFunction(const Function* f) override {
     VLOG(5) << "HandleFunction " << f->ToString();
-    if (f->IsParametric() || f->IsInProc() || f->IsMethodOnParametricStruct()) {
+    if (f->IsParametric() || f->IsInProc() ||
+        f->IsFunctionOnParametricStruct()) {
       // TODO: https://github.com/google/xls/issues/1029 - remove module-level
       // proc functions.
       VLOG(5) << "Skipping function " << f->identifier()
@@ -212,7 +213,7 @@ class ConversionRecordVisitor : public AstNodeRecursiveVisitor {
                                       bool handle_for_invocation) {
     XLS_RET_CHECK(module_ == f->owner());
     XLS_RET_CHECK(!f->IsInProc());
-    if (f->IsParametric() || f->IsMethodOnParametricStruct()) {
+    if (f->IsParametric() || f->IsFunctionOnParametricStruct()) {
       XLS_RET_CHECK(!env.empty());
       XLS_RET_CHECK_NE(type_info_->GetRoot(), type_info_);
     } else {

--- a/xls/dslx/ir_convert/function_converter.cc
+++ b/xls/dslx/ir_convert/function_converter.cc
@@ -3637,7 +3637,7 @@ absl::Status FunctionConverter::HandleFunction(
   // outside world, since they're driven and named by DSL instantiation, so we
   // forgo exposing them here.
   if (requires_implicit_token && (node->is_public() || is_top_) &&
-      !node->IsParametric() && !node->IsMethodOnParametricStruct()) {
+      !node->IsParametric() && !node->IsFunctionOnParametricStruct()) {
     XLS_ASSIGN_OR_RETURN(
         xls::Function * wrapper,
         EmitImplicitTokenEntryWrapper(ir_fn, node, is_top_,
@@ -4753,7 +4753,7 @@ absl::StatusOr<std::string> FunctionConverter::GetCalleeIdentifier(
   absl::btree_set<std::string> free_keys = f->GetFreeParametricKeySet();
   const CallingConvention convention = GetCallingConvention(f);
   Module* m = f->owner();
-  if (!f->IsParametric() && !f->IsMethodOnParametricStruct()) {
+  if (!f->IsParametric() && !f->IsFunctionOnParametricStruct()) {
     return MangleDslxName(m->name(), f->identifier(), convention, free_keys,
                           /*parametric_env=*/nullptr, scope);
   }

--- a/xls/dslx/ir_convert/ir_converter_test.cc
+++ b/xls/dslx/ir_convert/ir_converter_test.cc
@@ -4158,6 +4158,28 @@ TEST_F(IrConverterTest, ConvertInstanceMethodOnParametricStruct) {
   ExpectIr(converted);
 }
 
+TEST_F(IrConverterTest, ConvertStaticMethodOnParametricStruct) {
+  constexpr std::string_view program = R"(
+  struct S<A: u32> {
+    val: uN[A]
+  }
+
+  impl S<A> {
+    fn make(a: uN[A]) -> Self { S<A>{val: a} }
+  }
+
+  fn main() -> (u16, u32) {
+    const X = S<16>::make(100).val;
+    const Y = S<32>::make(200).val;
+    (X, Y)
+  }
+  )";
+
+  XLS_ASSERT_OK_AND_ASSIGN(std::string converted,
+                           ConvertModuleForTest(program));
+  ExpectIr(converted);
+}
+
 TEST_F(IrConverterTest, ConvertParametricInstanceMethodOnParametricStruct) {
   constexpr std::string_view program = R"(
   struct S<A: u32> {

--- a/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertStaticMethodOnParametricStruct.ir
+++ b/xls/dslx/ir_convert/testdata/ir_converter_test_ConvertStaticMethodOnParametricStruct.ir
@@ -1,0 +1,23 @@
+package test_module
+
+file_number 0 "test_module.x"
+
+fn __test_module__S_A___make__16(a: bits[16] id=1) -> (bits[16]) {
+  A: bits[32] = literal(value=16, id=2)
+  ret tuple.3: (bits[16]) = tuple(a, id=3)
+}
+
+fn __test_module__S_A___make__32(a: bits[32] id=4) -> (bits[32]) {
+  A: bits[32] = literal(value=32, id=5)
+  ret tuple.6: (bits[32]) = tuple(a, id=6)
+}
+
+fn __test_module__main() -> (bits[16], bits[32]) {
+  literal.7: bits[16] = literal(value=100, id=7)
+  literal.10: bits[32] = literal(value=200, id=10)
+  invoke.8: (bits[16]) = invoke(literal.7, to_apply=__test_module__S_A___make__16, id=8)
+  invoke.11: (bits[32]) = invoke(literal.10, to_apply=__test_module__S_A___make__32, id=11)
+  X: bits[16] = tuple_index(invoke.8, index=0, id=9)
+  Y: bits[32] = tuple_index(invoke.11, index=0, id=12)
+  ret tuple.13: (bits[16], bits[32]) = tuple(X, Y, id=13)
+}


### PR DESCRIPTION
Fixes #4692

`Function::IsMethodOnParametricStruct` requires `IsMethod()`, which only holds when the first parameter is `self`. A static function in an impl of a parametric struct has no `self`, so it was treated as fully existing despite its parameters referring to the struct's parametrics.

The failure points of this issue:

- `get_conversion_records.cc:180`: the guard doesn't skip and gets a conversion record with an empty `ParametricEnv`, resolving its `bits[N]` parameter then fails with `type was missing for AST node: bits[N]` (original issue)
- `get_conversion_records.cc:216`: takes the concrete branch of the env invariant, so the env supplied by the invocation fails on `RET_CHECK(env.empty())`
- `function_converter.cc:4746`: omits the instantiation suffix when mangling the callee, so the invocation looks up a non-existent name, failing with `Could not find name for invocation`
- `function_converter.cc:3634`: omits the same suffix when emitting the implicit-token wrapper, so both instantiations produce one symbol, failing with `not unique within package`

Fix is to replace `Function::IsMethodOnParametricStruct` with `Function::IsFunctionOnParametricStruct`, which doesn't have `IsMethod()` and is already the predicate `type_system_v2` uses for this distinction. 

Repro'd original bug (+ others), verified the more idiomatic Foo<N>::new(0) fails identically to the issue's Foo<N>::new(bits[N]:0). Verified that `xls/dslx/tests/parametric_impl.x`, `xls/dslx/stdlib/apfloat.x`, and the `ParametricProcDef` program produce byte-identical IR before and after.


