### PR TITLE
Raise macOS minimum OS to 10.15 for std::filesystem

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,11 +27,9 @@ build:ci --copt="-DXLS_IS_CI_RUN=1"
 build --incompatible_default_to_explicit_init_py=true
 
 # Mac settings
-# Use 10.13 as the minimum OS for host builds. This is needed to use
-# std::optional and absl::optional together, see
-# https://github.com/abseil/abseil-cpp/commit/512af68a1d397cd2cfa1ac9c6eca7694bf75f2b0.
-build:macos --host_macos_minimum_os=10.13
-build:macos --macos_minimum_os=10.13
+# Use 10.15 as the minimum OS; std::filesystem is only available from 10.15 on.
+build:macos --host_macos_minimum_os=10.15
+build:macos --macos_minimum_os=10.15
 
 # Minimum c++ standard used. We set it in the llvm toolchain, but
 # we also need to specify it here when it is not possible to use that toolchain.


### PR DESCRIPTION
Every target that touches `std::filesystem` currently fails to compile on macOS:

```
./xls/common/undeclared_outputs.h:27:32: error: 'path' is unavailable: introduced in macOS 10.15
std::optional<std::filesystem::path> GetUndeclaredOutputDirectory();
                               ^
.../__filesystem/path.h:382:33: note: 'path' has been explicitly marked unavailable here
```

`std::filesystem` carries availability annotations in libc++ and is not usable below 10.15, but the deployment target is pinned at 10.13.

That pin was there so `std::optional` and `absl::optional` could be used together. The constraint no longer applies: absl requires C++17 and `absl::optional` is an alias for `std::optional`, so the abseil commit the comment references is no longer relevant. This drops the stale rationale along with the pin.

10.15 is the minimum that makes `std::filesystem` usable; I deliberately did not raise it further. Everything else I hit that wanted a higher deployment target (`std::to_chars` needing 13.3, `std::atomic::wait` needing 11.0) was in third-party code — openroad and iverilog — and nothing in XLS's own sources needed more than 10.15.

Verified on macOS arm64 (`-c opt`): `//xls/common:undeclared_outputs` fails to compile before and builds after.

Context: #1434
