### PR TITLE
Fix bad transformation in division simplification

### DIFF
--- a/xls/passes/arith_simplification_pass.cc
+++ b/xls/passes/arith_simplification_pass.cc
@@ -1439,9 +1439,10 @@ absl::StatusOr<bool> MatchArithPatterns(int64_t opt_level, Node* n,
 
       const int64_t leading_zeros =
           query_engine.KnownLeadingZeros(y).value_or(0);
+      const Bits max_shift_bits = query_engine.MaxUnsignedValue(k);
       const int64_t max_shift =
-          query_engine.MaxUnsignedValue(k).FitsInInt64Unsigned()
-              ? query_engine.MaxUnsignedValue(k).ToInt64().value()
+          max_shift_bits.FitsInInt64Unsigned()
+              ? static_cast<int64_t>(max_shift_bits.ToUint64().value())
               : n->BitCountOrDie();
       const int64_t limit = leading_zeros - ((n->op() == Op::kSDiv) ? 1 : 0);
       if (max_shift <= limit) {

--- a/xls/passes/arith_simplification_pass_test.cc
+++ b/xls/passes/arith_simplification_pass_test.cc
@@ -2594,6 +2594,22 @@ TEST_F(ArithSimplificationPassTest, SDivByShiftedVariablePowerOfTwoWideShift) {
   ASSERT_THAT(Run(p.get()), IsOkAndHolds(false));
 }
 
+TEST_F(ArithSimplificationPassTest, UDivByOverflowingShiftedSelf) {
+  auto p = CreatePackage();
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, ParseFunction(R"(
+fn FuzzTest(p0: bits[1]) -> bits[14] {
+  wide: bits[14] = sign_ext(p0, new_bit_count=14)
+  shift: bits[2] = sign_ext(p0, new_bit_count=2)
+  shifted: bits[14] = shll(wide, shift)
+  ret result: bits[14] = udiv(shifted, shifted)
+}
+  )",
+                                                       p.get()));
+
+  ScopedVerifyEquivalence sve(f);
+  ASSERT_THAT(Run(p.get()), IsOk());
+}
+
 TEST_F(ArithSimplificationPassTest, FuzzTestInvalidSDivTransform) {
   auto p = CreatePackage();
   FunctionBuilder fb(TestName(), p.get());


### PR DESCRIPTION
The arithmetic simplification pass checks whether y << k can overflow before rewriting:

```
   x / (y << k)  →  (x / y) >> k
```

But it converted the unsigned maximum shift using signed ToInt64() which is incorrect as the semantics require interpretation of the value as an unsigned number.