### PR TITLE
Add --llvm_opt_level option to eval_proc_main

### DIFF
--- a/xls/jit/block_jit.cc
+++ b/xls/jit/block_jit.cc
@@ -336,19 +336,20 @@ BlockJit::InterfaceMetadata::CreateFromAotEntrypoint(
 }
 
 absl::StatusOr<std::unique_ptr<BlockJit>> BlockJit::Create(
-    Block* block, bool support_observer_callbacks) {
+    Block* block, bool support_observer_callbacks, int64_t opt_level) {
   XLS_ASSIGN_OR_RETURN(BlockElaboration elab,
                        BlockElaboration::Elaborate(block));
-  return BlockJit::Create(elab, support_observer_callbacks);
+  return BlockJit::Create(elab, support_observer_callbacks, opt_level);
 }
 
 absl::StatusOr<std::unique_ptr<BlockJit>> BlockJit::Create(
-    const BlockElaboration& elab, bool support_observer_callbacks) {
+    const BlockElaboration& elab, bool support_observer_callbacks,
+    int64_t opt_level) {
   Block* block;
   XLS_ASSIGN_OR_RETURN(
       std::unique_ptr<OrcJit> orc_jit,
       OrcJit::Create(
-          LlvmCompiler::kDefaultOptLevel,
+          opt_level,
           /*include_observer_callbacks=*/support_observer_callbacks));
   XLS_ASSIGN_OR_RETURN(auto data_layout, orc_jit->CreateDataLayout());
   auto jit_runtime = std::make_unique<JitRuntime>(data_layout);
@@ -881,7 +882,8 @@ JitBlockEvaluator::MakeNewContinuation(
   XLS_ASSIGN_OR_RETURN(
       auto jit,
       BlockJit::Create(elaboration,
-                       /*support_observer_callbacks=*/supports_observer_));
+                       /*support_observer_callbacks=*/supports_observer_,
+                       opt_level_));
   auto jit_cont = jit->NewContinuation(sample_time);
   XLS_RETURN_IF_ERROR(jit_cont->SetRegisters(initial_registers));
   return std::make_unique<BlockContinuationJitWrapper>(std::move(jit_cont),

--- a/xls/jit/block_jit.h
+++ b/xls/jit/block_jit.h
@@ -75,9 +75,11 @@ class BlockJit {
   };
 
   static absl::StatusOr<std::unique_ptr<BlockJit>> Create(
-      Block* block, bool support_observer_callbacks = false);
+      Block* block, bool support_observer_callbacks = false,
+      int64_t opt_level = LlvmCompiler::kDefaultOptLevel);
   static absl::StatusOr<std::unique_ptr<BlockJit>> Create(
-      const BlockElaboration& elab, bool support_observer_callbacks = false);
+      const BlockElaboration& elab, bool support_observer_callbacks = false,
+      int64_t opt_level = LlvmCompiler::kDefaultOptLevel);
 
   static absl::StatusOr<std::unique_ptr<BlockJit>> CreateFromAot(
       const AotEntrypointProto& entrypoint, std::string_view data_layout,
@@ -302,9 +304,12 @@ class BlockJitContinuation {
 // possible.
 class JitBlockEvaluator : public BlockEvaluator {
  public:
-  explicit constexpr JitBlockEvaluator(bool supports_observer = false)
+  explicit constexpr JitBlockEvaluator(
+      bool supports_observer = false,
+      int64_t opt_level = LlvmCompiler::kDefaultOptLevel)
       : BlockEvaluator(supports_observer ? "ObservableJit" : "Jit"),
-        supports_observer_(supports_observer) {}
+        supports_observer_(supports_observer),
+        opt_level_(opt_level) {}
   absl::StatusOr<JitRuntime*> GetRuntime(BlockContinuation* cont) const;
 
  protected:
@@ -315,6 +320,7 @@ class JitBlockEvaluator : public BlockEvaluator {
 
  private:
   bool supports_observer_;
+  int64_t opt_level_;
 };
 
 inline constexpr JitBlockEvaluator kJitBlockEvaluator(false);

--- a/xls/jit/jit_proc_runtime.cc
+++ b/xls/jit/jit_proc_runtime.cc
@@ -234,12 +234,13 @@ absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateAotRuntime(
 }
 
 absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateRuntime(
-    ProcElaboration elaboration, const EvaluatorOptions& options) {
+    ProcElaboration elaboration, const EvaluatorOptions& options,
+    const JitEvaluatorOptions& jit_options) {
   // We use the compiler to know the data layout.
   XLS_ASSIGN_OR_RETURN(
       std::unique_ptr<OrcJit> comp,
       OrcJit::Create(
-          LlvmCompiler::kDefaultOptLevel,
+          jit_options.opt_level(),
           /*include_observer_callbacks=*/options.support_observers()));
   XLS_ASSIGN_OR_RETURN(llvm::DataLayout layout, comp->CreateDataLayout());
   // Create a queue manager for the queues. This factory verifies that there an
@@ -254,10 +255,10 @@ absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateRuntime(
   for (Proc* proc : queue_manager->elaboration().procs()) {
     XLS_ASSIGN_OR_RETURN(
         std::unique_ptr<ProcJit> proc_jit,
-        ProcJit::Create(proc, &queue_manager->runtime(), queue_manager.get(),
-                        options,
-                        JitEvaluatorOptions().set_include_observer_callbacks(
-                            options.support_observers())));
+        ProcJit::Create(
+            proc, &queue_manager->runtime(), queue_manager.get(), options,
+            JitEvaluatorOptions(jit_options).set_include_observer_callbacks(
+                options.support_observers())));
     proc_jits.push_back(std::move(proc_jit));
   }
 
@@ -275,21 +276,23 @@ absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateRuntime(
 }  // namespace
 
 absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateJitSerialProcRuntime(
-    Package* package, const EvaluatorOptions& options) {
+    Package* package, const EvaluatorOptions& options,
+    const JitEvaluatorOptions& jit_options) {
   if (package->ChannelsAreProcScoped()) {
     XLS_ASSIGN_OR_RETURN(Proc * top, package->GetTopAsProc());
-    return CreateJitSerialProcRuntime(top, options);
+    return CreateJitSerialProcRuntime(top, options, jit_options);
   }
   XLS_ASSIGN_OR_RETURN(ProcElaboration elaboration,
                        ProcElaboration::ElaborateOldStylePackage(package));
-  return CreateRuntime(std::move(elaboration), options);
+  return CreateRuntime(std::move(elaboration), options, jit_options);
 }
 
 absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateJitSerialProcRuntime(
-    Proc* top, const EvaluatorOptions& options) {
+    Proc* top, const EvaluatorOptions& options,
+    const JitEvaluatorOptions& jit_options) {
   XLS_ASSIGN_OR_RETURN(ProcElaboration elaboration,
                        ProcElaboration::Elaborate(top));
-  return CreateRuntime(std::move(elaboration), options);
+  return CreateRuntime(std::move(elaboration), options, jit_options);
 }
 
 absl::StatusOr<JitObjectCode> CreateProcAotObjectCode(

--- a/xls/jit/jit_proc_runtime.h
+++ b/xls/jit/jit_proc_runtime.h
@@ -33,13 +33,15 @@ namespace xls {
 // Create a SerialProcRuntime composed of ProcJits. Works with old- or new-style
 // procs.
 absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateJitSerialProcRuntime(
-    Package* package, const EvaluatorOptions& options = EvaluatorOptions());
+    Package* package, const EvaluatorOptions& options = EvaluatorOptions(),
+    const JitEvaluatorOptions& jit_options = JitEvaluatorOptions());
 
 // Create a SerialProcRuntime composed of ProcJits. Constructed from the
 // elaboration of the given proc. Requires new-style (proc-scoped channel)
 // procs.
 absl::StatusOr<std::unique_ptr<SerialProcRuntime>> CreateJitSerialProcRuntime(
-    Proc* top, const EvaluatorOptions& options = EvaluatorOptions());
+    Proc* top, const EvaluatorOptions& options = EvaluatorOptions(),
+    const JitEvaluatorOptions& jit_options = JitEvaluatorOptions());
 
 struct ProcAotEntrypoints {
   // What proc these entrypoints are associated with.

--- a/xls/tools/eval_proc_main.cc
+++ b/xls/tools/eval_proc_main.cc
@@ -116,6 +116,9 @@ ABSL_FLAG(std::string, backend, "serial_jit",
           " * ir_interpreter: Interpreter at the IR level.\n"
           " * block_interpreter: Interpret a block generated from a proc.\n"
           " * block_jit: JIT-backed block execution generated from a proc.");
+ABSL_FLAG(int64_t, llvm_opt_level, xls::LlvmCompiler::kDefaultOptLevel,
+          "The optimization level of the LLVM JIT. Valid values are from 0 "
+          "(no optimizations) to 3 (maximum optimizations).");
 ABSL_FLAG(std::string, block_signature_proto, "",
           "Path to textproto file containing signature from codegen");
 ABSL_FLAG(int64_t, max_cycles_no_output, 100,
@@ -303,20 +306,24 @@ struct EvaluateProcsOptions {
   std::vector<int64_t> ticks = {-1};
   std::optional<std::string> top = std::nullopt;
   ScopedObserver observer;
+  int64_t llvm_opt_level = LlvmCompiler::kDefaultOptLevel;
 };
 
 static absl::StatusOr<std::unique_ptr<SerialProcRuntime>> GetRuntime(
-    Package* package, bool use_jit, EvaluatorOptions evaluator_options) {
+    Package* package, bool use_jit, EvaluatorOptions evaluator_options,
+    int64_t llvm_opt_level) {
+  JitEvaluatorOptions jit_options;
+  jit_options.set_opt_level(llvm_opt_level);
   if (package->ChannelsAreProcScoped()) {
     XLS_RET_CHECK(package->HasTop());
     XLS_ASSIGN_OR_RETURN(Proc * top, package->GetTopAsProc());
     if (use_jit) {
-      return CreateJitSerialProcRuntime(top, evaluator_options);
+      return CreateJitSerialProcRuntime(top, evaluator_options, jit_options);
     }
     return CreateInterpreterSerialProcRuntime(top, evaluator_options);
   }
   if (use_jit) {
-    return CreateJitSerialProcRuntime(package, evaluator_options);
+    return CreateJitSerialProcRuntime(package, evaluator_options, jit_options);
   }
 
   return CreateInterpreterSerialProcRuntime(package, evaluator_options);
@@ -342,7 +349,8 @@ absl::Status EvaluateProcs(
   }
   evaluator_options.set_support_observers(uses_observers);
   XLS_ASSIGN_OR_RETURN(runtime,
-                       GetRuntime(package, options.use_jit, evaluator_options));
+                       GetRuntime(package, options.use_jit, evaluator_options,
+                                  options.llvm_opt_level));
   if (options.use_jit) {
     XLS_ASSIGN_OR_RETURN(auto jit_queue, runtime->GetJitChannelQueueManager());
     jit = &jit_queue->runtime();
@@ -734,6 +742,7 @@ struct EvaluateBlockOptions {
   bool show_trace;
   bool fail_on_assert;
   ScopedObserver observer;
+  int64_t llvm_opt_level = LlvmCompiler::kDefaultOptLevel;
 };
 
 // Helper to hold various commonly needed port names for a particular ram.
@@ -882,18 +891,18 @@ absl::Status EvaluateBlock(
   }
 
   bool needs_observer = !options.observer.empty();
+  JitBlockEvaluator jit_block_evaluator(
+      /*supports_observer=*/needs_observer, options.llvm_opt_level);
   const BlockEvaluator& continuation_factory =
       options.use_jit
-          ? reinterpret_cast<const BlockEvaluator&>(
-                needs_observer ? kObservableJitBlockEvaluator
-                               : kJitBlockEvaluator)
+          ? static_cast<const BlockEvaluator&>(jit_block_evaluator)
           : reinterpret_cast<const BlockEvaluator&>(kInterpreterBlockEvaluator);
   XLS_ASSIGN_OR_RETURN(auto continuation, continuation_factory.NewContinuation(
                                               block, reg_state, kClocked));
   std::optional<JitRuntime*> jit;
   if (options.use_jit) {
     XLS_ASSIGN_OR_RETURN(jit,
-                         kJitBlockEvaluator.GetRuntime(continuation.get()));
+                         jit_block_evaluator.GetRuntime(continuation.get()));
   }
   bool is_coverage_observer = options.observer.has_coverage();
   if (needs_observer) {
@@ -1314,7 +1323,8 @@ absl::Status RealMain(
         .random_seed = random_seed,
         .prob_input_valid_assert = prob_input_valid_assert,
         .show_trace = show_trace,
-        .fail_on_assert = fail_on_assert};
+        .fail_on_assert = fail_on_assert,
+        .llvm_opt_level = absl::GetFlag(FLAGS_llvm_opt_level)};
     if (backend == "block_jit") {
       block_options.use_jit = true;
     } else if (backend == "block_interpreter") {
@@ -1336,6 +1346,7 @@ absl::Status RealMain(
       .ticks = ticks,
       .top = absl::GetFlag(FLAGS_top),
       .observer = std::move(observer),
+      .llvm_opt_level = absl::GetFlag(FLAGS_llvm_opt_level),
   };
 
   if (backend == "serial_jit") {
@@ -1385,6 +1396,10 @@ int main(int argc, char* argv[]) {
       backend != "block_interpreter" && backend != "block_jit") {
     LOG(QFATAL) << "Unrecognized backend choice.";
   }
+  QCHECK_GE(absl::GetFlag(FLAGS_llvm_opt_level), 0)
+      << "--llvm_opt_level must be between 0 and 3";
+  QCHECK_LE(absl::GetFlag(FLAGS_llvm_opt_level), 3)
+      << "--llvm_opt_level must be between 0 and 3";
 
   if ((backend == "block_interpreter" || backend == "block_jit") &&
       absl::GetFlag(FLAGS_block_signature_proto).empty()) {

--- a/xls/tools/eval_proc_main_test.py
+++ b/xls/tools/eval_proc_main_test.py
@@ -583,6 +583,104 @@ class EvalProcTest(parameterized.TestCase):
     output = run_command(shared_args + ["--backend", "serial_jit"])
     self.assertIn("Proc __eval_proc_main_test__test_proc_0_next", output.stderr)
 
+  @parameterized.named_parameters(
+      ("proc_serial_jit", PROC_PATH, "serial_jit", []),
+      ("block_jit", BLOCK_PATH, "block_jit", ["--block_signature_proto",
+                                               BLOCK_SIG_PATH, "--show_trace"]),
+  )
+  def test_llvm_opt_level(self, ir_path, backend, backend_extra_args):
+    input_file = self.create_tempfile(content=textwrap.dedent("""
+          eval_proc_main_test__in_ch : {
+            bits[64]:42
+            bits[64]:101
+          }
+          eval_proc_main_test__in_ch_2 : {
+            bits[64]:10
+            bits[64]:6
+          }
+        """))
+    output_file = self.create_tempfile(content=textwrap.dedent("""
+          eval_proc_main_test__out_ch : {
+            bits[64]:62
+            bits[64]:127
+          }
+          eval_proc_main_test__out_ch_2 : {
+            bits[64]:55
+            bits[64]:55
+          }
+        """))
+
+    shared_args = [
+        EVAL_PROC_MAIN_PATH,
+        ir_path,
+        "--ticks",
+        "2",
+        "-v=3",
+        "--logtostderr",
+        "--inputs_for_all_channels",
+        input_file.full_path,
+        "--expected_outputs_for_all_channels",
+        output_file.full_path,
+        "--backend",
+        backend,
+    ] + backend_extra_args
+
+    for opt_level in (0, 1, 2, 3):
+      output = run_command(shared_args + ["--llvm_opt_level", str(opt_level)])
+      if backend == "serial_jit":
+        self.assertIn(
+            "Proc __eval_proc_main_test__test_proc_0_next", output.stderr
+        )
+      else:
+        self.assertIn("Cycle[5]: resetting? false", output.stderr)
+
+  def test_llvm_opt_level_invalid(self):
+    input_file = self.create_tempfile(content=textwrap.dedent("""
+          eval_proc_main_test__in_ch : {
+            bits[64]:42
+            bits[64]:101
+          }
+          eval_proc_main_test__in_ch_2 : {
+            bits[64]:10
+            bits[64]:6
+          }
+        """))
+    output_file = self.create_tempfile(content=textwrap.dedent("""
+          eval_proc_main_test__out_ch : {
+            bits[64]:62
+            bits[64]:127
+          }
+          eval_proc_main_test__out_ch_2 : {
+            bits[64]:55
+            bits[64]:55
+          }
+        """))
+    shared_args = [
+        EVAL_PROC_MAIN_PATH,
+        PROC_PATH,
+        "--ticks",
+        "2",
+        "-v=3",
+        "--logtostderr",
+        "--inputs_for_all_channels",
+        input_file.full_path,
+        "--expected_outputs_for_all_channels",
+        output_file.full_path,
+        "--backend",
+        "serial_jit",
+    ]
+
+    for opt_level in ("-1", "4"):
+      comp = subprocess.run(
+          shared_args + ["--llvm_opt_level", opt_level],
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          encoding="utf-8",
+          check=False,
+      )
+      self.assertNotEqual(comp.returncode, 0)
+      self.assertIn("--llvm_opt_level must be between 0 and 3", comp.stderr)
+
   def test_reset_static(self):
     input_file = self.create_tempfile(content=textwrap.dedent("""
           bits[64]:42


### PR DESCRIPTION
Add a --llvm_opt_level flag (valid values 0-3) to eval_proc_main so the LLVM optimizer level used by the JIT can be selected from the command line. The requested level is threaded through CreateJitSerialProcRuntime (via JitEvaluatorOptions) and through JitBlockEvaluator / BlockJit::Create (via a new opt_level parameter), and validated to lie in [0, 3].