### PR TITLE
Use portable sed in package_bazel_build_test

### DIFF
--- a/xls/dev_tools/package_bazel_build_test.sh
+++ b/xls/dev_tools/package_bazel_build_test.sh
@@ -23,10 +23,13 @@ find ./
 TESTDATA_DIR="${TEST_TMPDIR}/testdata"
 cp -Lr $TOOLPATH/package_bazel_build_testdata ${TESTDATA_DIR}
 
-# Process fake manifest and turn into absolute paths
+# Process fake manifest and turn into absolute paths.
+# NB "sed -i" is not portable: BSD sed reads the next argument as a backup
+# suffix, so rewrite via a temporary file instead.
 chmod +w $TESTDATA_DIR/bazel-bin
-sed -i "s,{x},$TESTDATA_DIR,g" \
-  $TESTDATA_DIR/bazel-bin/package_test.runfiles_manifest
+MANIFEST=$TESTDATA_DIR/bazel-bin/package_test.runfiles_manifest
+sed "s,{x},$TESTDATA_DIR,g" "$MANIFEST" > "$MANIFEST.tmp"
+mv "$MANIFEST.tmp" "$MANIFEST"
 
 echo "Test Data Dir: ${TESTDATA_DIR}"
 find ${TESTDATA_DIR}


### PR DESCRIPTION
`sed -i` is a GNU extension. BSD sed, as shipped on macOS, reads the *next* argument as the backup suffix, so

```sh
sed -i "s,{x},$TESTDATA_DIR,g" $TESTDATA_DIR/bazel-bin/package_test.runfiles_manifest
```

treats the script as a suffix and then fails:

```
sed: 1: "/private/var/tmp/_bazel ...": invalid command code v
```

The substitution never runs, so the generated manifest keeps its literal `{x}` placeholders:

```
e/execroot_dep_0.sh {x}/hash/execroot/com_google_xls/execroot_dep.sh
o/output_root.sh {x}/hash/external/outputroot_dep.sh
```

`package_bazel_build.py` then reaches `os.path.commonpath([path, self._bazel_execroot])` with a relative mapping and a resolved absolute execroot, and the test dies with `ValueError: Can't mix absolute and relative paths` — which is a confusing way to surface a `sed` portability problem.

Rewriting through a temporary file behaves identically under GNU and BSD sed. `package_bazel_build.py` itself is unchanged; it was reporting the symptom, not the cause.

Verified on macOS arm64: `//xls/dev_tools:package_bazel_build_test` fails before and passes after.
