### PR TITLE
Support Darwin subprocess working directories with posix_spawn

### DIFF
--- a/xls/common/BUILD
+++ b/xls/common/BUILD
@@ -318,6 +318,7 @@ cc_test(
     deps = [
         ":subprocess",
         ":xls_gunit_main",
+        "//xls/common/file:temp_directory",
         "//xls/common/status:matchers",
         "@abseil-cpp//absl/status",
         "@abseil-cpp//absl/status:status_matchers",

--- a/xls/common/subprocess.cc
+++ b/xls/common/subprocess.cc
@@ -15,7 +15,9 @@
 #include "xls/common/subprocess.h"
 
 #include <fcntl.h>
+#if !defined(__APPLE__)
 #include <linux/memfd.h>
+#endif
 #include <signal.h>  // NOLINT
 #include <spawn.h>
 #include <stdlib.h>  // NOLINT for WIFEXITED, WEXITSTATUS; not in <cstdlib>
@@ -129,6 +131,7 @@ absl::StatusOr<posix_spawn_file_actions_t> CreateChildFileActions(
   return actions;
 }
 
+#if !defined(__APPLE__)
 class CleanableFd {
  public:
   explicit CleanableFd(int fd) : fd_(fd) {}
@@ -173,6 +176,22 @@ absl::StatusOr<CleanableFd> GetSubprocessHelperFd() {
   return std::move(fd);
 }
 
+#else
+int AddChdirFileAction(posix_spawn_file_actions_t* file_actions,
+                       const char* cwd) {
+#if defined(__MAC_26_0) && __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_26_0
+  return posix_spawn_file_actions_addchdir(file_actions, cwd);
+#else
+#if defined(__MAC_26_0) && __MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_26_0
+  if (__builtin_available(macOS 26.0, *)) {
+    return posix_spawn_file_actions_addchdir(file_actions, cwd);
+  }
+#endif
+  return posix_spawn_file_actions_addchdir_np(file_actions, cwd);
+#endif
+}
+#endif
+
 absl::StatusOr<pid_t> ExecInChildProcess(
     const std::vector<const char*>& argv_pointers,
     const std::optional<std::filesystem::path>& cwd, Pipe& stdout_pipe,
@@ -184,6 +203,11 @@ absl::StatusOr<pid_t> ExecInChildProcess(
   // better, but it's not fully clear what's safe between vfork() and exec()
   // either, so we just use posix_spawn for safety and convenience.
 
+#if defined(__APPLE__)
+  // Darwin can change the child directory without a helper executable.
+  std::string subprocess_helper = argv_pointers.front();
+  std::vector<const char*> helper_argv_pointers = argv_pointers;
+#else
   // Since we may need the child to have a different working directory (per
   // `cwd`), and posix_spawn does not (yet) have support for a chdir action, we
   // use a helper binary that chdir's to its first argument, then invokes
@@ -205,8 +229,19 @@ absl::StatusOr<pid_t> ExecInChildProcess(
   helper_argv_pointers.insert(helper_argv_pointers.end(), argv_pointers.begin(),
                               argv_pointers.end());
 
+#endif
+
   XLS_ASSIGN_OR_RETURN(posix_spawn_file_actions_t file_actions,
                        CreateChildFileActions(stdout_pipe, stderr_pipe));
+#if defined(__APPLE__)
+  if (cwd.has_value()) {
+    if (int err = AddChdirFileAction(&file_actions, cwd->c_str()); err != 0) {
+      posix_spawn_file_actions_destroy(&file_actions);
+      return absl::InternalError(absl::StrCat(
+          "Cannot add child working directory action: ", Strerror(err)));
+    }
+  }
+#endif
 
   // posix_spawnp takes a null-terminate array of char* for environment
   // variables. Each element has the form "NAME=VALUE".

--- a/xls/common/subprocess_test.cc
+++ b/xls/common/subprocess_test.cc
@@ -14,6 +14,7 @@
 
 #include "xls/common/subprocess.h"
 
+#include <filesystem>
 #include <optional>
 #include <string>
 #include <utility>
@@ -25,6 +26,7 @@
 #include "absl/status/statusor.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
+#include "xls/common/file/temp_directory.h"
 #include "xls/common/status/matchers.h"
 
 namespace xls {
@@ -41,6 +43,32 @@ TEST(SubprocessTest, EmptyArgvFails) {
   auto result = InvokeSubprocess({}, std::nullopt);
 
   EXPECT_THAT(result, StatusIs(absl::StatusCode::kInvalidArgument));
+}
+
+TEST(SubprocessTest, WorkingDirectoryDoesNotChangeParent) {
+  XLS_ASSERT_OK_AND_ASSIGN(TempDirectory directory, TempDirectory::Create());
+  const std::filesystem::path parent_directory =
+      std::filesystem::current_path();
+
+  XLS_ASSERT_OK_AND_ASSIGN(SubprocessResult result,
+                           SubprocessErrorAsStatus(InvokeSubprocess(
+                               {"pwd", "-P"}, directory.path())));
+
+  EXPECT_EQ(result.stdout_content,
+            std::filesystem::canonical(directory.path()).string() + "\n");
+  EXPECT_EQ(std::filesystem::current_path(), parent_directory);
+}
+
+TEST(SubprocessTest, RelativeExecutableUsesChildWorkingDirectory) {
+  XLS_ASSERT_OK_AND_ASSIGN(TempDirectory directory, TempDirectory::Create());
+  std::filesystem::create_symlink("/bin/pwd", directory.path() / "command");
+
+  XLS_ASSERT_OK_AND_ASSIGN(SubprocessResult result,
+                           SubprocessErrorAsStatus(InvokeSubprocess(
+                               {"./command", "-P"}, directory.path())));
+
+  EXPECT_EQ(result.stdout_content,
+            std::filesystem::canonical(directory.path()).string() + "\n");
 }
 
 TEST(SubprocessTest, NonZeroExitWorks) {


### PR DESCRIPTION
This PR was primarily authored by Codex.

Darwin builds of `xls/common/subprocess.cc` currently encounter Linux-only `memfd` support and the `/proc/self/fd` helper path. Use `posix_spawnp` directly on Darwin, with a child working-directory file action when requested. The Linux embedded-helper path and shared spawn setup retain their existing variable names and comments.

Apple's macOS 26 SDK introduces `posix_spawn_file_actions_addchdir` and deprecates the `_np` spelling. XLS still targets macOS 10.15. When the SDK declares the standard function, an availability check selects it on macOS 26 or later and retains `_np` for older supported systems. Builds whose minimum target is already macOS 26 use only the standard function; builds using older SDKs retain the older spelling. This avoids requiring a macOS 26 symbol on the earlier supported deployment targets.

The child keeps the existing argument, environment, output-capture, and timeout handling. New tests exercise PATH lookup with a child working directory, verify that the parent directory stays unchanged, and run an executable addressed relative to the child directory. Existing tests cover output capture, exit status, timeouts, and environment additions.

Validation: formatting, absolute-include checks, and `git diff --check` pass. A standalone probe of the API-selection helper compiled with deprecation and unguarded-availability warnings treated as errors for x86_64/macOS 10.15, arm64/macOS 11, and arm64/macOS 26 deployment targets; its native spawn/chdir smoke test passed. The full `//xls/common:subprocess_test` target passed all 14 tests on native Apple Silicon, including the new working-directory cases and the existing timeout/output/environment cases. Linux execution and execution on older macOS versions remain untested.
