### PR TITLE
Add LoopIdiomPass

### DIFF
--- a/docs_src/passes_list.md
+++ b/docs_src/passes_list.md
@@ -3345,6 +3345,25 @@ ret invoke.1
 
 
 
+## loop_idiom - Recognize loop idioms {#loop_idiom}
+
+
+Recognizes common loop idioms in `counted_for` loops and rewrites them into
+more direct IR forms BEFORE the loop is unrolled.
+
+First target: a zero-filled array shift (DSLX `data << shift` expressed as a
+`for` loop with `result[i] = if i < shift { false } else { data[i-shift] }`).
+The counted_for body lowers to an `array_update` of
+`sel(ult(i, shift), [array_index(data, [i - shift]), 0])`; rewriting that to
+a packed `shll` + per-bit `bit_slice` shape lets codegen emit a native shift
+instead of per-element index muxes.
+
+
+[Header](http://github.com/google/xls/tree/main/xls/passes/loop_idiom_pass.h)
+
+
+
+
 
 ## lut_conversion - LUT Conversion {#lut_conversion}
 

--- a/xls/codegen/BUILD
+++ b/xls/codegen/BUILD
@@ -17,7 +17,12 @@ load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@protobuf//bazel:py_proto_library.bzl", "py_proto_library")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
-load("//xls/build_rules:xls_build_defs.bzl", "xls_diff_test", "xls_ir_verilog")
+load("//xls/build_rules:xls_build_defs.bzl",
+     "xls_diff_test",
+     "xls_dslx_ir",
+     "xls_dslx_test",
+     "xls_ir_opt_ir",
+     "xls_ir_verilog")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -2163,6 +2168,42 @@ xls_diff_test(
     # accurately pick out only the node-ids. It also changes some constants and
     # line numbers.
     sed_transform = "s/_[0-9]+/_XXX/g",
+)
+
+# A zero-filled array shift written as a for loop. The loop is recognized by
+# the loop_idiom pass (before loop unrolling) and emitted as a native
+# SystemVerilog shift instead of one dynamic array lookup per output element.
+xls_dslx_ir(
+    name = "affine_shift_ir",
+    srcs = ["affine_shift.x"],
+    dslx_top = "main",
+)
+
+xls_dslx_test(
+    name = "affine_shift_dslx_test",
+    srcs = ["affine_shift.x"],
+    dslx_test_args = {"compare": "jit"},
+)
+
+xls_ir_opt_ir(
+    name = "affine_shift_opt_ir",
+    src = ":affine_shift_ir",
+)
+
+xls_ir_verilog(
+    name = "affine_shift_comb_sv",
+    src = ":affine_shift_opt_ir",
+    codegen_args = {
+        "generator": "combinational",
+        "use_system_verilog": "true",
+    },
+    verilog_file = "affine_shift_comb.sv",
+)
+
+xls_diff_test(
+    name = "affine_shift_comb_diff_test",
+    file = ":affine_shift_comb.sv",
+    golden = "testdata/affine_shift_comb.svtxt",
 )
 
 cc_test(

--- a/xls/codegen/affine_shift.x
+++ b/xls/codegen/affine_shift.x
@@ -1,0 +1,19 @@
+pub fn main(data: bool[8], shift: u3) -> bool[8] {
+    for (i, result): (u32, bool[8]) in u32:0..u32:8 {
+        let value = if i < (shift as u32) {
+            false
+        } else {
+            data[i - (shift as u32)]
+        };
+        update(result, i, value)
+    }(bool[8]:[false, ...])
+}
+
+#[test]
+fn shift_by_three_test() {
+    let data = bool[8]:[true, false, true, true, false, false, true, false];
+    assert_eq(
+        main(data, u3:3),
+        bool[8]:[false, false, false, true, false, true, true, false]
+    )
+}

--- a/xls/codegen/testdata/affine_shift_comb.svtxt
+++ b/xls/codegen/testdata/affine_shift_comb.svtxt
@@ -1,0 +1,27 @@
+module __affine_shift__main(
+  input wire [7:0] data,
+  input wire [2:0] shift,
+  output wire [7:0] out
+);
+  wire data_unflattened[8];
+  assign data_unflattened[0] = data[0:0];
+  assign data_unflattened[1] = data[1:1];
+  assign data_unflattened[2] = data[2:2];
+  assign data_unflattened[3] = data[3:3];
+  assign data_unflattened[4] = data[4:4];
+  assign data_unflattened[5] = data[5:5];
+  assign data_unflattened[6] = data[6:6];
+  assign data_unflattened[7] = data[7:7];
+  wire [7:0] shll_88;
+  wire array_99[8];
+  assign shll_88 = {data_unflattened[3'h7], data_unflattened[3'h6], data_unflattened[3'h5], data_unflattened[3'h4], data_unflattened[3'h3], data_unflattened[3'h2], data_unflattened[3'h1], data_unflattened[3'h0]} << shift;
+  assign array_99[0] = shll_88[0];
+  assign array_99[1] = shll_88[1];
+  assign array_99[2] = shll_88[2];
+  assign array_99[3] = shll_88[3];
+  assign array_99[4] = shll_88[4];
+  assign array_99[5] = shll_88[5];
+  assign array_99[6] = shll_88[6];
+  assign array_99[7] = shll_88[7];
+  assign out = {array_99[7], array_99[6], array_99[5], array_99[4], array_99[3], array_99[2], array_99[1], array_99[0]};
+endmodule

--- a/xls/passes/BUILD
+++ b/xls/passes/BUILD
@@ -96,6 +96,7 @@ xls_pass_registry(
         ":dfe_pass",
         ":identity_removal_pass",
         ":label_recovery_pass",
+        ":loop_idiom_pass",
         ":lut_conversion_pass",
         ":map_inlining_pass",
         ":next_value_optimization_pass",
@@ -412,6 +413,48 @@ cc_test(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
+        "@googletest//:gtest",
+    ],
+)
+
+xls_pass(
+    name = "loop_idiom_pass",
+    srcs = ["loop_idiom_pass.cc"],
+    hdrs = ["loop_idiom_pass.h"],
+    pass_class = "LoopIdiomPass",
+    deps = [
+        ":optimization_pass",
+        ":pass_base",
+        "//xls/common/status:status_macros",
+        "//xls/ir",
+        "//xls/ir:bits",
+        "//xls/ir:op",
+        "//xls/ir:type",
+        "//xls/ir:value",
+        "@abseil-cpp//absl/log",
+        "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/types:span",
+    ],
+)
+
+cc_test(
+    name = "loop_idiom_pass_test",
+    srcs = ["loop_idiom_pass_test.cc"],
+    deps = [
+        ":loop_idiom_pass",
+        ":optimization_pass",
+        ":pass_base",
+        "//xls/common:xls_gunit_main",
+        "//xls/common/fuzzing:fuzztest",
+        "//xls/common/status:matchers",
+        "//xls/common/status:status_macros",
+        "//xls/fuzzer/ir_fuzzer:ir_fuzz_domain",
+        "//xls/fuzzer/ir_fuzzer:ir_fuzz_test_library",
+        "//xls/ir",
+        "//xls/ir:ir_matcher",
+        "//xls/ir:ir_parser",
+        "@abseil-cpp//absl/status:statusor",
         "@googletest//:gtest",
     ],
 )

--- a/xls/passes/loop_idiom_pass.cc
+++ b/xls/passes/loop_idiom_pass.cc
@@ -1,0 +1,318 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/passes/loop_idiom_pass.h"
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include "absl/log/log.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/types/span.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/ir/bits.h"
+#include "xls/ir/function.h"
+#include "xls/ir/node.h"
+#include "xls/ir/nodes.h"
+#include "xls/ir/op.h"
+#include "xls/ir/type.h"
+#include "xls/ir/value.h"
+#include "xls/passes/optimization_pass.h"
+#include "xls/passes/pass_base.h"
+
+namespace xls {
+namespace {
+
+bool MatchInductionVar(Node* node, Param* i) {
+  if (node == i) {
+    return true;
+  }
+  if (node->op() != Op::kAdd) {
+    return false;
+  }
+  Node* lhs = node->operand(0);
+  Node* rhs = node->operand(1);
+  if (lhs == i && rhs->op() == Op::kLiteral &&
+      rhs->As<Literal>()->value().IsAllZeros()) {
+    return true;
+  }
+  if (rhs == i && lhs->op() == Op::kLiteral &&
+      lhs->As<Literal>()->value().IsAllZeros()) {
+    return true;
+  }
+  return false;
+}
+
+Param* MatchInvariantParam(Node* node, Function* body) {
+  Param* param = nullptr;
+  if (node->Is<Param>()) {
+    param = node->As<Param>();
+  } else if (node->op() == Op::kZeroExt) {
+    Node* operand = node->operand(0);
+    if (operand->Is<Param>()) {
+      param = operand->As<Param>();
+    }
+  }
+  if (param == nullptr || param->function_base() != body) {
+    return nullptr;
+  }
+
+  for (int64_t index = 2; index < static_cast<int64_t>(body->params().size());
+       ++index) {
+    if (body->params()[index] == param) {
+      return param;
+    }
+  }
+  return nullptr;
+}
+
+bool BodyHasSideEffects(Function* body) {
+  for (Node* node : body->nodes()) {
+    if (node->Is<Param>()) {
+      continue;
+    }
+    if (OpIsSideEffecting(node->op()) || node->Is<Invoke>()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+struct ArrayOverwriteLoop {
+  CountedFor* loop;
+  Param* i;             // body params()[0], the induction variable
+  Param* result;        // body params()[1], the loop-carry array
+  ArrayUpdate* update;  // the body's return value
+};
+
+std::optional<ArrayOverwriteLoop> MatchLoopStructure(CountedFor* loop) {
+  if (loop->stride() != 1) {
+    return std::nullopt;
+  }
+  if (!loop->GetType()->IsArray()) {
+    return std::nullopt;
+  }
+  ArrayType* result_type = loop->GetType()->AsArrayOrDie();
+  if (loop->trip_count() != result_type->size()) {
+    return std::nullopt;
+  }
+
+  Function* body = loop->body();
+  if (body->params().size() < 3) {
+    return std::nullopt;
+  }
+  Param* i = body->params()[0];
+  Param* result = body->params()[1];
+  if (result->GetType() != result_type) {
+    return std::nullopt;
+  }
+
+  Node* ret = body->return_value();
+  if (ret == nullptr || !ret->Is<ArrayUpdate>()) {
+    return std::nullopt;
+  }
+  ArrayUpdate* update = ret->As<ArrayUpdate>();
+  if (update->array_to_update() != result || update->indices().size() != 1 ||
+      !MatchInductionVar(update->indices()[0], i)) {
+    return std::nullopt;
+  }
+
+  if (result->users().size() != 1 || result->users()[0] != update) {
+    return std::nullopt;
+  }
+
+  return ArrayOverwriteLoop{loop, i, result, update};
+}
+
+struct ShiftIdiom {
+  CountedFor* loop;
+  Node* data;   // the array being shifted
+  Node* shift;  // the shift amount
+};
+
+std::optional<ShiftIdiom> MatchShiftIdiom(const ArrayOverwriteLoop& structure) {
+  CountedFor* loop = structure.loop;
+  Function* body = loop->body();
+  ArrayType* result_type = loop->GetType()->AsArrayOrDie();
+  if (!result_type->element_type()->IsBits() ||
+      result_type->element_type()->AsBitsOrDie()->bit_count() != 1) {
+    return std::nullopt;
+  }
+
+  Node* value = structure.update->update_value();
+  if (!value->Is<Select>()) {
+    return std::nullopt;
+  }
+  Select* sel = value->As<Select>();
+  if (sel->default_value().has_value() || sel->cases().size() != 2) {
+    return std::nullopt;
+  }
+  Node* cond = sel->selector();
+  if (!cond->Is<CompareOp>() ||
+      (cond->op() != Op::kULt && cond->op() != Op::kUGe)) {
+    return std::nullopt;
+  }
+  if (!MatchInductionVar(cond->operand(0), structure.i)) {
+    return std::nullopt;
+  }
+  Node* index_case;
+  Node* fill_case;
+  if (cond->op() == Op::kULt) {
+    index_case = sel->get_case(0);
+    fill_case = sel->get_case(1);
+  } else {
+    index_case = sel->get_case(1);
+    fill_case = sel->get_case(0);
+  }
+  // Only zero-filled (logical) shifts are handled.
+  if (!fill_case->Is<Literal>() ||
+      !fill_case->As<Literal>()->value().IsAllZeros() ||
+      fill_case->GetType() != result_type->element_type()) {
+    return std::nullopt;
+  }
+
+  Param* shift_param = MatchInvariantParam(cond->operand(1), body);
+  if (shift_param == nullptr) {
+    return std::nullopt;
+  }
+
+  if (!index_case->Is<ArrayIndex>()) {
+    return std::nullopt;
+  }
+  ArrayIndex* array_index = index_case->As<ArrayIndex>();
+  if (array_index->array()->GetType() != result_type ||
+      array_index->indices().size() != 1) {
+    return std::nullopt;
+  }
+  Node* index = array_index->indices()[0];
+  if (index->op() != Op::kSub ||
+      !MatchInductionVar(index->operand(0), structure.i)) {
+    return std::nullopt;
+  }
+
+  if (MatchInvariantParam(index->operand(1), body) != shift_param) {
+    return std::nullopt;
+  }
+  Param* data_param = MatchInvariantParam(array_index->array(), body);
+  if (data_param == nullptr || data_param == shift_param) {
+    return std::nullopt;
+  }
+
+  int64_t data_param_index = -1;
+  int64_t shift_param_index = -1;
+  for (int64_t index = 0; index < static_cast<int64_t>(body->params().size());
+       ++index) {
+    if (body->params()[index] == data_param) {
+      data_param_index = index;
+    }
+    if (body->params()[index] == shift_param) {
+      shift_param_index = index;
+    }
+  }
+  if (data_param_index < 2 || shift_param_index < 2) {
+    return std::nullopt;
+  }
+  Node* data_arg = loop->invariant_args()[data_param_index - 2];
+  Node* shift_arg = loop->invariant_args()[shift_param_index - 2];
+  return ShiftIdiom{loop, data_arg, shift_arg};
+}
+
+absl::Status RewriteShiftIdiom(const ShiftIdiom& idiom) {
+  FunctionBase* f = idiom.loop->function_base();
+  ArrayType* result_type = idiom.loop->GetType()->AsArrayOrDie();
+  const int64_t size = result_type->size();
+  const int64_t index_bit_count = Bits::MinBitCountUnsigned(size - 1);
+
+  std::vector<Node*> packed_elements;
+  packed_elements.reserve(size);
+  for (int64_t k = size - 1; k >= 0; --k) {
+    XLS_ASSIGN_OR_RETURN(
+        Literal * index,
+        f->MakeNode<Literal>(idiom.loop->loc(),
+                             Value(UBits(k, index_bit_count))));
+    std::vector<Node*> indices = {index};
+    XLS_ASSIGN_OR_RETURN(
+        Node * element,
+        f->MakeNode<ArrayIndex>(idiom.loop->loc(), idiom.data, indices,
+                                /*assumed_in_bounds=*/true));
+    packed_elements.push_back(element);
+  }
+  XLS_ASSIGN_OR_RETURN(
+      Node * packed,
+      f->MakeNode<Concat>(idiom.loop->loc(), absl::MakeSpan(packed_elements)));
+  XLS_ASSIGN_OR_RETURN(
+      Node * shifted,
+      f->MakeNode<BinOp>(idiom.loop->loc(), packed, idiom.shift, Op::kShll));
+
+  std::vector<Node*> result_elements;
+  result_elements.reserve(size);
+  for (int64_t k = 0; k < size; ++k) {
+    XLS_ASSIGN_OR_RETURN(
+        Node * bit, f->MakeNode<BitSlice>(idiom.loop->loc(), shifted, k, 1));
+    result_elements.push_back(bit);
+  }
+  XLS_ASSIGN_OR_RETURN(
+      Node * result,
+      f->MakeNode<Array>(idiom.loop->loc(), absl::MakeSpan(result_elements),
+                         result_type->element_type()));
+
+  XLS_RETURN_IF_ERROR(idiom.loop->ReplaceUsesWith(result));
+  return f->RemoveNode(idiom.loop);
+}
+
+CountedFor* FindCountedFor(FunctionBase* f, Node* after = nullptr) {
+  bool scanning = after == nullptr;
+  for (Node* node : f->nodes()) {
+    if (!scanning) {
+      if (node == after) {
+        scanning = true;
+      }
+      continue;
+    }
+    if (node->Is<CountedFor>() &&
+        (f->HasImplicitUse(node) || !node->users().empty())) {
+      return node->As<CountedFor>();
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+absl::StatusOr<bool> LoopIdiomPass::RunOnFunctionBaseInternal(
+    FunctionBase* f, const OptimizationPassOptions& options,
+    PassResults* results, OptimizationContext& context) const {
+  VLOG(1) << "LoopIdiomPass running on function: " << f->name();
+  bool changed = false;
+  CountedFor* candidate = FindCountedFor(f);
+  while (candidate != nullptr) {
+    std::optional<ArrayOverwriteLoop> structure = MatchLoopStructure(candidate);
+    std::optional<ShiftIdiom> idiom;
+    if (structure.has_value() && !BodyHasSideEffects(candidate->body())) {
+      idiom = MatchShiftIdiom(*structure);
+    }
+    if (idiom.has_value()) {
+      XLS_RETURN_IF_ERROR(RewriteShiftIdiom(*idiom));
+      changed = true;
+      candidate = FindCountedFor(f);
+      continue;
+    }
+    candidate = FindCountedFor(f, candidate);
+  }
+  return changed;
+}
+
+}  // namespace xls

--- a/xls/passes/loop_idiom_pass.h
+++ b/xls/passes/loop_idiom_pass.h
@@ -1,0 +1,58 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef XLS_PASSES_LOOP_IDIOM_PASS_H_
+#define XLS_PASSES_LOOP_IDIOM_PASS_H_
+
+#include <string_view>
+
+#include "absl/status/statusor.h"
+#include "xls/ir/function_base.h"
+#include "xls/passes/optimization_pass.h"
+#include "xls/passes/pass_base.h"
+
+namespace xls {
+
+// Recognizes common loop idioms in `counted_for` loops and rewrites them into
+// more direct IR forms BEFORE the loop is unrolled.
+//
+// First target: a zero-filled array shift (DSLX `data << shift` expressed as a
+// `for` loop with `result[i] = if i < shift { false } else { data[i-shift] }`).
+// The counted_for body lowers to an `array_update` of
+// `sel(ult(i, shift), [array_index(data, [i - shift]), 0])`; rewriting that to
+// a packed `shll` + per-bit `bit_slice` shape lets codegen emit a native shift
+// instead of per-element index muxes.
+class LoopIdiomPass : public OptimizationFunctionBasePass {
+ public:
+  static constexpr std::string_view kName = "loop_idiom";
+  LoopIdiomPass()
+      : OptimizationFunctionBasePass(kName, "Recognize loop idioms") {}
+
+  bool IsIdempotent() const override { return true; }
+
+  RedundancyGuard GetRedundancyGuard(
+      const OptimizationPassOptions& options,
+      OptimizationContext& context) const override {
+    return RedundancyGuard::CanSkip();
+  }
+
+ protected:
+  absl::StatusOr<bool> RunOnFunctionBaseInternal(
+      FunctionBase* f, const OptimizationPassOptions& options,
+      PassResults* results, OptimizationContext& context) const override;
+};
+
+}  // namespace xls
+
+#endif  // XLS_PASSES_LOOP_IDIOM_PASS_H_

--- a/xls/passes/loop_idiom_pass_test.cc
+++ b/xls/passes/loop_idiom_pass_test.cc
@@ -1,0 +1,440 @@
+// Copyright 2026 The XLS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "xls/passes/loop_idiom_pass.h"
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "absl/status/statusor.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "xls/common/fuzzing/fuzztest.h"
+#include "xls/common/status/matchers.h"
+#include "xls/common/status/status_macros.h"
+#include "xls/fuzzer/ir_fuzzer/ir_fuzz_domain.h"
+#include "xls/fuzzer/ir_fuzzer/ir_fuzz_test_library.h"
+#include "xls/ir/function.h"
+#include "xls/ir/ir_matcher.h"
+#include "xls/ir/ir_parser.h"
+#include "xls/ir/package.h"
+#include "xls/passes/optimization_pass.h"
+#include "xls/passes/pass_base.h"
+
+namespace m = ::xls::op_matchers;
+
+namespace xls {
+namespace {
+
+using ::absl_testing::IsOkAndHolds;
+
+// A zero-filled left shift of a bits[1][8] array written as a counted_for
+// loop, matching the DSLX lowering of
+//   for (i, result) in u32:0..u32:8 {
+//     update(result, i, if i < shift { false } else { data[i - shift] })
+//   }
+constexpr const char* kShiftLoopProgram = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  ult.5: bits[1] = ult(add.2, zero_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+
+// Runs the pass on the function with the given name and returns the function.
+absl::StatusOr<Function*> RunPassOn(Package* p, std::string_view fn_name) {
+  XLS_ASSIGN_OR_RETURN(Function * f, p->GetFunction(fn_name));
+  LoopIdiomPass pass;
+  PassResults results;
+  OptimizationContext context;
+  XLS_RETURN_IF_ERROR(
+      pass.RunOnFunctionBase(f, OptimizationPassOptions(), &results, context)
+          .status());
+  return f;
+}
+
+// The rewritten function must be the packed shift shape:
+//   array(bit_slice(shll(concat(data[7]..data[0]), shift), i, 1))
+MATCHER_P(MatchPackedShift, shift_name, "") {
+  const Node* array = arg;
+  if (!array->Is<Array>()) {
+    return false;
+  }
+  if (array->operand_count() != 8) {
+    return false;
+  }
+  for (int64_t i = 0; i < 8; ++i) {
+    Node* bit = array->operand(i);
+    if (!bit->Is<BitSlice>() || bit->operand(0)->op() != Op::kShll ||
+        bit->As<BitSlice>()->start() != i ||
+        bit->As<BitSlice>()->width() != 1) {
+      return false;
+    }
+  }
+  Node* shll = array->operand(0)->operand(0);
+  if (!shll->operand(1)->Is<Param>() ||
+      shll->operand(1)->As<Param>()->GetName() != shift_name) {
+    return false;
+  }
+  Node* packed = shll->operand(0);
+  if (!packed->Is<Concat>() || packed->operand_count() != 8) {
+    return false;
+  }
+  for (int64_t i = 0; i < 8; ++i) {
+    Node* element = packed->operand(7 - i);
+    if (!element->Is<ArrayIndex>() ||
+        !element->As<ArrayIndex>()->indices()[0]->Is<Literal>() ||
+        element->As<ArrayIndex>()
+                ->indices()[0]
+                ->As<Literal>()
+                ->value()
+                .bits()
+                .ToUint64()
+                .value() != i) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TEST(LoopIdiomPassTest, RewritesShiftLoop) {
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(kShiftLoopProgram));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), MatchPackedShift("shift"));
+}
+
+TEST(LoopIdiomPassTest, RewritesUgePolarityShiftLoop) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  uge.5: bits[1] = uge(add.2, zero_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(uge.5, cases=[literal.7, array_index.6])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), MatchPackedShift("shift"));
+}
+
+TEST(LoopIdiomPassTest, RewritesDirectInductionVar) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[3], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  sub.4: bits[3] = sub(i, shift)
+  ult.5: bits[1] = ult(i, shift)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[i])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), MatchPackedShift("shift"));
+}
+
+// A matching loop after a non-matching loop must still be rewritten: the pass
+// scans past candidates that do not match instead of stopping.
+TEST(LoopIdiomPassTest, RewritesShiftLoopAfterNonMatchingLoop) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn non_shift_body(i: bits[32], result: bits[1][8]) -> bits[1][8] {
+  literal.1: bits[1] = literal(value=1)
+  ret array_update.2: bits[1][8] = array_update(result, literal.1, indices=[i])
+}
+
+fn shift_body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.3: bits[32] = literal(value=0)
+  add.4: bits[32] = add(i, literal.3)
+  zero_ext.5: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.6: bits[32] = sub(add.4, zero_ext.5)
+  ult.7: bits[1] = ult(add.4, zero_ext.5)
+  array_index.8: bits[1] = array_index(data, indices=[sub.6])
+  literal.9: bits[1] = literal(value=0)
+  sel.10: bits[1] = sel(ult.7, cases=[array_index.8, literal.9])
+  ret array_update.11: bits[1][8] = array_update(result, sel.10, indices=[add.4])
+}
+
+fn mixed(data: bits[1][8], shift: bits[3]) -> (bits[1][8], bits[1][8]) {
+  literal.12: bits[1] = literal(value=0)
+  array.13: bits[1][8] = array(literal.12, literal.12, literal.12, literal.12, literal.12, literal.12, literal.12, literal.12)
+  array.14: bits[1][8] = array(literal.12, literal.12, literal.12, literal.12, literal.12, literal.12, literal.12, literal.12)
+  counted_for.15: bits[1][8] = counted_for(array.13, trip_count=8, stride=1, body=non_shift_body, invariant_args=[])
+  counted_for.16: bits[1][8] = counted_for(array.14, trip_count=8, stride=1, body=shift_body, invariant_args=[data, shift])
+  ret tuple.17: (bits[1][8], bits[1][8]) = tuple(counted_for.15, counted_for.16)
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "mixed"));
+  EXPECT_THAT(f->return_value(),
+              m::Tuple(m::CountedFor(), MatchPackedShift("shift")));
+}
+
+// The pass must not rewrite the loop if any part of the shape differs.
+TEST(LoopIdiomPassTest, DoesNotRewriteNonShiftLoops) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  ult.5: bits[1] = ult(add.2, zero_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=1)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteNonUnitStride) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  ult.5: bits[1] = ult(add.2, zero_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=2, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteNonBitsElements) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[2][8], data: bits[2][8], shift: bits[3]) -> bits[2][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  ult.5: bits[1] = ult(add.2, zero_ext.3)
+  array_index.6: bits[2] = array_index(data, indices=[sub.4])
+  literal.7: bits[2] = literal(value=0)
+  sel.8: bits[2] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[2][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[2][8], shift: bits[3]) -> bits[2][8] {
+  literal.10: bits[2] = literal(value=0)
+  array.11: bits[2][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[2][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteSignExtendedShift) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  sign_ext.3: bits[32] = sign_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, sign_ext.3)
+  ult.5: bits[1] = ult(add.2, sign_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.10: bits[1] = literal(value=0)
+  array.11: bits[1][8] = array(literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10, literal.10)
+  ret counted_for.12: bits[1][8] = counted_for(array.11, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteMismatchedShiftParams) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift_a: bits[3], shift_b: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift_a, new_bit_count=32)
+  zero_ext.4: bits[32] = zero_ext(shift_b, new_bit_count=32)
+  sub.5: bits[32] = sub(add.2, zero_ext.3)
+  ult.6: bits[1] = ult(add.2, zero_ext.4)
+  array_index.7: bits[1] = array_index(data, indices=[sub.5])
+  literal.8: bits[1] = literal(value=0)
+  sel.9: bits[1] = sel(ult.6, cases=[array_index.7, literal.8])
+  ret array_update.10: bits[1][8] = array_update(result, sel.9, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift_a: bits[3], shift_b: bits[3]) -> bits[1][8] {
+  literal.11: bits[1] = literal(value=0)
+  array.12: bits[1][8] = array(literal.11, literal.11, literal.11, literal.11, literal.11, literal.11, literal.11, literal.11)
+  ret counted_for.13: bits[1][8] = counted_for(array.12, trip_count=8, stride=1, body=body, invariant_args=[data, shift_a, shift_b])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteBodyWithSideEffects) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  zero_ext.3: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.4: bits[32] = sub(add.2, zero_ext.3)
+  ult.5: bits[1] = ult(add.2, zero_ext.3)
+  array_index.6: bits[1] = array_index(data, indices=[sub.4])
+  literal.7: bits[1] = literal(value=0)
+  sel.8: bits[1] = sel(ult.5, cases=[array_index.6, literal.7])
+  literal.10: token = literal(value=token)
+  literal.11: bits[1] = literal(value=1)
+  assert.12: token = assert(literal.10, literal.11, message="msg")
+  ret array_update.9: bits[1][8] = array_update(result, sel.8, indices=[add.2])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.13: bits[1] = literal(value=0)
+  array.14: bits[1][8] = array(literal.13, literal.13, literal.13, literal.13, literal.13, literal.13, literal.13, literal.13)
+  ret counted_for.15: bits[1][8] = counted_for(array.14, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+TEST(LoopIdiomPassTest, DoesNotRewriteBodyWithInvoke) {
+  const std::string program = R"(
+package loop_idiom_test
+
+fn helper(x: bits[32]) -> bits[32] {
+  ret x: bits[32] = param(name=x)
+}
+
+fn body(i: bits[32], result: bits[1][8], data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.1: bits[32] = literal(value=0)
+  add.2: bits[32] = add(i, literal.1)
+  invoke.3: bits[32] = invoke(add.2, to_apply=helper)
+  zero_ext.4: bits[32] = zero_ext(shift, new_bit_count=32)
+  sub.5: bits[32] = sub(invoke.3, zero_ext.4)
+  ult.6: bits[1] = ult(invoke.3, zero_ext.4)
+  array_index.7: bits[1] = array_index(data, indices=[sub.5])
+  literal.8: bits[1] = literal(value=0)
+  sel.9: bits[1] = sel(ult.6, cases=[array_index.7, literal.8])
+  ret array_update.10: bits[1][8] = array_update(result, sel.9, indices=[invoke.3])
+}
+
+fn shift_loop(data: bits[1][8], shift: bits[3]) -> bits[1][8] {
+  literal.11: bits[1] = literal(value=0)
+  array.12: bits[1][8] = array(literal.11, literal.11, literal.11, literal.11, literal.11, literal.11, literal.11, literal.11)
+  ret counted_for.13: bits[1][8] = counted_for(array.12, trip_count=8, stride=1, body=body, invariant_args=[data, shift])
+}
+)";
+  XLS_ASSERT_OK_AND_ASSIGN(std::unique_ptr<Package> p,
+                           Parser::ParsePackage(program));
+  XLS_ASSERT_OK_AND_ASSIGN(Function * f, RunPassOn(p.get(), "shift_loop"));
+  EXPECT_THAT(f->return_value(), m::CountedFor());
+}
+
+void IrFuzzLoopIdiom(FuzzPackageWithArgs fuzz_package_with_args) {
+  LoopIdiomPass pass;
+  OptimizationPassChangesOutputs(std::move(fuzz_package_with_args), pass);
+}
+FUZZ_TEST(IrFuzzTest, IrFuzzLoopIdiom)
+    .WithDomains(IrFuzzDomainWithArgs(/*arg_set_count=*/10));
+
+}  // namespace
+}  // namespace xls

--- a/xls/passes/optimization_pass_pipeline.txtpb
+++ b/xls/passes/optimization_pass_pipeline.txtpb
@@ -378,7 +378,7 @@ compound_passes: [
   {
     long_name: "Iteratively inline and simplify"
     short_name: "simplify-and-inline"
-    passes: ["pre-inlining", "one-leaf-inlining"]
+    passes: ["loop_idiom", "dfe", "pre-inlining", "one-leaf-inlining"]
     fixedpoint: true
     comment:
       "Inlining segment of the pipeline\n"


### PR DESCRIPTION
Adds a new pass - loop-idiom. For now just recognizes zero-filled array shift (DSLX `data << shift` expressed as a `for` loop with `result[i] = if i < shift { false } else { data[i-shift] }`). The counted_for body lowers to an `array_update` of `sel(ult(i, shift), [array_index(data, [i - shift]), 0])`; rewriting that to a packed `shll` + per-bit `bit_slice` shape lets codegen emit a native shift instead of per-element index muxes.
I measured PPA on this simple example:
```
pub fn main(data: bool[8], shift: u3) -> bool[8] {
    for (i, result): (u32, bool[8]) in u32:0..u32:8 {
        let value = if i < (shift as u32) {
            false
        } else {
            data[i - (shift as u32)]
        };
        update(result, i, value)
    }(bool[8]:[false, ...])
}
```
Yosys synthesis targeting ASAP7:
| metric | before | after | delta |
|---|---|---|---|
| cell area (µm²) | 13.8947 | 4.0970 | −70.5% |
| longest topological path | 10 | 4 | −60% |
| total cells | 136 | 41 | −69.9% |

