### PR TITLE
Fix CeilOfRatio template deduction in MLIR conversion_utils on macOS

### DIFF
--- a/xls/contrib/mlir/util/conversion_utils.cc
+++ b/xls/contrib/mlir/util/conversion_utils.cc
@@ -50,8 +50,8 @@ Bits bitsFromAPInt(APInt apInt) {
   auto span =
       absl::MakeConstSpan(reinterpret_cast<const uint8_t*>(apInt.getRawData()),
                           apInt.getNumWords() * sizeof(uint64_t));
-  InlineBitmap bitmap =
-      InlineBitmap::FromBytes(bitCount, span.first(CeilOfRatio(bitCount, 8L)));
+  InlineBitmap bitmap = InlineBitmap::FromBytes(
+      bitCount, span.first(CeilOfRatio(bitCount, int64_t{8})));
   return Bits::FromBitmap(std::move(bitmap));
 }
 


### PR DESCRIPTION
`CeilOfRatio` deduces `IntegralType` from both of its parameters, so passing `bitCount` (`int64_t`) together with the literal `8L` (`long`) only compiles where those two are the same type. On Darwin `int64_t` is `long long`, so deduction fails:

```
xls/contrib/mlir/util/conversion_utils.cc:54:52: error: no matching function for call to 'CeilOfRatio'
      InlineBitmap::FromBytes(bitCount, span.first(CeilOfRatio(bitCount, 8L)));
                                                   ^~~~~~~~~~~
./xls/common/math_util.h:88:31: note: candidate template ignored: deduced conflicting types for
parameter 'IntegralType' ('int64_t' (aka 'long long') vs. 'long')
```

Using `int64_t{8}` makes both arguments agree on every platform. No behavior change on Linux, where the two types are already identical.

Verified on macOS arm64: `bazel build -c opt //xls/contrib/mlir:conversion_utils` fails before and succeeds after.
